### PR TITLE
Call docs-document onLoaded in lifecycle

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -424,7 +424,6 @@ declare global {
 
   namespace StencilComponents {
     interface DocsDocument {
-      'hash': string;
       'isLoadingTimeout': number;
       'onLoaded': (document) => void;
       'pageClass': string;
@@ -451,7 +450,6 @@ declare global {
   }
   namespace JSXElements {
     export interface DocsDocumentAttributes extends HTMLAttributes {
-      'hash'?: string;
       'isLoadingTimeout'?: number;
       'onLoaded'?: (document) => void;
       'pageClass'?: string;

--- a/src/components/docs-document/docs-document.tsx
+++ b/src/components/docs-document/docs-document.tsx
@@ -15,16 +15,15 @@ export class DocsDocument {
   @Prop() pageClass: string;
   @Prop() onLoaded: (document) => void;
   @Prop() isLoadingTimeout = 1000;
-  @Prop() hash: string = null;
   @State() isLoading = false;
   @State() body: string;
   @State() title: string;
   @State() hideTOC = false;
   @State() frontMatter = {};
   @State() tocHeadings: HeadingStruc[] = [];
+  @State() attributes = {};
 
   loadingTimer = null;
-  scrollPending: string = null;
 
   componentDidLoad() {
     return this.fetchDocument();
@@ -55,21 +54,14 @@ export class DocsDocument {
       }));
   }
 
-  handleNewContent = ({attributes, body, headings}) => {
+  handleNewContent = ({ attributes, body, headings }) => {
     this.clearLoadingTimer();
     this.body = body;
     this.title = attributes.title;
     this.hideTOC = attributes.hideTOC;
     this.frontMatter = attributes;
     this.tocHeadings = this.hideTOC ? [] : headings;
-    this.scrollPending = this.hash;
-    this.onLoaded({
-      ...attributes,
-      body,
-      headings,
-      pageClass: this.pageClass
-    });
-
+    this.attributes = attributes;
   }
 
   handleFetchError = err => {
@@ -77,6 +69,16 @@ export class DocsDocument {
     this.title = '';
     this.hideTOC = true;
     this.body = err.message;
+  }
+
+  componentDidUpdate() {
+    const { attributes, body, tocHeadings: headings, pageClass } = this;
+    this.onLoaded({
+      attributes,
+      body,
+      headings,
+      pageClass
+    });
   }
 
   setLoadingTimer() {
@@ -100,24 +102,12 @@ export class DocsDocument {
     return { attributes, body };
   }
 
-  scrollInToView(el) {
-    if (!el || !el.scrollIntoView) return;
-    el.scrollIntoView();
-    this.scrollPending = null;
-  }
-
   render() {
     if (this.isLoading) {
       return <loading-indicator/>;
     }
 
     const headings = this.tocHeadings.filter(heading => heading.level < 3);
-
-    if (this.scrollPending) {
-      setTimeout(() => {
-        this.scrollInToView(document.querySelector(this.scrollPending));
-      }, 0, this);
-    }
 
     return [
       // <Helmet>

--- a/src/components/docs-root/docs-root.tsx
+++ b/src/components/docs-root/docs-root.tsx
@@ -11,7 +11,6 @@ export class DocsRoot {
   @State() previewCss: string;
   @State() isMenuOpen = false;
   @State() pageClass: string;
-  @State() path: string = null;
 
   @Listen('updatePreview')
   handleUpdatePreview(ev: any) {
@@ -62,7 +61,7 @@ export class DocsRoot {
                 ref={node => { this.contentElement = node; }}
                 onOverlayClick={this.closeMenu}
                 showOverlay={this.isMenuOpen}>
-                  <docs-document path={documentPath} hash={props.history.location.hash} onLoaded={this.handleDocumentLoad} pageClass={page}/>
+                  <docs-document path={documentPath} onLoaded={this.handleDocumentLoad} pageClass={page}/>
                   <docs-preview url={this.previewUrl} cssText={this.previewCss}/>
               </docs-content>
             </docs-layout>

--- a/src/components/docs-root/docs-root.tsx
+++ b/src/components/docs-root/docs-root.tsx
@@ -5,7 +5,7 @@ import '@stencil/router'; // tslint:disable-line:no-import-side-effect
   tag: 'docs-root'
 })
 export class DocsRoot {
-  contentElement: HTMLElement;
+  document: HTMLElement;
 
   @State() previewUrl: string;
   @State() previewCss: string;
@@ -26,10 +26,16 @@ export class DocsRoot {
   handleDocumentLoad = (document) => {
     this.previewUrl = document.previewUrl || null;
     this.pageClass = document.pageClass;
-    if (this.contentElement) {
-      this.contentElement.scrollTop = 0;
-    }
+    this.setScrollPosition();
     this.closeMenu();
+  }
+
+  setScrollPosition() {
+    const { hash } = window.location;
+    const target = hash ? document.querySelector(hash) : this.document;
+    if (target) {
+      target.scrollIntoView();
+    }
   }
 
   toggleMenu = () => {
@@ -58,10 +64,13 @@ export class DocsRoot {
               <docs-menu section={section} path={props.match.url}/>
               <docs-header section={section} isMenuOpen={this.isMenuOpen} onToggleClick={this.toggleMenu}/>
               <docs-content
-                ref={node => { this.contentElement = node; }}
                 onOverlayClick={this.closeMenu}
                 showOverlay={this.isMenuOpen}>
-                  <docs-document path={documentPath} onLoaded={this.handleDocumentLoad} pageClass={page}/>
+                  <docs-document
+                    ref={node => { this.document = node; }}
+                    path={documentPath}
+                    onLoaded={this.handleDocumentLoad}
+                    pageClass={page}/>
                   <docs-preview url={this.previewUrl} cssText={this.previewCss}/>
               </docs-content>
             </docs-layout>


### PR DESCRIPTION
#### Short description of what this resolves:
I noticed we had to do some weird things to set the scroll position. And it seemed like the issue was that `docs-document.onLoaded` can be called before the content has been updated. So I moved that call into `componentDidUpdate`. That allows us to confidently react to the document in that callback, knowing that the document has been rendered.

#### Changes proposed in this pull request:

- Only set document state in `handleNewContent`
- Call `docs-document.onLoaded` in `componentDidUpdate`
- Remove scroll scheduling logic and set scroll position in `onLoaded`

It's getting a little late, so let me know if this makes sense to you, @perrygovier 😄 
