### PR TITLE
refactor(preview): add generic preview messages with "previewMessage" event

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -195,7 +195,7 @@ declare global {
   }
   namespace JSXElements {
     export interface ColorGeneratorAttributes extends HTMLAttributes {
-      'onUpdatePreview'?: (event: CustomEvent) => void;
+      'onPreviewMessage'?: (event: CustomEvent) => void;
     }
   }
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -604,7 +604,6 @@ declare global {
 
   namespace StencilComponents {
     interface DocsPreview {
-      'cssText': string;
       'url': string;
     }
   }
@@ -628,7 +627,6 @@ declare global {
   }
   namespace JSXElements {
     export interface DocsPreviewAttributes extends HTMLAttributes {
-      'cssText'?: string;
       'url'?: string;
     }
   }

--- a/src/components/color-gen/color-generator/color-generator.tsx
+++ b/src/components/color-gen/color-generator/color-generator.tsx
@@ -11,7 +11,7 @@ import { convertCssToColors, generateColor, updateCssText } from '../parse-css';
 export class ColorGenerator {
 
   @Element() el: HTMLElement;
-  @Event() updatePreview: EventEmitter;
+  @Event() previewMessage: EventEmitter;
   @State() colors: ColorVariable[] = [];
   @State() cssText = DEFAULT_CSS_TEXT;
 
@@ -38,7 +38,7 @@ export class ColorGenerator {
       this.cssText = updateCssText(colorProperty + attrMap[key], this.cssText, genColor[key]);
     });
 
-    this.updatePreview.emit({cssText: this.cssText});
+    this.previewMessage.emit({cssText: this.cssText});
   }
 
   @Listen('cssTextChange')
@@ -48,7 +48,7 @@ export class ColorGenerator {
 
     if (colors.length > 0) {
       this.colors = colors;
-      this.updatePreview.emit({cssText: this.cssText});
+      this.previewMessage.emit({cssText: this.cssText});
     }
   }
 
@@ -57,7 +57,7 @@ export class ColorGenerator {
   }
 
   componentDidLoad () {
-    this.updatePreview.emit({
+    this.previewMessage.emit({
       cssText: this.cssText
     });
   }

--- a/src/components/color-gen/demo/index.html
+++ b/src/components/color-gen/demo/index.html
@@ -6,6 +6,7 @@
     padding: 0;
   }
 </style>
+<style id="color-style"></style>
 
 <ion-app>
   <ion-tabs useRouter="false">
@@ -147,3 +148,16 @@
 
   </ion-tabs>
 </ion-app>
+
+<script>
+  const styleTag = document.querySelector('#color-style');
+
+  function handleMessage(message) {
+    const cssText = message.data ? message.data.cssText : null;
+    if (cssText) {
+      styleTag.innerHTML = cssText;
+    }
+  }
+
+  window.addEventListener('message', handleMessage);
+</script>

--- a/src/components/docs-menu/docs-menu-map.ts
+++ b/src/components/docs-menu/docs-menu-map.ts
@@ -27,7 +27,7 @@ export const main = {
     'Web View': '/docs/building/webview',
     'Ionic Storage': '/docs/building/storage'
   },
-  //  'Components': '/docs/components',
+  'Components': '/docs/components',
   'Layout': {
     'Stucture': '/docs/layout/structure',
     'Responsive Grid': '/docs/layout/grid',

--- a/src/components/docs-preview/docs-preview.scss
+++ b/src/components/docs-preview/docs-preview.scss
@@ -30,6 +30,7 @@ docs-preview {
 }
 
 .docs-preview-device > figure > iframe {
+  border: none;
   height: 100%;
   left: 0;
   position: absolute;

--- a/src/components/docs-preview/docs-preview.tsx
+++ b/src/components/docs-preview/docs-preview.tsx
@@ -64,8 +64,7 @@ export class SitePreviewApp {
           <iframe
             src={`${this.url}?ionic:mode=${this.previewMode}`}
             ref={el => this.iframe = el as any}
-            onLoad={this.onIframeLoad.bind(this)}
-            frameborder="0"></iframe>
+            onLoad={this.onIframeLoad.bind(this)}/>
         </figure>
       </div>
     ];

--- a/src/components/docs-preview/docs-preview.tsx
+++ b/src/components/docs-preview/docs-preview.tsx
@@ -7,7 +7,7 @@ import { Component, Listen, Prop, State, Watch } from '@stencil/core';
 export class SitePreviewApp {
   @Prop() url: string;
   @Prop() cssText: string;
-  @State() previewMode = 'ios';
+  @State() ionicMode = 'ios';
   iframe: HTMLIFrameElement;
 
   @Listen('window:previewMessage')
@@ -53,16 +53,16 @@ export class SitePreviewApp {
       <div class="docs-preview-mode-toggle">
         {['ios', 'md'].map(mode => (
           <button
-            class={ mode === this.previewMode ? 'is-selected' : null }
-            onClick={() => { this.previewMode = mode; }}>
+            class={ mode === this.ionicMode ? 'is-selected' : null }
+            onClick={() => { this.ionicMode = mode; }}>
               { mode }
           </button>
         ))}
       </div>,
-      <div class={`docs-preview-device ${this.previewMode}`}>
+      <div class={`docs-preview-device ${this.ionicMode}`}>
         <figure>
           <iframe
-            src={`${this.url}?ionic:mode=${this.previewMode}`}
+            src={`${this.url}?ionic:mode=${this.ionicMode}`}
             ref={el => this.iframe = el as any}
             onLoad={this.onIframeLoad.bind(this)}/>
         </figure>

--- a/src/components/docs-preview/docs-preview.tsx
+++ b/src/components/docs-preview/docs-preview.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, State, Watch } from '@stencil/core';
+import { Component, Listen, Prop, State, Watch } from '@stencil/core';
 
 @Component({
   tag: 'docs-preview',
@@ -9,6 +9,15 @@ export class SitePreviewApp {
   @Prop() cssText: string;
   @State() previewMode = 'ios';
   iframe: HTMLIFrameElement;
+
+  @Listen('window:previewMessage')
+  postToIframe({ detail }: CustomEvent) {
+    try {
+      this.iframe.contentWindow.postMessage(detail, '*');
+    } catch (err) {
+      console.error('Failed to post message to preview: ', err);
+    }
+  }
 
   @Watch('cssText')
   onCssTextChange() {

--- a/src/components/docs-preview/docs-preview.tsx
+++ b/src/components/docs-preview/docs-preview.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, Prop, State, Watch } from '@stencil/core';
+import { Component, Listen, Prop, State } from '@stencil/core';
 
 @Component({
   tag: 'docs-preview',
@@ -6,7 +6,6 @@ import { Component, Listen, Prop, State, Watch } from '@stencil/core';
 })
 export class SitePreviewApp {
   @Prop() url: string;
-  @Prop() cssText: string;
   @State() ionicMode = 'ios';
   iframe: HTMLIFrameElement;
 
@@ -17,31 +16,6 @@ export class SitePreviewApp {
     } catch (err) {
       console.error('Failed to post message to preview: ', err);
     }
-  }
-
-  @Watch('cssText')
-  onCssTextChange() {
-    this.applyStyles();
-  }
-
-  applyStyles () {
-    if (this.iframe && this.iframe.contentDocument && this.iframe.contentDocument.documentElement) {
-      const iframeDoc = this.iframe.contentDocument;
-      const varStyleId = 'color-style';
-
-      let themerStyle: HTMLStyleElement = iframeDoc.getElementById(varStyleId) as any;
-      if (!themerStyle) {
-        themerStyle = iframeDoc.createElement('style');
-        themerStyle.id = varStyleId;
-        iframeDoc.documentElement.appendChild(themerStyle);
-      }
-
-      themerStyle.innerHTML = this.cssText;
-    }
-  }
-
-  onIframeLoad() {
-    this.applyStyles();
   }
 
   render() {
@@ -63,8 +37,7 @@ export class SitePreviewApp {
         <figure>
           <iframe
             src={`${this.url}?ionic:mode=${this.ionicMode}`}
-            ref={el => this.iframe = el as any}
-            onLoad={this.onIframeLoad.bind(this)}/>
+            ref={node => { this.iframe = node as HTMLIFrameElement; }}/>
         </figure>
       </div>
     ];

--- a/src/components/docs-root/docs-root.tsx
+++ b/src/components/docs-root/docs-root.tsx
@@ -1,4 +1,4 @@
-import { Component, Listen, State } from '@stencil/core';
+import { Component, State } from '@stencil/core';
 import '@stencil/router'; // tslint:disable-line:no-import-side-effect
 
 @Component({
@@ -8,15 +8,8 @@ export class DocsRoot {
   document: HTMLElement;
 
   @State() previewUrl: string;
-  @State() previewCss: string;
   @State() isMenuOpen = false;
   @State() pageClass: string;
-
-  @Listen('updatePreview')
-  handleUpdatePreview(ev: any) {
-    if (ev.detail.url) this.previewUrl = ev.detail.url;
-    if (ev.detail.cssText) this.previewCss = ev.detail.cssText;
-  }
 
   parseSection(path) {
     const match = /^(api|cli|native|pro)(\/.*)?/.exec(path);
@@ -69,7 +62,7 @@ export class DocsRoot {
                     ref={node => { this.document = node; }}
                     path={documentPath}
                     onUpdate={this.handleDocumentUpdate}/>
-                  <docs-preview url={this.previewUrl} cssText={this.previewCss}/>
+                  <docs-preview url={this.previewUrl}/>
               </docs-content>
             </docs-layout>
           );


### PR DESCRIPTION
We had a complicated setup where the color-generator would emit an event and then the preview would listen for it and operate on the iframe. This removes that logic in favor of one generic method to communicate with the preview window.

Now you emit a `previewMessage` event and the event's `detail` key will be forwarded on to the preview iframe.

```ts
@Event() previewMessage: EventEmitter;

updatePreviewSomehow() {
   this.previewMessage.emit({ foo: 'bar' });
}
```

And then listen for it in the iframe:
```ts
window.addEventListener('message', console.log);
//=> { data: { foo: 'bar' }}
```
