### PR TITLE
Fixed a typo

### DIFF
--- a/src/content/native.md
+++ b/src/content/native.md
@@ -7,7 +7,7 @@ Ionic Native wraps Cordova plugins in a Promise or Observable, providing a commo
 
 ## Usage with Angular apps
 
-To use a plugin, import and add the plugin inejectable to a `@NgModule`. For Angular, the import path should end with `/ngx`.
+To use a plugin, import and add the plugin injectable to a `@NgModule`. For Angular, the import path should end with `/ngx`.
 
 ```typescript
 // app.module.ts


### PR DESCRIPTION
Injectable was spelled as inejectable

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Fixes**: #
