### PR TITLE
feat(components-docs): add link to api docs for each component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -605,6 +605,39 @@ declare global {
 declare global {
 
   namespace StencilComponents {
+    interface DocsLink {
+      'compName': string;
+    }
+  }
+
+  interface HTMLDocsLinkElement extends StencilComponents.DocsLink, HTMLStencilElement {}
+
+  var HTMLDocsLinkElement: {
+    prototype: HTMLDocsLinkElement;
+    new (): HTMLDocsLinkElement;
+  };
+  interface HTMLElementTagNameMap {
+    'docs-link': HTMLDocsLinkElement;
+  }
+  interface ElementTagNameMap {
+    'docs-link': HTMLDocsLinkElement;
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      'docs-link': JSXElements.DocsLinkAttributes;
+    }
+  }
+  namespace JSXElements {
+    export interface DocsLinkAttributes extends HTMLAttributes {
+      'compName'?: string;
+    }
+  }
+}
+
+
+declare global {
+
+  namespace StencilComponents {
     interface DocsMenu {
       'history': RouterHistory;
       'path': string;

--- a/src/components/docs-document/docs-document.scss
+++ b/src/components/docs-document/docs-document.scss
@@ -18,3 +18,14 @@ docs-document > *:first-child {
 docs-document main {
   flex: 1;
 }
+
+docs-document #api-link {
+  font-size: 12px;
+  color: #3880ff;
+  background-color: #dfedff;
+  float: right;
+  text-align: center;
+  padding: 2px;
+  width: 2.8em;
+  border-radius: 25px;
+}

--- a/src/components/docs-document/docs-document.tsx
+++ b/src/components/docs-document/docs-document.tsx
@@ -53,7 +53,7 @@ export class DocsDocument {
       .then(this.stripTitle)
       .then(({ attributes, body }) => ({
           attributes,
-          ...renderMarkdown(body, attributes)
+          ...renderMarkdown(body, { ...attributes, path: this.path })
       }));
   }
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -60,6 +60,8 @@ export function renderMarkdown(markdown: string, options: RenderOptions): Marked
     return `
       <h${level} id="${anchorId}">
         <a href="#${anchorId}" class="linked">${text}</a>
+
+        <a id="api-link" href="/docs/api/${anchorId}">API</a>
       </h${level}>
     `;
   };


### PR DESCRIPTION
#### Short description of what this resolves:
This resolves the task we prioritized around adding a link to the api docs for each component in the component docs

#### Changes proposed in this pull request:

- generate new anchor tag that links to api docs
- adds css for this new anchor

