### PR TITLE
fix(img-zoom): title is "null"

### DIFF
--- a/src/components/img-zoom/img-zoom.tsx
+++ b/src/components/img-zoom/img-zoom.tsx
@@ -10,7 +10,8 @@ const ESCAPE = 27;
 export class ImgZoom {
   @State() zoomed = false;
 
-  onImageClick = () => {
+  @Listen('click')
+  onImageClick() {
     this.zoomed = !this.zoomed;
   }
 
@@ -24,7 +25,6 @@ export class ImgZoom {
   hostData() {
     return {
       class: { 'is-zoomed': this.zoomed },
-      onClick: this.onImageClick
     };
   }
 

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -47,9 +47,9 @@ export function renderMarkdown(markdown: string, options: RenderOptions): Marked
   const renderer = new marked.Renderer();
   const headings: HeadingStruc[] = [];
 
-  renderer.image = (href = '', title = '') => `
+  renderer.image = (href = '', title) => `
     <img-zoom>
-      <img src="${href}" title="${title}"/>
+      <img src="${href}" ${title && `title="${title}"`} />
     </img-zoom>
   `;
 


### PR DESCRIPTION
Only when undefined is passed, the default value is used, in this case, the render passes null.

<img width="1318" alt="screenshot 2018-07-29 at 03 28 27" src="https://user-images.githubusercontent.com/127379/43365220-7b26dbae-9329-11e8-889b-58e3911b05dc.png">

