### PR TITLE
docs(native) Fixed Ionic Platform  import

### DIFF
--- a/src/content/native.md
+++ b/src/content/native.md
@@ -36,7 +36,7 @@ After the plugin has been declared, it can be imported and injected like any oth
 
 ```typescript
 import { Geolocation } from '@ionic-native/geolocation/ngx';
-import { Platform } from 'ionic-angular';
+import { Platform } from '@ionic/angular';
 
 @Component({ ... })
 export class MyComponent {


### PR DESCRIPTION
Fixed the  Ionic Platform import because the import has changed with Ionic v4 from `ionic-angular` to `@ionic/angular`
