### PR TITLE
[V4] Remove img closing tag

### DIFF
--- a/src/content/components.md
+++ b/src/content/components.md
@@ -178,7 +178,7 @@ The list component is used to display rows of information, such as a contact lis
 <ion-list>
   <ion-item>
     <ion-avatar slot="start">
-      <img src="/docs/assets/img/avatar-finn.png"></img>
+      <img src="/docs/assets/img/avatar-finn.png">
     </ion-avatar>
     <ion-label>
       <h2>Finn</h2>


### PR DESCRIPTION
#### Short description of what this resolves:

The List section is contains an image in the example using the `img` tag which is a self closing tag in HTML5 and it will crash the browser if you try to load it using `ionic serve` as is.

#### Changes proposed in this pull request:

- Removing the `</img>` tag is enough to correct this.
