### PR TITLE
doc(theming): add missing # and remove busy word

### DIFF
--- a/src/content/theming/advanced.md
+++ b/src/content/theming/advanced.md
@@ -41,10 +41,10 @@ To change the default values of a color, all of the listed variations for that c
 }
 ```
 
-When `secondary` is applied to a button, not only is the base color (`#006600`) used, but the contrast color (`#ffffff`) is used for the text, along with shade (`#005a00`) and tint (`1a751a`) colors for the different states of the button.
+When `secondary` is applied to a button, not only is the base color (`#006600`) used, but the contrast color (`#ffffff`) is used for the text, along with shade (`#005a00`) and tint (`#1a751a`) colors for the different states of the button.
 
 <blockquote>
-  Not sure how to get the variation colors from the base color? Try out our [Color Generator](/docs/theming/color-generator) that calculates out all of the variations and provides code to copy/paste into an app!
+  Not sure how to get the variation colors from the base color? Try out our [Color Generator](/docs/theming/color-generator) that calculates all of the variations and provides code to copy/paste into an app!
 </blockquote>
 
 See the [CSS Variables documentation](/docs/theming/css-variables#setting-values) for more information on how to set CSS variables.


### PR DESCRIPTION
#### Short description of what this resolves:

Reviewing the docs as part of the doc party. Noticed a missing '#' and felt that 'out' was a "busy word"
