### PR TITLE
docs(theming): update broken relative URLs

### DIFF
--- a/src/content/theming/css-variables.md
+++ b/src/content/theming/css-variables.md
@@ -89,7 +89,7 @@ const color = el.style.getPropertyValue('--charcoal');
 
 ### Component Variables
 
-Ionic provides variables that exist at the component level, such as `--background` and `--color`. For a list of the custom properties a component accepts, view the `Custom Properties` section of its [API reference](../api). For example, see the [Button Custom Properties](../api/button#css-custom-properties).
+Ionic provides variables that exist at the component level, such as `--background` and `--color`. For a list of the custom properties a component accepts, view the `Custom Properties` section of its [API reference](/docs/api/). For example, see the [Button Custom Properties](/docs/api/button#css-custom-properties).
 
 
 ### Global Variables


### PR DESCRIPTION
#### Short description of what this resolves:

- Update previously broken relative URLs to point to a new location.

#### Changes proposed in this pull request:

- Instead of relative location based on the directory where the specific page is located, use URLs that point to the root of the domain.

_Related to:_ #38 
