### PR TITLE
docs(.github): update repository location

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 The ionic docs repo is licensed and managed separately from the ionic repo itself.
 
-By contributing to the driftyco/ionic-docs repo, you agree to have your contributions licensed under the Apache 2.0 license. See the `LICENSE` file for details on this license.
+By contributing to the [ionic-team/ionic-docs](https://github.com/ionic-team/ionic-docs) repo, you agree to have your contributions licensed under the Apache 2.0 license. See the `LICENSE` file for details on this license.
 
 ## GUIDELINES
 


### PR DESCRIPTION
#### Short description of what this resolves:

- The old repository URL `https://github.com/driftyco/ionic-docs` is no longer valid.

#### Changes proposed in this pull request:

- Update the repository name to the current location/name of the repository
- Add Markdown link from the name to the repository URL address
