### PR TITLE
Update apiMap to 4.0.0-beta.15, in accordance with src/versions.ts

### DIFF
--- a/src/components/docs-menu/docs-api-map.ts
+++ b/src/components/docs-menu/docs-api-map.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 
 export const apiMap = {
-  "4.0.0-beta.0": {
+  "4.0.0-beta.15": {
     "action-sheet": "/docs/api/action-sheet",
     "action-sheet-controller": "/docs/api/action-sheet-controller",
     "alert": "/docs/api/alert",


### PR DESCRIPTION
#### Short description of what this resolves:

In  Docs API Reference 4.0.0-beta.15 the list of components is not displayed, because docs-api-map.ts apiMap still is "4.0.0-beta.0"

#### Changes proposed in this pull request:

Update docs-api-map.ts
