### PR TITLE
Fix order of table of "Flex Container Properties"

### DIFF
--- a/src/content/layout/css-utilities.md
+++ b/src/content/layout/css-utilities.md
@@ -543,8 +543,8 @@ The default amount of `margin` to be applied is `16px` and is set by the `--ion-
 | `justify-content-start`   | `justify-content: flex-start`    | Items are packed toward the start on the main axis.                         |
 | `justify-content-end`     | `justify-content: flex-end`      | Items are packed toward the end on the main axis.                           |
 | `justify-content-center`  | `justify-content: center`        | Items are centered along the main axis.                                     |
-| `justify-content-between` | `justify-content: space-between` | Items are evenly distributed on the main axis.                              |
 | `justify-content-around`  | `justify-content: space-around`  | Items are evenly distributed on the main axis with equal space around them. |
+| `justify-content-between` | `justify-content: space-between` | Items are evenly distributed on the main axis.                              |
 | `justify-content-evenly`  | `justify-content: space-evenly`  | Items are distributed so that the spacing between any two items is equal.   |
 | `align-items-start`       | `align-items: flex-start`        | Items are packed toward the start on the cross axis.                        |
 | `align-items-end`         | `align-items: flex-end`          | Items are packed toward the end on the cross axis.                          |


### PR DESCRIPTION
Order of examples in table "Flex Container Properties" did not match the order of example above.
Specifically, the justify-content-between and justify-content-around were reversed

#### Short description of what this resolves:

Inconsistency in the order of the table and examples

#### Changes proposed in this pull request:

- Fix the order of the table
