### PR TITLE
docs(theming): update stepped color documentation to latest

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -38,9 +38,11 @@ export namespace Components {
   }
 
   interface CodeColor {
+    'display': string;
     'value': string;
   }
   interface CodeColorAttributes extends StencilHTMLAttributes {
+    'display'?: string;
     'value'?: string;
   }
 
@@ -251,6 +253,9 @@ export namespace Components {
     'section'?: string;
   }
 
+  interface SteppedColorGenerator {}
+  interface SteppedColorGeneratorAttributes extends StencilHTMLAttributes {}
+
   interface TabGroup {
     'initial': string;
     'tabs': string;
@@ -295,6 +300,7 @@ declare global {
     'LayeredColorsSelect': Components.LayeredColorsSelect;
     'LoadingIndicator': Components.LoadingIndicator;
     'SectionSwitch': Components.SectionSwitch;
+    'SteppedColorGenerator': Components.SteppedColorGenerator;
     'TabGroup': Components.TabGroup;
   }
 
@@ -331,6 +337,7 @@ declare global {
     'layered-colors-select': Components.LayeredColorsSelectAttributes;
     'loading-indicator': Components.LoadingIndicatorAttributes;
     'section-switch': Components.SectionSwitchAttributes;
+    'stepped-color-generator': Components.SteppedColorGeneratorAttributes;
     'tab-group': Components.TabGroupAttributes;
   }
 
@@ -527,6 +534,12 @@ declare global {
     new (): HTMLSectionSwitchElement;
   };
 
+  interface HTMLSteppedColorGeneratorElement extends Components.SteppedColorGenerator, HTMLStencilElement {}
+  var HTMLSteppedColorGeneratorElement: {
+    prototype: HTMLSteppedColorGeneratorElement;
+    new (): HTMLSteppedColorGeneratorElement;
+  };
+
   interface HTMLTabGroupElement extends Components.TabGroup, HTMLStencilElement {}
   var HTMLTabGroupElement: {
     prototype: HTMLTabGroupElement;
@@ -566,6 +579,7 @@ declare global {
     'layered-colors-select': HTMLLayeredColorsSelectElement
     'loading-indicator': HTMLLoadingIndicatorElement
     'section-switch': HTMLSectionSwitchElement
+    'stepped-color-generator': HTMLSteppedColorGeneratorElement
     'tab-group': HTMLTabGroupElement
   }
 
@@ -602,6 +616,7 @@ declare global {
     'layered-colors-select': HTMLLayeredColorsSelectElement;
     'loading-indicator': HTMLLoadingIndicatorElement;
     'section-switch': HTMLSectionSwitchElement;
+    'stepped-color-generator': HTMLSteppedColorGeneratorElement;
     'tab-group': HTMLTabGroupElement;
   }
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -37,6 +37,13 @@ export namespace Components {
     'language'?: string;
   }
 
+  interface CodeColor {
+    'value': string;
+  }
+  interface CodeColorAttributes extends StencilHTMLAttributes {
+    'value'?: string;
+  }
+
   interface CodePreview {
     'inline': boolean;
     'markup': string;
@@ -48,9 +55,6 @@ export namespace Components {
 
   interface ColorAccordion {}
   interface ColorAccordionAttributes extends StencilHTMLAttributes {}
-
-  interface ColorBlock {}
-  interface ColorBlockAttributes extends StencilHTMLAttributes {}
 
   interface ColorGenerator {}
   interface ColorGeneratorAttributes extends StencilHTMLAttributes {
@@ -234,6 +238,9 @@ export namespace Components {
     'mobile'?: boolean;
   }
 
+  interface LayeredColorsSelect {}
+  interface LayeredColorsSelectAttributes extends StencilHTMLAttributes {}
+
   interface LoadingIndicator {}
   interface LoadingIndicatorAttributes extends StencilHTMLAttributes {}
 
@@ -258,9 +265,9 @@ declare global {
   interface StencilElementInterfaces {
     'CardLink': Components.CardLink;
     'CodeBlock': Components.CodeBlock;
+    'CodeColor': Components.CodeColor;
     'CodePreview': Components.CodePreview;
     'ColorAccordion': Components.ColorAccordion;
-    'ColorBlock': Components.ColorBlock;
     'ColorGenerator': Components.ColorGenerator;
     'ColorGenCssText': Components.ColorGenCssText;
     'ColorGenPreview': Components.ColorGenPreview;
@@ -285,6 +292,7 @@ declare global {
     'FileTree': Components.FileTree;
     'ImgZoom': Components.ImgZoom;
     'IonicSearch': Components.IonicSearch;
+    'LayeredColorsSelect': Components.LayeredColorsSelect;
     'LoadingIndicator': Components.LoadingIndicator;
     'SectionSwitch': Components.SectionSwitch;
     'TabGroup': Components.TabGroup;
@@ -293,9 +301,9 @@ declare global {
   interface StencilIntrinsicElements {
     'card-link': Components.CardLinkAttributes;
     'code-block': Components.CodeBlockAttributes;
+    'code-color': Components.CodeColorAttributes;
     'code-preview': Components.CodePreviewAttributes;
     'color-accordion': Components.ColorAccordionAttributes;
-    'color-block': Components.ColorBlockAttributes;
     'color-generator': Components.ColorGeneratorAttributes;
     'color-gen-css-text': Components.ColorGenCssTextAttributes;
     'color-gen-preview': Components.ColorGenPreviewAttributes;
@@ -320,6 +328,7 @@ declare global {
     'file-tree': Components.FileTreeAttributes;
     'img-zoom': Components.ImgZoomAttributes;
     'ionic-search': Components.IonicSearchAttributes;
+    'layered-colors-select': Components.LayeredColorsSelectAttributes;
     'loading-indicator': Components.LoadingIndicatorAttributes;
     'section-switch': Components.SectionSwitchAttributes;
     'tab-group': Components.TabGroupAttributes;
@@ -338,6 +347,12 @@ declare global {
     new (): HTMLCodeBlockElement;
   };
 
+  interface HTMLCodeColorElement extends Components.CodeColor, HTMLStencilElement {}
+  var HTMLCodeColorElement: {
+    prototype: HTMLCodeColorElement;
+    new (): HTMLCodeColorElement;
+  };
+
   interface HTMLCodePreviewElement extends Components.CodePreview, HTMLStencilElement {}
   var HTMLCodePreviewElement: {
     prototype: HTMLCodePreviewElement;
@@ -348,12 +363,6 @@ declare global {
   var HTMLColorAccordionElement: {
     prototype: HTMLColorAccordionElement;
     new (): HTMLColorAccordionElement;
-  };
-
-  interface HTMLColorBlockElement extends Components.ColorBlock, HTMLStencilElement {}
-  var HTMLColorBlockElement: {
-    prototype: HTMLColorBlockElement;
-    new (): HTMLColorBlockElement;
   };
 
   interface HTMLColorGeneratorElement extends Components.ColorGenerator, HTMLStencilElement {}
@@ -500,6 +509,12 @@ declare global {
     new (): HTMLIonicSearchElement;
   };
 
+  interface HTMLLayeredColorsSelectElement extends Components.LayeredColorsSelect, HTMLStencilElement {}
+  var HTMLLayeredColorsSelectElement: {
+    prototype: HTMLLayeredColorsSelectElement;
+    new (): HTMLLayeredColorsSelectElement;
+  };
+
   interface HTMLLoadingIndicatorElement extends Components.LoadingIndicator, HTMLStencilElement {}
   var HTMLLoadingIndicatorElement: {
     prototype: HTMLLoadingIndicatorElement;
@@ -521,9 +536,9 @@ declare global {
   interface HTMLElementTagNameMap {
     'card-link': HTMLCardLinkElement
     'code-block': HTMLCodeBlockElement
+    'code-color': HTMLCodeColorElement
     'code-preview': HTMLCodePreviewElement
     'color-accordion': HTMLColorAccordionElement
-    'color-block': HTMLColorBlockElement
     'color-generator': HTMLColorGeneratorElement
     'color-gen-css-text': HTMLColorGenCssTextElement
     'color-gen-preview': HTMLColorGenPreviewElement
@@ -548,6 +563,7 @@ declare global {
     'file-tree': HTMLFileTreeElement
     'img-zoom': HTMLImgZoomElement
     'ionic-search': HTMLIonicSearchElement
+    'layered-colors-select': HTMLLayeredColorsSelectElement
     'loading-indicator': HTMLLoadingIndicatorElement
     'section-switch': HTMLSectionSwitchElement
     'tab-group': HTMLTabGroupElement
@@ -556,9 +572,9 @@ declare global {
   interface ElementTagNameMap {
     'card-link': HTMLCardLinkElement;
     'code-block': HTMLCodeBlockElement;
+    'code-color': HTMLCodeColorElement;
     'code-preview': HTMLCodePreviewElement;
     'color-accordion': HTMLColorAccordionElement;
-    'color-block': HTMLColorBlockElement;
     'color-generator': HTMLColorGeneratorElement;
     'color-gen-css-text': HTMLColorGenCssTextElement;
     'color-gen-preview': HTMLColorGenPreviewElement;
@@ -583,6 +599,7 @@ declare global {
     'file-tree': HTMLFileTreeElement;
     'img-zoom': HTMLImgZoomElement;
     'ionic-search': HTMLIonicSearchElement;
+    'layered-colors-select': HTMLLayeredColorsSelectElement;
     'loading-indicator': HTMLLoadingIndicatorElement;
     'section-switch': HTMLSectionSwitchElement;
     'tab-group': HTMLTabGroupElement;

--- a/src/components/code-color/code-color.css
+++ b/src/components/code-color/code-color.css
@@ -3,7 +3,7 @@ code-color {
   vertical-align: bottom;
 }
 
-.color-block {
+.code-color-block {
   display: inline-block;
 
   width: 20px;
@@ -13,7 +13,7 @@ code-color {
   border-radius: 4px;
 }
 
-.color-block,
-.color-code {
+.code-color-block,
+.code-color-value {
   vertical-align: middle;
 }

--- a/src/components/code-color/code-color.css
+++ b/src/components/code-color/code-color.css
@@ -1,0 +1,14 @@
+.color-block {
+  display: inline-block;
+
+  width: 20px;
+  height: 20px;
+
+  border: 1px solid var(--whiteish);
+  border-radius: 4px;
+}
+
+.color-block,
+.color-code {
+  vertical-align: middle;
+}

--- a/src/components/code-color/code-color.css
+++ b/src/components/code-color/code-color.css
@@ -1,3 +1,8 @@
+code-color {
+  display: inline-block;
+  vertical-align: bottom;
+}
+
 .color-block {
   display: inline-block;
 

--- a/src/components/code-color/code-color.tsx
+++ b/src/components/code-color/code-color.tsx
@@ -8,15 +8,19 @@ import { Component, Prop } from '@stencil/core';
 export class ColorBlock {
   @Prop() value: string;
 
+  @Prop() display: string;
+
   render() {
+    const display = this.display === undefined ? this.value.trim() : this.display.trim();
+
     return [
       <span
-        class="color-block"
+        class="code-color-block"
         style={{
           'background-color': this.value
         }}>
       </span>,
-      <code class="color-code">{ this.value.trim() }</code>
+      <code class="code-color-value">{ display }</code>
     ];
   }
 }

--- a/src/components/code-color/code-color.tsx
+++ b/src/components/code-color/code-color.tsx
@@ -1,0 +1,22 @@
+import { Component, Prop } from '@stencil/core';
+
+
+@Component({
+  tag: 'code-color',
+  styleUrl: 'code-color.css'
+})
+export class ColorBlock {
+  @Prop() value: string;
+
+  render() {
+    return [
+      <span
+        class="color-block"
+        style={{
+          'background-color': this.value
+        }}>
+      </span>,
+      <code class="color-code">{ this.value.trim() }</code>
+    ];
+  }
+}

--- a/src/components/color-gen/css-text/color-gen-css-text.css
+++ b/src/components/color-gen/css-text/color-gen-css-text.css
@@ -1,11 +1,17 @@
-textarea {
+.css-text__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.css-text__code {
   box-sizing: border-box;
   display: block;
   width: 100%;
   max-width: 100%;
   min-width: 100%;
   height: 1416px;
-  white-space: pre-line;
+  white-space: pre;
   background-color: #f5f6f9;
   border-radius: 4px;
   border: 0;
@@ -17,12 +23,8 @@ textarea {
   padding: 2em 2em;
   -webkit-font-smoothing: initial;
   color: var(--darkish);
-}
-
-.css-text__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  resize: both;
+  overflow: auto;
 }
 
 h3 {
@@ -30,7 +32,6 @@ h3 {
   color: var(--blackish);
   margin: 0;
 }
-
 
 .css-text__copy{
   position: relative;

--- a/src/components/color-gen/css-text/color-gen-css-text.tsx
+++ b/src/components/color-gen/css-text/color-gen-css-text.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, Prop, State } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Prop, State } from '@stencil/core';
 
 
 @Component({
@@ -10,6 +10,8 @@ export class CssText {
   @Prop({ mutable: true }) cssText = '';
   @State() showCopyConfirmation = false;
   @Event() cssTextChange: EventEmitter;
+
+  @Element() el: HTMLElement;
 
   onCssTextChange(ev: UIEvent) {
     if ((ev.target as HTMLTextAreaElement).value !== this.cssText) {
@@ -25,8 +27,11 @@ export class CssText {
   copyCssText() {
     this.showCopyConfirmation = true;
 
+    const cssEl = this.el.querySelector('#cssText');
+    const cssText = cssEl.textContent || '';
+
     const el = document.createElement('textarea');
-    el.value = this.cssText;
+    el.value = cssText;
     el.setAttribute('readonly', '');
     el.style.position = 'absolute';
     el.style.left = '-9999px';
@@ -56,12 +61,15 @@ export class CssText {
             </span>
           </div>
         </div>
-        <textarea
+        <div
+          id="cssText"
+          class="css-text__code"
+          contentEditable="true"
           spellcheck="false"
           onClick={function() { this.select(); }}
           onInput={this.onCssTextChange.bind(this)}
-          value={this.cssText}>
-        </textarea>
+          innerHTML={this.cssText}>
+        </div>
       </div>
     ];
   }

--- a/src/components/layered-colors-select/layered-colors-select.css
+++ b/src/components/layered-colors-select/layered-colors-select.css
@@ -1,4 +1,4 @@
-color-block {
+layered-colors-select {
   display: block;
 }
 
@@ -66,30 +66,4 @@ color-block {
 
 .color-description {
   width: 35%;
-}
-
-.color-block {
-  display: inline-block;
-
-  width: 20px;
-  height: 20px;
-
-  border: 1px solid var(--whiteish);
-  border-radius: 4px;
-}
-
-.color-block,
-.color-code {
-  vertical-align: middle;
-}
-
-/* TODO this is a temporary fix until a new Ionic version is released */
-.temp-fix ion-list,
-.temp-fix ion-list-header {
-  margin-bottom: 0;
-}
-
-.temp-fix ion-label {
-  margin-top: 0;
-  margin-bottom: 0;
 }

--- a/src/components/layered-colors-select/layered-colors-select.tsx
+++ b/src/components/layered-colors-select/layered-colors-select.tsx
@@ -2,8 +2,8 @@ import { Component, Element, State } from '@stencil/core';
 
 
 @Component({
-  tag: 'color-block',
-  styleUrl: 'color-block.css'
+  tag: 'layered-colors-select',
+  styleUrl: 'layered-colors-select.css'
 })
 export class ColorBlock {
   @Element() el: HTMLElement;
@@ -64,7 +64,10 @@ export class ColorBlock {
       }
     ];
 
+
     const blockItems = variations.map(variation => {
+      const codeColor = variation.rgb ? `rgb(${variation.value})` : `${variation.value}`;
+
       return (
         <tr>
           <td class="color-name">
@@ -74,13 +77,7 @@ export class ColorBlock {
             <code>{ variation.property }</code>
           </td>
           <td class="color-value">
-            <span
-              class="color-block"
-              style={{
-                'background-color': variation.rgb ? `rgb(${variation.value})` : `${variation.value}`
-              }}>
-            </span>
-            <code class="color-code">{ variation.value.trim() }</code>
+            <code-color value={ codeColor }></code-color>
           </td>
           <td class="color-description">
             { variation.description }

--- a/src/components/stepped-color-generator/parse-css.ts
+++ b/src/components/stepped-color-generator/parse-css.ts
@@ -1,0 +1,19 @@
+import { Color } from '../color-gen/color';
+
+
+export function generateSteppedColors(background = '#ffffff', text = '#000000') {
+  const color = new Color(background);
+  let steps = '';
+
+  for (let i = 5; i < 100; i = i + 5) {
+    const step = i + '0';
+    const amount = i / 100.0;
+
+    steps += `  --ion-color-step-${step}: <code-color value="${color.mix(text, amount).hex}"></code-color>;`;
+    if (i < 95) {
+      steps += '\n';
+    }
+  }
+
+  return steps;
+}

--- a/src/components/stepped-color-generator/stepped-color-generator.css
+++ b/src/components/stepped-color-generator/stepped-color-generator.css
@@ -1,0 +1,42 @@
+
+.stepped-color-pickers {
+  display: flex;
+
+  margin-bottom: 20px;
+}
+
+color-gen-variable-selector {
+  display: block;
+
+  width: 50%;
+  margin: 5px;
+
+  border: 0;
+  box-shadow: 0 4px 6px rgba(0,0,0,.1), 0 1px 3px rgba(0,0,0,.08);
+  border-radius: 4px;
+}
+
+@media (max-width: 700px) {
+  .stepped-color-pickers {
+    flex-direction: column;
+  }
+
+  color-gen-variable-selector {
+    width: 100%;
+  }
+}
+
+color-gen-css-text .css-text__code {
+  height: 630px;
+}
+
+color-gen-css-text code-color code {
+  background: transparent;
+  color: inherit;
+  margin: 0 0 0 6px;
+  padding: 0;
+}
+
+stepped-color-generator .stepped-color-header h3 {
+  margin-bottom: 1.5em;
+}

--- a/src/components/stepped-color-generator/stepped-color-generator.tsx
+++ b/src/components/stepped-color-generator/stepped-color-generator.tsx
@@ -1,0 +1,94 @@
+import { Component, Element, Listen, State } from '@stencil/core';
+// import { convertCssToColors, generateColor, updateCssText } from '../color-gen/parse-css';
+import { generateSteppedColors } from './parse-css';
+import { Color } from '../color-gen/color';
+
+
+@Component({
+  tag: 'stepped-color-generator',
+  styleUrl: 'stepped-color-generator.css'
+})
+export class ColorGenerator {
+  @State() cssText = DEFAULT_CSS_TEXT;
+
+  @State() backgroundColor = '#ffffff';
+  @State() textColor = '#000000';
+
+  @Element() el: HTMLElement;
+
+  @Listen('colorChange')
+  onColorChange() {
+    const background = (this.el.querySelector('#background') as any).value;
+    const text = (this.el.querySelector('#text') as any).value;
+
+    this.backgroundColor = background;
+    this.textColor = text;
+
+    const backgroundColor = new Color(background);
+    const textColor = new Color(text);
+
+    const steppedColors = generateSteppedColors(background, text);
+
+    this.cssText =
+`:root {
+  --ion-background-color: <code-color value="${background}"></code-color>;
+  --ion-background-color-rgb: <code-color value="${background}" display="${backgroundColor.toList()}"></code-color>;
+
+  --ion-text-color: <code-color value="${text}"></code-color>;
+  --ion-text-color-rgb: <code-color value="${text}" display="${textColor.toList()}"></code-color>;
+
+${steppedColors}
+}`;
+  }
+
+  @Listen('cssTextChange')
+  onCssTextChange(ev: any) {
+    this.cssText = ev.detail;
+  }
+
+  render() {
+    return [
+      // <div class="stepped-color-header">
+      //   <h3>Generate Stepped Color Variables</h3>
+      //   <p>Create a custom background and text color theme for your app. Update the background or text color’s hex values below, then copy and paste the generated code directly into your Ionic project.</p>
+      // </div>,
+      <div class="stepped-color-pickers">
+        <color-gen-variable-selector id="background" name="Background" value={ this.backgroundColor }></color-gen-variable-selector>
+        <color-gen-variable-selector id="text" name="Text" value={ this.textColor }></color-gen-variable-selector>
+      </div>,
+      <color-gen-css-text cssText={this.cssText}></color-gen-css-text>
+    ];
+  }
+
+}
+
+
+const DEFAULT_CSS_TEXT = `
+:root {
+  --ion-background-color: <code-color value="#ffffff"></code-color>;
+  --ion-background-color-rgb: <code-color value="#ffffff" display="255,255,255"></code-color>;
+
+  --ion-text-color: <code-color value="#000000"></code-color>;
+  --ion-text-color-rgb: <code-color value="#000000" display="0,0,0"></code-color>;
+
+  --ion-color-step-50: <code-color value="#f2f2f2"></code-color>;
+  --ion-color-step-100: <code-color value="#e6e6e6"></code-color>;
+  --ion-color-step-150: <code-color value="#d9d9d9"></code-color>;
+  --ion-color-step-200: <code-color value="#cccccc"></code-color>;
+  --ion-color-step-250: <code-color value="#bfbfbf"></code-color>;
+  --ion-color-step-300: <code-color value="#b3b3b3"></code-color>;
+  --ion-color-step-350: <code-color value="#a6a6a6"></code-color>;
+  --ion-color-step-400: <code-color value="#999999"></code-color>;
+  --ion-color-step-450: <code-color value="#8c8c8c"></code-color>;
+  --ion-color-step-500: <code-color value="#808080"></code-color>;
+  --ion-color-step-550: <code-color value="#737373"></code-color>;
+  --ion-color-step-600: <code-color value="#666666"></code-color>;
+  --ion-color-step-650: <code-color value="#595959"></code-color>;
+  --ion-color-step-700: <code-color value="#4d4d4d"></code-color>;
+  --ion-color-step-750: <code-color value="#404040"></code-color>;
+  --ion-color-step-800: <code-color value="#333333"></code-color>;
+  --ion-color-step-850: <code-color value="#262626"></code-color>;
+  --ion-color-step-900: <code-color value="#191919"></code-color>;
+  --ion-color-step-950: <code-color value="#0d0d0d"></code-color>;
+}
+`.trim();

--- a/src/content/theming/advanced.md
+++ b/src/content/theming/advanced.md
@@ -155,29 +155,13 @@ While updating the background (`--ion-background-color`) and text (`--ion-text-c
 
 In some components we use a shade darker than the background or lighter than the text. For example, an item heading text may need to be <code-color value="#404040"></code-color>, which is a few shades lighter than our default text color. Meanwhile, the loading component background is a shade darker than white, using <code-color value="#f2f2f2"></code-color>. We use stepped colors in order to define these slight variations. It is important to update the stepped colors when updating the background or text color of an application.
 
-By default, the Ionic stepped colors start at the default background color value <code-color value="#ffffff"></code-color> and mix with the text color value <code-color value="#000000"></code-color> using an increasing percentage. The full list of stepped colors is below, including the percentage that we use to generate the default values.
+By default, the Ionic stepped colors start at the default background color value <code-color value="#ffffff"></code-color> and mix with the text color value <code-color value="#000000"></code-color> using an increasing percentage. The full list of stepped colors is shown in the generator below.
 
-| Name                          | Percent   | Default Value                             |
-| ------------------------------| ----------| ------------------------------------------|
-| `--ion-color-step-50`         | 5%        | <code-color value="#f2f2f2"></code-color> |
-| `--ion-color-step-100`        | 10%       | <code-color value="#e6e6e6"></code-color> |
-| `--ion-color-step-150`        | 15%       | <code-color value="#d9d9d9"></code-color> |
-| `--ion-color-step-200`        | 20%       | <code-color value="#cccccc"></code-color> |
-| `--ion-color-step-250`        | 25%       | <code-color value="#bfbfbf"></code-color> |
-| `--ion-color-step-300`        | 30%       | <code-color value="#b3b3b3"></code-color> |
-| `--ion-color-step-350`        | 35%       | <code-color value="#a6a6a6"></code-color> |
-| `--ion-color-step-400`        | 40%       | <code-color value="#999999"></code-color> |
-| `--ion-color-step-450`        | 45%       | <code-color value="#8c8c8c"></code-color> |
-| `--ion-color-step-500`        | 50%       | <code-color value="#808080"></code-color> |
-| `--ion-color-step-550`        | 55%       | <code-color value="#737373"></code-color> |
-| `--ion-color-step-600`        | 60%       | <code-color value="#666666"></code-color> |
-| `--ion-color-step-650`        | 65%       | <code-color value="#595959"></code-color> |
-| `--ion-color-step-700`        | 70%       | <code-color value="#4d4d4d"></code-color> |
-| `--ion-color-step-750`        | 75%       | <code-color value="#404040"></code-color> |
-| `--ion-color-step-800`        | 80%       | <code-color value="#333333"></code-color> |
-| `--ion-color-step-850`        | 85%       | <code-color value="#262626"></code-color> |
-| `--ion-color-step-900`        | 90%       | <code-color value="#191919"></code-color> |
-| `--ion-color-step-950`        | 95%       | <code-color value="#0d0d0d"></code-color> |
+### Generate Stepped Color Variables
+
+Create a custom background and text color theme for your app. Update the background or text color’s hex values below, then copy and paste the generated code directly into your Ionic project.
+
+<stepped-color-generator></stepped-color-generator>
 
 
 ## Globals

--- a/src/content/theming/advanced.md
+++ b/src/content/theming/advanced.md
@@ -38,11 +38,11 @@ A color can be applied to an Ionic component in order to change the default colo
 
 Each color consists of the following properties: a `base`, `contrast`, `shade`, and `tint`. The `base` and `contrast` colors also require a `rgb` property which is the same color, just in <a href="https://developer.mozilla.org/en-US/docs/Glossary/RGB" target="_blank">rgb format</a>. See [The Alpha Problem](#the-alpha-problem) for an explanation of why the `rgb` property is also needed. Select from the dropdown below to see all of the default colors Ionic provides and their variations.
 
-<color-block></color-block>
+<layered-colors-select></layered-colors-select>
 
 ### Modifying Colors
 
-To change the default values of a color, all of the listed variations for that color should be set. For example, to change the secondary color to `#006600` (green), set the following CSS properties:
+To change the default values of a color, all of the listed variations for that color should be set. For example, to change the secondary color to <code-color value="#006600"></code-color>, set the following CSS properties:
 
 ```css
 :root {
@@ -55,7 +55,7 @@ To change the default values of a color, all of the listed variations for that c
 }
 ```
 
-When `secondary` is applied to a button, not only is the base color (`#006600`) used, but the contrast color (`#ffffff`) is used for the text, along with shade (`#005a00`) and tint (`#1a751a`) colors for the different states of the button.
+When `secondary` is applied to a button, not only is the base color <code-color value="#006600"></code-color> used, but the contrast color <code-color value="#ffffff"></code-color> is used for the text, along with shade <code-color value="#005a00"></code-color> and tint <code-color value="#1a751a"></code-color> colors for the different states of the button.
 
 <blockquote>
   Not sure how to get the variation colors from the base color? Try out our [Color Generator](/docs/theming/color-generator) that calculates all of the variations and provides code to copy/paste into an app!
@@ -116,8 +116,15 @@ Ionic provides several global variables that are used throughout components to c
 
 The application colors are used in multiple places in Ionic. These are useful for easily creating dark themes or themes that match a brand.
 
+It is important to note that the background and text color variables also require a rgb variable to be set in <a href="https://developer.mozilla.org/en-US/docs/Glossary/RGB" target="_blank">rgb format</a>. See [The Alpha Problem](#the-alpha-problem) for an explanation of why the `rgb` property is also needed.
+
+
 | Name                                     | Description                                         |
 | ---------------------------------------- | --------------------------------------------------- |
+| `--ion-background-color`                 | Background color of entire app                      |
+| `--ion-background-color-rgb`             | Background color of entire app, rgb format          |
+| `--ion-text-color`                       | Text color of entire app                            |
+| `--ion-text-color-rgb`                   | Text color of entire app, rgb format                |
 | `--ion-backdrop-color`                   | Color of the Backdrop component                     |
 | `--ion-overlay-background-color`         | Background color of the overlays                    |
 | `--ion-border-color`                     | Border color                                        |
@@ -142,61 +149,36 @@ The application colors are used in multiple places in Ionic. These are useful fo
 
 ### Stepped Colors
 
-After exploring many applications and themes, we found that designs rarely use just one background color. There are always subtle variations used to imply importance and depth throughout the design. In order to accommodate this pattern, we created stepped colors.
+After exploring different ways to customize the Ionic theme, we found that we couldn't use just one background or text color. In order to imply importance and depth throughout the design, we need to use different shades of the background and text colors. To accommodate this pattern, we created stepped colors.
 
-There are only two variables that have stepped colors: `--ion-text-color` and `--ion-background-color`.
+While updating the background (`--ion-background-color`) and text (`--ion-text-color`) variables will change the look of the app for most components, there are certain Ionic components where it may look off, or broken. This will be more apparent when applying a darker theme.
 
-Stepped colors allow for some finer color control over the look of your application. A color step is a subtle variation of a color moving toward another color. For example, the color steps for `--ion-text-color` are moving toward `--ion-background-color`. Stepped colors also require a property to be set in <a href="https://developer.mozilla.org/en-US/docs/Glossary/RGB" target="_blank">rgb format</a>. See [The Alpha Problem](#the-alpha-problem) for an explanation of why the `rgb` property is also needed.
+In some components we use a shade darker than the background or lighter than the text. For example, an item heading text may need to be <code-color value="#404040"></code-color>, which is a few shades lighter than our default text color. Meanwhile, the loading component background is a shade darker than white, using <code-color value="#f2f2f2"></code-color>. We use stepped colors in order to define these slight variations. It is important to update the stepped colors when updating the background or text color of an application.
 
+By default, the Ionic stepped colors start at the default background color value <code-color value="#ffffff"></code-color> and mix with the text color value <code-color value="#000000"></code-color> using an increasing percentage. The full list of stepped colors is below, including the percentage that we use to generate the default values.
 
-| Name                                     | Description                                         | Default Value    |
-| ---------------------------------------- | --------------------------------------------------- | ---------------- |
-| `--ion-background-color`                 | Background color of entire app                      | `#ffffff`        |
-| `--ion-background-color-rgb`             | Background color of entire app, rgb format          | `255,255,255`    |
-| `--ion-background-color-step-50`         | Background color mixed with text color by 5%        | `#f2f2f2`        |
-| `--ion-background-color-step-100`        | Background color mixed with text color by 10%       | `#e6e6e6`        |
-| `--ion-background-color-step-150`        | Background color mixed with text color by 15%       | `#d9d9d9`        |
-| `--ion-background-color-step-200`        | Background color mixed with text color by 20%       | `#cccccc`        |
-| `--ion-background-color-step-250`        | Background color mixed with text color by 25%       | `#bfbfbf`        |
-| `--ion-background-color-step-300`        | Background color mixed with text color by 30%       | `#b3b3b3`        |
-| `--ion-background-color-step-350`        | Background color mixed with text color by 35%       | `#a6a6a6`        |
-| `--ion-background-color-step-400`        | Background color mixed with text color by 40%       | `#999999`        |
-| `--ion-background-color-step-450`        | Background color mixed with text color by 45%       | `#8c8c8c`        |
-| `--ion-background-color-step-500`        | Background color mixed with text color by 50%       | `#808080`        |
-| `--ion-background-color-step-550`        | Background color mixed with text color by 55%       | `#737373`        |
-| `--ion-background-color-step-600`        | Background color mixed with text color by 60%       | `#666666`        |
-| `--ion-background-color-step-650`        | Background color mixed with text color by 65%       | `#595959`        |
-| `--ion-background-color-step-700`        | Background color mixed with text color by 70%       | `#4d4d4d`        |
-| `--ion-background-color-step-750`        | Background color mixed with text color by 75%       | `#404040`        |
-| `--ion-background-color-step-800`        | Background color mixed with text color by 80%       | `#333333`        |
-| `--ion-background-color-step-850`        | Background color mixed with text color by 85%       | `#262626`        |
-| `--ion-background-color-step-900`        | Background color mixed with text color by 90%       | `#191919`        |
-| `--ion-background-color-step-950`        | Background color mixed with text color by 95%       | `#0d0d0d`        |
-| `--ion-background-color-step-1000`       | Background color mixed with text color by 100%      | `#000000`        |
-| `--ion-text-color`                       | Text color of entire app                            | `#000000`        |
-| `--ion-text-color-rgb`                   | Text color of entire app, rgb format                | `0,0,0`          |
-| `--ion-text-color-step-50`               | Text color mixed with background color by 5%        | `#0d0d0d`        |
-| `--ion-text-color-step-100`              | Text color mixed with background color by 10%       | `#1a1a1a`        |
-| `--ion-text-color-step-150`              | Text color mixed with background color by 15%       | `#262626`        |
-| `--ion-text-color-step-200`              | Text color mixed with background color by 20%       | `#333333`        |
-| `--ion-text-color-step-250`              | Text color mixed with background color by 25%       | `#404040`        |
-| `--ion-text-color-step-300`              | Text color mixed with background color by 30%       | `#4d4d4d`        |
-| `--ion-text-color-step-350`              | Text color mixed with background color by 35%       | `#595959`        |
-| `--ion-text-color-step-400`              | Text color mixed with background color by 40%       | `#666666`        |
-| `--ion-text-color-step-450`              | Text color mixed with background color by 45%       | `#737373`        |
-| `--ion-text-color-step-500`              | Text color mixed with background color by 50%       | `#808080`        |
-| `--ion-text-color-step-550`              | Text color mixed with background color by 55%       | `#8c8c8c`        |
-| `--ion-text-color-step-600`              | Text color mixed with background color by 60%       | `#999999`        |
-| `--ion-text-color-step-650`              | Text color mixed with background color by 65%       | `#a6a6a6`        |
-| `--ion-text-color-step-700`              | Text color mixed with background color by 70%       | `#b3b3b3`        |
-| `--ion-text-color-step-750`              | Text color mixed with background color by 75%       | `#bfbfbf`        |
-| `--ion-text-color-step-800`              | Text color mixed with background color by 80%       | `#cccccc`        |
-| `--ion-text-color-step-850`              | Text color mixed with background color by 85%       | `#d9d9d9`        |
-| `--ion-text-color-step-900`              | Text color mixed with background color by 90%       | `#e6e6e6`        |
-| `--ion-text-color-step-950`              | Text color mixed with background color by 95%       | `#f2f2f2`        |
-| `--ion-text-color-step-1000`             | Text color mixed with background color by 100%      | `#ffffff`        |
+| Name                          | Percent   | Default Value                             |
+| ------------------------------| ----------| ------------------------------------------|
+| `--ion-color-step-50`         | 5%        | <code-color value="#f2f2f2"></code-color> |
+| `--ion-color-step-100`        | 10%       | <code-color value="#e6e6e6"></code-color> |
+| `--ion-color-step-150`        | 15%       | <code-color value="#d9d9d9"></code-color> |
+| `--ion-color-step-200`        | 20%       | <code-color value="#cccccc"></code-color> |
+| `--ion-color-step-250`        | 25%       | <code-color value="#bfbfbf"></code-color> |
+| `--ion-color-step-300`        | 30%       | <code-color value="#b3b3b3"></code-color> |
+| `--ion-color-step-350`        | 35%       | <code-color value="#a6a6a6"></code-color> |
+| `--ion-color-step-400`        | 40%       | <code-color value="#999999"></code-color> |
+| `--ion-color-step-450`        | 45%       | <code-color value="#8c8c8c"></code-color> |
+| `--ion-color-step-500`        | 50%       | <code-color value="#808080"></code-color> |
+| `--ion-color-step-550`        | 55%       | <code-color value="#737373"></code-color> |
+| `--ion-color-step-600`        | 60%       | <code-color value="#666666"></code-color> |
+| `--ion-color-step-650`        | 65%       | <code-color value="#595959"></code-color> |
+| `--ion-color-step-700`        | 70%       | <code-color value="#4d4d4d"></code-color> |
+| `--ion-color-step-750`        | 75%       | <code-color value="#404040"></code-color> |
+| `--ion-color-step-800`        | 80%       | <code-color value="#333333"></code-color> |
+| `--ion-color-step-850`        | 85%       | <code-color value="#262626"></code-color> |
+| `--ion-color-step-900`        | 90%       | <code-color value="#191919"></code-color> |
+| `--ion-color-step-950`        | 95%       | <code-color value="#0d0d0d"></code-color> |
 
-Generally, color steps are a mirror image of each other. For example, `--ion-text-color-step-750` will equal `ion-background-color-step-250`. However, steps are provided for both background and text colors to allow designers to customize a specific step, if need be. For example, maybe a design calls for `ion-text-color-step-250` to be `pink` instead of the normal progression.
 
 ## Globals
 


### PR DESCRIPTION
#### Short description of what this resolves:
Updates the advanced theming documentation to use the latest step variables, from this PR: https://github.com/ionic-team/ionic/pull/16543

#### Changes proposed in this pull request:

- updates the documentation to include the correct variables
- renames the `color-block` component to `layered-colors-select` as this is a better description of what it is
- moves the code color block component out of the layered colors select component into its own `code-color` so it can be reused inline with hex values
- adds stepped color generator

Example of the newly separated component being used:

<img width="708" alt="screen shot 2018-11-30 at 5 39 11 pm" src="https://user-images.githubusercontent.com/6577830/49318608-2ae32a80-f4c7-11e8-9561-a9caaea28dac.png">

Adds a stepped color generator:

<img src="http://g.recordit.co/9QITiIq2MW.gif">