### PR TITLE
deploy.getCurrentVersion() returns a Promise so need an await

### DIFF
--- a/src/content/pro/deploy/api.md
+++ b/src/content/pro/deploy/api.md
@@ -94,7 +94,7 @@ ___
 ```js
 async performAutomaticUpdate() {
   try {
-    const currentVersion = Pro.deploy.getCurrentVersion();
+    const currentVersion = await Pro.deploy.getCurrentVersion();
     const resp = await Pro.deploy.sync({updateMethod: 'auto'});
     if (currentVersion.versionId !== resp.versionId){
       // We found an update, and are in process of redirecting you since you put auto!


### PR DESCRIPTION
await is missing in sync() example for getCurrentVersion() call. Result is actually a promise and not the ISnapshot result which results to an error 2 lines after (versionId doesn't exists for a Promise)

#### Short description of what this resolves:
sync() example is not generating an error

#### Changes proposed in this pull request:

- replace `const currentVersion = Pro.deploy.getCurrentVersion();` by `const currentVersion = await Pro.deploy.getCurrentVersion();`

**Fixes**: #
