### PR TITLE
docs(ios): livereload with capacitor works

### DIFF
--- a/src/content/building/ios.md
+++ b/src/content/building/ios.md
@@ -83,8 +83,6 @@ In this workflow, Xcode can automatically fix common compilation and signing iss
 
 The Ionic CLI can build, copy, and deploy Ionic apps to iOS simulators and devices with a single command. It can also spin up a development server, like the one used in `ionic serve`, to provide [live-reload](/docs/faq/glossary#livereload) functionality.
 
-Unfortunately, live-reload for Capacitor is not yet available. Follow [this issue](https://github.com/ionic-team/ionic-cli/issues/3130) for updates.
-
 For Cordova, run the following to start a long-running CLI process that boots up a live-reload server:
 
 ```shell


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes an inconsistency about Capacitor between the iOS and Android documentation.

**Fixes**:
- Adding the change from @dwieeb's previous commit (https://github.com/ionic-team/ionic-docs/commit/cbb617c0d02e7326db415373ec605348326b79cc) on the Android docs to the iOS doc