### PR TITLE
docs(intro): Changing Ionic Pro references to Appflow

### DIFF
--- a/src/content/intro.md
+++ b/src/content/intro.md
@@ -70,11 +70,13 @@ Ionic Framework V4 is a major advance in the underlying technology and capabilit
 
 By moving to web standards, V4 allows the core of Ionic to rely on the standard component model supported in modern browsers, rather than a framework-specific model. This can mean faster load time, better performance, and less overall code.
 
-## Ionic Pro
+## Ionic Appflow
 
-To help manage Ionic apps throughout their lifecycle, we also offer a commercial app platform for production apps called <a href="https://ionicframework.com/pro" target="_blank">Ionic Pro</a>, which is <strong>separate from the open source Framework.</strong>
+To help manage Ionic apps throughout their lifecycle, we also offer a commercial app platform for production apps called <a href="https://ionicframework.com/appflow" target="_blank">Ionic Appflow</a>, which is <strong>separate from the open source Framework.</strong>
 
-Ionic Pro helps developers and teams monitor and track runtime errors, compile native app builds, and deploy live code updates to Ionic apps from a centralized dashboard. Pro requires an <a href="https://dashboard.ionicframework.com/signup" target="_blank">Ionic Account</a> and comes with a free “Starter” plan for those interested in playing around with some of its features. Optional upgrades to paid plans for more advanced capabilities and scale are available as well.
+Ionic Appflow helps developers and teams compile native app builds and deploy live code updates to Ionic apps from a centralized dashboard. Optional paid upgrades are available for more advanced capabilities like workflow automation, single sign-on (SSO) and access to connected services and integrations. 
+
+Appflow requires an <a href="https://dashboard.ionicframework.com/signup" target="_blank">Ionic Account</a> and comes with a free “Starter” plan for those interested in playing around with some of its features.
 
 ## Ecosystem
 


### PR DESCRIPTION
#### Short description of what this resolves:
Ionic Pro was rebranded in late November to Ionic Appflow. This makes some minor changes to the documentation to reflect these changes.

**Fixes**:
- Updates "Ionic Pro" references to "Ionic Appflow", including links
- Clarifies section on Appflow capabilities, including paid upgrades
- Minor formatting changes