### PR TITLE
docs(pro): change word "pro" to "appflow".

### DIFF
--- a/src/content/developer-resources/guides.md
+++ b/src/content/developer-resources/guides.md
@@ -8,7 +8,7 @@ nextUrl: '/docs/developer-resources/posts'
 # Guides
 
 ### [Your First Ionic App - v3](/docs/developer-resources/guides/first-app-v3/intro)
-Follow along as we create a working Photo Gallery app using Ionic Framework v3 and Ionic Pro.
+Follow along as we create a working Photo Gallery app using Ionic Framework v3 and Ionic Appflow.
 
 ### [Your First Ionic App - v4](/docs/developer-resources/guides/first-app-v4/intro)
 Follow along as we create a working Photo Gallery app using Ionic Framework v4.

--- a/src/content/developer-resources/guides/first-app-v3/creating-photo-gallery-device-storage.md
+++ b/src/content/developer-resources/guides/first-app-v3/creating-photo-gallery-device-storage.md
@@ -192,7 +192,7 @@ ngOnInit() {
 
 Sweet! Photos are now saved to your device. To demonstrate that they are indeed being saved, force close DevApp, reopen it, and open the About page.  Or, shake your device to have the Control Menu pop up, then tap “Exit preview.” Afterwards, reload this app to view the photos.
 
-Finally, back up your changes to Ionic Pro:
+Finally, back up your changes to Ionic Appflow:
 
 ```shell
 git add .

--- a/src/content/developer-resources/guides/first-app-v3/intro.md
+++ b/src/content/developer-resources/guides/first-app-v3/intro.md
@@ -36,9 +36,9 @@ This starter project comes complete with three pre-built pages and best practice
 
 Type “y” and press Enter. Project setup may take a few moments.
 
-<strong>“Install the free Ionic Pro SDK and connect your app?”</strong>
+<strong>“Install the free Ionic Appflow SDK and connect your app?”</strong>
 
-Type “y” and press Enter. [Ionic Pro](https://ionicframework.com/pro) is a powerful set of services and features built on top of the flagship Ionic Framework. This includes updating your app instantly (skipping the app store review process!), packaging apps in the cloud, and error monitoring.
+Type “y” and press Enter. [Ionic Appflow](https://ionicframework.com/pro) is a powerful set of services and features built on top of the flagship Ionic Framework. This includes updating your app instantly (skipping the app store review process!), packaging apps in the cloud, and error monitoring.
 
 <strong>Log into your Ionic Account</strong>
 
@@ -46,18 +46,18 @@ Sign in now to easily access awesome features like Live Deploys later in this tu
 
 <strong>What would you like to do?</strong>
 
-Choose “Create a new app on Ionic Pro.”
+Choose “Create a new app on Ionic Appflow.”
 
 <strong>Which git host would you like to use?</strong>
 
-Choose “Ionic Pro.”
+Choose “Ionic Appflow.”
 
-<strong>“How would you like to connect to Ionic Pro?”</strong>
+<strong>“How would you like to connect to Ionic Appflow?”</strong>
 
-* Choose “Automatically setup a new SSH key pair for Ionic Pro” if you haven’t used SSH before.
+* Choose “Automatically setup a new SSH key pair for Ionic Appflow” if you haven’t used SSH before.
 * Choose “Use an existing SSH key pair” if you’ve used SSH before. 
 
-Next, change into the app folder, then push your code to Ionic Pro:
+Next, change into the app folder, then push your code to Ionic Appflow:
 
 ```shell
 $ cd photo-gallery
@@ -108,7 +108,7 @@ Next, open `src/pages/tabs/tabs.html`. Change the tabTitle to “Gallery” and 
 </ion-tabs>
 ```
 
-Now, back up your changes to Ionic Pro:
+Now, back up your changes to Ionic Appflow:
 
 ```shell
 $ git add .

--- a/src/content/developer-resources/guides/first-app-v3/ios-android-camera.md
+++ b/src/content/developer-resources/guides/first-app-v3/ios-android-camera.md
@@ -150,7 +150,7 @@ Take notice: there’s no mention of iOS or Android! This is the awesome power o
 
 Save this file then tap the Camera button in DevApp. Voila! The camera should open on your device. Once a photo has been taken, it displays on the Photo Gallery page.
 
-Finally, back up your changes to Ionic Pro:
+Finally, back up your changes to Ionic Appflow:
 
 ```shell
 git add .

--- a/src/content/developer-resources/guides/first-app-v3/realtime-updates-ionic-deploy.md
+++ b/src/content/developer-resources/guides/first-app-v3/realtime-updates-ionic-deploy.md
@@ -8,23 +8,23 @@ nextUrl: '/docs/developer-resources/guides/first-app-v3/track-bugs-ionic-monitor
 # Realtime App Updates with Ionic Deploy
 
 <p class="intro">
-As you’ve seen so far, building web and mobile apps is quick and easy with the Ionic Framework. However, nothing disrupts rapid iteration faster than App Store delays. Fortunately, with Ionic Pro’s Deploy feature, you can send live code changes directly to your users. Paired with seamless background updates, they are always upgraded to the latest version.
+As you’ve seen so far, building web and mobile apps is quick and easy with the Ionic Framework. However, nothing disrupts rapid iteration faster than App Store delays. Fortunately, with Ionic Appflow’s Deploy feature, you can send live code changes directly to your users. Paired with seamless background updates, they are always upgraded to the latest version.
 </p>
 
-Setting it up is quick and easy. For reference, continue to refer to [the part 3 folder](https://github.com/ionic-team/photo-gallery-tutorial-ionic3/tree/master/part3) on GitHub. First, install the Ionic Pro JavaScript library:
+Setting it up is quick and easy. For reference, continue to refer to [the part 3 folder](https://github.com/ionic-team/photo-gallery-tutorial-ionic3/tree/master/part3) on GitHub. First, install the Ionic Appflow JavaScript library:
 
 ```shell
 $ npm install @ionic/pro@latest --save
 ```
 
-Then, add the Ionic Pro plugin. Here’s the command to install it:
+Then, add the Ionic Appflow plugin. Here’s the command to install it:
 
 ```shell
 $ ionic cordova plugin add cordova-plugin-ionic@latest --save
 --variable APP_ID=YOUR_APP_ID --variable CHANNEL_NAME=YOUR_CHANNEL_NAME
 ```
 
-There are two unique values to provide: your app id and channel name. Sign into Ionic Pro, then find the App Id on your app’s dashboard:
+There are two unique values to provide: your app id and channel name. Sign into Ionic Appflow, then find the App Id on your app’s dashboard:
 
 ![app id location](/docs/assets/img/guides/first-app-v3/app-id-location.png)
 
@@ -49,7 +49,7 @@ After this plugin has been added, you’ll notice that `config.xml` and `package
 </plugin>
 ```
 
-Next, modify `src/app/app.module.ts` to include the initialization of Ionic Pro on app startup:
+Next, modify `src/app/app.module.ts` to include the initialization of Ionic Appflow on app startup:
 
 ```javascript
 import { Pro } from '@ionic/pro';
@@ -67,7 +67,7 @@ Pro.init('381533B9', {
 });
 ```
 
-Next, push the code up to Ionic Pro:
+Next, push the code up to Ionic Appflow:
 
 ```shell
 git add .
@@ -109,7 +109,7 @@ In the upper right hand corner, click the Play button. Select your connected dev
 <script src="https://fast.wistia.net/assets/external/E-v1.js" async></script>
 
 ## Deploying Changes
-With Ionic Pro Deploy, any JavaScript, HTML, or CSS changes can be pushed automatically to app users. Open the Photo Gallery app in your favorite code editor, then update the title of the Gallery page:
+With Ionic Appflow Deploy, any JavaScript, HTML, or CSS changes can be pushed automatically to app users. Open the Photo Gallery app in your favorite code editor, then update the title of the Gallery page:
 
 ```html
 <ion-header>
@@ -119,7 +119,7 @@ With Ionic Pro Deploy, any JavaScript, HTML, or CSS changes can be pushed automa
 </ion-header>
 ```
 
-Next, push the code up to Ionic Pro:
+Next, push the code up to Ionic Appflow:
 
 ```shell
 $ git add .
@@ -127,17 +127,17 @@ $ git commit -m “change name to Photo Viewer”
 $ git push ionic master
 ```
 
-Log into the [Ionic Pro dashboard](https://dashboard.ionicframework.com) and navigate to Deploy -> Builds. You’ll see this newest commit begin to build immediately. Since we assigned the Ionic Pro plugin to the Master branch (the one we always Git Push to), the Channel label will also point to this commit, effectively auto-deploying this change to all app users:
+Log into the [Ionic Appflow dashboard](https://dashboard.ionicframework.com) and navigate to Deploy -> Builds. You’ll see this newest commit begin to build immediately. Since we assigned the Ionic Appflow plugin to the Master branch (the one we always Git Push to), the Channel label will also point to this commit, effectively auto-deploying this change to all app users:
 
 ![deploy channel](/docs/assets/img/guides/first-app-v3/deploy-channel.png)
 
 A Channel points to a specific JavaScript Build or Snapshot of your app that will be shared with devices listening to that channel for updates. You can change which Build a Channel points to whenever you’d like. 
 
-Each time a user launches our Photo Gallery app, it will poll for updates from Ionic Pro. If new code is available, the update is downloaded in the background. There are [a handful of ways](/docs/pro/deploy/api/#update_method) to control how updates are performed, but by default they will be applied the next time the user closes then opens the app.
+Each time a user launches our Photo Gallery app, it will poll for updates from Ionic Appflow. If new code is available, the update is downloaded in the background. There are [a handful of ways](/docs/pro/deploy/api/#update_method) to control how updates are performed, but by default they will be applied the next time the user closes then opens the app.
 
 When the latest Build has been successful, close your local copy of Photo Gallery app or put it in the background for 30 seconds (the [MIN_BACKGROUND_DURATION default](/docs/pro/deploy/api/#min_background_duration)), then reopen it. The title of the Photo Gallery page should change from “Photo Gallery” to “Photo Viewer.”
 
-What if you deploy a change, then realize that there is a bug? Or perhaps you’re just not happy with the name “Photo Viewer?” No problem: Ionic Pro Deploy makes it easy to roll back changes as well!
+What if you deploy a change, then realize that there is a bug? Or perhaps you’re just not happy with the name “Photo Viewer?” No problem: Ionic Appflow Deploy makes it easy to roll back changes as well!
 
 On the Deploy Builds page, click the “Assign to Channel” button on the previous commit, then click “Deploy.”  App users will be reverted to the previous version, and our “Photo Gallery” name has been restored.
 
@@ -147,8 +147,8 @@ This was just a taste of what you can do with Ionic Deploy! You can also set up 
 
 ## Stuck on creating local native builds?
 
-Building native app binaries for Android and iOS can be painful. The tooling isn’t great, new OS versions often result in challenging upgrades, and creating consistent builds across your dev team can be frustrating. Fortunately, Ionic Pro’s Package feature makes this easy: simply upload your iOS certificate and Android keystore files, then we take care of the rest!
+Building native app binaries for Android and iOS can be painful. The tooling isn’t great, new OS versions often result in challenging upgrades, and creating consistent builds across your dev team can be frustrating. Fortunately, Ionic Appflow’s Package feature makes this easy: simply upload your iOS certificate and Android keystore files, then we take care of the rest!
 
 [Start packaging your app in the cloud](https://dashboard.ionicframework.com/settings/billing) along with 10,000 Ionic Deploys per month.
 
-Up next, we look at Ionic Pro Monitoring - track your app errors in realtime.
+Up next, we look at Ionic Appflow Monitoring - track your app errors in realtime.

--- a/src/content/developer-resources/guides/first-app-v3/theming.md
+++ b/src/content/developer-resources/guides/first-app-v3/theming.md
@@ -53,4 +53,4 @@ Now, the iOS version of our app has a Material Design skin!
 
 Creating gorgeous-looking Ionic apps is easy with Sass variables and platform-specific styling. You now have everything you need to get started with Ionic. Go forth and build great apps!
 
-If you're interested in taking your Ionic apps to the next level, continue on with our exploration of Ionic Pro next.
+If you're interested in taking your Ionic apps to the next level, continue on with our exploration of Ionic Appflow next.

--- a/src/content/developer-resources/guides/first-app-v3/track-bugs-ionic-monitoring.md
+++ b/src/content/developer-resources/guides/first-app-v3/track-bugs-ionic-monitoring.md
@@ -6,10 +6,10 @@ previousUrl: '/docs/developer-resources/guides/first-app-v3/theming'
 # Track Bugs in Realtime with Ionic Monitoring 
 
 <p class="intro">
-Bugs happen, and can be hard to track down - especially with hundreds of possible combinations of mobile devices and operating systems. Ionic Pro Monitoring allows you to track errors in your app on users’ phones and it sends them directly to you instantly, even if your code is minified!
+Bugs happen, and can be hard to track down - especially with hundreds of possible combinations of mobile devices and operating systems. Ionic Appflow Monitoring allows you to track errors in your app on users’ phones and it sends them directly to you instantly, even if your code is minified!
 </p>
 
-Reducing customer frustration by fixing major issues quickly in your production apps are a substantial part of providing a high quality app experience. Combined with Ionic Pro Deploy, new updates can be rolled out quickly to address problems in real-time.
+Reducing customer frustration by fixing major issues quickly in your production apps are a substantial part of providing a high quality app experience. Combined with Ionic Appflow Deploy, new updates can be rolled out quickly to address problems in real-time.
 
 To begin, let’s add a global error handler that will catch and report all unhandled exceptions that occur in the app.  Open `src/app/app.module.ts`, then add two import statements:
 
@@ -80,7 +80,7 @@ With our intentional error in place, let’s try it out to see what happens. Run
 $ ionic serve
 ```
 
-Tap on the Gallery tab, then the camera button. A runtime error should occur. In a browser, head over to the [Ionic Pro dashboard](https://dashboard.ionicframework.com), then Monitor -> Monitoring. After a few minutes, the error should appear:
+Tap on the Gallery tab, then the camera button. A runtime error should occur. In a browser, head over to the [Ionic Appflow dashboard](https://dashboard.ionicframework.com), then Monitor -> Monitoring. After a few minutes, the error should appear:
 
 ![event monitoring](/docs/assets/img/guides/first-app-v3/monitoring-event.png)
 
@@ -95,4 +95,4 @@ This is a TypeScript bug, meaning a fix can be released using Ionic Deploy. Give
 * Push the fix using Git. Remember, “git push ionic master.”
 * Roll out the fix using Ionic Deploy from the Ionic dashboard.
 
-Supporting hundreds of mobile device types is so much easier with Ionic Pro Monitoring. [Upgrade to the Ionic Pro Developer plan today](https://dashboard.ionicframework.com/settings/billing) to get instant notification when bugs occur, save error history for sixty days (instead of seven), and unlock 10,000 live Deploy updates per month!
+Supporting hundreds of mobile device types is so much easier with Ionic Appflow Monitoring. [Upgrade to the Ionic Appflow Developer plan today](https://dashboard.ionicframework.com/settings/billing) to get instant notification when bugs occur, save error history for sixty days (instead of seven), and unlock 10,000 live Deploy updates per month!

--- a/src/content/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
+++ b/src/content/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
@@ -196,7 +196,7 @@ ngOnInit() {
 
 Sweet! Photos are now saved to your device. To demonstrate that they are indeed being saved, force close DevApp, reopen it, and open the Tab2 page.  Or, shake your device to have the Control Menu pop up, then tap “Exit preview.” Afterwards, reload this app to view the photos.
 
-Finally, back up your changes to Ionic Pro:
+Finally, back up your changes to Ionic Appflow:
 
 ```shell
 git add .

--- a/src/content/developer-resources/guides/first-app-v4/ios-android-camera.md
+++ b/src/content/developer-resources/guides/first-app-v4/ios-android-camera.md
@@ -161,7 +161,7 @@ $ ionic cordova platform add ios
 $ ionic cordova platform add android 
 ```
 
-Finally, back up your changes to Ionic Pro:
+Finally, back up your changes to Ionic Appflow:
 
 ```shell
 git add .

--- a/src/content/installation/cli.md
+++ b/src/content/installation/cli.md
@@ -8,7 +8,7 @@ nextUrl: '/docs/installation/cdn'
 # Installing Ionic
 
 <p class="intro" markdown="1">
-Ionic apps are created and developed primarily through the Ionic [command-line](/docs/faq/glossary#cli) utility. The Ionic CLI is the preferred method of installation, as it offers a wide range of dev tools and help options along the way. It is also the main tool through which to run the app and connect it to other services, such as Ionic Pro.
+Ionic apps are created and developed primarily through the Ionic [command-line](/docs/faq/glossary#cli) utility. The Ionic CLI is the preferred method of installation, as it offers a wide range of dev tools and help options along the way. It is also the main tool through which to run the app and connect it to other services, such as Ionic Appflow.
 </p>
 
 ## Install the Ionic CLI

--- a/src/content/intro.md
+++ b/src/content/intro.md
@@ -45,7 +45,7 @@ This documentation content (found in the <a href="https://github.com/ionic-team/
 
 ## Ionic CLI
 
-The official [Ionic CLI](/docs/cli), or Command Line Interface, is a tool that quickly scaffolds Ionic apps and provides a number of helpful commands to Ionic developers. In addition to installing and updating Ionic, the CLI comes with a built-in development server, build and debugging tools, and much more. If you are an [Ionic Pro](#ionic-pro) member, the CLI can be used to perform cloud builds and deployments, and administer your account.
+The official [Ionic CLI](/docs/cli), or Command Line Interface, is a tool that quickly scaffolds Ionic apps and provides a number of helpful commands to Ionic developers. In addition to installing and updating Ionic, the CLI comes with a built-in development server, build and debugging tools, and much more. If you are an [Ionic Appflow](#ionic-pro) member, the CLI can be used to perform cloud builds and deployments, and administer your account.
 
 ## Framework Compatibility
 

--- a/src/content/pro.md
+++ b/src/content/pro.md
@@ -1,10 +1,10 @@
-# Ionic Pro
+# Ionic Appflow
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ZB5lQTP987s" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
-Ionic Pro is a powerful set of services and features built on top of the flagship Ionic Framework that brings a totally new level of app development agility to mobile dev teams.
+Ionic Appflow is a powerful set of services and features built on top of the flagship Ionic Framework that brings a totally new level of app development agility to mobile dev teams.
 
-Ionic Pro has several core services that help you through the full app lifecycle, including
+Ionic Appflow has several core services that help you through the full app lifecycle, including
 
  * [Deploy](/docs/pro/deploy/): Update your app remotely in real-time without app store delays.
  * [Package](/docs/pro/package/): Build app binaries in the cloud for iOS and Android.
@@ -15,9 +15,9 @@ Each one of these services is based around a simple git-based workflow that shou
 
 ## Create an Account
 
-To get started with Ionic Pro, first [create an account](https://dashboard.ionicframework.com/signup).
+To get started with Ionic Appflow, first [create an account](https://dashboard.ionicframework.com/signup).
 
-Ionic Pro has a free plan for development and kicking the tires, and paid plans for production app usage. Larger teams can also create Organizations to administer team members and make it easy to manage projects.
+Ionic Appflow has a free plan for development and kicking the tires, and paid plans for production app usage. Larger teams can also create Organizations to administer team members and make it easy to manage projects.
 
 ## Getting Started
 

--- a/src/content/pro/automation/intro.md
+++ b/src/content/pro/automation/intro.md
@@ -1,6 +1,6 @@
 # Automation
 
-Ionic Pro's automation features let you generate builds whenever you need them. Webhooks with secure, signed download URL's and build information are also easily configurable and updatable, ensuring your app gets in the necessary hands quickly and automatically.
+Ionic Appflow's automation features let you generate builds whenever you need them. Webhooks with secure, signed download URL's and build information are also easily configurable and updatable, ensuring your app gets in the necessary hands quickly and automatically.
 
 ## Automation Types
 

--- a/src/content/pro/basics/getting-started.md
+++ b/src/content/pro/basics/getting-started.md
@@ -2,19 +2,19 @@
 layout: fluid/pro_docs_base
 category: pro-basics
 id: pro-getting-started
-title: Getting Started with Ionic Pro - Ionic Pro Documentation
+title: Getting Started with Ionic Appflow - Ionic Appflow Documentation
 body_class: 'pro-docs'
 hide_header_search: true
 dark_header: true
 ---
 
-# Getting Started with Ionic Pro
+# Getting Started with Ionic Appflow
 
-If you're new to Ionic Pro, please read the [Welcome](/docs/pro/) introduction for a quick overview of Ionic pro and instructions on creating an account.
+If you're new to Ionic Appflow, please read the [Welcome](/docs/pro/) introduction for a quick overview of Ionic pro and instructions on creating an account.
 
 ## Install Ionic CLI
 
-Ionic Pro uses the latest version of the Ionic CLI to interface between your local code and our tools and services. To make sure you're using the latest CLI, upgrade using the following command:
+Ionic Appflow uses the latest version of the Ionic CLI to interface between your local code and our tools and services. To make sure you're using the latest CLI, upgrade using the following command:
 
 ```bash
 npm install -g ionic
@@ -24,37 +24,37 @@ Note: you may need to add `sudo` to this command on Mac/Linux.
 
 ## Starting a New App
 
-If you are looking to create a brand new App to use with Ionic Pro, you can either start the process in [your dashboard](https://dashboard.ionicframework.com) or use the CLI locally. If you already have an App you'd like to link, skip this step.
+If you are looking to create a brand new App to use with Ionic Appflow, you can either start the process in [your dashboard](https://dashboard.ionicframework.com) or use the CLI locally. If you already have an App you'd like to link, skip this step.
 
 To create a new app, run the `ionic start` command, or follow the official [Ionic Framework Getting Started](/getting-started) guide.
 
 If this is your first time create an App on Pro, you may have to perform some additional steps that the CLI will walk you through such as logging into your account and setting up SSH keys.
 
-Once the command finishes, you'll be prompted to create a new Ionic Pro app or link to an existing one. Go ahead and choose the option you'd like to do.
+Once the command finishes, you'll be prompted to create a new Ionic Appflow app or link to an existing one. Go ahead and choose the option you'd like to do.
 
 ## Linking an Existing app
 
-Already have an existing Ionic app you'd like to link? No problem. Run `ionic link` in the directory of that app to connect it to Ionic Pro:
+Already have an existing Ionic app you'd like to link? No problem. Run `ionic link` in the directory of that app to connect it to Ionic Appflow:
 
 ```bash
 cd myApp
 ionic link
 ```
 
-The command will prompt you to create a new Ionic Pro app or link to an existing app.
+The command will prompt you to create a new Ionic Appflow app or link to an existing app.
 
 If this is your first time running `ionic link` you may be prompted to perform additional steps such as logging in to your Pro account and setting up your SSH keys.
 
 ## Pushing your Code to Ionic
 
-Now that you are logged into your Ionic Pro account from the CLI and have an app you'd like to use, the next
-step is to push commits to your Ionic Pro account.
+Now that you are logged into your Ionic Appflow account from the CLI and have an app you'd like to use, the next
+step is to push commits to your Ionic Appflow account.
 
-Follow the [Git Workflow](/docs/pro/basics/git/) to learn more about the workflow you should use while developing your App with Ionic Pro.
+Follow the [Git Workflow](/docs/pro/basics/git/) to learn more about the workflow you should use while developing your App with Ionic Appflow.
 
 ## Pro Client Setup
 
-The Ionic Pro Client gives you access to the Monitoring and Deploy APIs inside of your app.
+The Ionic Appflow Client gives you access to the Monitoring and Deploy APIs inside of your app.
 
 The first thing you have to do is set up the Pro Client (or update it to the latest version) in your project. Inside of your app directory, make sure you are on the latest version of the Pro Client and App Scripts:
 
@@ -62,7 +62,7 @@ The first thing you have to do is set up the Pro Client (or update it to the lat
 npm install @ionic/app-scripts@latest @ionic/pro@latest
 ```
 
-You'll want to initialize Pro Client with your App ID and App Version from Ionic Pro inside of `app.module.ts`.
+You'll want to initialize Pro Client with your App ID and App Version from Ionic Appflow inside of `app.module.ts`.
 
 Modify your `app.module.ts` to include the following code:
 
@@ -113,6 +113,6 @@ export class MyErrorHandler implements ErrorHandler {
 export class AppModule {}
 ```
 
-`YOUR_APP_ID` is the Ionic Pro App ID found on the dashboard for your app:
+`YOUR_APP_ID` is the Ionic Appflow App ID found on the dashboard for your app:
 
 `APP_VERSION` is the version of the code running for the purposes of tracking code changes. We strongly recommend that this mirrors the version in `package.json` or `config.xml`.

--- a/src/content/pro/basics/git.md
+++ b/src/content/pro/basics/git.md
@@ -1,6 +1,6 @@
 # Working with Git
 
-Ionic Pro integrates with [Git](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control) version control software in order to manage the versions of your app that you release with Live Deploy and iOS & Android binaries built on Ionic Pro. If you're familiar with how Heroku works, then you'll find Ionic Pro's git workflow similar to use.
+Ionic Appflow integrates with [Git](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control) version control software in order to manage the versions of your app that you release with Live Deploy and iOS & Android binaries built on Ionic Appflow. If you're familiar with how Heroku works, then you'll find Ionic Appflow's git workflow similar to use.
 
 ## Installing Git
 If you are on Mac or Linux, git should already be installed and configured properly.
@@ -9,9 +9,9 @@ For Windows, download and install [Git for Windows](https://git-scm.com/download
 
 If you're using the GitHub integration you can also use GitHub's [Desktop Client](https://desktop.github.com/) to commit and push versions of your app.
 
-## Sharing your code with Ionic Pro
+## Sharing your code with Ionic Appflow
 
-Ionic Pro to needs access to your source code to build native binaries and release live deploys & bug fixes. Using Git allows you to specify the exact versions of your app which you would like to operate on. There are two ways in which you can give Ionic Pro access you your source code and Git versioning history.
+Ionic Appflow to needs access to your source code to build native binaries and release live deploys & bug fixes. Using Git allows you to specify the exact versions of your app which you would like to operate on. There are two ways in which you can give Ionic Appflow access you your source code and Git versioning history.
 
 * [GitHub & Bitbucket Cloud Integration](#github--bitbucket-cloud-integration)
 * [Ionic Git Remote](#ionic-git)
@@ -19,21 +19,21 @@ Ionic Pro to needs access to your source code to build native binaries and relea
 
 ## GitHub & Bitbucket Cloud Integration
 
-If you are already using [GitHub](https://github.com/) or [Bitbucket Cloud](https://bitbucket.org/) you can link your repository with your Ionic Pro app to push code automatically. In order to enable the integration with your Ionic Pro app you will need an existing repository on GitHub or Bitbucket Cloud. Navigate to the `Git` section of the app settings tab in your app on the Ionic Pro dashboard choose the tab of the correct integration. If this is your first time connecting you'll need to click the `Connect` button. Then you can choose the repository to link from the list of available repos.
+If you are already using [GitHub](https://github.com/) or [Bitbucket Cloud](https://bitbucket.org/) you can link your repository with your Ionic Appflow app to push code automatically. In order to enable the integration with your Ionic Appflow app you will need an existing repository on GitHub or Bitbucket Cloud. Navigate to the `Git` section of the app settings tab in your app on the Ionic Appflow dashboard choose the tab of the correct integration. If this is your first time connecting you'll need to click the `Connect` button. Then you can choose the repository to link from the list of available repos.
 
 <div style="text-align: center">
   <img style="width: 950px" src="/img/pro/github-connect-app.png">
 </div>
 
-When you link the repository a webhook will be created for the repository and events will be sent to Ionic Pro so that we can automatically trigger builds for any of the branches you specify during the linking process. Be sure to specify all the branches you would like to trigger builds for. By default only pushes to the `master` branch will trigger builds.
+When you link the repository a webhook will be created for the repository and events will be sent to Ionic Appflow so that we can automatically trigger builds for any of the branches you specify during the linking process. Be sure to specify all the branches you would like to trigger builds for. By default only pushes to the `master` branch will trigger builds.
 
 ## Using Ionic as a git remote
 
-**Ionic Pro is not a replacement for your source code repository service. It is recommended that you use a git hosting service to manage your primary app source code (GitHub, Bitbucket,  GitLab, etc.)! The `ionic` remote is used only for interacting with the Ionic Pro suite of services.**
+**Ionic Appflow is not a replacement for your source code repository service. It is recommended that you use a git hosting service to manage your primary app source code (GitHub, Bitbucket,  GitLab, etc.)! The `ionic` remote is used only for interacting with the Ionic Appflow suite of services.**
 
-If you are not using GitHub or Bitbucket Cloud you can push your source code directly to Ionic Pro using Git. Simply choose `Ionic` as your git remote during `ionic start` or run `ionic link` in the root directory of your existing app in order to create the `ionic` git remote. You can learn about git remotes [here](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes).
+If you are not using GitHub or Bitbucket Cloud you can push your source code directly to Ionic Appflow using Git. Simply choose `Ionic` as your git remote during `ionic start` or run `ionic link` in the root directory of your existing app in order to create the `ionic` git remote. You can learn about git remotes [here](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes).
 
-Follow the steps at [Getting Started](/docs/pro/basics/getting-started) to start a new App or link an existing App to Ionic Pro.
+Follow the steps at [Getting Started](/docs/pro/basics/getting-started) to start a new App or link an existing App to Ionic Appflow.
 
 Once you've created and linked your app to the Ionic remote you can learn about:
 
@@ -44,7 +44,7 @@ Once you've created and linked your app to the Ionic remote you can learn about:
 
 ### Pushing New Builds
 
-Once you have changes locally that you'd like to build and manage on Ionic Pro, first commit your code changes, and then push to the `ionic` remote:
+Once you have changes locally that you'd like to build and manage on Ionic Appflow, first commit your code changes, and then push to the `ionic` remote:
 
 ```bash
 git add .
@@ -53,7 +53,7 @@ git push ionic master
 ```
 
 Don't forget to also periodically push to your `origin` [git hosting service](#using-a-git-hosting-service)
-as Ionic Pro is not a replacement for GitHub, Bitbucket Cloud, GitLab, or a self-hosted git repository.
+as Ionic Appflow is not a replacement for GitHub, Bitbucket Cloud, GitLab, or a self-hosted git repository.
 
 ### Working with Branches
 
@@ -91,9 +91,9 @@ and walk them through the required setup. After they are linked, they can use `g
 
 ### Adding SSH Keys
 
-The Ionic CLI automatically detects and adds your public key (or creates new ones) to your Ionic Pro account as part of the `link` and `start` commands when
-you choose Ionic for your git remote. If you have additional public keys you'd like to link to Ionic Pro, create them manually using `ssh-keygen`,
-log into your Ionic Pro account, and add the keys manually under "SSH Keys"
+The Ionic CLI automatically detects and adds your public key (or creates new ones) to your Ionic Appflow account as part of the `link` and `start` commands when
+you choose Ionic for your git remote. If you have additional public keys you'd like to link to Ionic Appflow, create them manually using `ssh-keygen`,
+log into your Ionic Appflow account, and add the keys manually under "SSH Keys"
 
 ## Using a Git Hosting Service
 

--- a/src/content/pro/builds/environments.md
+++ b/src/content/pro/builds/environments.md
@@ -18,7 +18,7 @@ The following environment variables are provided in every build, which can be ac
 
 ## Custom Environments
 
-In addition to the [default environment](#default-environment), it's easy to create and manage custom sets of key/value pairs to further customize builds on Ionic Pro. To get started with custom environments, open the app you wish to work on and navigate in the sidebar to **Automate -> Environments**, then click **New Environment** on the top right. You should see a form like this:
+In addition to the [default environment](#default-environment), it's easy to create and manage custom sets of key/value pairs to further customize builds on Ionic Appflow. To get started with custom environments, open the app you wish to work on and navigate in the sidebar to **Automate -> Environments**, then click **New Environment** on the top right. You should see a form like this:
 
 <img src="/docs/assets/img/pro/ss-environments-create.png" class="browser" />
 

--- a/src/content/pro/builds/intro.md
+++ b/src/content/pro/builds/intro.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The [Git Workflow](/docs/pro/basics/git/) at the core of Ionic Pro allows you to push commits of your app code,
+The [Git Workflow](/docs/pro/basics/git/) at the core of Ionic Appflow allows you to push commits of your app code,
 which can then be used to trigger two distinct types of builds: Deploy and Package Builds.
 
 ### Concurrency limits

--- a/src/content/pro/deploy/api.md
+++ b/src/content/pro/deploy/api.md
@@ -103,7 +103,7 @@ async performAutomaticUpdate() {
     }
   } catch (err) {
     // We encountered an error.
-    // Here's how we would log it to Ionic Pro Monitoring while also catching:
+    // Here's how we would log it to Ionic Appflow Monitoring while also catching:
 
     // Pro.monitoring.exception(err);
   }
@@ -318,7 +318,7 @@ ___
 `string`
 
 
-The [Ionic Pro](https://ionicframework.com/docs/pro/) app id.
+The [Ionic Appflow](https://ionicframework.com/docs/pro/) app id.
 
 ___
 
@@ -485,8 +485,8 @@ cordova plugin add cordova-plugin-ionic --variable MIN_BACKGROUND_DURATION=60 ..
 
 ### `APP_ID` - `Required`
 
-The `APP_ID` variable sets app in the pro dashboard the plugin should check for updates.
-The App ID can be updated at runtime via the [Deploy Pro Client](/docs/pro/deploy/api).
+The `APP_ID` variable sets app in the Appflow dashboard the plugin should check for updates.
+The App ID can be updated at runtime via the [Deploy Appflow Client](/docs/pro/deploy/api).
 
 ### `CHANNEL_NAME` - `Required`
 
@@ -498,7 +498,7 @@ The Channel can be updated at runtime via the [configure method](/docs/pro/deplo
 `Default: background`
 
 The `UPDATE_METHOD` determines how updates are applied to your app.
-When you are installing the Ionic Pro plugin, you have the option to choose which update method to use.
+When you are installing the Ionic Appflow plugin, you have the option to choose which update method to use.
 The three options are:
 
 `background` - mode will check for updates when a user first opens your app from a completely closed state

--- a/src/content/pro/deploy/channels.md
+++ b/src/content/pro/deploy/channels.md
@@ -17,7 +17,7 @@ channel to run a native binary on your phone during development that gets automa
 Once you've set up a Channel, just click **Set Up Deploy** next to that Channel and it will walk you
 through the options available and generate the Command Line command that you should run.
 
-To create new channels beyond these two, you must have a paid Ionic Pro membership. To add new channels,
+To create new channels beyond these two, you must have a paid Ionic Appflow membership. To add new channels,
 simply view the channels list by going to Code -> Channels, and then click the New Channel button.
 
 

--- a/src/content/pro/deploy/intro.md
+++ b/src/content/pro/deploy/intro.md
@@ -1,6 +1,6 @@
 # Deploy
 
-Ionic Pro's Live Deploy feature let you update the UI and business logic of your app remotely, in real-time. Push HTML, JS, and CSS updates directly to your users without going through the
+Ionic Appflow's Live Deploy feature let you update the UI and business logic of your app remotely, in real-time. Push HTML, JS, and CSS updates directly to your users without going through the
 app store to quickly fix bugs and ship new features.
 
 This enables you to

--- a/src/content/pro/deploy/setup.md
+++ b/src/content/pro/deploy/setup.md
@@ -1,9 +1,9 @@
 # Using Ionic Deploy
 
-Ionic Pro's Deploy feature makes it easy to deploy app updates in real time without going through a
+Ionic Appflow's Deploy feature makes it easy to deploy app updates in real time without going through a
 traditional app store submission process for the vast majority of business logic, UI, and style changes.
 
-The Deploy feature works with the Ionic Pro [Git Workflow](/docs/pro/basics/git/) to deploy new code updates
+The Deploy feature works with the Ionic Appflow [Git Workflow](/docs/pro/basics/git/) to deploy new code updates
 in production (or testing) apps.
 
 *Note: The Deploy feature only works on binary compatible changes (HTML, CSS, JS),
@@ -11,14 +11,14 @@ meaning if you rely on native code updates you must resubmit to the app store fi
 
 ## Installation
 
-In order to use Ionic Pro's Deploy feature you'll need to at a minimum
+In order to use Ionic Appflow's Deploy feature you'll need to at a minimum
 [install and configure the Pro Plugin](#installing-ionic-pro-plugin).
 Additionally we recommend [install the Pro Client](#pro-client-setup) which is configured to be injectable in
 Angular projects and will provide access to both the Deploy API as well as the Monitoring API.
 
 ### Pro Client Setup
 
-The Ionic Pro Client gives you access to the Monitoring and Deploy APIs inside of your app.
+The Ionic Appflow Client gives you access to the Monitoring and Deploy APIs inside of your app.
 
 The first thing you have to do is set up the Pro Client (or update it to the latest version) in your project. Inside of your app directory, make sure you are on the latest version of the Pro Client and App Scripts:
 
@@ -26,7 +26,7 @@ The first thing you have to do is set up the Pro Client (or update it to the lat
 npm install @ionic/app-scripts@latest @ionic/pro@latest
 ```
 
-You'll want to initialize Pro Client with your App ID and App Version from Ionic Pro inside of `app.module.ts`.
+You'll want to initialize Pro Client with your App ID and App Version from Ionic Appflow inside of `app.module.ts`.
 
 ```typescript
 // All of your imports that are already there
@@ -75,7 +75,7 @@ export class MyErrorHandler implements ErrorHandler {
 export class AppModule {}
 ```
 
-`YOUR_APP_ID` is the Ionic Pro App ID found on the dashboard for your app.
+`YOUR_APP_ID` is the Ionic Appflow App ID found on the dashboard for your app.
 
 `APP_VERSION` is the version of the code running for the purposes of tracking code changes. We strongly recommend that this mirrors the version in `package.json` or `config.xml`.
 
@@ -83,9 +83,9 @@ export class AppModule {}
 service will know when regressions have happened, as well as mapping your code to any
 Source Maps you've provided.</div>
 
-### Installing Ionic Pro Plugin
+### Installing Ionic Appflow Plugin
 
-The Ionic Pro plugin comes with Ionic Pro's Deploy feature for detecting and syncing your app with updates that you've pushed to channels.
+The Ionic Appflow plugin comes with Ionic Appflow's Deploy feature for detecting and syncing your app with updates that you've pushed to channels.
 
 To install the plugin, we recommend following the automatic instructions after clicking "Set Up Deploy" on the channels list:
 
@@ -95,7 +95,7 @@ To install the plugin manually, run the following command in the root of your Io
 cordova plugin add cordova-plugin-ionic --save --variable APP_ID="YOUR_APP_ID" --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" --variable UPDATE_METHOD="background|auto|none" --variable MAX_STORE="2"
 ```
 
-Where `YOUR_APP_ID` is the ID of the app in Ionic Pro, and `YOUR_CHANNEL_NAME` is the name of a [channel](/docs/pro/deploy/channels).
+Where `YOUR_APP_ID` is the ID of the app in Ionic Appflow, and `YOUR_CHANNEL_NAME` is the name of a [channel](/docs/pro/deploy/channels).
 Make sure to use the exact name of your channel, including the exact casing.
 [MAX_STORE](/docs/pro/deploy/api/#max_store) tells us how many previous versions of code to keep inside your app,
 this enables you to revert to those versions quickly, or swap between versions.
@@ -106,8 +106,8 @@ available [plugin variables in our api docs](/docs/pro/deploy/api/#plugin-variab
 
 After you have installed and configured the Pro Plugin & Client libraries you can begin receiving updates in your app.
 To push new updates to your app, first trigger a [build](/docs/pro/builds/intro) by making a change to your app
-committing it to version control and pushing the changes to Ionic Pro. The triggered build will be viewable in the
-Ionic Pro dashboard.
+committing it to version control and pushing the changes to Ionic Appflow. The triggered build will be viewable in the
+Ionic Appflow dashboard.
 
 Once the build is available you can deploy it live in your app by either
 [manually assigning the build to the channel](/docs/pro/deploy/channels/#assigning-a-build-to-a-channel)

--- a/src/content/pro/package/credentials.md
+++ b/src/content/pro/package/credentials.md
@@ -17,7 +17,7 @@ that you need for the desired platform below.
 
 ## Creating Security Profiles
 
-After you have generated your Security Profile, you must upload it to Ionic Pro. Navigate to your App, then click on Settings Tab and choose Certificates on the left hand side.
+After you have generated your Security Profile, you must upload it to Ionic Appflow. Navigate to your App, then click on Settings Tab and choose Certificates on the left hand side.
 
 Click the **Add Profile** button to create a new Profile. Both iOS and Android certifications can be used with one Profile, so we recommend making things like "Real App Store Profile", etc.
 

--- a/src/content/pro/package/intro.md
+++ b/src/content/pro/package/intro.md
@@ -1,6 +1,6 @@
 # Packaging Native Binaries
 
-Ionic Pro's Package feature makes it easy to build native app binaries for iOS and Android in the cloud. Perfect for automating binary builds and for developers using Windows that want to build iOS apps.
+Ionic Appflow's Package feature makes it easy to build native app binaries for iOS and Android in the cloud. Perfect for automating binary builds and for developers using Windows that want to build iOS apps.
 
 ## Getting Started
 

--- a/src/content/publishing/app-store.md
+++ b/src/content/publishing/app-store.md
@@ -63,6 +63,6 @@ From there, TestFlight can be enabled for beta testing, or the App can be sent f
 As an app grows, it will need to be updated with new features and fixes.
 An app can be updated by either submitting a new version to Apple, or by using a live update service like <a href="https://ionicframework.com/pro/deploy" target="_blank">Ionic Deploy</a>.
 
-With <strong>Ionic Deploy</strong>, app changes can be pushed in realtime directly to users from the Ionic Pro dashboard, without waiting for App Store approvals.
+With <strong>Ionic Deploy</strong>, app changes can be pushed in realtime directly to users from the Ionic Appflow dashboard, without waiting for App Store approvals.
 
 > In order for the iOS App Store to accept the updated build, the config.xml file will need to be edited to increment the version value, then rebuild the app for release following the same instructions above.

--- a/src/content/publishing/play-store.md
+++ b/src/content/publishing/play-store.md
@@ -66,6 +66,6 @@ When ready, upload the signed release APK that was generated and publish the app
 
 ## Updating an app
 
-As an app evolves, it will need to be updated with new features and fixes. An app can be updated by either submitting a new version to the Google Play Store, or by using a live update service like Ionic Deploy. Using Ionic Deploy, changes can be pushed directly to users from the Ionic Pro dashboard, without submitting changes to the Play Store. Learn more about Ionic Deploy <a href="https://ionicframework.com/pro/deploy" target="_blank">here</a>.
+As an app evolves, it will need to be updated with new features and fixes. An app can be updated by either submitting a new version to the Google Play Store, or by using a live update service like Ionic Deploy. Using Ionic Deploy, changes can be pushed directly to users from the Ionic Appflow dashboard, without submitting changes to the Play Store. Learn more about Ionic Deploy <a href="https://ionicframework.com/pro/deploy" target="_blank">here</a>.
 
 > In order for the Google Play Store to accept updated APKs, the config.xml file will need to be edited to increment the version value, then rebuild the app for release following the instructions above.


### PR DESCRIPTION
#### Short description of what this resolves:
change word, "Ionic Pro" to "Ionic Appflow".

#### Changes proposed in this pull request:

- "Ionic Pro" to "Ionic Appflow"
- "Pro" to "Appflow".
- directory name and path name was not changed.

**Fixes**: #
