### PR TITLE
docs : Line 180 - typo fix

### DIFF
--- a/src/content/building/migration.md
+++ b/src/content/building/migration.md
@@ -177,7 +177,7 @@ async showAlert() {
 
 In V4, navigation received the most changes. Now, instead of using Ionic's own `NavController`, we integrate with the official Angular Router. This not only provides a consistent routing experience across apps, but is much more dependable. The Angular team has an <a href="http://angular.io/guide/router" target="_blank">excellent guide</a> on their docs site that covers the Router in great detail.
 
-To provide the platform specific animations that users are used to, we have created `ion-router-outlet` for Angular Apps. This behaves in a similar manor to Angular's `rouer-outlet` but provides a stack-based navigation (tabs) and animations.
+To provide the platform specific animations that users are used to, we have created `ion-router-outlet` for Angular Apps. This behaves in a similar manor to Angular's `router-outlet` but provides a stack-based navigation (tabs) and animations.
 
 For a detailed explanation in navigation works in a V4 project, checkout the [Angular navigation guide](/docs/navigation/angular).
 


### PR DESCRIPTION
#### Short description of what this resolves:
Better dev docs read.

#### Changes proposed in this pull request:

- Typo from `rouer-outlet` to `router-outlet`

**Fixes**: # Spelling
