### PR TITLE
docs(installation/android.md): strengthen JDK8 requirement wording

### DIFF
--- a/src/pages/installation/android.md
+++ b/src/pages/installation/android.md
@@ -11,10 +11,10 @@ To target the Android platform, some additional environment setup is required. A
 
 ## Java
 
-Native Android apps are compiled with the <a href="https://java.com/en/" target="_blank">Java</a> programming language. Download JDK8 from the <a href="http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html" target="_blank">download page</a>.
+Native Android apps are compiled with the <a href="https://java.com/en/" target="_blank">Java</a> programming language. Download JDK8 from the <a href="https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html" target="_blank">download page</a>.
 
 <blockquote>
-  <p>Java 10 is still a bit too new and doesn't work well with Cordova. We recommend JDK8.</p>
+  <p>Cordova is not compatible with Java 11 yet. You must install JDK8 to build Cordova Android apps.</p>
 </blockquote>
 
 ## Gradle


### PR DESCRIPTION
It's not just recommended, it's required. I tried this today and there is a flat out version check in the source code that locks it to JDK8.

Also, added https to the download link as the site runs on that now.

FYI if you don't have much time to research this then here is some help:

I also worked with the cordova-android team to clarify this in their error messages and it's been accepted:

 - https://github.com/apache/cordova-android/pull/619
 - https://github.com/apache/cordova-android/pull/620

If you look in the files changed the version check is just around those changed lines.