### PR TITLE
fix(docs): change previousUrl of Color Generator

### DIFF
--- a/src/pages/theming/advanced.md
+++ b/src/pages/theming/advanced.md
@@ -2,7 +2,7 @@
 initialTab: 'preview'
 inlineHtmlPreviews: true
 previousText: 'Color Generator'
-previousUrl: '/docs/layout/color-generator'
+previousUrl: '/docs/theming/color-generator'
 nextText: 'Publishing an app'
 nextUrl: '/docs/publishing/app-store'
 ---


### PR DESCRIPTION
https://ionicframework.com/docs/layout/color-generator is not found instead the previousUrl should point to https://ionicframework.com/docs/theming/color-generator/