### PR TITLE
Add path key to page objects

### DIFF
--- a/scripts/build-pages/index.ts
+++ b/scripts/build-pages/index.ts
@@ -70,7 +70,7 @@ function patchPage(page: Page): Page {
     href: `#${heading.getAttribute('id')}`
   }));
 
-  const pageClass = `page-${slugify(page.path.slice(PAGES_DIR.length + 1).replace('.json', ''))}`;
+  const pageClass = `page-${slugify(page.path.slice(6))}`;
 
   return {
     ...page,
@@ -81,8 +81,10 @@ function patchPage(page: Page): Page {
 }
 
 function writePage(page: Page): Promise<any> {
-  const { path, ...contents } = page;
-  return fs.outputJson(path, contents, {
+  return fs.outputJson(toFilePath(page.path), page, {
     spaces: 2
   });
 }
+
+const toFilePath = (urlPath: string) =>
+  `${resolve(PAGES_DIR, urlPath.slice(6))}.json`;

--- a/scripts/build-pages/page-types/api.ts
+++ b/scripts/build-pages/page-types/api.ts
@@ -1,11 +1,9 @@
 import {
-  PAGES_DIR,
   Page,
   buildPages
 } from '../index';
 
 import { components } from '@ionic/docs/core.json';
-import { join } from 'path';
 import markdownRenderer from '../markdown-renderer';
 
 export default {
@@ -16,7 +14,7 @@ export default {
 async function getAPIPages(): Promise<Page[]> {
   return components.map(component => {
     const title = component.tag;
-    const path = `${join(PAGES_DIR, 'api', title.slice(4))}.json`;
+    const path = `/docs/api/${title.slice(4)}`;
     const { readme, usage, props, methods, ...contents } = component;
     return {
       title,

--- a/scripts/build-pages/page-types/cli.ts
+++ b/scripts/build-pages/page-types/cli.ts
@@ -1,10 +1,8 @@
 import {
-  PAGES_DIR,
   Page,
   buildPages
 } from '../index';
 
-import { join } from 'path';
 import renderMarkdown from '../markdown-renderer';
 import { commands } from '../../data/cli.json';
 
@@ -20,7 +18,7 @@ async function getCLIPages(): Promise<Page[]> {
     return {
       title: name,
       body: renderMarkdown(description),
-      path: join(PAGES_DIR, `cli/commands/${name.slice(6).replace(/\s/g, '-')}.json`),
+      path: `/docs/cli/commands/${name.slice(6).replace(/\s/g, '-')}`,
       summary: renderMarkdown(summary),
       inputs: renderInputs(inputs),
       options: renderOptions(options),

--- a/scripts/build-pages/page-types/native.ts
+++ b/scripts/build-pages/page-types/native.ts
@@ -1,12 +1,10 @@
 import {
-  PAGES_DIR,
   Page,
   buildPages
 } from '../index';
 
 import plugins from '../../data/native.json';
 import renderMarkdown from '../markdown-renderer';
-import { join } from 'path';
 
 export default {
   title: 'Build native pages',
@@ -16,7 +14,7 @@ export default {
 async function getNativePages(): Promise<Page[]> {
   return plugins.map(plugin => {
     const title = plugin.displayName.trim();
-    const path = `${join(PAGES_DIR, 'native', plugin.name.slice(14))}.json`;
+    const path = `/docs/native/${plugin.name.slice(14)}`;
     const { description, usage, repo, platforms } = plugin;
     return {
       title,

--- a/scripts/build-pages/page-types/static.ts
+++ b/scripts/build-pages/page-types/static.ts
@@ -27,7 +27,7 @@ const getMarkdownPaths = (cwd: string): Promise<string[]> =>
 
 export const toPage = async (path: string) => {
   return {
-    path: path.replace(/md$/, 'json'),
+    path: path.replace(PAGES_DIR, '/docs').replace(/md$/, ''),
     ...renderMarkdown(await readMarkdown(path))
   };
 };

--- a/src/components/page/templates/api.tsx
+++ b/src/components/page/templates/api.tsx
@@ -1,5 +1,5 @@
 export default (props) => {
-  const { page, history } = props;
+  const { page } = props;
   const headings = [...page.headings];
   const usage = renderUsage(page.usage);
   const properties = renderProperties(page.props);
@@ -48,7 +48,7 @@ export default (props) => {
       <div class="docs-content-pane">
         <div class="docs-content">
           <h1>{ page.title }</h1>
-          <docs-table-of-contents links={headings} basepath={history.location.pathname}/>
+          <docs-table-of-contents links={headings} basepath={page.path}/>
           <section class="markdown-content" innerHTML={page.body}/>
           { usage }
           { properties }

--- a/src/components/page/templates/cli.tsx
+++ b/src/components/page/templates/cli.tsx
@@ -37,7 +37,7 @@ export default (props) => {
   return (
     <main class="docs-content-pane">
       <h1>{ page.title }</h1>
-      <docs-table-of-contents links={headings} basepath={props.history.location.pathname} />
+      <docs-table-of-contents links={headings} basepath={page.path} />
       <section class="summary intro" innerHTML={page.summary} />
       { renderUsage(page) }
       <section class="description" innerHTML={page.body} />

--- a/src/components/page/templates/default.tsx
+++ b/src/components/page/templates/default.tsx
@@ -4,7 +4,7 @@ export default (props) => {
   return (
     <main class="docs-content-pane">
       <h1>{ page.title }</h1>
-      <docs-table-of-contents links={page.headings} basepath={props.history.location.pathname}/>
+      <docs-table-of-contents links={page.headings} basepath={page.path}/>
       <section class="markdown-content" innerHTML={page.body}/>
     </main>
   );

--- a/src/components/page/templates/native.tsx
+++ b/src/components/page/templates/native.tsx
@@ -32,7 +32,7 @@ export default (props) => {
   return (
     <main class="docs-content-pane">
       <h1>{ page.title }</h1>
-      <docs-table-of-contents links={headings} basepath={props.history.location.pathname}/>
+      <docs-table-of-contents links={headings} basepath={page.path}/>
       <section class="markdown-content" innerHTML={page.body}/>
       { repo }
       { installation }


### PR DESCRIPTION
This adds the URL path as a key on each page object during build so it can be used on the client instead of reading the router history.