### PR TITLE
fix(appflow): Tweak Appflow SDK setup CLI prompt

### DIFF
--- a/src/pages/appflow/quickstart/installation.md
+++ b/src/pages/appflow/quickstart/installation.md
@@ -22,7 +22,13 @@ To install the plugin manually, run the following command in the root directory 
 making sure to substitute the correct values for your app:
 
 <command-line>
-<command-prompt>cordova plugin add cordova-plugin-ionic --save --variable APP_ID="YOUR_APP_ID" --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" --variable UPDATE_METHOD="background|auto|none" --variable MAX_STORE="3"</command-prompt>
+    <command-prompt>
+    cordova plugin add cordova-plugin-ionic --save<br /> 
+        --variable APP_ID="YOUR_APP_ID" <br />
+        --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" <br />
+        --variable UPDATE_METHOD="background|auto|none" <br />
+        --variable MAX_STORE="3"
+    </command-prompt>
 </command-line>
 
 ### Plugin Variables

--- a/src/pages/appflow/quickstart/installation.md
+++ b/src/pages/appflow/quickstart/installation.md
@@ -21,15 +21,13 @@ on the Channels list in the Appflow Dashboard.
 To install the plugin manually, run the following command in the root directory of your Ionic app,
 making sure to substitute the correct values for your app:
 
-<command-line>
-    <command-prompt>
+```shell
     cordova plugin add cordova-plugin-ionic --save<br /> 
         --variable APP_ID="YOUR_APP_ID" <br />
         --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" <br />
         --variable UPDATE_METHOD="background|auto|none" <br />
         --variable MAX_STORE="3"
-    </command-prompt>
-</command-line>
+```
 
 ### Plugin Variables
 * `YOUR_APP_ID` is the ID of the app in Ionic Appflow.

--- a/src/pages/appflow/quickstart/installation.md
+++ b/src/pages/appflow/quickstart/installation.md
@@ -22,10 +22,10 @@ To install the plugin manually, run the following command in the root directory 
 making sure to substitute the correct values for your app:
 
 ```shell
-cordova plugin add cordova-plugin-ionic --save<br /> 
-    --variable APP_ID="YOUR_APP_ID" <br />
-    --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" <br />
-    --variable UPDATE_METHOD="background|auto|none" <br />
+cordova plugin add cordova-plugin-ionic --save \
+    --variable APP_ID="YOUR_APP_ID" \
+    --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" \
+    --variable UPDATE_METHOD="background|auto|none" \
     --variable MAX_STORE="3"
 ```
 

--- a/src/pages/appflow/quickstart/installation.md
+++ b/src/pages/appflow/quickstart/installation.md
@@ -22,11 +22,11 @@ To install the plugin manually, run the following command in the root directory 
 making sure to substitute the correct values for your app:
 
 ```shell
-    cordova plugin add cordova-plugin-ionic --save<br /> 
-        --variable APP_ID="YOUR_APP_ID" <br />
-        --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" <br />
-        --variable UPDATE_METHOD="background|auto|none" <br />
-        --variable MAX_STORE="3"
+cordova plugin add cordova-plugin-ionic --save<br /> 
+    --variable APP_ID="YOUR_APP_ID" <br />
+    --variable CHANNEL_NAME="YOUR_CHANNEL_NAME" <br />
+    --variable UPDATE_METHOD="background|auto|none" <br />
+    --variable MAX_STORE="3"
 ```
 
 ### Plugin Variables


### PR DESCRIPTION
### Changes
* Added some breaks to the command prompt for installing the Appflow SDK to make it easier for copy/paste (cc @mhartington)