### PR TITLE
docs(): add Utilities and Config sections

### DIFF
--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -15,6 +15,9 @@ const items = {
     'iOS Setup': '/docs/installation/ios',
     'Android Setup': '/docs/installation/android',
   },
+  'Utilities': {
+    'Config': '/docs/utilities/config'
+  },
   'Building': {
     'Starting': '/docs/building/starting',
     'Scaffolding': '/docs/building/scaffolding',

--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -15,9 +15,6 @@ const items = {
     'iOS Setup': '/docs/installation/ios',
     'Android Setup': '/docs/installation/android',
   },
-  'Utilities': {
-    'Config': '/docs/utilities/config'
-  },
   'Building': {
     'Starting': '/docs/building/starting',
     'Scaffolding': '/docs/building/scaffolding',
@@ -45,6 +42,9 @@ const items = {
   },
   'Navigation': {
     'Angular': '/docs/navigation/angular'
+  },
+  'Utilities': {
+    'Config': '/docs/utilities/config'
   },
   'Publishing': {
     'Progressive Web App': '/docs/publishing/progressive-web-app',

--- a/src/pages/utilities/config.md
+++ b/src/pages/utilities/config.md
@@ -105,7 +105,7 @@ Below is a list of config options that Ionic uses.
 | `infiniteLoadingSpinner` | `SpinnerTypes`     | Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.
 | `loadingEnter`           | `AnimationBuilder` | Provides a custom enter animation for all `ion-loading`, overriding the default "animation".
 | `loadingLeave`           | `AnimationBuilder` | Provides a custom leave animation for all `ion-loading`, overriding the default "animation".
-| `loadingSpinner`         | `SpinnerTypes`     | Overrides the default spinner for all `ion-loading` overlays, ie. the ones.
+| `loadingSpinner`         | `SpinnerTypes`     | Overrides the default spinner for all `ion-loading` overlays.
 | `menuIcon`               | `string`           | Overrides the default icon in all `<ion-menu-button>` components.
 | `menuType`               | `string`           | Overrides the default menu type for all `<ion-menu>` components.
 | `modalEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-modal`, overriding the default "animation".

--- a/src/pages/utilities/config.md
+++ b/src/pages/utilities/config.md
@@ -7,7 +7,7 @@ nextUrl: ''
 
 # Config
 
-The Config lets you configure your entire app or specific platforms. You can set the tab placement, icon mode, animations, and more here.
+The Config lets you configure your entire app. You can set the tab button layout, icon mode, animations, and more here.
 
 ## Usage
 

--- a/src/pages/utilities/config.md
+++ b/src/pages/utilities/config.md
@@ -9,14 +9,30 @@ nextUrl: ''
 
 The Config lets you configure your entire app or specific platforms. You can set the tab placement, icon mode, animations, and more here.
 
-## Passing as Parameter
+## Usage
 
-## Setting Globally
+```typescript
+import { IonicModule } from '@ionic/angular';
+
+@NgModule({
+  ...
+  imports: [
+    BrowserModule, 
+    IonicModule.forRoot({
+      rippleEffect: false,
+      mode: 'md'
+    }), 
+    AppRoutingModule
+  ],
+  ...
+})
+```
+
+In this example, we are disabling the material design ripple effect across the app as well as forcing the app mode to be material design.
 
 ## Config Options
 
-Below is a list of config options that Ionic uses. You can also add you're own custom config keys to the global object for you're own needs.
-
+Below is a list of config options that Ionic uses.
 
 | Config                   | type               | Description                                                                                              |
 |--------------------------|--------------------|----------------------------------------------------------------------------------------------------------|
@@ -50,28 +66,3 @@ Below is a list of config options that Ionic uses. You can also add you're own c
 | `tabButtonLayout`        | `TabButtonLayout`  | Overrides the default "layout" of all `ion-bar-button` across the whole application.
 | `toastEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-toast`, overriding the default "animation".
 | `toastLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-toast`, overriding the default "animation".
-
-## Methods
-
-### `get(key: keyof IonicConfig, fallback?: any) => any`
-
-Get the value of the given key. If return value is null, use fallback instead.
-
-#### Parameters
-
-| Name       | Type                | Description                          |
-|------------|---------------------|--------------------------------------|
-| `key`      | `keyof IonicConfig` | Config key to get                    |
-| `fallback` | `any`               | Fallback value to use if key is null |
-
-
-### `set(key: keyof IonicConfig, value: any) => void`
-
-Set the value of the given key.
-
-#### Parameters
-
-| Name    | Type                | Description          |
-|---------|---------------------|----------------------|
-| `key`   | `keyof IonicConfig` | Config key to set    |
-| `value` | `any`               | Value to set the key |

--- a/src/pages/utilities/config.md
+++ b/src/pages/utilities/config.md
@@ -11,6 +11,8 @@ The Config lets you configure your entire app. You can set the tab button layout
 
 ## Usage
 
+### Basic example
+
 ```typescript
 import { IonicModule } from '@ionic/angular';
 
@@ -28,22 +30,78 @@ import { IonicModule } from '@ionic/angular';
 })
 ```
 
-In this example, we are disabling the material design ripple effect across the app as well as forcing the app mode to be material design.
+In the above example, we are disabling the Material Design ripple effect across the app, as well as forcing the mode to be Material Design.
+
+### Customizing Animations
+
+```typescript
+import { IonicModule } from '@ionic/angular';
+
+@NgModule({
+  ...
+  imports: [
+    BrowserModule, 
+    IonicModule.forRoot({
+      toastEnter: (AnimationC: Animation, baseEl: ShadowRoot, position: string): Promise<Animation> => {
+        const baseAnimation = new AnimationC();
+
+        const wrapperAnimation = new AnimationC();
+      
+        const hostEl = (baseEl.host || baseEl) as HTMLElement;
+        const wrapperEl = baseEl.querySelector('.toast-wrapper') as HTMLElement;
+      
+        wrapperAnimation.addElement(wrapperEl);
+      
+        const bottom = `calc(8px + var(--ion-safe-area-bottom, 0px))`;
+        const top = `calc(8px + var(--ion-safe-area-top, 0px))`;
+      
+        switch (position) {
+          case 'top':
+            wrapperEl.style.top = top;
+            wrapperEl.style.opacity = 1;
+            wrapperAnimation.fromTo('transform', `translateY(-${hostEl.clientHeight}px)`, 'translateY(10px)')
+            break;
+          case 'middle':
+            const topPosition = Math.floor(
+              hostEl.clientHeight / 2 - wrapperEl.clientHeight / 2
+            );
+            wrapperEl.style.top = `${topPosition}px`;
+            wrapperAnimation.fromTo('opacity', 0.01, 1);
+            break;
+          default:
+            wrapperEl.style.bottom = bottom;
+            wrapperAnimation.fromTo('opacity', 0.01, 1);
+            break;
+        }
+        return Promise.resolve(baseAnimation
+          .addElement(hostEl)
+          .easing('cubic-bezier(.36,.66,.04,1)')
+          .duration(400)
+          .add(wrapperAnimation));
+      },
+    }), 
+    AppRoutingModule
+  ],
+  ...
+})
+```
+
+In the above example, we are customizing the "enter" animation for the `ion-toast` component. When an `ion-toast` component is presented from the top, it will slide down instead of fading in.
 
 ## Config Options
 
 Below is a list of config options that Ionic uses.
 
-| Config                   | type               | Description                                                                                              |
+| Config                   | Type               | Description                                                                                              |
 |--------------------------|--------------------|----------------------------------------------------------------------------------------------------------|
 | `actionSheetEnter`       | `AnimationBuilder` | Provides a custom enter animation for all `ion-action-sheet`, overriding the default "animation".
 | `actionSheetLeave`       | `AnimationBuilder` | Provides a custom leave animation for all `ion-action-sheet`, overriding the default "animation".
 | `alertEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-alert`, overriding the default "animation".
 | `alertLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-alert`, overriding the default "animation".
-| `animated`               | `boolean`          | When it's set to `false`, disables all animation and transition across the app.
+| `animated`               | `boolean`          | If `false`, Ionic will disable all animations and transitions across the app.
 | `backButtonIcon`         | `string`           | Overrides the default icon in all `<ion-back-button>` components.
 | `backButtonText`         | `string`           | Overrides the default text in all `<ion-back-button>` components.
-| `hardwareBackButton`     | `boolean`          | Wherever ionic will respond to hardware go back buttons in an Android device.
+| `hardwareBackButton`     | `boolean`          | If `true`, Ionic will respond to the hardware back button in an Android device
 | `infiniteLoadingSpinner` | `SpinnerTypes`     | Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.
 | `loadingEnter`           | `AnimationBuilder` | Provides a custom enter animation for all `ion-loading`, overriding the default "animation".
 | `loadingLeave`           | `AnimationBuilder` | Provides a custom leave animation for all `ion-loading`, overriding the default "animation".
@@ -61,8 +119,8 @@ Below is a list of config options that Ionic uses.
 | `refreshingIcon`         | `string`           | Overrides the default icon in all `<ion-refresh-content>` components.
 | `refreshingSpinner`      | `SpinnerTypes`     | Overrides the default spinner type in all `<ion-refresh-content>` components.
 | `spinner`                | `SpinnerTypes`     | Overrides the default spinner in all `<ion-spinner>` components.
-| `statusTap`              | `boolean`          | Whenever clicking the top status bar should cause the scroll to top in an application.
-| `swipeBackEnabled`       | `boolean`          | Global switch that disables or enables "swipe-to-go-back" gesture across your application.
+| `statusTap`              | `boolean`          | If `true`, clicking or tapping the status bar will cause the content to scroll to the top.
+| `swipeBackEnabled`       | `boolean`          | If `false`, Ionic will disable the "swipe-to-go-back" gesture across your application.
 | `tabButtonLayout`        | `TabButtonLayout`  | Overrides the default "layout" of all `ion-bar-button` across the whole application.
 | `toastEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-toast`, overriding the default "animation".
 | `toastLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-toast`, overriding the default "animation".

--- a/src/pages/utilities/config.md
+++ b/src/pages/utilities/config.md
@@ -1,0 +1,77 @@
+---
+previousText: ''
+previousUrl: ''
+nextText: ''
+nextUrl: ''
+---
+
+# Config
+
+The Config lets you configure your entire app or specific platforms. You can set the tab placement, icon mode, animations, and more here.
+
+## Passing as Parameter
+
+## Setting Globally
+
+## Config Options
+
+Below is a list of config options that Ionic uses. You can also add you're own custom config keys to the global object for you're own needs.
+
+
+| Config                   | type               | Description                                                                                              |
+|--------------------------|--------------------|----------------------------------------------------------------------------------------------------------|
+| `actionSheetEnter`       | `AnimationBuilder` | Provides a custom enter animation for all `ion-action-sheet`, overriding the default "animation".
+| `actionSheetLeave`       | `AnimationBuilder` | Provides a custom leave animation for all `ion-action-sheet`, overriding the default "animation".
+| `alertEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-alert`, overriding the default "animation".
+| `alertLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-alert`, overriding the default "animation".
+| `animated`               | `boolean`          | When it's set to `false`, disables all animation and transition across the app.
+| `backButtonIcon`         | `string`           | Overrides the default icon in all `<ion-back-button>` components.
+| `backButtonText`         | `string`           | Overrides the default text in all `<ion-back-button>` components.
+| `hardwareBackButton`     | `boolean`          | Wherever ionic will respond to hardware go back buttons in an Android device.
+| `infiniteLoadingSpinner` | `SpinnerTypes`     | Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.
+| `loadingEnter`           | `AnimationBuilder` | Provides a custom enter animation for all `ion-loading`, overriding the default "animation".
+| `loadingLeave`           | `AnimationBuilder` | Provides a custom leave animation for all `ion-loading`, overriding the default "animation".
+| `loadingSpinner`         | `SpinnerTypes`     | Overrides the default spinner for all `ion-loading` overlays, ie. the ones
+| `menuIcon`               | `string`           | Overrides the default icon in all `<ion-menu-button>` components.
+| `menuType`               | `string`           | Overrides the default menu type for all `<ion-menu>` components.
+| `modalEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-modal`, overriding the default "animation".
+| `modalLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-modal`, overriding the default "animation".
+| `mode`                   | `Mode`             | The mode determines which platform styles to use for the whole application.
+| `navAnimation`           | `AnimationBuilder` | Overrides the default "animation" of all `ion-nav` and `ion-router-outlet` across the whole application.
+| `pickerEnter`            | `AnimationBuilder` | Provides a custom enter animation for all `ion-picker`, overriding the default "animation".
+| `pickerLeave`            | `AnimationBuilder` | Provides a custom leave animation for all `ion-picker`, overriding the default "animation".
+| `popoverEnter`           | `AnimationBuilder` | Provides a custom enter animation for all `ion-popover`, overriding the default "animation".
+| `popoverLeave`           | `AnimationBuilder` | Provides a custom leave animation for all `ion-popover`, overriding the default "animation".
+| `refreshingIcon`         | `string`           | Overrides the default icon in all `<ion-refresh-content>` components.
+| `refreshingSpinner`      | `SpinnerTypes`     | Overrides the default spinner type in all `<ion-refresh-content>` components.
+| `spinner`                | `SpinnerTypes`     | Overrides the default spinner in all `<ion-spinner>` components.
+| `statusTap`              | `boolean`          | Whenever clicking the top status bar should cause the scroll to top in an application.
+| `swipeBackEnabled`       | `boolean`          | Global switch that disables or enables "swipe-to-go-back" gesture across your application.
+| `tabButtonLayout`        | `TabButtonLayout`  | Overrides the default "layout" of all `ion-bar-button` across the whole application.
+| `toastEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-toast`, overriding the default "animation".
+| `toastLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-toast`, overriding the default "animation".
+
+## Methods
+
+### `get(key: keyof IonicConfig, fallback?: any) => any`
+
+Get the value of the given key. If return value is null, use fallback instead.
+
+#### Parameters
+
+| Name       | Type                | Description                          |
+|------------|---------------------|--------------------------------------|
+| `key`      | `keyof IonicConfig` | Config key to get                    |
+| `fallback` | `any`               | Fallback value to use if key is null |
+
+
+### `set(key: keyof IonicConfig, value: any) => void`
+
+Set the value of the given key.
+
+#### Parameters
+
+| Name    | Type                | Description          |
+|---------|---------------------|----------------------|
+| `key`   | `keyof IonicConfig` | Config key to set    |
+| `value` | `any`               | Value to set the key |

--- a/src/pages/utilities/config.md
+++ b/src/pages/utilities/config.md
@@ -7,7 +7,7 @@ nextUrl: ''
 
 # Config
 
-The Config lets you configure your entire app. You can set the tab button layout, icon mode, animations, and more here.
+The Config service provides a way to change the properties of components globally across an app. It can set the app mode, tab button layout, animations, and more.
 
 ## Usage
 
@@ -98,14 +98,14 @@ Below is a list of config options that Ionic uses.
 | `actionSheetLeave`       | `AnimationBuilder` | Provides a custom leave animation for all `ion-action-sheet`, overriding the default "animation".
 | `alertEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-alert`, overriding the default "animation".
 | `alertLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-alert`, overriding the default "animation".
-| `animated`               | `boolean`          | If `false`, Ionic will disable all animations and transitions across the app.
+| `animated`               | `boolean`          | If `true`, Ionic will enable all animations and transitions across the app.
 | `backButtonIcon`         | `string`           | Overrides the default icon in all `<ion-back-button>` components.
 | `backButtonText`         | `string`           | Overrides the default text in all `<ion-back-button>` components.
-| `hardwareBackButton`     | `boolean`          | If `true`, Ionic will respond to the hardware back button in an Android device
+| `hardwareBackButton`     | `boolean`          | If `true`, Ionic will respond to the hardware back button in an Android device.
 | `infiniteLoadingSpinner` | `SpinnerTypes`     | Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.
 | `loadingEnter`           | `AnimationBuilder` | Provides a custom enter animation for all `ion-loading`, overriding the default "animation".
 | `loadingLeave`           | `AnimationBuilder` | Provides a custom leave animation for all `ion-loading`, overriding the default "animation".
-| `loadingSpinner`         | `SpinnerTypes`     | Overrides the default spinner for all `ion-loading` overlays, ie. the ones
+| `loadingSpinner`         | `SpinnerTypes`     | Overrides the default spinner for all `ion-loading` overlays, ie. the ones.
 | `menuIcon`               | `string`           | Overrides the default icon in all `<ion-menu-button>` components.
 | `menuType`               | `string`           | Overrides the default menu type for all `<ion-menu>` components.
 | `modalEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-modal`, overriding the default "animation".
@@ -120,7 +120,7 @@ Below is a list of config options that Ionic uses.
 | `refreshingSpinner`      | `SpinnerTypes`     | Overrides the default spinner type in all `<ion-refresh-content>` components.
 | `spinner`                | `SpinnerTypes`     | Overrides the default spinner in all `<ion-spinner>` components.
 | `statusTap`              | `boolean`          | If `true`, clicking or tapping the status bar will cause the content to scroll to the top.
-| `swipeBackEnabled`       | `boolean`          | If `false`, Ionic will disable the "swipe-to-go-back" gesture across your application.
+| `swipeBackEnabled`       | `boolean`          | If `true`, Ionic will enable the "swipe-to-go-back" gesture across the application.
 | `tabButtonLayout`        | `TabButtonLayout`  | Overrides the default "layout" of all `ion-bar-button` across the whole application.
 | `toastEnter`             | `AnimationBuilder` | Provides a custom enter animation for all `ion-toast`, overriding the default "animation".
 | `toastLeave`             | `AnimationBuilder` | Provides a custom leave animation for all `ion-toast`, overriding the default "animation".


### PR DESCRIPTION
This PR adds basic "Config" documentation. It also creates a "Utilities" section for documenting other APIs like this.