### PR TITLE
fix: remove picker-column from components menu

### DIFF
--- a/src/components/menu/templates/components.tsx
+++ b/src/components/menu/templates/components.tsx
@@ -35,7 +35,6 @@ const items = {
   },
   'Date & Time Pickers': {
     'ion-datetime': '/docs/api/datetime',
-    'ion-picker-column': '/docs/api/picker-column',
     'ion-picker-controller': '/docs/api/picker-controller',
     'ion-picker': '/docs/api/picker'
   },


### PR DESCRIPTION
picker-column is only used internally and is excluded from the
generated docs data.