### PR TITLE
feat(build): parse heading for textContent before slugifying

### DIFF
--- a/scripts/build-pages/markdown-renderer/heading.ts
+++ b/scripts/build-pages/markdown-renderer/heading.ts
@@ -1,7 +1,9 @@
+import { JSDOM } from 'jsdom';
 import { slugify } from '../../../src/utils';
 
 export default (text: string, level: number) => {
-  const hash = slugify(text);
+  const { textContent } = JSDOM.fragment(text);
+  const hash = slugify(textContent);
   return `
     <h${level} id="${hash}">
       <a href="#${hash}">${text}</a>


### PR DESCRIPTION
In some cases, we are rendering headings that contain inline html
instead of just text, this parses headings during build using JSDOM
and uses the parsed textContent as the hash instead