### PR TITLE
chore: add trailing slashes to header root links

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -33,7 +33,7 @@ export class DocsHeader {
   render() {
     return (
       <header>
-        <stencil-route-link url="/docs">
+        <stencil-route-link url="/docs/">
           <Logo/>
         </stencil-route-link>
         <docs-section-nav/>

--- a/src/components/section-nav/section-nav.tsx
+++ b/src/components/section-nav/section-nav.tsx
@@ -31,7 +31,7 @@ const Appflow = () => (
 const Framework = () => (
   <nav class="SectionNav">
     <Dropdown label="Framework"/>
-    <stencil-route-link url="/docs" urlMatch={[/^\/docs(?!\/(api|components|cli|native)).*$/]}>Guide</stencil-route-link>
+    <stencil-route-link url="/docs/" urlMatch={[/^\/docs(?!\/(api|components|cli|native)).*$/]}>Guide</stencil-route-link>
     <stencil-route-link url="/docs/components" urlMatch={['/docs/api', '/docs/components']}>Components</stencil-route-link>
     <stencil-route-link url="/docs/cli">CLI</stencil-route-link>
     <stencil-route-link url="/docs/native">Native</stencil-route-link>


### PR DESCRIPTION
The development can't serve the root without a trailing slash,
so let's add these for now.