### PR TITLE
Update outdated ion-col syntax to match current grid documentation

### DIFF
--- a/src/pages/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
+++ b/src/pages/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
@@ -88,14 +88,14 @@ Next, in `tab2.page.html`, remove the currentImage img tag. In its place, use an
 ```html
 <ion-grid>
   <ion-row>
-  <ion-col col-6 *ngFor="let photo of photoService.photos">
+    <ion-col size="6" *ngFor="let photo of photoService.photos">
       <img [src]="photo.data" />
-      </ion-col>
+    </ion-col>
   </ion-row>
 </ion-grid>
 ```
 
-Here, we loop through each photo in the PhotoServices photos array, adding a new column for each. Since an ion-row consists of 12 “blocks” of space, and we’re setting the size to 6 (“col-6”), only 2 photos are displayed per row.
+Here, we loop through each photo in the PhotoServices photos array, adding a new column for each. Since an ion-row consists of 12 “blocks” of space, and we’re setting the size to 6 (`size="6"`), only 2 photos are displayed per row.
 
 Last, update the Fab button to call the PhotoService’s `takePicture` method:
 


### PR DESCRIPTION
While going through the *first-app-v4* Ionic tutorial, I ran into an issue with the grid layout. The tutorial was using the older syntax of `col-6` instead of `size="6"`, which doesn't work properly on V4 of Ionic and caused the photos to all display on one line instead of inside a grid.

By using the updated grid syntax located in the current docs at https://ionicframework.com/docs/api/grid/, the layout performs as intended by adding two photos per row in the grid. This PR updates the documentation to reflect the current grid documentation.