### PR TITLE
content(browser-support): copy edits and table styles

### DIFF
--- a/src/pages/intro/browser-support.md
+++ b/src/pages/intro/browser-support.md
@@ -7,7 +7,7 @@ nextUrl: '/docs/intro/versioning'
 
 # Browser Support
 
-Ionic's original goal was to make it easy to develop mobile apps using web technologies, including HTML, CSS and JavaScript. By using web technologies, Ionic is able to work across a wide range of devices, operating systems and browsers, all while using the same codebase.
+Ionic's earliest goal was to make it easy to develop mobile apps using web technologies like HTML, CSS, and JavaScript. Because of this foundation in web technologies, Ionic can run anywhere the web runs — iOS, Android, browsers, Electron, PWAs, and more.
 
 
 ## Mobile

--- a/src/pages/intro/browser-support.md
+++ b/src/pages/intro/browser-support.md
@@ -12,21 +12,24 @@ Ionic's original goal was to make it easy to develop mobile apps using web techn
 
 ## Mobile
 
-Browser support was first centered around supporting mobile devices through [Platform Continuity](/docs/intro/concepts#platform-continuity), and has been heavily tested on the operating systems listed below:
+In pursuit of [platform continuity](/docs/intro/concepts#platform-continuity), Ionic fully supports and is well tested on the mobile platforms listed below:
 
-- ### Android 4.4+
-  - [Latest Android Stats](https://developer.android.com/about/dashboards/)
-- ### iOS 10+
-  - [Latest iOS Stats](https://developer.apple.com/support/app-store/)
+| Platform     | Supported Versions |
+| ------------ | ------------------ |
+| **Android**  | 4.4+               |
+| **iOS**      | 10+                |
+
+> Check the [latest Android stats](https://developer.android.com/about/dashboards/) and the [latest iOS stats](https://developer.apple.com/support/app-store/) for up-to-date platform information.
 
 
 ## Desktop
 
-Ionic not only works great on mobile devices, but since it's based on web technologies it works great on desktop browsers too.
+Because Ionic is based on web technologies, it works just as well on desktop browsers as it does on mobile devices. For more information on desktop layouts, see [Cross Platform](/docs/building/cross-platform#desktop).
 
-- ### Chrome
-- ### Safari
-- ### Edge
-- ### Firefox
 
-For more information on desktop layouts, see [Cross Platform](/docs/building/cross-platform).
+| Browser     | Supported |
+| ----------- | --------- |
+| **Chrome**  | ✔         |
+| **Safari**  | ✔         |
+| **Edge**    | ✔         |
+| **Firefox** | ✔         |

--- a/src/pages/intro/browser-support.md
+++ b/src/pages/intro/browser-support.md
@@ -33,3 +33,7 @@ Because Ionic is based on web technologies, it works just as well on desktop bro
 | **Safari**  | ✔         |
 | **Edge**    | ✔         |
 | **Firefox** | ✔         |
+| **IE**      | 11+       |
+
+
+> Because Ionic is built with Stencil, see [Stencil's browser support](https://stenciljs.com/docs/browser-support) for a more detailed breakdown of support.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,3 +4,4 @@
 @import './pages/components.css';
 @import './pages/guides.css';
 @import './pages/appflow.css';
+@import './pages/browser-support.css';

--- a/src/styles/pages/browser-support.css
+++ b/src/styles/pages/browser-support.css
@@ -1,0 +1,3 @@
+.page-intro-browser-support tbody {
+  font-size: 18px;
+}


### PR DESCRIPTION
Cleans up the copy on the browser support page and presents the support lists in a different way.

<img width="704" alt="screen shot 2019-02-07 at 8 50 54 am" src="https://user-images.githubusercontent.com/2547860/52419379-93491c00-2ab5-11e9-97ef-0853156fbdb8.png">
