### PR TITLE
fix(nav): use non-strict matching for stencil-route-link

### DIFF
--- a/src/components/nav/nav.tsx
+++ b/src/components/nav/nav.tsx
@@ -36,6 +36,7 @@ export class DocsNav {
     return (
       <stencil-route-link
         url={url}
+        strict={false}
         exact>
           {text}
       </stencil-route-link>


### PR DESCRIPTION
This ensures that links in the nav are set as active whether or not there is a trailing slash in the URL.

```
/docs/api/fab
/docs/api/fab/
```