### PR TITLE
docs(demos): add demos for api docs

### DIFF
--- a/src/demos/api/anchor/index.html
+++ b/src/demos/api/anchor/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Anchor</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Anchor</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <p>
+        <ion-anchor href="#">Anchor</ion-anchor>
+      </p>
+
+      <p>
+        <ion-anchor href="#" style="text-decoration: underline">Underline Anchor</ion-anchor>
+      </p>
+
+      <p>
+        <ion-anchor href="#" class="custom">Custom Anchor</ion-anchor>
+      </p>
+
+      <p>
+        <ion-anchor color="dark" href="#">Dark Anchor</ion-anchor>
+      </p>
+
+      <p>
+        <ion-anchor color="danger" href="#">Danger Anchor</ion-anchor>
+      </p>
+
+      <p>
+        <ion-anchor id="toggleColor" color="tertiary" href="#">Dynamic Color</ion-anchor>
+      </p>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/avatar/index.html
+++ b/src/demos/api/avatar/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Avatar</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Avatar</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <ion-avatar>
+        <img src="/src/components/avatar/test/avatar.svg">
+      </ion-avatar>
+
+      <ion-chip>
+        <ion-avatar>
+          <img src="/src/components/avatar/test/avatar.svg">
+        </ion-avatar>
+        <ion-label>Chip Avatar</ion-label>
+      </ion-chip>
+
+      <ion-item>
+        <ion-avatar slot="start">
+          <img src="/src/components/avatar/test/avatar.svg">
+        </ion-avatar>
+        <ion-label>Item Avatar</ion-label>
+      </ion-item>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/chip/index.html
+++ b/src/demos/api/chip/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chip</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Chip</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <h2>Basic Chips</h2>
+      <ion-chip>
+        <ion-label>Default</ion-label>
+      </ion-chip>
+      <ion-chip style="border-radius: 4px;">
+        <ion-label>Border Radius</ion-label>
+      </ion-chip>
+      <ion-chip>
+        <ion-icon name="checkmark-circle"></ion-icon>
+        <ion-label>With Icon</ion-label>
+      </ion-chip>
+      <ion-chip>
+        <ion-avatar>
+          <img
+            src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSIjYzVkYmZmIiBkPSJNMCAwaDUxMnY1MTJIMHoiLz48cGF0aCBkPSJNMjU2IDMwNGM2MS42IDAgMTEyLTUwLjQgMTEyLTExMlMzMTcuNiA4MCAyNTYgODBzLTExMiA1MC40LTExMiAxMTIgNTAuNCAxMTIgMTEyIDExMnptMCA0MGMtNzQuMiAwLTIyNCAzNy44LTIyNCAxMTJ2NTZoNDQ4di01NmMwLTc0LjItMTQ5LjgtMTEyLTIyNC0xMTJ6IiBmaWxsPSIjODJhZWZmIi8+PC9zdmc+" />
+        </ion-avatar>
+        <ion-label>With Avatar</ion-label>
+      </ion-chip>
+      <ion-chip>
+        <ion-avatar>
+          <img
+            src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSIjYzVkYmZmIiBkPSJNMCAwaDUxMnY1MTJIMHoiLz48cGF0aCBkPSJNMjU2IDMwNGM2MS42IDAgMTEyLTUwLjQgMTEyLTExMlMzMTcuNiA4MCAyNTYgODBzLTExMiA1MC40LTExMiAxMTIgNTAuNCAxMTIgMTEyIDExMnptMCA0MGMtNzQuMiAwLTIyNCAzNy44LTIyNCAxMTJ2NTZoNDQ4di01NmMwLTc0LjItMTQ5LjgtMTEyLTIyNC0xMTJ6IiBmaWxsPSIjODJhZWZmIi8+PC9zdmc+" />
+        </ion-avatar>
+        <ion-label>With Icon and Avatar</ion-label>
+        <ion-icon name="close-circle"></ion-icon>
+      </ion-chip>
+
+      <h2>Color Chips</h2>
+      <ion-chip color="primary">
+        <ion-label>Primary</ion-label>
+      </ion-chip>
+      <ion-chip color="danger">
+        <ion-label>Danger</ion-label>
+      </ion-chip>
+      <ion-chip color="tertiary">
+        <ion-icon name="checkmark-circle"></ion-icon>
+        <ion-label>Tertiary with Icon</ion-label>
+      </ion-chip>
+      <ion-chip color="primary">
+        <ion-avatar>
+          <img
+            src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSIjYzVkYmZmIiBkPSJNMCAwaDUxMnY1MTJIMHoiLz48cGF0aCBkPSJNMjU2IDMwNGM2MS42IDAgMTEyLTUwLjQgMTEyLTExMlMzMTcuNiA4MCAyNTYgODBzLTExMiA1MC40LTExMiAxMTIgNTAuNCAxMTIgMTEyIDExMnptMCA0MGMtNzQuMiAwLTIyNCAzNy44LTIyNCAxMTJ2NTZoNDQ4di01NmMwLTc0LjItMTQ5LjgtMTEyLTIyNC0xMTJ6IiBmaWxsPSIjODJhZWZmIi8+PC9zdmc+" />
+        </ion-avatar>
+        <ion-label>Primary with Avatar</ion-label>
+      </ion-chip>
+      <ion-chip color="success">
+        <ion-label>Success with Icon</ion-label>
+        <ion-icon name="calendar"></ion-icon>
+      </ion-chip>
+
+      <h2>Outline Chips</h2>
+      <ion-chip outline>
+        <ion-label>Outline</ion-label>
+      </ion-chip>
+      <ion-chip outline color="danger">
+        <ion-label>Danger Outline</ion-label>
+      </ion-chip>
+      <ion-chip outline color="secondary">
+        <ion-icon name="checkmark-circle"></ion-icon>
+        <ion-label>Secondary Outline with Icon</ion-label>
+      </ion-chip>
+      <ion-chip outline color="primary">
+        <ion-label>Primary Outline with Avatar</ion-label>
+        <ion-avatar>
+          <img
+            src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj48cGF0aCBmaWxsPSIjYzVkYmZmIiBkPSJNMCAwaDUxMnY1MTJIMHoiLz48cGF0aCBkPSJNMjU2IDMwNGM2MS42IDAgMTEyLTUwLjQgMTEyLTExMlMzMTcuNiA4MCAyNTYgODBzLTExMiA1MC40LTExMiAxMTIgNTAuNCAxMTIgMTEyIDExMnptMCA0MGMtNzQuMiAwLTIyNCAzNy44LTIyNCAxMTJ2NTZoNDQ4di01NmMwLTc0LjItMTQ5LjgtMTEyLTIyNC0xMTJ6IiBmaWxsPSIjODJhZWZmIi8+PC9zdmc+" />
+        </ion-avatar>
+      </ion-chip>
+      <ion-chip outline>
+        <ion-icon name="git-pull-request"></ion-icon>
+        <ion-label>Outline with Icon and Avatar</ion-label>
+        <ion-icon name="close-circle"></ion-icon>
+      </ion-chip>
+
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/icon/index.html
+++ b/src/demos/api/icon/index.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Icon</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Icon</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <ion-list>
+        <ion-item>
+          <ion-icon name="home" id="dynamicColor" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="home"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="home" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="home"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon id="dynamicHomeIcon" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              id="dynamicHomeIcon"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="md-home" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="md-home"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="ios-home" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="ios-home"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="ios-home" slot="end"></ion-icon>
+          <ion-label>
+            <code>
+              name="ios-home"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="ios-star-outline" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="ios-star-outline"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="IOS-STAR-OUTLINE" slot="end"></ion-icon>
+          <ion-label>
+            <code>
+              name="IOS-STAR-OUTLINE"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="md-home" color="primary" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="md-home"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="logo-twitter" color="secondary" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="logo-twitter"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon ios="logo-apple" md="logo-android" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              ios="logo-apple" md="logo-android"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon name="color-filter" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="color-filter"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon ios="ios-color-filter" md="md-color-filter" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              ios="ios-color-filter" md="md-color-filter"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon ios="MD-COLOR-FILTER" md="IOS-COLOR-FILTER" slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              ios="MD-COLOR-FILTER" md="IOS-COLOR-FILTER"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item>
+          <ion-icon slot="start"></ion-icon>
+          <ion-label>
+            <code>
+              name="null"
+            </code>
+          </ion-label>
+        </ion-item>
+
+        <ion-item detail="true">
+          <ion-label>
+            <code>
+              ion-item w/ [detail="true"] attr. text text text text text text
+            </code>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/note/index.html
+++ b/src/demos/api/note/index.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Note</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Note</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <ion-list>
+        <ion-list-header>Notes Right</ion-list-header>
+        <ion-item>
+          <ion-label>Default Note</ion-label>
+          <ion-note slot="end">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Primary Note</ion-label>
+          <ion-note slot="end" color="primary">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Secondary Note</ion-label>
+          <ion-note slot="end" color="secondary">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Tertiary Note</ion-label>
+          <ion-note slot="end" color="tertiary">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Success Note</ion-label>
+          <ion-note slot="end" color="success">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Warning Note</ion-label>
+          <ion-note slot="end" color="warning">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Danger Note</ion-label>
+          <ion-note slot="end" color="danger">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Light Note</ion-label>
+          <ion-note slot="end" color="light">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Medium Note</ion-label>
+          <ion-note slot="end" color="medium">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Dark Note</ion-label>
+          <ion-note slot="end" color="dark">99</ion-note>
+        </ion-item>
+
+        <ion-item onclick="toggleColor()">
+          <ion-note id="toggleColor" slot="end" color="primary">primary</ion-note>
+          <ion-label>Dynamic Note Color (toggle)</ion-label>
+        </ion-item>
+      </ion-list>
+
+      <ion-list>
+        <ion-list-header>Notes Left</ion-list-header>
+        <ion-item>
+          <ion-label>Default Note</ion-label>
+          <ion-note slot="start">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Primary Note</ion-label>
+          <ion-note slot="start" color="primary">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Secondary Note</ion-label>
+          <ion-note slot="start" color="secondary">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Tertiary Note</ion-label>
+          <ion-note slot="start" color="tertiary">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Success Note</ion-label>
+          <ion-note slot="start" color="success">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Warning Note</ion-label>
+          <ion-note slot="start" color="warning">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Danger Note</ion-label>
+          <ion-note slot="start" color="danger">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Light Note</ion-label>
+          <ion-note slot="start" color="light">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Medium Note</ion-label>
+          <ion-note slot="start" color="medium">99</ion-note>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Dark Note</ion-label>
+          <ion-note slot="start" color="dark">99</ion-note>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/radio/index.html
+++ b/src/demos/api/radio/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Radio</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Radio</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <ion-list>
+        <ion-radio-group id="fruitRadio">
+          <ion-item-divider>
+            <ion-label>Fruits (Group w/ values)</ion-label>
+          </ion-item-divider>
+          <ion-item>
+            <ion-label>Apple</ion-label>
+            <ion-radio slot="start" value="apple"></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Grape, checked, disabled</ion-label>
+            <ion-radio slot="start" id="grapeChecked" value="grape" checked disabled></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Cherry</ion-label>
+            <ion-radio slot="start" color="danger" value="cherry"></ion-radio>
+          </ion-item>
+        </ion-radio-group>
+
+        <ion-radio-group id="pizzaRadio">
+          <ion-item-divider>
+            <ion-label>Extra Pizza Topping (Group w/ no values)</ion-label>
+          </ion-item-divider>
+          <ion-item>
+            <ion-label>Pepperoni</ion-label>
+            <ion-radio slot="end" name="pepperoni" checked></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Sausage</ion-label>
+            <ion-radio slot="end" color="danger" name="sausage"></ion-radio>
+          </ion-item>
+        </ion-radio-group>
+
+        <ion-radio-group id="veggiesRadio" allow-empty-selection>
+          <ion-item-divider>
+            <ion-label>Veggies (Group w/ allow empty)</ion-label>
+          </ion-item-divider>
+          <ion-item>
+            <ion-label>Carrot</ion-label>
+            <ion-radio slot="end" value="carrot"></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Tomato</ion-label>
+            <ion-radio slot="end" value="tomato"></ion-radio>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>Broccoli</ion-label>
+            <ion-radio id="dangerRadio" slot="end" color="danger" value="broccoli" checked></ion-radio>
+          </ion-item>
+        </ion-radio-group>
+
+        <ion-item>
+          <ion-button slot="start" onClick="toggleBoolean('grapeChecked', 'checked')" fill="outline" size="small">
+            Checked</ion-button>
+          <ion-button slot="start" onClick="toggleBoolean('grapeChecked', 'disabled')" fill="outline" size="small">
+            Disabled</ion-button>
+          <ion-button slot="end" onClick="printRadioValues()" fill="outline" size="small">Print</ion-button>
+          <ion-button slot="end" onClick="toggleString('dangerRadio', 'color', 'danger', 'secondary')" fill="outline"
+            size="small" color="danger">Color</ion-button>
+        </ion-item>
+      </ion-list>
+
+      <pre id="valuesCode"></pre>
+
+      <ion-list>
+        <ion-list-header>
+          No Radio Group
+        </ion-list-header>
+        <ion-item>
+          <ion-label>Kiwi, (ionChange) Secondary color</ion-label>
+          <ion-radio slot="start" color="secondary"></ion-radio>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Strawberry, (ionChange) checked="true"</ion-label>
+          <ion-radio slot="start" color="light" checked="true"></ion-radio>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Checkbox right, checked, really long text that should ellipsis</ion-label>
+          <ion-radio slot="end" color="danger" checked></ion-radio>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Checkbox right side</ion-label>
+          <ion-radio slot="end" checked></ion-radio>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Button w/ right side default icon, really long text that should ellipsis</ion-label>
+          <ion-icon name="information-circle" slot="end"></ion-icon>
+        </ion-item>
+
+      </ion-list>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/reorder/index.html
+++ b/src/demos/api/reorder/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reorder</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Reorder</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <ion-list>
+        <ion-reorder-group id="reorder">
+          <ion-item>
+            <ion-label>
+              Item 1 (default ion-reorder)
+            </ion-label>
+            <ion-reorder slot="end"></ion-reorder>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>
+              Item 2 (default ion-reorder)
+            </ion-label>
+            <ion-reorder slot="end"></ion-reorder>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>
+              Item 3 (default ion-reorder slot="start")
+            </ion-label>
+            <ion-reorder slot="start"></ion-reorder>
+          </ion-item>
+
+          <ion-item color="secondary">
+            <ion-label>
+              Item 4 (default ion-reorder slot="start")
+            </ion-label>
+            <ion-reorder slot="start"></ion-reorder>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>
+              Item 5 (custom ion-reorder)
+            </ion-label>
+            <ion-reorder slot="end">
+              <ion-icon name="pizza"></ion-icon>
+            </ion-reorder>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>
+              Item 6 (custom ion-reorder)
+            </ion-label>
+            <ion-reorder slot="end">
+              <ion-icon name="pizza"></ion-icon>
+            </ion-reorder>
+          </ion-item>
+
+          <ion-item>
+            <ion-label>
+              Item 7 (custom ion-reorder slot="start")
+            </ion-label>
+            <ion-reorder slot="start">
+              <ion-icon name="pizza"></ion-icon>
+            </ion-reorder>
+          </ion-item>
+
+          <ion-reorder>
+            <ion-item>
+              <ion-label>
+                Item 8 (the whole item can be dragged)
+              </ion-label>
+            </ion-item>
+          </ion-reorder>
+
+          <ion-reorder>
+            <ion-item>
+              <ion-label>
+                Item 9 (the whole item can be dragged)
+              </ion-label>
+            </ion-item>
+          </ion-reorder>
+
+          <ion-reorder>
+            <ion-item>
+              <ion-label>
+                Item 10 (the whole item can be dragged)
+              </ion-label>
+            </ion-item>
+          </ion-reorder>
+
+        </ion-reorder-group>
+      </ion-list>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    function toggleEdit() {
+      const reorderGroup = document.getElementById('reorder');
+      reorderGroup.disabled = !reorderGroup.disabled;
+    }
+  </script>
+</body>
+
+</html>

--- a/src/demos/api/segment/index.html
+++ b/src/demos/api/segment/index.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Segment</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Segment</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <!-- Label only -->
+      <ion-segment>
+        <ion-segment-button checked>
+          <ion-label>Item One</ion-label>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-label>Item Two</ion-label>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-label>Item Three</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Icon only -->
+      <ion-segment>
+        <ion-segment-button>
+          <ion-icon name="call"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button checked>
+          <ion-icon name="heart"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-icon name="pin"></ion-icon>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Icon top -->
+      <ion-segment>
+        <ion-segment-button>
+          <ion-label>Item One</ion-label>
+          <ion-icon name="call"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button checked>
+          <ion-label>Item Two</ion-label>
+          <ion-icon name="heart"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-label>Item Three</ion-label>
+          <ion-icon name="pin"></ion-icon>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Icon bottom -->
+      <ion-segment>
+        <ion-segment-button checked layout="icon-bottom">
+          <ion-icon name="call"></ion-icon>
+          <ion-label>Item One</ion-label>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-bottom">
+          <ion-icon name="heart"></ion-icon>
+          <ion-label>Item Two</ion-label>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-bottom">
+          <ion-icon name="pin"></ion-icon>
+          <ion-label>Item Three</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Icon start -->
+      <ion-segment scrollable>
+        <ion-segment-button checked layout="icon-start">
+          <ion-label>Item One</ion-label>
+          <ion-icon name="call"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-start">
+          <ion-label>Item Two</ion-label>
+          <ion-icon name="heart"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-start">
+          <ion-label>Item Three</ion-label>
+          <ion-icon name="pin"></ion-icon>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Icon end -->
+      <ion-segment scrollable>
+        <ion-segment-button checked layout="icon-end">
+          <ion-icon name="call"></ion-icon>
+          <ion-label>Item One</ion-label>
+        </ion-segment-button>
+        <ion-segment-button disabled layout="icon-end">
+          <ion-icon name="heart"></ion-icon>
+          <ion-label>Item Two</ion-label>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-end">
+          <ion-icon name="pin"></ion-icon>
+          <ion-label>Item Three</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Disabled -->
+      <ion-segment scrollable disabled>
+        <ion-segment-button checked layout="icon-end">
+          <ion-icon name="call"></ion-icon>
+          <ion-label>Item One</ion-label>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-end">
+          <ion-icon name="heart"></ion-icon>
+          <ion-label>Item Two</ion-label>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-end">
+          <ion-icon name="pin"></ion-icon>
+          <ion-label>Item Three</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Color -->
+      <ion-segment scrollable color="secondary">
+        <ion-segment-button checked layout="icon-end">
+          <ion-icon name="call"></ion-icon>
+          <ion-label>Item One</ion-label>
+        </ion-segment-button>
+        <ion-segment-button disabled layout="icon-end">
+          <ion-icon name="heart"></ion-icon>
+          <ion-label>Item Two</ion-label>
+        </ion-segment-button>
+        <ion-segment-button layout="icon-end">
+          <ion-icon name="pin"></ion-icon>
+          <ion-label>Item Three</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+
+      <!-- Overflow Icons -->
+      <ion-segment scrollable color="tertiary">
+        <ion-segment-button>
+          <ion-icon name="home"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button checked>
+          <ion-icon name="heart"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-icon name="pin"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-icon name="star"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-icon name="call"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-icon name="globe"></ion-icon>
+        </ion-segment-button>
+        <ion-segment-button>
+          <ion-icon name="basket"></ion-icon>
+        </ion-segment-button>
+      </ion-segment>
+
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/thumbnail/index.html
+++ b/src/demos/api/thumbnail/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Thumbnail</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Thumbnail</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <ion-thumbnail>
+        <img src="/src/components/thumbnail/test/thumbnail.svg">
+      </ion-thumbnail>
+
+      <ion-item>
+        <ion-thumbnail slot="start">
+          <img src="/src/components/thumbnail/test/thumbnail.svg">
+        </ion-thumbnail>
+        <ion-label>Item Thumbnail</ion-label>
+      </ion-item>
+
+      <ion-item>
+        <ion-thumbnail slot="start">
+          <img src="/src/components/thumbnail/test/thumbnail.svg">
+        </ion-thumbnail>
+        <ion-label>Wide Thumbnail</ion-label>
+      </ion-item>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/src/demos/api/toggle/index.html
+++ b/src/demos/api/toggle/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toggle</title>
+  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
+  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-title>Toggle</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content fullscreen padding>
+      <ion-list>
+        <ion-item>
+          <ion-label>Apple</ion-label>
+          <ion-toggle slot="start" name="apple" checked></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Banana</ion-label>
+          <ion-toggle slot="start" name="banana" checked></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Cherry, disabled</ion-label>
+          <ion-toggle slot="start" color="danger" name="cherry" disabled></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Grape, checked, disabled</ion-label>
+          <ion-toggle slot="start" id="grapeChecked" name="grape" checked disabled></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Kiwi, (ionChange) Secondary color</ion-label>
+          <ion-toggle slot="start" color="secondary" (ionChange)="kiwiChange($event)"></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Strawberry, (ionChange) checked="true"</ion-label>
+          <ion-toggle slot="start" color="light" (ionChange)="strawberryChange($event)" checked="true"></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Checkbox right, checked, really long text that should ellipsis</ion-label>
+          <ion-toggle slot="end" color="danger" checked></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Checkbox right side</ion-label>
+          <ion-toggle slot="end" checked></ion-toggle>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Button w/ right side default icon, really long text that should ellipsis</ion-label>
+          <ion-icon name="information-circle" slot="end"></ion-icon>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>


### PR DESCRIPTION
adds the following demos
- anchor
- avatar
- chip
- icon
- note
- radio
- reorder
- segment
- thumbnail
- toggle

taken from API demos in ionic

references #463 

:warning: needs the images for avatar/thumbnail :warning: