### PR TITLE
chore: self-host ionic instead of using unpkg

### DIFF
--- a/src/demos/api/action-sheet/index.html
+++ b/src/demos/api/action-sheet/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Action Sheet</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/alert/index.html
+++ b/src/demos/api/alert/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Alert</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/anchor/index.html
+++ b/src/demos/api/anchor/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Anchor</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/avatar/index.html
+++ b/src/demos/api/avatar/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Avatar</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/badge/index.html
+++ b/src/demos/api/badge/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Badge</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/button/index.html
+++ b/src/demos/api/button/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Button</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/card/index.html
+++ b/src/demos/api/card/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Card</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/checkbox/index.html
+++ b/src/demos/api/checkbox/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Checkbox</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/chip/index.html
+++ b/src/demos/api/chip/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Chip</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/datetime/index.html
+++ b/src/demos/api/datetime/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DateTime</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/fab/index.html
+++ b/src/demos/api/fab/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Fab</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/grid/index.html
+++ b/src/demos/api/grid/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Grid</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/icon/index.html
+++ b/src/demos/api/icon/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Icon</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/input/index.html
+++ b/src/demos/api/input/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Input</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/list/index.html
+++ b/src/demos/api/list/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>List</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/loading/index.html
+++ b/src/demos/api/loading/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Action Sheet</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/menu/index.html
+++ b/src/demos/api/menu/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Menu</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/modal/index.html
+++ b/src/demos/api/modal/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Modal</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/nav/index.html
+++ b/src/demos/api/nav/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Nav</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/note/index.html
+++ b/src/demos/api/note/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Note</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/radio/index.html
+++ b/src/demos/api/radio/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Radio</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/range/index.html
+++ b/src/demos/api/range/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Range</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/reorder/index.html
+++ b/src/demos/api/reorder/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Reorder</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/searchbar/index.html
+++ b/src/demos/api/searchbar/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Searchbar</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/segment/index.html
+++ b/src/demos/api/segment/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Segment</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/select/index.html
+++ b/src/demos/api/select/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Select</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/slides/index.html
+++ b/src/demos/api/slides/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Slides</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script defer src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script defer src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/spinner/index.html
+++ b/src/demos/api/spinner/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Spinner</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/tabs/index.html
+++ b/src/demos/api/tabs/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tabs</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/thumbnail/index.html
+++ b/src/demos/api/thumbnail/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Thumbnail</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/toast/index.html
+++ b/src/demos/api/toast/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Toast</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css"/>
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/src/demos/api/toggle/index.html
+++ b/src/demos/api/toggle/index.html
@@ -5,8 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Toggle</title>
-  <link rel="stylesheet" href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" />
-  <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css" />
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
   <style>
     :root {
       --ion-safe-area-top: 20px;

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -16,6 +16,7 @@ export const config: Config = {
     { src: 'pages/**/*.json' },
     { src: 'demos' },
     { src: 'components/color-gen/demo/index.html', dest: 'pages/theming/color-generator/index.html' },
-    { src: 'robots.txt', dest: '../robots.txt' }
+    { src: 'robots.txt', dest: '../robots.txt' },
+    { src: '../node_modules/@ionic/core', dest: 'assets/ionic' }
   ]
 };


### PR DESCRIPTION
This adds a copy task that places Ionic at `/docs/assets/ionic`. So we can now use Ionic in the demos like this:

```html
  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
  <script src="/docs/assets/ionic/dist/ionic.js"></script>
```

closes #104 