### PR TITLE
docs(toolbar): add toolbar examples

### DIFF
--- a/src/demos/api/toolbar/index.html
+++ b/src/demos/api/toolbar/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Toolbar</title>
+  <link rel="stylesheet" href="/docs/assets/ionic/css/ionic.bundle.css"/>
+  <script src="/docs/assets/ionic/dist/ionic.js"></script>
+  <style>
+    :root {
+      --ion-safe-area-top: 20px;
+      --ion-safe-area-bottom: 22px;
+    }
+  </style>
+</head>
+<body>
+  <ion-app>
+    <ion-header translucent>
+      <ion-toolbar>
+        <ion-buttons slot="secondary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="logo-ionic"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      
+        <ion-title>Header</ion-title>
+        
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="star"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    
+    <ion-content fullscreen>
+      <ion-toolbar>
+        <ion-title>Default</ion-title>
+      </ion-toolbar>
+    
+      <ion-toolbar color="primary">
+        <ion-title>Primary</ion-title>
+      </ion-toolbar>
+      
+      <ion-toolbar color="secondary">
+        <ion-title>Secondary</ion-title>
+      </ion-toolbar>
+      
+      <ion-toolbar color="tertiary">
+        <ion-title>Tertiary</ion-title>
+      </ion-toolbar>
+      
+      <ion-toolbar color="success">
+        <ion-title>Success</ion-title>
+      </ion-toolbar>
+      
+      <ion-toolbar color="warning">
+        <ion-title>Warning</ion-title>
+      </ion-toolbar>
+      
+      <ion-toolbar color="danger">
+        <ion-title>Danger</ion-title>
+      </ion-toolbar>
+      
+      <ion-toolbar>
+        <ion-buttons slot="secondary">
+          <ion-button>Messages (1)</ion-button>
+        </ion-buttons>
+        
+        <ion-title>Buttons</ion-title>
+        
+        <ion-buttons slot="primary">
+          <ion-button>Log Out</ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-content>
+    
+    <ion-footer>
+      <ion-toolbar>
+        <ion-buttons slot="secondary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="finger-print"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+
+        <ion-title>Footer</ion-title>
+        
+        <ion-buttons slot="primary">
+          <ion-button>
+            <ion-icon slot="icon-only" name="more"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-footer>
+  </ion-app>
+</body>
+</html>


### PR DESCRIPTION
Adds examples for ion-toolbar (ion-header, ion-buttons, ion-title, etc)

references #463