### PR TITLE
update firebase config with default @angular/pwa service worker filename

### DIFF
--- a/src/pages/publishing/progressive-web-app.md
+++ b/src/pages/publishing/progressive-web-app.md
@@ -64,7 +64,7 @@ The last thing needed is to make sure caching headers are being set correctly. T
     ]
   },
   {
-    "source": "sw.js",
+    "source": "ngsw-worker.js",
     "headers": [
       {
         "key": "Cache-Control",


### PR DESCRIPTION
The example Firebase config shows **sw.js** as the name of the service worker for which a cache policy should be set. However, the default filename used by @angular/pwa is **ngsw-worker.js**. This change reflects the default filename.