### PR TITLE
fix(usage): remove margin between heading and usage examples

### DIFF
--- a/src/components/code/code.css
+++ b/src/components/code/code.css
@@ -19,3 +19,7 @@ docs-code:before {
   text-transform: uppercase;
   top: 0;
 }
+
+docs-code pre {
+  margin-top: 0;
+}

--- a/src/components/tabs/tabs.css
+++ b/src/components/tabs/tabs.css
@@ -6,7 +6,6 @@ docs-tabs {
 
 docs-tabs header {
   border-bottom: solid 1px rgba(0,32,88, 0.1);
-  margin-bottom: 1rem;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
per ben

<img width="693" alt="screen shot 2019-03-06 at 3 12 35 pm" src="https://user-images.githubusercontent.com/6577830/53910677-68a1a300-4022-11e9-812c-725689176e3e.png">
