### PR TITLE
docs(layout): add information on global stylesheets

### DIFF
--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -31,6 +31,7 @@ const items = {
   'Layout': {
     'Structure': '/docs/layout/structure',
     'Responsive Grid': '/docs/layout/grid',
+    'Global Stylesheets': '/docs/layout/global-stylesheets',
     'CSS Utilities': '/docs/layout/css-utilities',
   },
   'Theming': {

--- a/src/pages/faq/tips.md
+++ b/src/pages/faq/tips.md
@@ -14,7 +14,7 @@ contributors:
 To update a [npm](https://www.npmjs.com/) dependency, run the following, where `<package-name>` is the package to update:
 
 ```shell
-$ npm install <package-name>@<version|latest> --save
+$ npm install &lt;package-name>@<version|latest&gt; --save
 ```
 
 For instance, to update the `@ionic/angular` package to the release tagged `latest`, run:

--- a/src/pages/installation/cdn.md
+++ b/src/pages/installation/cdn.md
@@ -119,7 +119,7 @@ See [Global Stylesheets](../layout/global-stylesheets) for the styles that each 
 
 ## Ionicons CDN
 
-Ionicons is packaged by default with the Ionic Framework, so no installation is necessary if you're using Ionic. To use Ionicons without Ionic Framework, place the following `<script>` near the end of your page, right before the closing `</body>` tag, to enable them.
+Ionicons is packaged by default with the Ionic Framework, so no installation is necessary if you're using Ionic. To use Ionicons without Ionic Framework, place the following `<script>` near the end of your page, right before the closing `</body>` tag.
 
 ```html
 <script src="https://unpkg.com/ionicons@latest/dist/ionicons.js"></script>

--- a/src/pages/installation/cdn.md
+++ b/src/pages/installation/cdn.md
@@ -10,44 +10,121 @@ contributors:
 
 # Ionic Packages
 
-Depending on whether you're using Angular, another framework, or none at all, there are a few different ways to install Ionic.
+Ionic provides different packages that can be used to quickly get started using Ionic Framework or Ionicons in a test environment, Angular, any other framework, or none at all.
 
-## Using Ionic in Angular
+## Ionic Framework CDN
 
-When using Ionic in an Angular project, install the latest `@ionic/angular` package from [npm](/docs/faq/glossary#npm). This comes with all of the Ionic components and Angular specific services and features.
+Ionic Framework can be quickly included from a CDN for quick testing in a [Plunker](https://plnkr.co/), [Codepen](codepen.io), or any other online code editor!
 
-```shell
-$ npm install @ionic/angular@latest --save
-```
-
-Each time there is a new Ionic release, the [version](/docs/intro/versioning) will increment. The version can be [updated using npm](/docs/faq/tips#updating-dependencies), as well.
-
-
-## Using Ionic from a CDN
-
-Ionic can also be included from a CDN!
-
-It's recommended to use [unpkg](https://unpkg.com) to access the Framework from a CDN. To get the latest version, add the following inside the `<head></head>` element in an HTML file:
+It's recommended to use [unpkg](https://unpkg.com) to access the Framework from a CDN. To get the latest version, add the following inside the `<head>` element in an HTML file, or where external assets are included in the online code editor:
 
 ```html
 <script src="https://unpkg.com/@ionic/core@latest/dist/ionic.js"></script>
 <link href="https://unpkg.com/@ionic/core@latest/css/ionic.bundle.css" rel="stylesheet">
 ```
 
-With this it's possible to use all of the Ionic components without having to install anything.
+With this it's possible to use all of the Ionic Framework core components without having to install a framework. The CSS bundle will include all of the Ionic [Global Stylesheets](../layout/global-stylesheets).
 
 <blockquote>
   <p>
-    This does not install Angular or any frameworks. This allows use of Ionic components without a framework.
+    This does not install Angular or any other frameworks. This allows use of the Ionic Framework core components without a framework.
   </p>
 </blockquote>
 
 
-## Ionicons from a CDN
+## Angular + Ionic Framework
 
-Ionicons is packaged by default with the Ionic Framework, so no installation is necessary if you're using Ionic. Want to use Ionicons without Ionic Framework? Place the following `<script>` near the end of your page, right before the closing `</body>` tag, to enable them.
+When using Ionic Framework in an Angular project, install the latest `@ionic/angular` package from [npm](/docs/faq/glossary#npm). This comes with all of the Ionic Framework components and Angular specific services and features.
+
+```shell
+$ npm install @ionic/angular@latest --save
+```
+
+Each time there is a new Ionic Framework release, this [version](/docs/intro/versioning) will need to be updated to get the latest features and fixes. The version can be [updated using npm](/docs/faq/tips#updating-dependencies), as well.
+
+
+### CSS
+
+Create a global stylesheet file and add it to the `styles` object in the [Angular workspace config](https://angular.io/guide/workspace-config). Add the following imports to that file:
+
+```css
+/* Core CSS required for Ionic components to work properly */
+@import "~@ionic/angular/css/core.css";
+
+/* Basic CSS for apps built with Ionic */
+@import "~@ionic/angular/css/normalize.css";
+@import "~@ionic/angular/css/structure.css";
+@import "~@ionic/angular/css/typography.css";
+
+/* Optional CSS utils that can be commented out */
+@import "~@ionic/angular/css/padding.css";
+@import "~@ionic/angular/css/float-elements.css";
+@import "~@ionic/angular/css/text-alignment.css";
+@import "~@ionic/angular/css/text-transformation.css";
+@import "~@ionic/angular/css/flex-utils.css";
+@import "~@ionic/angular/css/display.css";
+```
+
+See [Global Stylesheets](../layout/global-stylesheets) for the styles that each of these files contain.
+
+
+## Stencil + Ionic Framework
+
+When using Ionic Framework in a Stencil project, install the latest `@ionic/core` package from [npm](/docs/faq/glossary#npm). This comes with all of the Ionic Framework components.
+
+```shell
+$ npm install @ionic/core@latest --save
+```
+
+### JS
+
+Include an import of `@ionic/core` in the root app file:
+
+```typescript
+import '@ionic/core';
+```
+
+### CSS
+
+Create a global stylesheet file and add it to the `config` object in the [Stencil Config](https://stenciljs.com/docs/config).
+
+```javascript
+exports.config = {
+  // ...
+
+  globalStyle: 'src/global.css'
+
+  // ...
+};
+```
+
+Add the following imports to that file:
+
+```css
+/* Core CSS required for Ionic components to work properly */
+@import "~@ionic/core/css/core.css";
+
+/* Basic CSS for apps built with Ionic */
+@import "~@ionic/core/css/normalize.css";
+@import "~@ionic/core/css/structure.css";
+@import "~@ionic/core/css/typography.css";
+
+/* Optional CSS utils that can be commented out */
+@import "~@ionic/core/css/padding.css";
+@import "~@ionic/core/css/float-elements.css";
+@import "~@ionic/core/css/text-alignment.css";
+@import "~@ionic/core/css/text-transformation.css";
+@import "~@ionic/core/css/flex-utils.css";
+@import "~@ionic/core/css/display.css";
+```
+
+See [Global Stylesheets](../layout/global-stylesheets) for the styles that each of these files contain.
+
+
+## Ionicons CDN
+
+Ionicons is packaged by default with the Ionic Framework, so no installation is necessary if you're using Ionic. To use Ionicons without Ionic Framework, place the following `<script>` near the end of your page, right before the closing `</body>` tag, to enable them.
 
 ```html
 <script src="https://unpkg.com/ionicons@latest/dist/ionicons.js"></script>
 ```
-

--- a/src/pages/installation/cdn.md
+++ b/src/pages/installation/cdn.md
@@ -14,7 +14,7 @@ Ionic provides different packages that can be used to quickly get started using 
 
 ## Ionic Framework CDN
 
-Ionic Framework can be quickly included from a CDN for quick testing in a [Plunker](https://plnkr.co/), [Codepen](https://codepen.io), or any other online code editor!
+Ionic Framework can be included from a CDN for quick testing in a [Plunker](https://plnkr.co/), [Codepen](https://codepen.io), or any other online code editor!
 
 It's recommended to use [unpkg](https://unpkg.com) to access the Framework from a CDN. To get the latest version, add the following inside the `<head>` element in an HTML file, or where external assets are included in the online code editor:
 

--- a/src/pages/installation/cdn.md
+++ b/src/pages/installation/cdn.md
@@ -14,7 +14,7 @@ Ionic provides different packages that can be used to quickly get started using 
 
 ## Ionic Framework CDN
 
-Ionic Framework can be quickly included from a CDN for quick testing in a [Plunker](https://plnkr.co/), [Codepen](codepen.io), or any other online code editor!
+Ionic Framework can be quickly included from a CDN for quick testing in a [Plunker](https://plnkr.co/), [Codepen](https://codepen.io), or any other online code editor!
 
 It's recommended to use [unpkg](https://unpkg.com) to access the Framework from a CDN. To get the latest version, add the following inside the `<head>` element in an HTML file, or where external assets are included in the online code editor:
 
@@ -25,11 +25,7 @@ It's recommended to use [unpkg](https://unpkg.com) to access the Framework from 
 
 With this it's possible to use all of the Ionic Framework core components without having to install a framework. The CSS bundle will include all of the Ionic [Global Stylesheets](../layout/global-stylesheets).
 
-<blockquote>
-  <p>
-    This does not install Angular or any other frameworks. This allows use of the Ionic Framework core components without a framework.
-  </p>
-</blockquote>
+> This does not install Angular or any other frameworks. This allows use of the Ionic Framework core components without a framework.
 
 
 ## Angular + Ionic Framework
@@ -128,3 +124,5 @@ Ionicons is packaged by default with the Ionic Framework, so no installation is 
 ```html
 <script src="https://unpkg.com/ionicons@latest/dist/ionicons.js"></script>
 ```
+
+> See [Ionicons usage](https://ionicons.com/usage) for more information on using Ionicons.

--- a/src/pages/layout/css-utilities.md
+++ b/src/pages/layout/css-utilities.md
@@ -1,8 +1,8 @@
 ---
 initialTab: 'preview'
 inlineHtmlPreviews: true
-previousText: 'Responsive Grid'
-previousUrl: '/docs/layout/grid'
+previousText: 'Global Stylesheets'
+previousUrl: '/docs/layout/global-stylesheets'
 nextText: 'Theming'
 nextUrl: '/docs/theming/basics'
 contributors:
@@ -17,7 +17,7 @@ contributors:
 
 # CSS Utilities
 
-Ionic provides a set of CSS utility classes that can be used on any element in order to modify the text, element placement or adjust the padding and margin.
+Ionic Framework provides a set of CSS utility classes that can be used on any element in order to modify the text, element placement or adjust the padding and margin.
 
 
 ## Text Modification
@@ -204,7 +204,7 @@ The display CSS property determines if an element should be visible or not. The 
 
 | Class         | Style Rule                      | Description                                                                                               |
 |---------------|---------------------------------|-----------------------------------------------------------------------------------------------------------|
-| `.ion-hide`   | `display: none`                 | The element will be hidden. 
+| `.ion-hide`   | `display: none`                 | The element will be hidden.
 
 ### Responsive Display Attributes
 

--- a/src/pages/layout/css-utilities.md
+++ b/src/pages/layout/css-utilities.md
@@ -19,6 +19,12 @@ contributors:
 
 Ionic Framework provides a set of CSS utility classes that can be used on any element in order to modify the text, element placement or adjust the padding and margin.
 
+<blockquote>
+  <p>
+    If your app was not started using an available Ionic Framework starter, the stylesheets listed in the <a href="./global-stylesheets#optional">optional section of the global stylesheets</a> will need to be included in order for these styles to work.
+  </p>
+</blockquote>
+
 
 ## Text Modification
 

--- a/src/pages/layout/global-stylesheets.md
+++ b/src/pages/layout/global-stylesheets.md
@@ -1,0 +1,75 @@
+---
+initialTab: 'preview'
+inlineHtmlPreviews: true
+previousText: 'Responsive Grid'
+previousUrl: '/docs/layout/grid'
+nextText: 'CSS Utilities'
+nextUrl: '/docs/layout/css-utilities'
+contributors:
+  - brandyscarney
+---
+
+# Global Stylesheets
+
+While Ionic Framework component styles are self-contained, there are several global stylesheets that should be included in order to use all of Ionic's features. Some of the stylesheets are required in order for an Ionic Framework app to look and behave properly, and others include optional utilities to quickly style your app.
+
+## Available Stylesheets
+
+### Required
+
+The following CSS file must be included in order for Ionic Framework to work properly.
+
+#### core.css
+
+This file is the only stylesheet that is required in order for Ionic components to work properly. It includes app specific styles, and allows the `color` property to work across components. If this file is not included the colors will not show up and some elements may not appear properly.
+
+
+### Recommended
+
+The following CSS files are recommended to be included in an Ionic Framework app. If they are not included, some elements may have undesired styles. If Ionic Framework components are being used outside of an app, these files may not be necessary.
+
+#### structure.css
+
+Applies styles to `<html>` and defaults `box-sizing` to `border-box`. It ensures scrolling behaves like native in mobile devices.
+
+#### typography.css
+
+Typography changes the font-family of the entire document and modifies the font styles for heading elements. It also applies positioning styles to some native text elements.
+
+#### normalize.css
+
+Makes browsers render all elements more consistently and in line with modern standards. It is based on [Normalize.css](https://necolas.github.io/normalize.css/).
+
+
+### Optional
+
+The following set of CSS files are optional and can safely be commented out or removed if the application is not using any of the features.
+
+#### padding.css
+
+Adds utility classes to modify the padding or margin on any element, see [CSS Utilities](./css-utilities#content-space) for usage information.
+
+#### float-elements.css
+
+Adds utility classes to float an element based on the breakpoint and side, see [CSS Utilities](./css-utilities#element-placement) for usage information.
+
+#### text-alignment.css
+
+Adds utility classes to align the text of an element or adjust the white space based on the breakpoint, see [CSS Utilities](./css-utilities#text-alignment) for usage information.
+
+#### text-transformation.css
+
+Adds utility classes to transform the text of an element to `uppercase`, `lowercase` or `capitalize` based on the breakpoint, see [CSS Utilities](./css-utilities#text-transformation) for usage information.
+
+#### flex-utils.css
+
+Adds utility classes to align flex containers and items, see [CSS Utilities](./css-utilities#flex-properties) for usage information.
+
+#### display.css
+
+Adds utility classes to hide any element based on the breakpoint, see [CSS Utilities](./css-utilities#element-display) for usage information.
+
+
+## Including Stylesheets
+
+Refer to the [Ionic Packages](../installation/cdn) section for how to include the global stylesheets based on the framework.

--- a/src/pages/layout/global-stylesheets.md
+++ b/src/pages/layout/global-stylesheets.md
@@ -13,7 +13,7 @@ contributors:
 
 While Ionic Framework component styles are self-contained, there are several global stylesheets that should be included in order to use all of Ionic's features. Some of the stylesheets are required in order for an Ionic Framework app to look and behave properly, and others include optional utilities to quickly style your app.
 
-## Available Stylesheets
+## Available
 
 ### Required
 
@@ -70,6 +70,6 @@ Adds utility classes to align flex containers and items, see [CSS Utilities](./c
 Adds utility classes to hide any element based on the breakpoint, see [CSS Utilities](./css-utilities#element-display) for usage information.
 
 
-## Including Stylesheets
+## Usage
 
-Refer to the [Ionic Packages](../installation/cdn) section for how to include the global stylesheets based on the framework.
+Refer to [Ionic Packages](../installation/cdn) for how to include the global stylesheets based on the framework and [CSS Utilities](./css-utilities) for how to use the optional utilities.

--- a/src/pages/layout/grid.md
+++ b/src/pages/layout/grid.md
@@ -3,8 +3,8 @@ initialTab: 'preview'
 inlineHtmlPreviews: true
 previousText: 'Structure'
 previousUrl: '/docs/layout/structure'
-nextText: 'CSS Utilities'
-nextUrl: '/docs/layout/css-utilities'
+nextText: 'Global Stylesheets'
+nextUrl: '/docs/layout/global-stylesheets'
 contributors:
   - brandyscarney
 ---


### PR DESCRIPTION
- adds a page for global stylesheet information
- adds information on including CSS for angular, stencil, and the bundle to packages/cdn
- renames some headings in ionic packages
- adds blockquote in CSS utilities that links to including them

closes #54

<img width="719" alt="Screen Shot 2019-03-08 at 4 45 38 PM" src="https://user-images.githubusercontent.com/6577830/54057710-b0126580-41c1-11e9-9c07-6003254fe09d.png">
<img width="719" alt="Screen Shot 2019-03-08 at 4 45 49 PM" src="https://user-images.githubusercontent.com/6577830/54057711-b0aafc00-41c1-11e9-9b58-0de12a6f2631.png">
