### PR TITLE
fix(menu): base default menu state on viewport size

### DIFF
--- a/src/components/root/root.css
+++ b/src/components/root/root.css
@@ -14,6 +14,7 @@
 
 @media (max-width: 768px) {
   .Layout {
+    --menu-transform: translateX(calc(-1 * var(--menu-width)));
     --page-padding: 1.5rem;
     --page-margin-left: 0;
   }
@@ -21,9 +22,5 @@
   .Layout.is-menu-toggled {
     --menu-transform: none;
     --page-transform: translateX(var(--menu-width));
-  }
-
-  .Layout:not(.is-menu-toggled) {
-    --menu-transform: translateX(calc(-1 * var(--menu-width)));
   }
 }

--- a/src/components/root/root.css
+++ b/src/components/root/root.css
@@ -7,7 +7,7 @@
   width: 100%;
 }
 
-.Layout.is-collapsed {
+.Layout.is-menu-toggled {
   --menu-transform: translateX(calc(-1 * var(--menu-width)));
   --page-margin-left: 0;
 }
@@ -18,7 +18,12 @@
     --page-margin-left: 0;
   }
 
-  .Layout:not(.is-collapsed) {
+  .Layout.is-menu-toggled {
+    --menu-transform: none;
     --page-transform: translateX(var(--menu-width));
+  }
+
+  .Layout:not(.is-menu-toggled) {
+    --menu-transform: translateX(calc(-1 * var(--menu-width)));
   }
 }

--- a/src/components/root/root.tsx
+++ b/src/components/root/root.tsx
@@ -1,8 +1,6 @@
 import '@ionic/core';
-
 import { Component, State } from '@stencil/core';
 import { LocationSegments, RouterHistory } from '@stencil/router';
-
 
 @Component({
   tag: 'docs-root',
@@ -11,7 +9,7 @@ import { LocationSegments, RouterHistory } from '@stencil/router';
 export class DocsRoot {
   history: RouterHistory = null;
 
-  @State() isCollapsed = false;
+  @State() isMenuToggled = false;
 
   setHistory = ({ history }: { history: RouterHistory }) => {
     if (!this.history) {
@@ -22,13 +20,13 @@ export class DocsRoot {
     }
   }
 
-  toggleCollapsed = () => {
-    this.isCollapsed = !this.isCollapsed;
+  toggleMenu = () => {
+    this.isMenuToggled = !this.isMenuToggled;
   }
 
   handlePageClick = () => {
-    if (this.isSmallViewport() && !this.isCollapsed) {
-      this.isCollapsed = true;
+    if (this.isSmallViewport() && !this.isMenuToggled) {
+      this.isMenuToggled = true;
     }
   }
 
@@ -36,21 +34,17 @@ export class DocsRoot {
     return matchMedia && matchMedia('(max-width: 768px)').matches;
   }
 
-  componentWillLoad() {
-    this.isCollapsed = this.isSmallViewport();
-  }
-
   render() {
     const layout = {
       'Layout': true,
-      'is-collapsed': this.isCollapsed
+      'is-menu-toggled': this.isMenuToggled
     };
 
     return (
       <stencil-router class={layout}>
         <stencil-route style={{ display: 'none' }} routeRender={this.setHistory}/>
-        <docs-header onToggleClick={this.toggleCollapsed}/>
-        <docs-menu onToggleClick={this.toggleCollapsed}/>
+        <docs-header onToggleClick={this.toggleMenu}/>
+        <docs-menu onToggleClick={this.toggleMenu}/>
         <stencil-route url="/docs/:page*" routeRender={props => (
           <docs-page
             history={props.history}

--- a/src/components/root/root.tsx
+++ b/src/components/root/root.tsx
@@ -11,7 +11,7 @@ import { LocationSegments, RouterHistory } from '@stencil/router';
 export class DocsRoot {
   history: RouterHistory = null;
 
-  @State() isCollapsed = this.isSmallViewport();
+  @State() isCollapsed = false;
 
   setHistory = ({ history }: { history: RouterHistory }) => {
     if (!this.history) {
@@ -34,6 +34,10 @@ export class DocsRoot {
 
   isSmallViewport() {
     return matchMedia && matchMedia('(max-width: 768px)').matches;
+  }
+
+  componentWillLoad() {
+    this.isCollapsed = this.isSmallViewport();
   }
 
   render() {

--- a/src/components/root/root.tsx
+++ b/src/components/root/root.tsx
@@ -25,8 +25,8 @@ export class DocsRoot {
   }
 
   handlePageClick = () => {
-    if (this.isSmallViewport() && !this.isMenuToggled) {
-      this.isMenuToggled = true;
+    if (this.isSmallViewport() && this.isMenuToggled) {
+      this.isMenuToggled = false;
     }
   }
 


### PR DESCRIPTION
Rather than try to set the menu state `isCollapsed` based on the viewport size during render, this changes the state name to `isMenuToggled` and the default state is in CSS only.