### PR TITLE
feat(color-generator):  add function of share generated color.

### DIFF
--- a/src/components/color-gen/color-generator/color-generator.tsx
+++ b/src/components/color-gen/color-generator/color-generator.tsx
@@ -54,6 +54,24 @@ export class ColorGenerator {
 
   componentWillLoad() {
     this.colors = convertCssToColors(this.cssText);
+    const getParamColor = (name) => {
+      name = name.replace(/[\[\]]/g, '\\$&');
+      const regex = new RegExp('[?&]' + name + '(=(#[^&]*)|&|#|$)');
+      const results = regex.exec(window.location.href);
+      if (!results || !results[2]) return null;
+      return decodeURIComponent(results[2].replace(/\+/g, ' '));
+    };
+
+    this.colors.forEach(c => {
+      if (getParamColor(c.name.toLocaleLowerCase())) {
+        this.onColorChange({
+          detail: {
+            property: c.property,
+            value: getParamColor(c.name.toLocaleLowerCase())
+          }
+        });
+      }
+    });
   }
 
   componentDidLoad() {

--- a/src/components/color-gen/css-text/color-gen-css-text.css
+++ b/src/components/color-gen/css-text/color-gen-css-text.css
@@ -4,6 +4,10 @@
   align-items: center;
 }
 
+.css-text__header-buttons {
+  display: flex;
+}
+
 .css-text__code {
   box-sizing: border-box;
   display: block;
@@ -47,6 +51,11 @@ h3 {
   position: absolute;
   right: 0;
   top: 0;
+}
+
+.css-text__copy-share {
+  top: 0;
+  right: 56px;
 }
 
 .css-text__copy-link {

--- a/src/components/color-gen/css-text/color-gen-css-text.tsx
+++ b/src/components/color-gen/css-text/color-gen-css-text.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, Event, EventEmitter, Prop, State } from '@stencil/core';
+import { convertCssToColors } from '../parse-css';
 
 
 @Component({
@@ -9,6 +10,7 @@ export class CssText {
 
   @Prop({ mutable: true }) cssText = '';
   @State() showCopyConfirmation = false;
+  @State() showShareConfirmation = false;
   @Event() cssTextChange: EventEmitter;
 
   @Element() el: HTMLElement;
@@ -22,6 +24,34 @@ export class CssText {
 
       this.cssTextChange.emit(this.cssText);
     }
+  }
+
+  shareCssText() {
+    this.showShareConfirmation = true;
+
+    const cssEl = this.el.querySelector('#cssText');
+    const cssText = cssEl.textContent || '';
+    const colors = convertCssToColors(cssText);
+    let urlParams = '';
+    colors.forEach(c => {
+      urlParams = urlParams + c.name.toLocaleLowerCase() + '=' + c.value + '&';
+    });
+    urlParams = urlParams.slice(0, -1);
+    history.pushState(null, null, '?' + urlParams);
+
+    const el = document.createElement('textarea');
+    el.value = location.href;
+    el.setAttribute('readonly', '');
+    el.style.position = 'absolute';
+    el.style.left = '-9999px';
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+
+    setTimeout(() => {
+      this.showShareConfirmation = false;
+    }, 2000);
   }
 
   copyCssText() {
@@ -51,15 +81,26 @@ export class CssText {
         <div class="css-text__header">
           <h3>CSS Variables</h3>
 
-          <div class={{ 'css-text__copy': true, 'show-confirmation': this.showCopyConfirmation }} >
-            <a class="css-text__copy-link" onClick={this.copyCssText.bind(this)}>Copy</a>
-            <span class="css-text__copy-confirmation">
+          <section class="css-text__header-buttons">
+            <div class={{ 'css-text__copy': true, 'show-confirmation': this.showShareConfirmation }}>
+              <a class="css-text__copy-link css-text__copy-share" onClick={this.shareCssText.bind(this)}>ShareURL</a>
+              <span class="css-text__copy-confirmation css-text__copy-share">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="26px" height="26px">
+                <path d="M362.6 192.9L345 174.8c-.7-.8-1.8-1.2-2.8-1.2-1.1 0-2.1.4-2.8 1.2l-122 122.9-44.4-44.4c-.8-.8-1.8-1.2-2.8-1.2-1 0-2 .4-2.8 1.2l-17.8 17.8c-1.6 1.6-1.6 4.1 0 5.7l56 56c3.6 3.6 8 5.7 11.7 5.7 5.3 0 9.9-3.9 11.6-5.5h.1l133.7-134.4c1.4-1.7 1.4-4.2-.1-5.7z"/>
+              </svg>
+              Changed
+            </span>
+            </div>
+            <div class={{ 'css-text__copy': true, 'show-confirmation': this.showCopyConfirmation }}>
+              <a class="css-text__copy-link" onClick={this.copyCssText.bind(this)}>Copy</a>
+              <span class="css-text__copy-confirmation">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="26px" height="26px">
                 <path d="M362.6 192.9L345 174.8c-.7-.8-1.8-1.2-2.8-1.2-1.1 0-2.1.4-2.8 1.2l-122 122.9-44.4-44.4c-.8-.8-1.8-1.2-2.8-1.2-1 0-2 .4-2.8 1.2l-17.8 17.8c-1.6 1.6-1.6 4.1 0 5.7l56 56c3.6 3.6 8 5.7 11.7 5.7 5.3 0 9.9-3.9 11.6-5.5h.1l133.7-134.4c1.4-1.7 1.4-4.2-.1-5.7z"/>
               </svg>
               Copied
             </span>
-          </div>
+            </div>
+          </section>
         </div>
         <div
           id="cssText"


### PR DESCRIPTION
Add function of share generate color. 
I think this makes the document easy to use for development communication.

1) Color Generator reflect URL Params.
For example: `https://ionicframework.com/docs/theming/color-generator/?primary=#3880ff&secondary=#0cd1e8&tertiary=#7044ff&success=#10dc60&warning=#ffce00&danger=#f04141&dark=#222428&medium=#989aa2&light=#f4f5f8` .

2) Add URL reflect button.
When click this button, add color params to URL by history API.

<img width="677" alt="スクリーンショット 2019-04-01 19 17 08" src="https://user-images.githubusercontent.com/9690024/55320723-c8b92700-54b2-11e9-9c50-656bed814977.png">
