### PR TITLE
feat(release-notes): add a page for displaying the last 10 releases

### DIFF
--- a/scripts/build-data/index.ts
+++ b/scripts/build-data/index.ts
@@ -1,9 +1,11 @@
 import Listr from 'listr';
 import buildApiReference from './api-reference';
+import buildReleaseNotes from './release-notes';
 import buildSearchIndex from './search-index';
 
 const tasks = new Listr([
   buildApiReference,
+  buildReleaseNotes,
   buildSearchIndex
 ]);
 

--- a/scripts/build-data/release-notes.ts
+++ b/scripts/build-data/release-notes.ts
@@ -1,0 +1,51 @@
+import { resolve } from 'path';
+import { outputJson } from 'fs-extra';
+
+import renderMarkdown from '../build-pages/markdown-renderer';
+
+import fetch from 'node-fetch';
+
+import url from 'url';
+
+const OUTPUT_PATH = resolve(
+  __dirname,
+  '../../src/components/page/data/release-notes.json'
+);
+
+export default {
+  title: 'Build Release Notes data',
+  task: async () => outputJson(OUTPUT_PATH, await getReleases(), { spaces: 2 })
+};
+
+// Get the GitHub Releases from Ionic
+// This requires an environment GITHUB_TOKEN
+// otherwise it may fail silently
+async function getReleases() {
+  try {
+    const request = await fetch(url.format({
+      protocol: 'https',
+      hostname: 'api.github.com',
+      pathname: 'repos/ionic-team/ionic/releases',
+      query: {
+        access_token: process.env.GITHUB_TOKEN
+      }
+    }));
+
+    let releases = await request.json();
+    releases = releases.slice(0, 10);
+
+    return releases.map(release => {
+      const body = renderMarkdown(release.body);
+      const { name, tag_name, published_at } = release;
+
+      return {
+        name,
+        body,
+        tag_name,
+        published_at
+      };
+    });
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,8 +8,8 @@
 import '@stencil/core';
 
 import '@stencil/router';
-import '@stencil/state-tunnel';
 import '@ionic/core';
+import '@stencil/state-tunnel';
 import 'ionicons';
 import {
   ColorVariable,

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,8 +8,8 @@
 import '@stencil/core';
 
 import '@stencil/router';
-import '@ionic/core';
 import '@stencil/state-tunnel';
+import '@ionic/core';
 import 'ionicons';
 import {
   ColorVariable,

--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -6,6 +6,7 @@ const items = {
     'Core Concepts': '/docs/intro/concepts',
     'Browser Support': '/docs/intro/browser-support',
     'Versioning': '/docs/intro/versioning',
+    'Release Notes': '/docs/intro/release-notes',
     'Support': '/docs/intro/support'
   },
   'Installation': {

--- a/src/components/page/templates/index.ts
+++ b/src/components/page/templates/index.ts
@@ -5,6 +5,7 @@ import cli from './cli';
 import enterprisePlugin from './enterprise-plugin';
 import error from './error';
 import native from './native';
+import releaseNotes from './release-notes';
 
 export default {
   'default': defaultTemplate,
@@ -13,5 +14,6 @@ export default {
   'cli': cli,
   'enterprise-plugin': enterprisePlugin,
   'error': error,
-  'native': native
+  'native': native,
+  'release-notes': releaseNotes,
 };

--- a/src/components/page/templates/release-notes.tsx
+++ b/src/components/page/templates/release-notes.tsx
@@ -1,10 +1,5 @@
 import releases from '../data/release-notes.json';
 
-const listStyle = {
-  fontFamily: 'var(--code-font-family)',
-  fontSize: '13px'
-};
-
 export default (props) => {
   const { page } = props;
 
@@ -18,18 +13,36 @@ export default (props) => {
   return (
     <article>
       <h1>{page.title}</h1>
-      {/* <section class="markdown-content" innerHTML={page.body}/> */}
-      {/* <hr/> */}
-      <div style={listStyle}>
+      <section class="markdown-content" innerHTML={page.body}/>
+      <div class="release-notes">
         { releases.map(release =>
-          <div>
-            <a href="https://github.com/ionic-team/ionic/releases/tag/{v4.3.0}" target="_blank">
-              <h2>{release.name}</h2>
-            </a>
+          <section class="release-note">
+          <div class="release-tag-wrapper">
+            <h2 id={release.version}>
+              <a href={`#${release.version}`} class={getTagClasses(release)}>
+                {release.version}
+              </a>
+            </h2>
+          </div>
+          <div class="release-info">
+            <div class="release-published">
+              <h2>{release.published_at}</h2>
+            </div>
             <div innerHTML={release.body}></div>
           </div>
+          </section>
         )}
       </div>
+      <blockquote>
+        To see more releases, visit <a href="https://github.com/ionic-team/ionic/releases/" target="_blank">Github</a>.
+      </blockquote>
     </article>
   );
 };
+
+function getTagClasses(release) {
+  return {
+    'release-tag': true,
+    'release-tag-patch': release.patch
+  };
+}

--- a/src/components/page/templates/release-notes.tsx
+++ b/src/components/page/templates/release-notes.tsx
@@ -1,0 +1,35 @@
+import releases from '../data/release-notes.json';
+
+const listStyle = {
+  fontFamily: 'var(--code-font-family)',
+  fontSize: '13px'
+};
+
+export default (props) => {
+  const { page } = props;
+
+  if (releases.length === 0) {
+    return [
+      <h1>{page.title}</h1>,
+      <p>Unable to load Releases. Please see all releases on <a href="https://github.com/ionic-team/ionic/releases/" target="_blank">Github</a>.</p>
+    ];
+  }
+
+  return (
+    <article>
+      <h1>{page.title}</h1>
+      {/* <section class="markdown-content" innerHTML={page.body}/> */}
+      {/* <hr/> */}
+      <div style={listStyle}>
+        { releases.map(release =>
+          <div>
+            <a href="https://github.com/ionic-team/ionic/releases/tag/{v4.3.0}" target="_blank">
+              <h2>{release.name}</h2>
+            </a>
+            <div innerHTML={release.body}></div>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+};

--- a/src/pages/intro/release-notes.md
+++ b/src/pages/intro/release-notes.md
@@ -1,0 +1,9 @@
+---
+template: release-notes
+previousText: 'Versioning'
+previousUrl: '/docs/intro/versioning'
+nextText: 'Support'
+nextUrl: '/docs/intro/support'
+---
+
+# Release Notes

--- a/src/pages/intro/versioning.md
+++ b/src/pages/intro/versioning.md
@@ -1,8 +1,8 @@
 ---
 previousText: 'Browser Support'
 previousUrl: '/docs/intro/browser-support'
-nextText: 'Support'
-nextUrl: '/docs/intro/support'
+nextText: 'Release Notes'
+nextUrl: '/docs/intro/release-notes'
 ---
 
 # Versioning

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,3 +6,4 @@
 @import './pages/appflow.css';
 @import './pages/browser-support.css';
 @import './pages/native-ee.css';
+@import './pages/release-notes.css';

--- a/src/styles/pages/release-notes.css
+++ b/src/styles/pages/release-notes.css
@@ -1,0 +1,57 @@
+.page-intro-release-notes {
+  --page-width: 1000px;
+}
+
+.page-intro-release-notes .release-note {
+  display: flex;
+  align-items: top;
+}
+
+.page-intro-release-notes h2 {
+  margin: 0;
+
+  font-size: 24px;
+  line-height: normal;
+}
+
+.page-intro-release-notes h3 {
+  font-size: 18px;
+}
+
+.page-intro-release-notes h2,
+.page-intro-release-notes h3 {
+  padding-top: 0;
+}
+
+.page-intro-release-notes .release-tag-wrapper {
+  margin-right: 8px;
+}
+
+.page-intro-release-notes .release-tag-wrapper h2 {
+  font-size: 15px;
+}
+
+.page-intro-release-notes .release-tag {
+  padding: 6px 4px;
+  display: inline-block;
+  width: 65px;
+  text-align: center;
+  font-weight: 600;
+  border-radius: 3px;
+
+  background: var(--accent-color);
+  color: #fff;
+
+  line-height: normal;
+}
+
+.page-intro-release-notes blockquote {
+  margin-left: 0;
+
+  background: rgba(var(--accent-color-rgb), 0.05);
+  border-color: var(--accent-color);
+}
+
+.page-intro-release-notes a {
+  color: var(--accent-color);
+}


### PR DESCRIPTION
Adds the following page at the URL: `/docs/intro/release-notes`

![localhost_3333_docs_intro_release-notes (1)](https://user-images.githubusercontent.com/6577830/56835474-51bd4700-6842-11e9-8ece-e0c335b12f79.png)
