### PR TITLE
fix(release-notes): update release note design

### DIFF
--- a/scripts/build-data/release-notes.ts
+++ b/scripts/build-data/release-notes.ts
@@ -89,9 +89,9 @@ function getVersionType(version: string) {
 
   if (version.indexOf('-alpha') > -1 || version.indexOf('-beta') > -1 || version.indexOf('-rc') > -1) {
     type = 'prerelease';
-  } else if (version.indexOf('.0.0') > -1) {
+  } else if (version.endsWith('.0.0')) {
     type = 'major';
-  } else if (version.indexOf('.0') > -1) {
+  } else if (version.endsWith('.0')) {
     type = 'minor';
   }
 

--- a/scripts/build-data/release-notes.ts
+++ b/scripts/build-data/release-notes.ts
@@ -37,15 +37,19 @@ async function getReleases() {
       const body = parseMarkdown(release.body);
       const published_at = parseDate(release.published_at);
       const version = release.tag_name.replace('v', '');
-      const patch = release.name.length < 7;
+      const type = getVersionType(version);
+      const symbol = getVersionSymbol(version);
+      const element = getVersionElement(version);
       const { name, tag_name } = release;
 
       return {
         body,
-        patch,
+        element,
         name,
         published_at,
+        symbol,
         tag_name,
+        type,
         version
       };
     }).sort((a, b) => {
@@ -57,7 +61,9 @@ async function getReleases() {
       }
       // a must be equal to b
       return 0;
-    }).slice(0, 10);
+    }).filter((release) =>
+      !release.tag_name.includes('alpha') && !release.tag_name.includes('beta') && !release.tag_name.includes('rc')
+    );
   } catch (error) {
     throw error;
   }
@@ -70,8 +76,195 @@ function parseDate(datetime: string) {
   return date.toLocaleString('en-us', { month: 'long' }) + ' ' + date.getDate() + ' ' + date.getFullYear();
 }
 
-function parseMarkdown(content) {
+function parseMarkdown(content: any) {
   const markdown = renderMarkdown(content);
 
   return markdown.replace('<a href=\"#bug-fixes\">Bug Fixes</a>', 'Bug Fixes').replace('<a href=\"#features\">Features</a>', 'Features');
 }
+
+// Given a version, return if it is a
+// major, minor, or patch release
+function getVersionType(version: string) {
+  let type = 'patch';
+
+  if (version.indexOf('-alpha') > -1 || version.indexOf('-beta') > -1 || version.indexOf('-rc') > -1) {
+    type = 'prerelease';
+  } else if (version.indexOf('.0.0') > -1) {
+    type = 'major';
+  } else if (version.indexOf('.0') > -1) {
+    type = 'minor';
+  }
+
+  return type;
+}
+
+// Given a version, return its element symbol
+function getVersionSymbol(version) {
+  const v = versions.filter(
+    versions => version.startsWith(`${versions.minor}.`)
+  );
+
+  return v[v.length - 1].symbol;
+}
+
+// Given a version, return its element name
+function getVersionElement(version) {
+  const v = versions.filter(
+    versions => version.startsWith(`${versions.minor}.`)
+  );
+
+  return v[v.length - 1].element;
+}
+
+const versions = [
+  {
+    'minor': '4.0',
+    'symbol': 'N',
+    'element': 'Neutronium'
+  },
+  {
+    'minor': '4.1',
+    'symbol': 'H',
+    'element': 'Hydrogen'
+  },
+  {
+    'minor': '4.2',
+    'symbol': 'He',
+    'element': 'Helium'
+  },
+  {
+    'minor': '4.3',
+    'symbol': 'Li',
+    'element': 'Lithium'
+  },
+  {
+    'minor': '4.4',
+    'symbol': 'Be',
+    'element': 'Beryllium'
+  },
+  {
+    'minor': '4.5',
+    'symbol': 'B',
+    'element': 'Boron'
+  },
+  {
+    'minor': '4.6',
+    'symbol': 'C',
+    'element': 'Carbon'
+  },
+  {
+    'minor': '4.7',
+    'symbol': 'N',
+    'element': 'Nitrogen'
+  },
+  {
+    'minor': '4.8',
+    'symbol': 'O',
+    'element': 'Oxygen'
+  },
+  {
+    'minor': '4.9',
+    'symbol': 'F',
+    'element': 'Fluorine'
+  },
+  {
+    'minor': '4.10',
+    'symbol': 'Ne',
+    'element': 'Neon'
+  },
+  {
+    'minor': '4.11',
+    'symbol': 'Na',
+    'element': 'Sodium'
+  },
+  {
+    'minor': '4.12',
+    'symbol': 'Mg',
+    'element': 'Magnesium'
+  },
+  {
+    'minor': '4.13',
+    'symbol': 'Al',
+    'element': 'Aluminium'
+  },
+  {
+    'minor': '4.14',
+    'symbol': 'Si',
+    'element': 'Silicon'
+  },
+  {
+    'minor': '4.15',
+    'symbol': 'P',
+    'element': 'Phosphorus'
+  },
+  {
+    'minor': '4.16',
+    'symbol': 'S',
+    'element': 'Sulfur'
+  },
+  {
+    'minor': '4.17',
+    'symbol': 'Cl',
+    'element': 'Chlorine'
+  },
+  {
+    'minor': '4.18',
+    'symbol': 'Ar',
+    'element': 'Argon'
+  },
+  {
+    'minor': '4.19',
+    'symbol': 'K',
+    'element': 'Potassium'
+  },
+  {
+    'minor': '4.20',
+    'symbol': 'Ca',
+    'element': 'Calcium'
+  },
+  {
+    'minor': '4.21',
+    'symbol': 'Sc',
+    'element': 'Scandium'
+  },
+  {
+    'minor': '4.22',
+    'symbol': 'Ti',
+    'element': 'Titanium'
+  },
+  {
+    'minor': '4.23',
+    'symbol': 'V',
+    'element': 'Vanadium'
+  },
+  {
+    'minor': '4.24',
+    'symbol': 'Cr',
+    'element': 'Chromium'
+  },
+  {
+    'minor': '4.25',
+    'symbol': 'Mn',
+    'element': 'Manganese'
+  },
+  {
+    'minor': '4.26',
+    'symbol': 'Fe',
+    'element': 'Iron'
+  },
+  {
+    'minor': '4.27',
+    'symbol': 'Co',
+    'element': 'Cobalt'
+  },
+  {
+    'minor': '4.28',
+    'symbol': 'Ni',
+    'element': 'Nickel'
+  },
+  {
+    'minor': '4.29',
+    'symbol': 'Cu',
+    'element': 'Copper'
+  }
+];

--- a/scripts/build-data/release-notes.ts
+++ b/scripts/build-data/release-notes.ts
@@ -61,9 +61,12 @@ async function getReleases() {
       }
       // a must be equal to b
       return 0;
-    }).filter((release) =>
-      !release.tag_name.includes('alpha') && !release.tag_name.includes('beta') && !release.tag_name.includes('rc')
-    );
+    }).filter((release) => {
+      const releasePattern = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+      // All non-prerelease, non-alpha, non-beta, non-rc release
+      return releasePattern.test(release.tag_name);
+    });
   } catch (error) {
     throw error;
   }
@@ -85,9 +88,11 @@ function parseMarkdown(content: any) {
 // Given a version, return if it is a
 // major, minor, or patch release
 function getVersionType(version: string) {
+  const releasePattern = /^(\d+)\.(\d+)\.(\d+)$/;
+
   let type = 'patch';
 
-  if (version.indexOf('-alpha') > -1 || version.indexOf('-beta') > -1 || version.indexOf('-rc') > -1) {
+  if (!releasePattern.test(version)) {
     type = 'prerelease';
   } else if (version.endsWith('.0.0')) {
     type = 'major';

--- a/src/components/page/templates/release-notes.tsx
+++ b/src/components/page/templates/release-notes.tsx
@@ -15,12 +15,12 @@ export default (props) => {
       <h1>{page.title}</h1>
       <section class="markdown-content" innerHTML={page.body}/>
       <div class="release-notes">
-        { releases.map(release =>
-          <section class="release-note">
+        { releases.map((release, index) =>
+          <section class={getReleaseClasses(release)}>
 
             <div class="release-tag-wrapper">
               <h2 id={release.version}>
-                <a href={`#${release.version}`} class={getTagClasses(release)}>
+                <a href={`#${release.version}`} class="release-tag">
                   <span class="release-symbol">{release.symbol}</span>
                   <span class="release-version">{release.version}</span>
                 </a>
@@ -30,10 +30,14 @@ export default (props) => {
             <div class="release-info">
               <div class="release-header">
                 <h2>{release.name}</h2>
-                <span class={getBadgeClasses(release)}>{release.type}</span>
+                <span class="release-badge">{release.type}</span>
+                { index === 0
+                  ? <span class="release-badge release-badge-latest">Latest Production Version</span>
+                  : null
+                }
               </div>
               <div class="release-published">
-                <h2>{release.published_at}</h2>
+                <h3>{release.published_at}</h3>
               </div>
               <div innerHTML={release.body}></div>
             </div>
@@ -48,16 +52,9 @@ export default (props) => {
   );
 };
 
-function getTagClasses(release) {
+function getReleaseClasses(release) {
   return {
-    'release-tag': true,
-    [`release-tag-${release.type}`]: true
-  };
-}
-
-function getBadgeClasses(release) {
-  return {
-    'release-badge': true,
-    [`release-badge-${release.type}`]: true
+    'release-note': true,
+    [`release-note-${release.type}`]: true
   };
 }

--- a/src/components/page/templates/release-notes.tsx
+++ b/src/components/page/templates/release-notes.tsx
@@ -29,7 +29,10 @@ export default (props) => {
 
             <div class="release-info">
               <div class="release-header">
-                <h2>{release.name}</h2>
+                <h2>
+                  <span class="release-version">{release.version}</span>
+                  { release.type !== 'patch' ? ' ' + release.element : null }
+                </h2>
                 <span class="release-badge">{release.type}</span>
                 { index === 0
                   ? <span class="release-badge release-badge-latest">Latest Production Version</span>

--- a/src/components/page/templates/release-notes.tsx
+++ b/src/components/page/templates/release-notes.tsx
@@ -17,19 +17,27 @@ export default (props) => {
       <div class="release-notes">
         { releases.map(release =>
           <section class="release-note">
-          <div class="release-tag-wrapper">
-            <h2 id={release.version}>
-              <a href={`#${release.version}`} class={getTagClasses(release)}>
-                {release.name}
-              </a>
-            </h2>
-          </div>
-          <div class="release-info">
-            <div class="release-published">
-              <h2>{release.published_at}</h2>
+
+            <div class="release-tag-wrapper">
+              <h2 id={release.version}>
+                <a href={`#${release.version}`} class={getTagClasses(release)}>
+                  <span class="release-symbol">{release.symbol}</span>
+                  <span class="release-version">{release.version}</span>
+                </a>
+              </h2>
             </div>
-            <div innerHTML={release.body}></div>
-          </div>
+
+            <div class="release-info">
+              <div class="release-header">
+                <h2>{release.name}</h2>
+                <span class={getBadgeClasses(release)}>{release.type}</span>
+              </div>
+              <div class="release-published">
+                <h2>{release.published_at}</h2>
+              </div>
+              <div innerHTML={release.body}></div>
+            </div>
+
           </section>
         )}
       </div>
@@ -43,6 +51,13 @@ export default (props) => {
 function getTagClasses(release) {
   return {
     'release-tag': true,
-    'release-tag-patch': release.patch
+    [`release-tag-${release.type}`]: true
+  };
+}
+
+function getBadgeClasses(release) {
+  return {
+    'release-badge': true,
+    [`release-badge-${release.type}`]: true
   };
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -8,6 +8,17 @@
 :root {
   --accent-color: #3880ff;
   --accent-color-rgb: 56, 128, 255;
+
+  --accent-color-100: #4d8dff;
+  --accent-color-200: #639cff;
+  --accent-color-300: #4d8dff;
+  --accent-color-400: #7cabff;
+  --accent-color-500: #97bdff;
+  --accent-color-600: #b2ceff;
+  --accent-color-700: #cddfff;
+  --accent-color-800: #e3edff;
+  --accent-color-900: #f0f6ff;
+
   --background: #ffffff;
   --code-background: #f5f7fa;
   --code-color: var(--text-color--dark);

--- a/src/styles/pages/release-notes.css
+++ b/src/styles/pages/release-notes.css
@@ -23,6 +23,7 @@
 }
 
 .page-release-notes h3 {
+  margin-top: 32px;
   margin-bottom: 0;
 
   font-size: 20px;

--- a/src/styles/pages/release-notes.css
+++ b/src/styles/pages/release-notes.css
@@ -3,21 +3,31 @@
 }
 
 .page-release-notes .release-note {
+  position: relative;
+
   display: flex;
   align-items: top;
 
-  margin-bottom: 40px;
+  padding-bottom: 40px;
+}
+
+/* Turn off the # on anchor hover */
+.page-release-notes h2 a[href^="#"]:hover:before,
+.page-release-notes h3 a[href^="#"]:hover:before,
+.page-release-notes h4 a[href^="#"]:hover:before,
+.page-release-notes h5 a[href^="#"]:hover:before,
+.page-release-notes h6 a[href^="#"]:hover:before {
+  opacity: 0;
 }
 
 .page-release-notes h2 {
   margin: 0;
 
-  font-size: 24px;
-  line-height: normal;
+  font-size: 32px;
 }
 
 .page-release-notes h3 {
-  font-size: 18px;
+  font-size: 20px;
 }
 
 .page-release-notes h2,
@@ -25,10 +35,21 @@
   padding-top: 0;
 }
 
-/* Release Note Header */
+/*
+ * Release Note Header
+ * --------------------------------------------------------
+ */
 
 .page-release-notes .release-header {
   display: flex;
+}
+
+.page-release-notes .release-published h3 {
+  font-family: var(--font-family);
+
+  font-weight: 300;
+
+  margin-top: 0;
 }
 
 .page-release-notes .release-badge {
@@ -50,8 +71,13 @@
   letter-spacing: 0.08em;
 }
 
-.page-release-notes .release-badge-major,
-.page-release-notes .release-badge-minor {
+.page-release-notes .release-note-major .release-badge {
+  background: var(--text-color--dark);
+  border-color: var(--text-color--dark);
+  color: white;
+}
+
+.page-release-notes .release-note-minor .release-badge {
   background: #b2becd;
   border-color: #b2becd;
   color: white;
@@ -63,7 +89,10 @@
 }
 
 
-/* Release Note Tag */
+/*
+ * Release Note Element Tag
+ * --------------------------------------------------------
+ */
 
 .page-release-notes .release-tag-wrapper h2 {
   font-size: 15px;
@@ -71,9 +100,20 @@
   margin-right: 30px;
 }
 
+.page-release-notes .release-note-patch .release-tag-wrapper:after {
+  content: "";
+  background-image: linear-gradient(to bottom, #ebf0f6, #ebf0f6);
+  width: 3px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc((65px / 2));
+  z-index: -1;
+}
+
 .page-release-notes .release-tag {
   line-height: 200%;
-  color: #639CFF;
+  color: var(--accent-color-200);
 
   padding: 6px 12px;
   display: inline-block;
@@ -81,8 +121,9 @@
   font-weight: 600;
   border-radius: 16px;
   width: 64px;
+  height: 64px;
 
-  background: transparent;
+  background: var(--background);
   color: var(--accent-color-200);
 
   border: 2px solid var(--accent-color-200);
@@ -90,16 +131,28 @@
   line-height: normal;
 }
 
-.page-release-notes .release-tag-major,
-.page-release-notes .release-tag-minor {
+.page-release-notes .release-tag:hover {
+  background: var(--accent-color-800);
+}
+
+.page-release-notes .release-note-major .release-tag,
+.page-release-notes .release-note-minor .release-tag {
   background: var(--accent-color-200);
   color: #fff;
+}
+
+.page-release-notes .release-note-major:hover .release-tag,
+.page-release-notes .release-note-minor:hover .release-tag {
+  background: var(--accent-color-100);
 }
 
 .page-release-notes .release-tag .release-symbol {
   display: block;
 
   font-size: 24px;
+
+  margin-top: 3px;
+  margin-bottom: -10px;
 }
 
 .page-release-notes .release-tag .release-version {
@@ -109,7 +162,10 @@
 }
 
 
-/* Release Note Blockquote */
+/*
+ * Release Note Blockquote
+ * --------------------------------------------------------
+ */
 
 .page-release-notes blockquote {
   margin-left: 0;

--- a/src/styles/pages/release-notes.css
+++ b/src/styles/pages/release-notes.css
@@ -1,14 +1,10 @@
-.page-release-notes {
-  --page-width: 1000px;
-}
-
 .page-release-notes .release-note {
   position: relative;
 
   display: flex;
   align-items: top;
 
-  padding-bottom: 40px;
+  padding-bottom: 80px;
 }
 
 /* Turn off the # on anchor hover */
@@ -27,12 +23,23 @@
 }
 
 .page-release-notes h3 {
+  margin-bottom: 0;
+
   font-size: 20px;
 }
 
 .page-release-notes h2,
 .page-release-notes h3 {
   padding-top: 0;
+}
+
+.page-release-notes ul {
+  margin-top: .8em;
+}
+
+.page-release-notes ul li {
+  line-height: 1.5;
+  margin-bottom: 8px;
 }
 
 /*
@@ -42,6 +49,15 @@
 
 .page-release-notes .release-header {
   display: flex;
+  align-items: center;
+}
+
+.page-release-notes .release-header h2 {
+  font-family: var(--font-family);
+}
+
+.page-release-notes .release-header .release-version {
+  font-weight: 500;
 }
 
 .page-release-notes .release-published h3 {
@@ -49,11 +65,13 @@
 
   font-weight: 300;
 
-  margin-top: 0;
+  margin-top: 4px;
+  color: #4E5B6A;
 }
 
 .page-release-notes .release-badge {
   margin-left: 8px;
+  margin-bottom: 2px;
 
   text-transform: uppercase;
 
@@ -61,9 +79,10 @@
   color: #b2becd;
   border: 1px solid #b2becd;
   border-radius: 14px;
-  height: 28px;
-  padding: 2px 12px;
+  height: 24px;
+  padding: 2px 8px;
 
+  font-weight: 600;
   font-size: 10px;
   line-height: 14px;
   display: flex;
@@ -103,11 +122,11 @@
 .page-release-notes .release-note-patch .release-tag-wrapper:after {
   content: "";
   background-image: linear-gradient(to bottom, #ebf0f6, #ebf0f6);
-  width: 3px;
+  width: 2px;
   position: absolute;
   top: 0;
   bottom: 0;
-  left: calc((65px / 2));
+  left: calc((65px / 2) - 1px);
   z-index: -1;
 }
 
@@ -147,12 +166,15 @@
 }
 
 .page-release-notes .release-tag .release-symbol {
+  font-family: var(--font-family);
+  font-weight: 300;
+
   display: block;
 
   font-size: 24px;
 
   margin-top: 3px;
-  margin-bottom: -10px;
+  margin-bottom: -7px;
 }
 
 .page-release-notes .release-tag .release-version {

--- a/src/styles/pages/release-notes.css
+++ b/src/styles/pages/release-notes.css
@@ -25,30 +25,91 @@
   padding-top: 0;
 }
 
-.page-release-notes .release-tag-wrapper {
-  min-width: 180px;
+/* Release Note Header */
 
-  text-align: right;
+.page-release-notes .release-header {
+  display: flex;
 }
+
+.page-release-notes .release-badge {
+  margin-left: 8px;
+
+  text-transform: uppercase;
+
+  background: transparent;
+  color: #b2becd;
+  border: 1px solid #b2becd;
+  border-radius: 14px;
+  height: 28px;
+  padding: 2px 12px;
+
+  font-size: 10px;
+  line-height: 14px;
+  display: flex;
+  align-items: center;
+  letter-spacing: 0.08em;
+}
+
+.page-release-notes .release-badge-major,
+.page-release-notes .release-badge-minor {
+  background: #b2becd;
+  border-color: #b2becd;
+  color: white;
+}
+
+.page-release-notes .release-badge-latest {
+  color: #43c465;
+  border-color: #43c465;
+}
+
+
+/* Release Note Tag */
 
 .page-release-notes .release-tag-wrapper h2 {
   font-size: 15px;
 
-  margin-right: 20px;
+  margin-right: 30px;
 }
 
 .page-release-notes .release-tag {
+  line-height: 200%;
+  color: #639CFF;
+
   padding: 6px 12px;
   display: inline-block;
   text-align: center;
   font-weight: 600;
-  border-radius: 3px;
+  border-radius: 16px;
+  width: 64px;
 
-  background: var(--accent-color);
-  color: #fff;
+  background: transparent;
+  color: var(--accent-color-200);
+
+  border: 2px solid var(--accent-color-200);
 
   line-height: normal;
 }
+
+.page-release-notes .release-tag-major,
+.page-release-notes .release-tag-minor {
+  background: var(--accent-color-200);
+  color: #fff;
+}
+
+.page-release-notes .release-tag .release-symbol {
+  display: block;
+
+  font-size: 24px;
+}
+
+.page-release-notes .release-tag .release-version {
+  font-family: var(--code-font-family);
+  font-size: 10px;
+  letter-spacing: -0.08em;
+}
+
+
+/* Release Note Blockquote */
 
 .page-release-notes blockquote {
   margin-left: 0;


### PR DESCRIPTION
This PR updates the release notes page to pull in all recent releases, removes the alpha/beta/rc releases from the data, and updates the design to reflect Ben's changes.

![localhost_3334_docs_release-notes (4)](https://user-images.githubusercontent.com/6577830/56978757-3a35d500-6b46-11e9-8655-5aa8dad5495d.png)
