### PR TITLE
allow readme/index.md for pages dir index

### DIFF
--- a/scripts/build-pages/page-types/static.ts
+++ b/scripts/build-pages/page-types/static.ts
@@ -29,7 +29,7 @@ const getMarkdownPaths = (cwd: string): Promise<string[]> =>
 
 export const toPage = async (path: string) => {
   return {
-    path: path.replace(PAGES_DIR, '/docs').replace(/\.md$/, ''),
+    path: path.replace(PAGES_DIR, '/docs').replace(/(\/(index|readme))\.md$/i, ''),
     github: await getGitHubData(path),
     ...renderMarkdown(await readMarkdown(path))
   };


### PR DESCRIPTION
This allows authors to use `index.md` or `readme.md` files within a pages directory as the content for the root of the directory.