### PR TITLE
Remove closing img tag

### DIFF
--- a/src/demos/api/list/index.html
+++ b/src/demos/api/list/index.html
@@ -29,7 +29,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-finn.png"></img>
+            <img src="./avatar-finn.png">
           </ion-avatar>
           <ion-label>
             <h2>Finn</h2>
@@ -40,7 +40,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-han.png"></img>
+            <img src="./avatar-han.png">
           </ion-avatar>
           <ion-label>
             <h2>Han</h2>
@@ -51,7 +51,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-rey.png"></img>
+            <img src="./avatar-rey.png">
           </ion-avatar>
           <ion-label>
             <h2>Rey</h2>
@@ -62,7 +62,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-luke.png"></img>
+            <img src="./avatar-luke.png">
           </ion-avatar>
           <ion-label>
             <h2>Luke</h2>
@@ -79,7 +79,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-poe.png"></img>
+            <img src="./avatar-poe.png">
           </ion-avatar>
           <ion-label>
             <h2>Poe</h2>
@@ -90,7 +90,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-ben.png"></img>
+            <img src="./avatar-ben.png">
           </ion-avatar>
           <ion-label>
             <h2>Ben</h2>
@@ -101,7 +101,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-leia.png"></img>
+            <img src="./avatar-leia.png">
           </ion-avatar>
           <ion-label>
             <h2>Leia</h2>
@@ -112,7 +112,7 @@
 
         <ion-item>
           <ion-avatar slot="start">
-            <img src="./avatar-yoda.png"></img>
+            <img src="./avatar-yoda.png">
           </ion-avatar>
           <ion-label>
             <h2>Yoda</h2>


### PR DESCRIPTION
img tag is a void element. The closing tag causes template parsing errors.