### PR TITLE
revert: color generator description change

### DIFF
--- a/src/pages/theming/color-generator.md
+++ b/src/pages/theming/color-generator.md
@@ -12,6 +12,6 @@ contributors:
 
 # Color Generator
 
-Create custom color palettes for your app’s UI. Update a color’s hex values, check the demo app on the right to confirm, then copy and paste the generated code directly into your Ionic project (e.g. the variables.scss file in the theme folder of your project). 
+Create custom color palettes for your app’s UI. Update a color’s hex values, check the demo app on the right to confirm, then copy and paste the generated code directly into your Ionic project.
 
 <color-generator mode="md" no-prerender></color-generator>


### PR DESCRIPTION
This makes no sense in the context of a non-angular or non-scss app. I don't think it should be here at all. If anything we can have a separate section that goes into more detail of where you can put this code or what `:root` means, but it doesn't *have* to go into the variables file either. 