### PR TITLE
feat(fab-button): slot for close icon once new feature merged

### DIFF
--- a/src/components/color-gen/demo/index.html
+++ b/src/components/color-gen/demo/index.html
@@ -127,6 +127,7 @@
         <ion-fab vertical="bottom" horizontal="end" id="fab4" slot="fixed">
           <ion-fab-button color="tertiary" color="light" class="e2eFabBottomLeft">
             <ion-icon name="arrow-up"></ion-icon>
+            <ion-icon slot="close" name="close"></ion-icon>
           </ion-fab-button>
           <ion-fab-list side="top">
             <ion-fab-button color="dark"><ion-icon name="logo-facebook"></ion-icon></ion-fab-button>

--- a/src/demos/api/fab/index.html
+++ b/src/demos/api/fab/index.html
@@ -25,6 +25,7 @@
       <ion-fab horizontal="end" vertical="top" slot="fixed" edge>
         <ion-fab-button>
           <ion-icon name="add"></ion-icon>
+          <ion-icon slot="close" name="close"></ion-icon>
         </ion-fab-button>
         <ion-fab-list>
           <ion-fab-button color="light">
@@ -48,6 +49,7 @@
       <ion-fab horizontal="end" vertical="bottom" slot="fixed">
         <ion-fab-button color="light">
           <ion-icon name="arrow-dropleft"></ion-icon>
+          <ion-icon slot="close" name="close"></ion-icon>
         </ion-fab-button>
         <ion-fab-list side="start">
           <ion-fab-button color="light">
@@ -65,6 +67,7 @@
       <ion-fab horizontal="start" vertical="bottom" slot="fixed">
         <ion-fab-button color="dark">
           <ion-icon name="arrow-dropup"></ion-icon>
+          <ion-icon slot="close" name="close"></ion-icon>
         </ion-fab-button>
         <ion-fab-list side="top">
           <ion-fab-button color="light">
@@ -85,6 +88,7 @@
       <ion-fab horizontal="start" vertical="top" slot="fixed">
         <ion-fab-button color="secondary">
           <ion-icon name="arrow-dropright"></ion-icon>
+          <ion-icon slot="close" name="close"></ion-icon>
         </ion-fab-button>
         <ion-fab-list side="end">
           <ion-fab-button color="light">
@@ -105,6 +109,7 @@
       <ion-fab horizontal="center" vertical="center" slot="fixed">
         <ion-fab-button color="light">
           <ion-icon name="share"></ion-icon>
+          <ion-icon slot="close" name="close"></ion-icon>
         </ion-fab-button>
         <ion-fab-list side="top">
           <ion-fab-button color="primary">


### PR DESCRIPTION
Once PR https://github.com/ionic-team/ionic/pull/18827 merged in `@ionic/core` and updated in this repo, the `fab-button` using in containers with `fab-list` will have to implement an `close` button provided as slot

Linked with Feature request https://github.com/ionic-team/ionic/issues/18442