### PR TITLE
docs(devapp): add ionic cordova prepare command

### DIFF
--- a/src/pages/appflow/devapp.md
+++ b/src/pages/appflow/devapp.md
@@ -36,7 +36,7 @@ First, ensure you are running the latest release of the Ionic CLI. Run `npm inst
 
 Once the latest CLI is installed, run `ionic serve --devapp` in the app of your choice on your computer and let it finish building. Next, open your iOS or Android device and connect to _the same network_ as your computer (through Wi-Fi). Open the DevApp, and you should see your local app show up in the list.
 
-> Note that currently you might need to run `ionic cordova prepare` with the default project before running `ionic serve --devapp` in order to copy the cordova assets to prepare the native build for the mobile platform.
+> Note: Cordova must be installed in your project before DevApp can be used, so you may need to run `ionic cordova prepare [platform]` before running `ionic serve --devapp`.
 
 ## CORS
 

--- a/src/pages/appflow/devapp.md
+++ b/src/pages/appflow/devapp.md
@@ -36,6 +36,8 @@ First, ensure you are running the latest release of the Ionic CLI. Run `npm inst
 
 Once the latest CLI is installed, run `ionic serve --devapp` in the app of your choice on your computer and let it finish building. Next, open your iOS or Android device and connect to _the same network_ as your computer (through Wi-Fi). Open the DevApp, and you should see your local app show up in the list.
 
+> Note that currently you might need to run `ionic cordova prepare` with th default project before running `ionic serve --devapp` in order to copy the cordova assets to prepare the native build for the mobile platform.
+
 ## CORS
 
 If your web requests are failing, you may be running into issues with

--- a/src/pages/appflow/devapp.md
+++ b/src/pages/appflow/devapp.md
@@ -36,7 +36,7 @@ First, ensure you are running the latest release of the Ionic CLI. Run `npm inst
 
 Once the latest CLI is installed, run `ionic serve --devapp` in the app of your choice on your computer and let it finish building. Next, open your iOS or Android device and connect to _the same network_ as your computer (through Wi-Fi). Open the DevApp, and you should see your local app show up in the list.
 
-> Note that currently you might need to run `ionic cordova prepare` with th default project before running `ionic serve --devapp` in order to copy the cordova assets to prepare the native build for the mobile platform.
+> Note that currently you might need to run `ionic cordova prepare` with the default project before running `ionic serve --devapp` in order to copy the cordova assets to prepare the native build for the mobile platform.
 
 ## CORS
 


### PR DESCRIPTION
Added a note when explaining the use of the `ionic serve --devapp` command because when using the default project the following error is triggered: Could not find cordova integration in the default project. and we need to run `ionic cordova prepare` in order to be able to use the devapp