### PR TITLE
Amended spelling mistake of 'cordoava' to 'cordova'

### DIFF
--- a/src/pages/appflow/deploy/tutorials.md
+++ b/src/pages/appflow/deploy/tutorials.md
@@ -23,7 +23,7 @@ You can follow the guide below or watch this video:
 ### Deploy Upgrade Guide
 You'll need specific versions of each of the following libraries:
 * `cordova-plugin-ionic-webview >= 2.0.0`
-* `cordoava-plugin-ionic >= 5.0.0`
+* `cordova-plugin-ionic >= 5.0.0`
 * `@ionic/pro >= 2.0.0`
 
 The following commands inside the root of you Ionic app should remove the old versions and install the new ones for you:


### PR DESCRIPTION
I noticed a spelling mistake of **cordoava** on https://ionicframework.com/docs/appflow/deploy/tutorials/#upgrading-to-the-new-deploy-plugin so have decided to correct it.