### PR TITLE
fix(appflow): Improve Deploy and Package CLI document readability

### DIFF
--- a/src/pages/appflow/deploy/cli.md
+++ b/src/pages/appflow/deploy/cli.md
@@ -89,7 +89,7 @@ multiple channels need to be specified; more infos about channels are available 
 
 ### Customize the Deploy build with Advanced Options
 
-The Advanced Options available to customize the build:
+The Advanced Options available to customize the build include:
 
 * `--commit=<sha1>` The commit defaults to HEAD; to use a different commit you can use this option with the full SHA1 of the commit.
 

--- a/src/pages/appflow/deploy/cli.md
+++ b/src/pages/appflow/deploy/cli.md
@@ -8,44 +8,43 @@ nextUrl: '/docs/appflow/package/intro'
 # Deploy builds on Appflow using the Ionic CLI
 
 <blockquote>
-  <p><b>Note:</b>This feature is only available on our Scale plan <a href="/sales">contact us</a> to enable this feature.</p>
+  <p><b>Note:</b> This feature is only available on our <b>Scale</b> plan. Please <a href="/sales">contact us</a> to enable this feature.</p>
 </blockquote>
 
-It is possible to trigger deploy builds on Appflow directly from the CLI.
-This is extremely useful if you need to integrate the deploy build step inside an existing external CI/CD process.
+It is possible to trigger Deploy builds on Appflow directly from the CLI.
+This is extremely useful if you need to integrate the Deploy build step inside an existing external CI/CD process.
 
 ### Prerequisites
 Upgrade the Ionic CLI to at least version `4.8.0`.
 
-To use environments, a proper subscription that allows the usage of Automations is needed.
+To use environments, a proper Appflow subscription that allows the usage of Automations is needed.
 
 ### Authentication
 
-The Ionic CLI has to be authenticated on Appflow to be able to trigger a deploy build.
+The Ionic CLI has to be authenticated on Appflow to be able to trigger a Deploy build.
 
-To login type
+To login type:
 ```bash
 $ ionic login <email> <password>
 ```
 
-this will prompt for the Appflow username/password.
+This will prompt for the Appflow username/password.
 
-The CLI can be authenticated also via environment variable (for example if it is used during a CI/CD task).
+The CLI can also be authenticated via an environment variable (for example, if it is used during a CI/CD task).
 
-To set up the authentication via environment variable, first login with an user who has access to the app you want to trigger
-deploy builds for for
+To set up the authentication via environment variable, first login via the CLI with an Appflow user who has access to the app you want to trigger Deploy builds for:
 
 ```bash
 $ ionic login <email> <password>
 ```
 
-then export the authentication token
+Then, export the authentication token:
 
 ```bash
 $ ionic config get -g tokens.user
 ```
 
-finally export the token in an environment variable of your shell or your CI/CD service.
+Finally, export the token in an environment variable of your shell or your CI/CD service.
 
 ```bash
 $ export IONIC_TOKEN=<your token>
@@ -53,7 +52,7 @@ $ export IONIC_TOKEN=<your token>
 
 ### Link the app
 
-Your app must be linked to the remote app on Appflow. If the app is not linked yet, just run
+Your app must be linked to the remote app on Appflow. If the app is not linked yet, run:
 
 ```bash
 $ ionic link <app id>
@@ -64,13 +63,13 @@ and commit the changes to `ionic.config.json`.
 
 ### Trigger a deploy build
 
-Currently deploy build can be triggered only from the app project directory.
+Currently, a Deploy build can be triggered only from the root project directory:
 
 ```bash
 $ cd /path/to/your/app
 ```
 
-Assuming the CLI is authenticated, to trigger a deploy build run
+Assuming the CLI is authenticated, to trigger a Deploy build, run:
 
 ```bash
 $ ionic deploy build
@@ -78,9 +77,9 @@ $ ionic deploy build
 
 Once the build is successfully triggered, the CLI will automatically start tailing the logs from Appflow.
 
-### Customize the deploy build with Options
+### Customize the Deploy build with Options
 
-The Options available to customize the build:
+The Options available to customize the build include:
 
 * `--environment=<name>` to specify the group of environment variables to be exposed to the build
 (available only with Automation; more info about environments are available [here](/docs/appflow/environments/))
@@ -88,24 +87,23 @@ The Options available to customize the build:
 multiple channels need to be specified; more infos about channels are available [here](/docs/appflow/deploy/channels/)
 
 
-### Customize the deploy build with Advanced Options
+### Customize the Deploy build with Advanced Options
 
 The Advanced Options available to customize the build:
 
-* `--commit=<sha1>` The commit defaults to HEAD; to use a different commit you can use this option
-with the full SHA1 of the commit
+* `--commit=<sha1>` The commit defaults to HEAD; to use a different commit you can use this option with the full SHA1 of the commit.
 
 ### Note about referencing Options values by name
 
-Names are case sensitive and need to be specified including spaces, for instance
+Names are case sensitive and need to be specified including spaces, for instance:
 
 ```bash
 $ ionic deploy build --channel="My Custom Channel"
 ```
 
-Apart from the `--commit` options, all the others require the full name setup within the Appflow Dashboard.
+Apart from the `--commit` option, all others require the full name setup within the Appflow Dashboard.
 
-For the Environments and Channels it is the Name
+Look for the name on the Environments and Channels pages in Appflow:
 
 ![CLI Environments List](/docs/assets/img/appflow/cli-environments-list.png)
 ![CLI Channels List](/docs/assets/img/appflow/cli-channels-list.png)

--- a/src/pages/appflow/package/cli.md
+++ b/src/pages/appflow/package/cli.md
@@ -8,46 +8,45 @@ nextUrl: '/docs/appflow/automation/intro'
 # Package builds on Appflow using the Ionic CLI
 
 <blockquote>
-  <p><b>Note:</b>This feature is only available on our Scale plan <a href="/sales">contact us</a> to enable this feature.</p>
+  <p><b>Note:</b> This feature is only available on our <b>Scale</b> plan. Please <a href="/sales">contact us</a> to enable this feature.</p>
 </blockquote>
 
-It is possible to trigger package builds on Appflow directly from the CLI.
-This is extremely useful if you need to integrate the package build step inside an existing external CI/CD process.
+It is possible to trigger Package builds on Appflow directly from the CLI.
+This is extremely useful if you need to integrate the Package build step as part of an existing external CI/CD process.
 
 ### Prerequisites
 Upgrade the Ionic CLI to at least version `4.7.0`.
 
-To trigger package builds on Appflow from the Ionic CLI, a proper subscription to run package builds is needed.
+To trigger Package builds on Appflow from the Ionic CLI, a proper subscription to run Package builds is needed.
 
-To use environments, a proper subscription that allows the usage of Automations is needed.
+To use Environments, a proper subscription that allows the usage of Automations is needed.
 
 ### Authentication
 
-The Ionic CLI has to be authenticated on Appflow to be able to trigger a package build.
+The Ionic CLI has to be authenticated on Appflow to be able to trigger a Deploy build.
 
-To login type
+To login type:
 ```bash
 $ ionic login <email> <password>
 ```
 
-this will prompt for the Appflow username/password.
+This will prompt for the Appflow username/password.
 
-The CLI can be authenticated also via environment variable (for example if it is used during a CI/CD task).
+The CLI can also be authenticated via an environment variable (for example, if it is used during a CI/CD task).
 
-To set up the authentication via environment variable, first login with an user who has access to the app you want to trigger
-package builds for for
+To set up the authentication via environment variable, first login via the CLI with an Appflow user who has access to the app you want to trigger Deploy builds for:
 
 ```bash
 $ ionic login <email> <password>
 ```
 
-then export the authentication token
+Then, export the authentication token:
 
 ```bash
 $ ionic config get -g tokens.user
 ```
 
-finally export the token in an environment variable of your shell or your CI/CD service.
+Finally, export the token in an environment variable of your shell or your CI/CD service.
 
 ```bash
 $ export IONIC_TOKEN=<your token>
@@ -55,7 +54,7 @@ $ export IONIC_TOKEN=<your token>
 
 ### Link the app
 
-Your app must be linked to the remote app on Appflow. If the app is not linked yet, just run
+Your app must be linked to the remote app on Appflow. If the app is not linked yet, run:
 
 ```bash
 $ ionic link <app id>
@@ -66,38 +65,36 @@ and commit the changes to `ionic.config.json`.
 
 ### Trigger a package build
 
-Currently package build can be triggered only from the app project directory.
+Currently, Package builds can only be triggered from the root project directory:
 
 ```bash
 $ cd /path/to/your/app
 ```
 
-Assuming the CLI is authenticated, to trigger a package build run
+Assuming the CLI is authenticated, to trigger a Package build, run:
 
 ```bash
 $ ionic package build
 ```
 
-this will prompt for the desired platform (`ios`/`android`) and build type specific for the platform.
+This will prompt for the desired platform (`ios`/`android`) and build type for the platform.
 
-For iOS or Android `release` builds, a valid security profile is required and can be specified
-using the `--security-profile=<name>` option.
+For iOS or Android `release` builds, a valid security profile is required and can be specified using the `--security-profile=<name>` option.
 
-To setup valid security profiles see [here](/docs/appflow/package/credentials).
+For information on setting up security profiles, see [here](/docs/appflow/package/credentials).
 
-The previous command can be execute in one single step, for instance
+The previous commands can be executed in a single step:
 
 ```bash
 $ ionic package build ios development --security-profile="My Security Profile"
 ```
 
-Once the build is successfully triggered, the CLI will automatically start tailing the logs from Appflow and,
-if the build is successful, download the `apk`/`ipa` file in the current directory.
+Once the build is successfully triggered, the CLI will automatically start tailing the logs from Appflow and, if the build is successful, download the `apk`/`ipa` file in the current directory.
 
 
 ### Customize the package build with Options
 
-The Options available to customize the build:
+The Options available to customize the build include:
 
 * `--environment=<name>` to specify the group of environment variables to be exposed to the build
 (available only with Automation; more info about environments are available [here](/docs/appflow/environments/))
@@ -107,7 +104,7 @@ build (more info about native configs are available [here](/docs/appflow/package
 
 ### Customize the package build with Advanced Options
 
-The Advanced Options available to customize the build:
+The Advanced Options available to customize the build include:
 
 * `--commit=<sha1>` The commit defaults to HEAD; to use a different commit you can use this option
 with the full SHA1 of the commit
@@ -118,20 +115,20 @@ build to have a consistent name for the produced artifact.
 
 ### Note about referencing Options values by name
 
-Names are case sensitive and need to be specified including spaces, for instance
+Names are case sensitive and need to be specified including spaces, for instance:
 
 ```bash
-$ ionic package build ios development --security-profile="iOS dev"
+$ ionic package build ios development --security-profile="iOS Dev"
 ```
 
-Apart from the `--commit` options, all the others require the full name setup within the Appflow Dashboard.
+Apart from the `--commit` option, all others require the full name setup within the Appflow Dashboard.
 
-For the Security Profiles, Environments and Native Configs it is the Name
+Look for the name on the Security Profiles, Environments and Native Configs pages in Appflow:
 
 ![Security Profiles](/docs/assets/img/appflow/cli-security-profile-list.png)
 ![Environments](/docs/assets/img/appflow/cli-environments-list.png)
 ![Native Configs](/docs/assets/img/appflow/cli-native-config-list.png)
 
-For the Target Platform, it is one of the strings identifying the platform in the Applflow Package Build Form.
+For the Target Platform, use one of the strings identifying the platform in the Applflow Package Build form:
 
 ![Target Platform](/docs/assets/img/appflow/cli-target-platform.png)

--- a/src/pages/appflow/package/cli.md
+++ b/src/pages/appflow/package/cli.md
@@ -23,7 +23,7 @@ To use Environments, a proper subscription that allows the usage of Automations 
 
 ### Authentication
 
-The Ionic CLI has to be authenticated on Appflow to be able to trigger a Deploy build.
+The Ionic CLI has to be authenticated on Appflow to be able to trigger a Package build.
 
 To login type:
 ```bash


### PR DESCRIPTION
## Changes

- Improved the readability of the Deploy and Package CLI documentation
- Improved consistency of language between the two docs
- Fixed some typos