### PR TITLE
getCurrentVersion can be undefined

### DIFF
--- a/src/pages/appflow/deploy/api.md
+++ b/src/pages/appflow/deploy/api.md
@@ -393,7 +393,7 @@ async performAutomaticUpdate() {
     const resp = await Deploy.sync({updateMethod: 'auto'}, percentDone => {
       console.log(`Update is ${percentDone}% done!`);
     });
-    if (currentVersion.versionId !== resp.versionId){
+    if (!currentVersion || currentVersion.versionId !== resp.versionId){
       // We found an update, and are in process of redirecting you since you put auto!
     }else{
       // No update available


### PR DESCRIPTION
GetCurrentVersion should be safe checked before accessing the versionId field.