### PR TITLE
docs(platform): expand variable name

### DIFF
--- a/src/pages/utilities/platform.md
+++ b/src/pages/utilities/platform.md
@@ -18,7 +18,7 @@ import { Platform } from '@ionic/angular';
 
 @Component({...})
 export class MyPage {
-  constructor(public plt: Platform) {
+  constructor(public platform: Platform) {
 
   }
 }


### PR DESCRIPTION
I'm not sure if its official but I have inferred that with Ionic4 names are expanded like `ctrl` to `controller`. This shortening of `platform` to `plt` doesn't seem in line with this.