### PR TITLE
docs(css-variables): section name different

### DIFF
--- a/src/pages/theming/css-variables.md
+++ b/src/pages/theming/css-variables.md
@@ -92,7 +92,7 @@ const color = el.style.getPropertyValue('--charcoal');
 
 ### Component Variables
 
-Ionic provides variables that exist at the component level, such as `--background` and `--color`. For a list of the custom properties a component accepts, view the `Custom Properties` section of its [API reference](/docs/api/). For example, see the [Button Custom Properties](/docs/api/button#css-custom-properties).
+Ionic provides variables that exist at the component level, such as `--background` and `--color`. For a list of the custom properties a component accepts, view the `CSS Custom Properties` section of its [API reference](/docs/api/). For example, see the [Button CSS Custom Properties](/docs/api/button#css-custom-properties).
 
 
 ### Global Variables


### PR DESCRIPTION
updated to reflect what the name of the section is on the page - easily inferred but I've opened it because i spotted it and its easier to just offer up the pr to see if you are bothered about this level of specificity.