### PR TITLE
Removes reference to deprecated component

### DIFF
--- a/src/pages/layout/structure.md
+++ b/src/pages/layout/structure.md
@@ -200,7 +200,7 @@ By default, the split pane view will show when the screen is larger than `768px`
       </ion-content>
     </ion-menu>
 
-    <ion-page class="ion-page" main>
+    <div class="ion-page" main>
       <ion-header>
         <ion-toolbar>
           <ion-buttons slot="start">
@@ -216,7 +216,7 @@ By default, the split pane view will show when the screen is larger than `768px`
       <ion-content padding>
         <h1>Main Content</h1>
       </ion-content>
-    </ion-page>
+    </div>
 
   </ion-split-pane>
 </ion-app>


### PR DESCRIPTION
The example for Split Pane Layout uses a deprecated tag that no longer exists in Ionic 4. By replacing `<ion-page class="ion-page" main>` with `<div class="ion-page" main>`, the example works as expected.