### PR TITLE
feat(native): add note on Capacitor incompatible plugins

### DIFF
--- a/scripts/build-pages/page-types/native.ts
+++ b/scripts/build-pages/page-types/native.ts
@@ -15,7 +15,7 @@ async function getNativePages(): Promise<Page[]> {
   return plugins.map(plugin => {
     const title = plugin.displayName.trim();
     const path = `/docs/native/${plugin.packageName.slice(14)}`;
-    const { description, usage, repo, platforms } = plugin;
+    const { capacitorIncompatible, description, usage, repo, platforms } = plugin;
     return {
       title,
       path,
@@ -25,6 +25,7 @@ async function getNativePages(): Promise<Page[]> {
       codeUsage: usage ? renderMarkdown(usage) : null,
       package: plugin.packageName,
       cordova: plugin.cordovaPlugin.name,
+      capacitorIncompatible: capacitorIncompatible ? capacitorIncompatible : false,
       template: 'native'
     };
   });

--- a/scripts/data/native.json
+++ b/scripts/data/native.json
@@ -84,7 +84,8 @@
     "repo": "https://github.com/floatinghotpot/cordova-admob-pro",
     "cordovaPlugin": {
       "name": "cordova-plugin-admobpro"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/admob",
@@ -699,7 +700,8 @@
     "installVariables": [],
     "cordovaPlugin": {
       "name": "cordova-plugin-braintree"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/branch-io",
@@ -1594,7 +1596,8 @@
     "repo": "https://github.com/arnesson/cordova-plugin-firebase",
     "cordovaPlugin": {
       "name": "cordova-plugin-firebase"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/flashlight",
@@ -2131,7 +2134,8 @@
     "repo": "https://github.com/ionic-team/cordova-plugin-ionic-webview",
     "cordovaPlugin": {
       "name": "cordova-plugin-ionic-webview"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/is-debug",
@@ -2190,7 +2194,8 @@
     "repo": "https://github.com/ionic-team/cordova-plugin-ionic-keyboard",
     "cordovaPlugin": {
       "name": "cordova-plugin-ionic-keyboard"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/keychain-touch-id",
@@ -2455,7 +2460,8 @@
     "repo": "https://github.com/homerours/cordova-music-controls-plugin",
     "cordovaPlugin": {
       "name": "cordova-plugin-music-controls"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/native-audio",
@@ -2910,7 +2916,8 @@
     "repo": "https://github.com/bitpay/cordova-plugin-qrscanner",
     "cordovaPlugin": {
       "name": "cordova-plugin-qrscanner"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/quikkly",
@@ -3206,7 +3213,8 @@
     "repo": "https://github.com/apache/cordova-plugin-splashscreen",
     "cordovaPlugin": {
       "name": "cordova-plugin-splashscreen"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/spotify-auth",
@@ -3315,7 +3323,8 @@
     "repo": "https://github.com/apache/cordova-plugin-statusbar",
     "cordovaPlugin": {
       "name": "cordova-plugin-statusbar"
-    }
+    },
+    "capacitorIncompatible": true
   },
   {
     "packageName": "@ionic-native/stepcounter",

--- a/src/components/page/templates/native.tsx
+++ b/src/components/page/templates/native.tsx
@@ -9,6 +9,7 @@ export default (props) => {
   const installation = renderInstallation(page.cordova, page.package);
   const platforms = renderPlatforms(page.platforms);
   const usage = renderUsage(page.codeUsage);
+  const capIncompat = renderCapIncompat(page.capacitorIncompatible);
 
   if (installation) {
     headings.push({
@@ -21,6 +22,13 @@ export default (props) => {
     headings.push({
       text: 'Supported Platforms',
       href: '#platforms'
+    });
+  }
+
+  if (capIncompat) {
+    headings.push({
+      text: 'Capacitor',
+      href: '#capacitor'
     });
   }
 
@@ -41,6 +49,7 @@ export default (props) => {
       { repo }
       { installation }
       { platforms }
+      { capIncompat }
       { usage }
     </article>
   );
@@ -122,6 +131,21 @@ const renderUsage = (usage: any) => {
         <a href="#usage">Usage</a>
       </h2>
       {toHypertext(h, usage)}
+    </section>
+  );
+};
+
+const renderCapIncompat = (capacitorIncompatible: boolean) => {
+  if (!capacitorIncompatible) {
+    return null;
+  }
+
+  return (
+    <section>
+      <h2 id="capacitor">
+        <a href="#capacitor">Capacitor</a>
+      </h2>
+      Not compatible
     </section>
   );
 };


### PR DESCRIPTION
When a plugin has the `"capacitorIncompatible": true`, adds a new Capacitor section where it says "Not compatible"

Closes #972 