### PR TITLE
(docs) Fix configuration.xml to config.xml of Geolocation section

### DIFF
--- a/src/pages/enterprise/geolocation.md
+++ b/src/pages/enterprise/geolocation.md
@@ -36,7 +36,7 @@ minor: 4.0.X
 
 This API is based on the W3C Geolocation API Specification, and only executes on devices that don't already provide an implementation.
 
-For iOS you have to add this configuration to your configuration.xml file
+For iOS you have to add this configuration to your config.xml file
 
 ```xml
 <edit-config file="*-Info.plist" mode="merge" target="NSLocationWhenInUseUsageDescription">

--- a/src/pages/es/enterprise/geolocation.md
+++ b/src/pages/es/enterprise/geolocation.md
@@ -36,7 +36,7 @@ minor: 4.0.X
 
 This API is based on the W3C Geolocation API Specification, and only executes on devices that don't already provide an implementation.
 
-For iOS you have to add this configuration to your configuration.xml file
+For iOS you have to add this configuration to your config.xml file
 
 ```xml
 <edit-config file="*-Info.plist" mode="merge" target="NSLocationWhenInUseUsageDescription">

--- a/src/pages/pt/enterprise/geolocation.md
+++ b/src/pages/pt/enterprise/geolocation.md
@@ -36,7 +36,7 @@ minor: 4.0.X
 
 This API is based on the W3C Geolocation API Specification, and only executes on devices that don't already provide an implementation.
 
-For iOS you have to add this configuration to your configuration.xml file
+For iOS you have to add this configuration to your config.xml file
 
 ```xml
 <edit-config file="*-Info.plist" mode="merge" target="NSLocationWhenInUseUsageDescription">

--- a/src/pages/zh/enterprise/geolocation.md
+++ b/src/pages/zh/enterprise/geolocation.md
@@ -36,7 +36,7 @@ minor: 4.0.X
 
 This API is based on the W3C Geolocation API Specification, and only executes on devices that don't already provide an implementation.
 
-For iOS you have to add this configuration to your configuration.xml file
+For iOS you have to add this configuration to your config.xml file
 
 ```xml
 <edit-config file="*-Info.plist" mode="merge" target="NSLocationWhenInUseUsageDescription">


### PR DESCRIPTION
This PR fixes a typo in markdown page for Geolocation.

Page that's been affected is:
https://ionicframework.com/docs/enterprise/geolocation

Path to the source file: src/pages/enterprise/geolocation.md

I have updated the other languages' files related to the abovementioned file