### PR TITLE
Update css-utilities.md

### DIFF
--- a/src/pages/layout/css-utilities.md
+++ b/src/pages/layout/css-utilities.md
@@ -638,6 +638,28 @@ The default amount of `margin` to be applied is `16px` and is set by the `--ion-
 | `.ion-align-self-stretch`  | `align-self: stretch`    | Item is stretched to fill the container.                                            |
 | `.ion-align-self-auto`     | `align-self: auto`       | Item is positioned according to the parent's `align-items` value.                   |
 
+## Border Display
+
+The border display CSS property determines if the border should be visible or not. The property can be applied to the ion-header and the ion-footer.
+
+```html
+<ion-header class="ion-no-border">
+  <ion-toolbar>
+    <ion-title>Header - No Border</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+        
+<ion-footer class="ion-no-border">
+  <ion-toolbar>
+    <ion-title>Footer - No Border</ion-title>
+  </ion-toolbar>
+</ion-footer>
+```
+
+| Class              |  Description                                                                                               |
+|--------------------|-----------------------------------------------------------------------------------------------------------|
+| `.ion-no-border`  |  The element will have no border.  
 
 ## Ionic Breakpoints
 


### PR DESCRIPTION
Added the Border Display CSS property to the CSS Utilities page. This property was not documented here in CSS Utilities. When i saw the v5.0.0-beta.0 pre-release, I taught why not now?  https://github.com/ionic-team/ionic/pull/18954