### PR TITLE
Ionic native: add IV cap details and mark incompatible cap plugins

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -161,6 +161,7 @@ export namespace Components {
   }
   interface LayeredColorsSelect {}
   interface NativeEntInstall {
+    'capacitorSlug'?: string;
     'pluginId': string;
     'variables'?: string;
   }
@@ -637,6 +638,7 @@ declare namespace LocalJSX {
   }
   interface LayeredColorsSelect extends JSXBase.HTMLAttributes<HTMLLayeredColorsSelectElement> {}
   interface NativeEntInstall extends JSXBase.HTMLAttributes<HTMLNativeEntInstallElement> {
+    'capacitorSlug'?: string;
     'pluginId'?: string;
     'variables'?: string;
   }

--- a/src/components/native-ent-install/native-ent-install.tsx
+++ b/src/components/native-ent-install/native-ent-install.tsx
@@ -6,6 +6,7 @@ import { Component, Prop, h } from '@stencil/core';
 export class NativeEnterpriseInstall {
   @Prop() pluginId: string;
   @Prop() variables?: string;
+  @Prop() capacitorSlug?: string;
 
   render() {
     if (!this.pluginId) {
@@ -25,10 +26,17 @@ export class NativeEnterpriseInstall {
           <command-prompt>{`ionic cordova plugin add @ionic-enterprise/${this.pluginId} ${this.variables}`}</command-prompt>
         </command-line>
         <strong>Capacitor:</strong>
-        <command-line>
-          <command-prompt>{`npm install @ionic-enterprise/${this.pluginId}`}</command-prompt>
+        {
+          this.capacitorSlug ?
+            <div>Available as a
+              <a href={`https://capacitor.ionicframework.com/docs/apis/${this.capacitorSlug}`}> core Capacitor plugin</a>.
+            </div>
+          :
+          <command-line>
+            <command-prompt>{`npm install @ionic-enterprise/${this.pluginId}`}</command-prompt>
           <command-prompt>npx cap sync</command-prompt>
-        </command-line>
+          </command-line>
+        }
       </section>
     );
   }

--- a/src/pages/enterprise/filesystem.md
+++ b/src/pages/enterprise/filesystem.md
@@ -9,7 +9,7 @@ otherVersions:
 
 The Filesystem plugin presents a simple and intuitive interface for common file operations such as reading/writing and listing the contents of directories.
 
-<native-ent-install plugin-id="filesystem" variables=""></native-ent-install>
+<native-ent-install plugin-id="filesystem" variables="" capacitor-slug="filesystem"></native-ent-install>
 
 Usage
 -----

--- a/src/pages/enterprise/identity-vault.md
+++ b/src/pages/enterprise/identity-vault.md
@@ -22,6 +22,16 @@ Without Ionic Identity Vault, Ionic developers have to resort to combining third
 
 <native-ent-install plugin-id="identity-vault" variables=""></native-ent-install>
 
+Update the native project config files:
+
+```xml
+// iOS - Info.plist
+<key>NSFaceIDUsageDescription</key>
+<string>Use Face ID to authenticate yourself and login</string>
+
+// Android - No additional changes needed
+```
+
 ## Reference App
 
 A complete [login/logout experience](https://github.com/ionic-team/cs-demo-iv) that includes biometrics (Face ID with passcode as a fallback), secure token storage, background data hiding, and session timeouts.

--- a/src/pages/enterprise/keyboard.md
+++ b/src/pages/enterprise/keyboard.md
@@ -10,7 +10,7 @@ Keyboard
 
 The Keyboard plugin allows you to configure the keyboard behavior (show/hide) and display (sizing/visibility).
 
-<native-ent-install plugin-id="keyboard" variables=""></native-ent-install>
+<native-ent-install plugin-id="keyboard" variables="" capacitor-slug="keyboard"></native-ent-install>
 
 Usage
 -----

--- a/src/pages/enterprise/splashscreen.md
+++ b/src/pages/enterprise/splashscreen.md
@@ -7,7 +7,7 @@ minor: 5.0.X
 
 The Splash Screen plugin provides control options for displaying and hiding a splash screen, commonly during application launch.
 
-<native-ent-install plugin-id="splashscreen" variables=""></native-ent-install>
+<native-ent-install plugin-id="splashscreen" variables="" capacitor-slug="splash-screen"></native-ent-install>
 
 ## Index
 

--- a/src/pages/enterprise/statusbar.md
+++ b/src/pages/enterprise/statusbar.md
@@ -7,7 +7,7 @@ minor: 2.4.X
 
 The Status Bar plugin provides the ability to customize the appearance of the native mobile status bar, including setting visibility, background color, and more.
 
-<native-ent-install plugin-id="statusbar" variables=""></native-ent-install>
+<native-ent-install plugin-id="statusbar" variables="" capacitor-slug="status-bar"></native-ent-install>
 
 ## Index
 


### PR DESCRIPTION
Mark Capacitor incompatible plugins by pointing to the community version:
- Filesystem
- Statusbar
- Keyboard
- Splashscreen

Also, add IV details for Capacitor.