### PR TITLE
chore(): clarify Angular Config, move Config and Platform to Angular subheader

### DIFF
--- a/src/assets/locales/en/messages.json
+++ b/src/assets/locales/en/messages.json
@@ -60,6 +60,8 @@
   "menu-angular-your-first-app": "Build Your First App",
   "menu-angular-lifecycle": "Lifecycle",
   "menu-angular-navigation": "Navigation/Routing",
+  "menu-angular-config": "Config",
+  "menu-angular-platform": "Platform",
   "menu-angular-performance": "Performance",
 
   "menu-react": "React",
@@ -75,10 +77,6 @@
   "menu-vue-your-first-app": "Build Your First App",
   "menu-vue-lifecycle": "Lifecycle",
   "menu-vue-navigation": "Navigation/Routing",
-
-  "menu-utilities": "Utilities",
-  "menu-utilities-config": "Config",
-  "menu-utilities-platform": "Platform",
 
   "menu-publishing": "Publishing",
   "menu-publishing-progressive-web-app": "Progressive Web App",

--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -53,6 +53,8 @@ const items = {
     'menu-angular-your-first-app': '/docs/angular/your-first-app',
     'menu-angular-lifecycle': '/docs/angular/lifecycle',
     'menu-angular-navigation': '/docs/angular/navigation',
+    'menu-angular-config': '/docs/angular/config',
+    'menu-angular-platform': '/docs/angular/platform',
     'menu-angular-performance': '/docs/angular/performance'
   },
   'menu-react': {
@@ -68,10 +70,6 @@ const items = {
     'menu-vue-your-first-app': '/docs/vue/your-first-app',
     'menu-vue-lifecycle': '/docs/vue/lifecycle',
     'menu-vue-navigation': '/docs/vue/navigation'
-  },
-  'menu-utilities': {
-    'menu-utilities-config': '/docs/utilities/config',
-    'menu-utilities-platform': '/docs/utilities/platform'
   },
   'menu-publishing': {
     'menu-publishing-progressive-web-app': '/docs/publishing/progressive-web-app',

--- a/src/pages/angular/config.md
+++ b/src/pages/angular/config.md
@@ -1,8 +1,8 @@
 ---
-previousText: ''
-previousUrl: ''
+previousText: 'Navigation/Routing'
+previousUrl: '/docs/angular/navigation'
 nextText: 'Platform'
-nextUrl: '/docs/utilities/platform'
+nextUrl: '/docs/angular/platform'
 contributors:
   - liamdebeasi
   - mhartington
@@ -10,13 +10,13 @@ contributors:
 
 # Config
 
-The Config service provides a way to change the properties of components globally across an app. It can set the app mode, tab button layout, animations, and more.
+Ionic Config provides a way to change the properties of components globally across an app. It can set the app mode, tab button layout, animations, and more.
 
 ## Usage
 
 ### Global
 
-#### Basic example
+To override the initial Ionic config for the app, provide a config in `IonicModule.forRoot` in the `app.module.ts` file.
 
 ```typescript
 import { IonicModule } from '@ionic/angular';
@@ -37,7 +37,10 @@ import { IonicModule } from '@ionic/angular';
 
 In the above example, we are disabling the Material Design ripple effect across the app, as well as forcing the mode to be Material Design.
 
-#### Customizing Animations
+
+### By Component
+
+Ionic Config is not reactive, so it is recommended to use a component's properties when you want to override its default behavior rather than set its config globally.
 
 ```typescript
 import { IonicModule } from '@ionic/angular';
@@ -47,43 +50,7 @@ import { IonicModule } from '@ionic/angular';
   imports: [
     BrowserModule,
     IonicModule.forRoot({
-      toastEnter: (AnimationC: Animation, baseEl: ShadowRoot, position: string): Promise<Animation> => {
-        const baseAnimation = new AnimationC();
-
-        const wrapperAnimation = new AnimationC();
-
-        const hostEl = (baseEl.host || baseEl) as HTMLElement;
-        const wrapperEl = baseEl.querySelector('.toast-wrapper') as HTMLElement;
-
-        wrapperAnimation.addElement(wrapperEl);
-
-        const bottom = `calc(8px + var(--ion-safe-area-bottom, 0px))`;
-        const top = `calc(8px + var(--ion-safe-area-top, 0px))`;
-
-        switch (position) {
-          case 'top':
-            wrapperEl.style.top = top;
-            wrapperEl.style.opacity = 1;
-            wrapperAnimation.fromTo('transform', `translateY(-${hostEl.clientHeight}px)`, 'translateY(10px)')
-            break;
-          case 'middle':
-            const topPosition = Math.floor(
-              hostEl.clientHeight / 2 - wrapperEl.clientHeight / 2
-            );
-            wrapperEl.style.top = `${topPosition}px`;
-            wrapperAnimation.fromTo('opacity', 0.01, 1);
-            break;
-          default:
-            wrapperEl.style.bottom = bottom;
-            wrapperAnimation.fromTo('opacity', 0.01, 1);
-            break;
-        }
-        return Promise.resolve(baseAnimation
-          .addElement(hostEl)
-          .easing('cubic-bezier(.36,.66,.04,1)')
-          .duration(400)
-          .add(wrapperAnimation));
-      },
+      backButtonText: 'Go Back'
     }),
     AppRoutingModule
   ],
@@ -91,25 +58,14 @@ import { IonicModule } from '@ionic/angular';
 })
 ```
 
-In the above example, we are customizing the "enter" animation for the `ion-toast` component. When an `ion-toast` component is presented from the top, it will slide down instead of fading in.
+This will set the default text for `ion-back-button` to `Go Back`. However, if you were to change the value of the `backButtonText` config to `Do Not Go Back`, the `ion-back-button` default text would still default to `Go Back` as the component has already been initialized and rendered. Instead, it is recommended to use the `text` property on `ion-back-button`.
 
-
-
-### By Component
-
-#### Basic Example
-
-```typescript
-import { Component } from '@angular/core';
-import { Config } from '@ionic/angular';
-@Component({...})
-export class HomePage {
-  constructor(private config: Config) {
-    const text = this.config.get('backButtonText');
-    this.config.set('backButtonIcon', 'home');
-  }
-}
+```html
+<ion-back-button [text]="getBackButtonText()"></ion-back-button>
 ```
+
+In this example we have used our `ion-back-button` in such a way that it can dynamically update the text if there were to be a change that warranted it, such as language or locale change. Your `getBackButtonText` method would be responsible for returning the correct text.
+
 
 ## Config Options
 

--- a/src/pages/angular/config.md
+++ b/src/pages/angular/config.md
@@ -64,7 +64,7 @@ This will set the default text for `ion-back-button` to `Go Back`. However, if y
 <ion-back-button [text]="getBackButtonText()"></ion-back-button>
 ```
 
-In this example we have used our `ion-back-button` in such a way that it can dynamically update the text if there were to be a change that warranted it, such as language or locale change. Your `getBackButtonText` method would be responsible for returning the correct text.
+In this example we have used our `ion-back-button` in such a way that the text can be dynamically updated if there were to be a change that warranted it, such as a language or locale change. The `getBackButtonText` method would be responsible for returning the correct text.
 
 
 ## Config Options

--- a/src/pages/angular/navigation.md
+++ b/src/pages/angular/navigation.md
@@ -1,8 +1,8 @@
 ---
 previousText: 'Lifecycle'
 previousUrl: '/docs/angular/lifecycle'
-nextText: 'Performance'
-nextUrl: '/docs/angular/performance'
+nextText: 'Config'
+nextUrl: '/docs/angular/config'
 contributors:
   - mhartington
 ---

--- a/src/pages/angular/performance.md
+++ b/src/pages/angular/performance.md
@@ -1,6 +1,6 @@
 ---
-previousText: 'Navigation'
-previousUrl: '/docs/angular/navigation'
+previousText: 'Platform'
+previousUrl: '/docs/angular/platform'
 ---
 
 # Angular Performance

--- a/src/pages/angular/platform.md
+++ b/src/pages/angular/platform.md
@@ -1,8 +1,8 @@
 ---
 previousText: 'Config'
-previousUrl: '/docs/utilities/config'
-nextText: ''
-nextUrl: ''
+previousUrl: '/docs/angular/config'
+nextText: 'Performance'
+nextUrl: '/docs/angular/performance'
 contributors:
   - liamdebeasi
 ---


### PR DESCRIPTION
1. Moved Config and Platform (previously under "Utilities" subheader) to under the "Angular" subheader.
2. Clarified that Ionic Config in Angular is not reactive.
3. Provided an example for configuring apps on a per-component level in a reactive manner.
4. Updated wording to not mention Config service as it is deprecated.
5. Removed the animations example while I was in there. This functionality/example is covered in https://github.com/ionic-team/ionic-docs/pull/976.