### PR TITLE
Typo in placename

### DIFF
--- a/src/demos/api/searchbar/index.html
+++ b/src/demos/api/searchbar/index.html
@@ -34,7 +34,7 @@
         <ion-item>Edinburgh</ion-item>
         <ion-item>Geneva</ion-item>
         <ion-item>Genoa</ion-item>
-        <ion-item>Glasglow</ion-item>
+        <ion-item>Glasgow</ion-item>
         <ion-item>Hanoi</ion-item>
         <ion-item>Hong Kong</ion-item>
         <ion-item>Islamabad</ion-item>


### PR DESCRIPTION
Glasgow is spelt incorrectly.