### PR TITLE
fix(enterprise): Fixing plugin ID for AC child pages

### DIFF
--- a/src/pages/enterprise/auth-connect/auth0.md
+++ b/src/pages/enterprise/auth-connect/auth0.md
@@ -30,7 +30,7 @@ Auth0 is now ready to use in your Ionic app.
 
 Run the following command to install the Auth Connect plugin. For the `AUTH_URL_SCHEME` variable, use the globally unique App Id (ex: `com.company.app`) you decided on when configuring the Auth0 app above.
 
-<native-ent-install plugin-id="auth-connect" variables="--variable AUTH_URL_SCHEME=com.company.app"></native-ent-install>
+<native-ent-install plugin-id="auth" variables="--variable AUTH_URL_SCHEME=com.company.app"></native-ent-install>
 
 ### Configure Auth Connect
 

--- a/src/pages/enterprise/auth-connect/aws-cognito.md
+++ b/src/pages/enterprise/auth-connect/aws-cognito.md
@@ -14,7 +14,7 @@ When creating a User Pool, be sure to add an app client. Additional Auth Connect
 
 Run the following command to install the Auth Connect plugin. For the `AUTH_URL_SCHEME` variable, use the globally unique App Id (ex: `com.company.app`) you decided on when configuring the Azure AD app above.
 
-<native-ent-install plugin-id="auth-connect" variables="--variable AUTH_URL_SCHEME=com.company.app"></native-ent-install>
+<native-ent-install plugin-id="auth" variables="--variable AUTH_URL_SCHEME=com.company.app"></native-ent-install>
 
 ### Configure Auth Connect
 

--- a/src/pages/enterprise/auth-connect/azure-ad-b2c.md
+++ b/src/pages/enterprise/auth-connect/azure-ad-b2c.md
@@ -44,7 +44,7 @@ Azure AD B2C is now ready to use with Auth Connect.
 
 Run the following command to install the Auth Connect plugin. For the `AUTH_URL_SCHEME` variable, use the globally unique App Id (ex: `com.company.app`) you decided on when configuring the Azure AD app above.
 
-<native-ent-install plugin-id="auth-connect" variables="--variable AUTH_URL_SCHEME=com.company.app"></native-ent-install>
+<native-ent-install plugin-id="auth" variables="--variable AUTH_URL_SCHEME=com.company.app"></native-ent-install>
 
 ### Configure Auth Connect
 


### PR DESCRIPTION
## Changes
- Fixes the `plugin-id` parameter on the individual AuthConnect pages to match the overview page