### PR TITLE
fix(appflow): Fix missing colon in environment setup

### DIFF
--- a/src/pages/appflow/quickstart/environment.md
+++ b/src/pages/appflow/quickstart/environment.md
@@ -79,7 +79,7 @@ Here's what your <code>angular.json</code> configurations section might look lik
       }
     ],
   },
-  "local" {}, // leave this blank to use the default src/environments/environment.ts file
+  "local": {}, // leave this blank to use the default src/environments/environment.ts file
   ...
 }
 


### PR DESCRIPTION
## What Changed
- Fixes missing colon in `angular.json` in Environments walkthrough