### PR TITLE
Fix typo in variable

### DIFF
--- a/src/pages/angular/your-first-app/3-saving-photos.md
+++ b/src/pages/angular/your-first-app/3-saving-photos.md
@@ -48,7 +48,7 @@ private async readAsBase64(cameraPhoto: CameraPhoto) {
   return await this.convertBlobToBase64(blob) as string;  
 }
 
-convertBlobToBase64 = (blog: Blob) => new Promise((resolve, reject) => {
+convertBlobToBase64 = (blob: Blob) => new Promise((resolve, reject) => {
   const reader = new FileReader;
   reader.onerror = reject;
   reader.onload = () => {


### PR DESCRIPTION
*Fix*
Fixing typo that causes compiliation failure on Saving Photo Tutorial.

Changing blog to blob fixes this.



*Issue*
On this page https://ionicframework.com/docs/angular/your-first-app/3-saving-photos in the convertBlobToBase64 function the variable definition is shown like this `blog: Blob` which makes the compiler fail as it should be `blob: Blob.`

It will result in the following error in terminal when compiling:
`[ng] ERROR in src/app/services/photo.service.ts(87,26): error TS2552: Cannot find name 'blob'. Did you mean 'Blob'?
`

Created this issue for visibility https://github.com/ionic-team/ionic-docs/issues/1179


