### PR TITLE
docs(appflow): Adding note about iOS creds for native configs

### DIFF
--- a/src/pages/appflow/package/native-configs.md
+++ b/src/pages/appflow/package/native-configs.md
@@ -17,13 +17,17 @@ Native configs allow you overwrite certain configurations without having to comm
 * overwrite the [Appflow SDK or Deploy Plugin variables and preferences](/docs/appflow/deploy/api#plugin-variables)
 
 This makes it easy to build your app for multiple environments from the same version of the code.
-If using an [automation](/docs/appflow/automation/intro) you can trigger multiple automations from
+If using an [Automation](/docs/appflow/automation/intro), you can trigger multiple automations from
 the same branch that will produce different builds.
 
 Common use cases are:
-* making Staging, QA, and Production versions of you app with different Bundle IDs, App names, and
+* Making Staging, QA, and Production versions of you app with different Bundle IDs, App names, and
 Deploy Channels so that you can install all the environments on a single device and easily tell the apart
-* leaving the [DisableDeploy](/docs/appflow/deploy/api#disabledeploy) `true` for development and automatically setting it back to `false` when building binaries for release
+* Leaving the [DisableDeploy](/docs/appflow/deploy/api#disabledeploy) `true` for development and automatically setting it back to `false` when building binaries for release
+
+<blockquote>
+  <b>Note:</b> If you plan to use Native Configurations to modify Bundle IDs with your iOS Package builds, you will need to setup code signing credentials using those alternate Bundle IDs. See our section on <a href="/docs/appflow/package/credentials">Generating Credentials</a> for more information.
+</blockquote>
 
 To create one go to the `Package > Native Configs` tab in the sidebar and click `New native config`.
 

--- a/src/pages/appflow/quickstart/native-config.md
+++ b/src/pages/appflow/quickstart/native-config.md
@@ -47,7 +47,11 @@ the `Native Config` dropdown and click `Save`.
 
 ![Add Native Config to Automation](/docs/assets/img/appflow/gif-add-native-config.gif)
 
-Now your apps should automatically use a different `bundle id`, app name, and deploy channel between your development and production
+Now your apps should automatically have a different `bundle id`, app name, and deploy channel between your development and production
 builds. This means you can install both your development and production applications on the same device and easily tell them apart! 🔥
+
+<blockquote>
+  <b>Note:</b> If you plan to use Native Configurations to modify Bundle IDs with your iOS Package builds, you will need to setup code signing credentials using those alternate Bundle IDs. See our section on <a href="/docs/appflow/package/credentials">Generating Credentials</a> for more information.
+</blockquote>
 
 ![Multiple Enviroments on a Device](/docs/assets/img/appflow/ss-multiple-envs-device.png)


### PR DESCRIPTION
## What Changed

- Added notes to the QuickStart and Native Config Package documentation about needing matching Bundle ID credentials for iOS builds