### PR TITLE
fix(native): Fix Document Scanner plugin usage example

### DIFF
--- a/scripts/data/native.json
+++ b/scripts/data/native.json
@@ -1223,7 +1223,7 @@
     "packageName": "@ionic-native/document-scanner",
     "displayName": "Document Scanner",
     "description": "\nThis plugin processes images of documents, compensating for perspective.\n",
-    "usage": "\n```typescript\nimport { DocumentScanner, DocumentScannerOptions } from '@ionic-native/document-scanner';\n\n\nconstructor(private documentScanner: DocumentScanner) { }\n\n...\n\nlet opts: DocumentScannerOptions = {};\nthis.documentScanner.scanDocument(opts)\n  .then((res: string) => console.log(res))\n  .catch((error: any) => console.error(error));\n\n```\n",
+    "usage": "\n```typescript\nimport { DocumentScanner, DocumentScannerOptions } from '@ionic-native/document-scanner';\n\n\nconstructor(private documentScanner: DocumentScanner) { }\n\n...\n\nlet opts: DocumentScannerOptions = {};\nthis.documentScanner.scanDoc(opts)\n  .then((res: string) => console.log(res))\n  .catch((error: any) => console.error(error));\n\n```\n",
     "platforms": [
       "Android",
       "iOS"


### PR DESCRIPTION
Fix function name in Document Scanner usage example, according to plugin docs:
https://github.com/NeutrinosPlatform/cordova-plugin-document-scanner#usage