### PR TITLE
docs(ion-segment): set unique values for segments

### DIFF
--- a/src/demos/api/segment/index.html
+++ b/src/demos/api/segment/index.html
@@ -116,7 +116,7 @@
 
       <!-- Icon end -->
       <ion-segment color="danger" scrollable value="map">
-        <ion-segment-button value="map" layout="icon-end">
+        <ion-segment-button value="call" layout="icon-end">
           <ion-icon name="call"></ion-icon>
           <ion-label>Call</ion-label>
         </ion-segment-button>


### PR DESCRIPTION
Sets the call segment's value to call to avoid overlapping values.
Overlapping values highlight multiple segments.