### PR TITLE
Updates a command and a folder in the React PWA document

### DIFF
--- a/src/pages/react/pwa.md
+++ b/src/pages/react/pwa.md
@@ -32,7 +32,7 @@ serviceWorker.register();
 
 
 
-Once this package has been added run `ionic build --prod` and the `www` directory will be ready to deploy as a PWA.
+Once this package has been added run `ionic build` and the `build` directory will be ready to deploy as a PWA.
 
 > By default, react apps package comes with the Ionic logo for the app icons. Be sure to update the manifest to use the correct app name and also replace the icons.
 


### PR DESCRIPTION
In the Line 
"Once this package has been added run `ionic build --prod` and the `www` directory will be ready to deploy as a PWA."
In react, the --prod on the ionic build command doesn't seem needed and the directory that is generated to be deployed is "build" instead of "www"