### PR TITLE
update required imports for angular usage

### DIFF
--- a/src/pages/utilities/animations.md
+++ b/src/pages/utilities/animations.md
@@ -57,7 +57,7 @@ Developers using Angular should install the latest version of `@ionic/angular`. 
 
 ```typescript
 
-import { Animation, AnimationController } from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 ...
 


### PR DESCRIPTION
before : import { Animation, AnimationController } from '@ionic/angular';
after : import { AnimationController } from '@ionic/angular';
Because it look like Animation is not part of '@ionic/angular', please check.
Thank you