### PR TITLE
Make sure that the keytool command shown generates JKS over PKCS12

### DIFF
--- a/src/pages/appflow/package/credentials.md
+++ b/src/pages/appflow/package/credentials.md
@@ -24,7 +24,7 @@ that you need for the desired platform below.
 The [Android keystore](https://developer.android.com/training/articles/keystore.html), used for signing apps, can be generated using keytool, which is included in the [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html). Change `MY-RELEASE-KEY` and `MY_ALIAS_NAME` to be relevant to your app. The tool will ask you to enter a keystore password and a key password.
 
 ```bash
-$ keytool -genkey -v -keystore MY-RELEASE-KEY.keystore -alias MY_ALIAS_NAME -keyalg RSA -keysize 2048 -validity 10000
+$ keytool -genkey -v -keystore MY-RELEASE-KEY.keystore -alias MY_ALIAS_NAME -keyalg RSA -keysize 2048 -validity 10000 -storetype jks
 ```
 
 ## iOS Credentials


### PR DESCRIPTION
As discussed in Ionic forum (https://forum.ionicframework.com/t/cant-submit-android-keystore/184737/6) the key needs to be in the JKS format which is not the default at least on JDK11 version of the keytool. If the keystore is not in JKS format you'll get an error message whilst uploading it to Ionic Appflow and the error message doesn't do anything to point you to the right direction.