### PR TITLE
chore(yfa-react): Add missing return type

### DIFF
--- a/src/pages/react/your-first-app/3-saving-photos.md
+++ b/src/pages/react/your-first-app/3-saving-photos.md
@@ -22,7 +22,7 @@ const { deleteFile, getUri, readFile, writeFile } = useFilesystem();
 Next, create a couple of new functions in `usePhotoGallery`:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string) => {
+const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
   const base64Data = await base64FromPath(photo.webPath!);
   const savedFile = await writeFile({
     path: fileName,


### PR DESCRIPTION
First App React guide was missing a required return type of Promise<Photo>. Without it, TypeScript complains.