### PR TITLE
add a note about min ver for push to app store app flow cli

### DIFF
--- a/src/pages/appflow/destinations/cli.md
+++ b/src/pages/appflow/destinations/cli.md
@@ -5,6 +5,7 @@ previousUrl: '/docs/appflow/destinations/builds'
 nextText: 'Manual'
 nextUrl: '/docs/appflow/destinations/manual'
 ---
+> **NOTE:** To deploy a build you will need to be running `@ionic/cli` of at least version 6.8
 
 You can also create a build that will be deployed to an app store or deploy an already completed build as well.
 


### PR DESCRIPTION
does not look too bad, but as a note, a third note on the same page might not work.