### PR TITLE
feat(api): add encapsulation type to the api components

### DIFF
--- a/src/components/page/page.css
+++ b/src/components/page/page.css
@@ -48,7 +48,37 @@ docs-page .full-screen {
   padding: 0;
 }
 
+docs-page .page-heading-encapsulation {
+  text-transform: uppercase;
+
+  background: var(--accent-color-200);
+  color: #fff;
+
+  border: 2px solid var(--accent-color-200);
+  border-radius: 14px;
+  height: 24px;
+  padding: 2px 8px;
+
+  font-weight: 600;
+  font-size: 10px;
+  line-height: 14px;
+  display: inline-flex;
+  align-items: center;
+
+  align-self: center;
+  justify-self: flex-end;
+
+  letter-spacing: 0.08em;
+}
+
+docs-page .page-heading-encapsulation:hover {
+  background: var(--accent-color-100);
+}
+
 docs-page h1 {
+  display: flex;
+  justify-content: space-between;
+
   margin-top: 2rem;
   margin-bottom: 1rem;
 }

--- a/src/components/page/page.css
+++ b/src/components/page/page.css
@@ -51,10 +51,10 @@ docs-page .full-screen {
 docs-page .page-heading-encapsulation {
   text-transform: uppercase;
 
-  background: var(--accent-color-200);
-  color: #fff;
+  background: transparent;
+  color: #2d4665;
 
-  border: 2px solid var(--accent-color-200);
+  border: 1px solid #dee3ea;
   border-radius: 14px;
   height: 24px;
   padding: 2px 8px;
@@ -72,7 +72,7 @@ docs-page .page-heading-encapsulation {
 }
 
 docs-page .page-heading-encapsulation:hover {
-  background: var(--accent-color-100);
+  border-color: #92a1b3;
 }
 
 docs-page h1 {

--- a/src/components/page/templates/api.tsx
+++ b/src/components/page/templates/api.tsx
@@ -7,6 +7,7 @@ const [getFramework] = useLocalStorage('ionic-docs:framework');
 export default (props) => {
   const { page } = props;
   const headings = [...page.headings];
+  const encapsulation = renderEncapsulation(page.encapsulation);
   const usage = renderUsage(page.usage, page.path);
   const properties = renderProperties(page.props);
   const events = renderEvents(page.events);
@@ -58,7 +59,10 @@ export default (props) => {
 
   return (
     <article>
-      <h1>{ page.title }</h1>
+      <h1>
+        { page.title }
+        { encapsulation }
+      </h1>
       <div class="page-meta">
         <docs-table-of-contents links={headings} basepath={page.path}/>
         <internal-ad></internal-ad>
@@ -73,6 +77,18 @@ export default (props) => {
       { customProps }
       { slots }
     </article>
+  );
+};
+
+const renderEncapsulation = (encapsulation = {}) => {
+  if (encapsulation === 'none') {
+    return;
+  }
+
+  const path = `/docs/reference/glossary#${encapsulation}`;
+
+  return (
+    <a href={path} class="page-heading-encapsulation">{encapsulation}</a>
   );
 };
 

--- a/src/pages/reference/glossary.md
+++ b/src/pages/reference/glossary.md
@@ -53,6 +53,11 @@ nextUrl: '/docs/reference/versioning'
     <p><a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">CORS</a> (Cross-Origin Resource Sharing) is a mechanism for servers to control client access to web assets. See the <a href="/docs/faq/cors">CORS FAQs</a> for more information.</p>
   </section>
 
+  <section id="css-variables">
+    <a href="#css-variables"><h3>CSS Variables</h3></a>
+    <p>You may be familiar with variables from Sass. <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">CSS Variables</a> enable the same functionality but are built into the browser. CSS Variables are available in all evergreen browsers.</p>
+  </section>
+
   <section id="decorators">
     <a href="#decorators"><h3>Decorators</h3></a>
     <p>Decorators are expressions that return a function. They allow you to take an existing function, and extend its behavior. With TypeScript, you can also decorate <i>classes</i> and <i>parameters</i>. When you decorate a <strong>class</strong>, you are wrapping and extending the behavior of its constructor. In other words, the decorator will add some functionality when the constructor is called, and will then return the original constructor. When you decorate a <strong>parameter</strong>, you are wrapping the argument that gets passed in for that parameter. The decorator will add functionality when an argument is passed to the method, and then return the original argument.
@@ -156,14 +161,19 @@ nextUrl: '/docs/reference/versioning'
     <p><a href="https://angular.github.io/protractor/#/" target="_blank">Protractor</a> is a testing framework written for and by the Angular team. Protractor can be used with test runners, like Karma, for end-to-end testing. Test runners allow you to quickly and programmatically verify code quality.</p>
   </section>
 
-  <section id="css-variables">
-    <a href="#css-variables"><h3>CSS Variables</h3></a>
-    <p>You may be familiar with variables from Sass. <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">CSS Variables</a> enable the same functionality but are built into the browser. CSS Variables are available in all evergreen browsers.</p>
-  </section>
-
   <section id="sass">
     <a href="#sass"><h3>Sass</h3></a>
     <p>Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features such as <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">variables</a>, <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">mixins</a>, and <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">loops</a>.</p>
+  </section>
+
+  <section id="scoped">
+    <a href="#scoped"><h3>Scoped Encapsulation</h3></a>
+    <p>A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a data attribute at run time. Overriding scoped selectors in CSS requires a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a> selector.</p>
+  </section>
+
+  <section id="shadow">
+    <a href="#shadow"><h3>Shadow DOM</h3></a>
+    <p><a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a> is a native browser solution for DOM and style encapsulation of a component. It shields the component from its surrounding environment. To externally style a Shadow DOM component you must use <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a>.</p>
   </section>
 
   <section id="shim">

--- a/src/pages/reference/glossary.md
+++ b/src/pages/reference/glossary.md
@@ -168,12 +168,12 @@ nextUrl: '/docs/reference/versioning'
 
   <section id="scoped">
     <a href="#scoped"><h3>Scoped Encapsulation</h3></a>
-    <p>A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a data attribute at run time. Overriding scoped selectors in CSS requires a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a> selector.</p>
+    <p>A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a data attribute at run time. Overriding scoped selectors in CSS requires a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a> selector. Scoped components can also be styled using <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>.</p>
   </section>
 
   <section id="shadow">
     <a href="#shadow"><h3>Shadow DOM</h3></a>
-    <p><a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a> is a native browser solution for DOM and style encapsulation of a component. It shields the component from its surrounding environment. To externally style a Shadow DOM component you must use <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a>.</p>
+    <p><a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a> is a native browser solution for DOM and style encapsulation of a component. It shields the component from its surrounding environment. To externally style internal elements of a Shadow DOM component you must use <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a>.</p>
   </section>
 
   <section id="shim">


### PR DESCRIPTION
Adds encapsulation type to the API components & glossary entries for scoped & shadow that it links to

closes https://github.com/ionic-team/ionic-docs/issues/591

✅ Design is Ben approved

<img width="719" alt="Screen Shot 2020-05-08 at 6 03 12 PM" src="https://user-images.githubusercontent.com/6577830/81452918-31fb7700-9156-11ea-8212-9eeab6c0281d.png">
<img width="700" alt="Screen Shot 2020-05-08 at 5 54 24 PM" src="https://user-images.githubusercontent.com/6577830/81452505-0b890c00-9155-11ea-8f47-9bdfb140dbfc.png">
<img width="686" alt="Screen Shot 2020-05-08 at 5 54 29 PM" src="https://user-images.githubusercontent.com/6577830/81452506-0c21a280-9155-11ea-9c6b-934a4d441979.png">

