### PR TITLE
Add animationCtrl to the constructor in Angular

### DIFF
--- a/src/pages/utilities/animations.md
+++ b/src/pages/utilities/animations.md
@@ -978,7 +978,8 @@ import { ModalPage } from '../modal/modal.page';
   styleUrls: ['./modal-example.css']
 })
 export class ModalExample {
-  constructor(public modalController: ModalController) { }
+  constructor(public modalController: ModalController,
+              public animationCtrl: AnimationController) { }
 
   async presentModal() {
     const enterAnimation = (baseEl: any) => {

--- a/src/pages/utilities/animations.md
+++ b/src/pages/utilities/animations.md
@@ -969,7 +969,7 @@ function presentModal() {
 
 ```typescript
 import { Component } from '@angular/core';
-import { ModalController } from '@ionic/angular';
+import { ModalController, AnimationController } from '@ionic/angular';
 import { ModalPage } from '../modal/modal.page';
 
 @Component({


### PR DESCRIPTION
Add animationCtrl to the constructor of the ModalExample in Angular/Typescript otherwise, the code would not compile since animationCtrl  is used later.