### PR TITLE
Syntax Error fix:  Cannot find name 'cameraPhoto'.

### DIFF
--- a/src/pages/react/your-first-app/2-taking-photos.md
+++ b/src/pages/react/your-first-app/2-taking-photos.md
@@ -97,7 +97,7 @@ When the camera is done taking a picture, the resulting CameraPhoto returned fro
 const fileName = new Date().getTime() + '.jpeg';
 const newPhotos = [{
   filepath: fileName,
-  webviewPath: cameraPhoto.webPath
+  webviewPath: CameraPhoto.webPath
 }, ...photos];
 setPhotos(newPhotos)
 ```


### PR DESCRIPTION
There was a minor issue where you referenced a wrong variable.