### PR TITLE
fix(color-generator): update colors from CSS

### DIFF
--- a/src/components/color-gen/css-text/color-gen-css-text.tsx
+++ b/src/components/color-gen/css-text/color-gen-css-text.tsx
@@ -16,9 +16,9 @@ export class CssText {
   @Event() cssTextChange!: EventEmitter;
 
   onCssTextChange(ev: Event) {
-    if ((ev.target as HTMLTextAreaElement).value !== this.cssText) {
-      const value = (ev.target as HTMLTextAreaElement).value;
-      if (value.length === 0) { return; }
+    if ((ev.target as HTMLDivElement).textContent !== this.cssText) {
+      const value = (ev.target as HTMLDivElement).textContent;
+      if (value === null || value.length === 0) { return; }
 
       this.cssText = value;
 


### PR DESCRIPTION
This fixes a bug that currently does not to allow to import values as CSS.

# Steps to reproduce
1. go to the color generator page (https://ionicframework.com/docs/theming/color-generator)
2. scroll down to the `CSS Variables` section
3. edit the CSS, e.g. by pasting previously generated colors

# What is expected
The colors in the inputs should be updated accordingly as well as the colors in the demo app.

# What actually happens
Nothing.

# What was the reason
Obviously the code expected the CSS text input to be a `textarea` but actually it is a `div` with `[contenteditable=true]` which is why `ev.target.value` will always evaluate to `undefined` and so `value.length` will throw an exception:
https://github.com/ionic-team/ionic-docs/blob/bdf3a610a72783567e5c8868101dbd1bcf214176/src/components/color-gen/css-text/color-gen-css-text.tsx#L19-L21