### PR TITLE
docs(guide): add CSS Shadow Parts guide

### DIFF
--- a/src/assets/locales/en/messages.json
+++ b/src/assets/locales/en/messages.json
@@ -41,6 +41,7 @@
   "menu-theming-basics": "Basics",
   "menu-theming-platform-styles": "Platform Styles",
   "menu-theming-css-variables": "CSS Variables",
+  "menu-theming-css-shadow-parts": "CSS Shadow Parts",
   "menu-theming-colors": "Colors",
   "menu-theming-themes": "Themes",
   "menu-theming-dark-mode": "Dark Mode",

--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -30,6 +30,7 @@ const items = {
     'menu-theming-basics': '/docs/theming/basics',
     'menu-theming-platform-styles': '/docs/theming/platform-styles',
     'menu-theming-css-variables': '/docs/theming/css-variables',
+    'menu-theming-css-shadow-parts': '/docs/theming/css-shadow-parts',
     'menu-theming-colors': '/docs/theming/colors',
     'menu-theming-themes': '/docs/theming/themes',
     'menu-theming-dark-mode': '/docs/theming/dark-mode',

--- a/src/pages/theming/basics.md
+++ b/src/pages/theming/basics.md
@@ -30,8 +30,12 @@ Ionic has two **modes** that are used to customize the look of components based 
 
 ## CSS Variables
 
-All of the Ionic components are themed using <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS properties (variables)</a>. CSS variables add dynamic values to an otherwise static language. This is something that has traditionally required a CSS preprocessor like Sass. The look of an application can easily be changed by changing the value of any of the [Ionic Variables](/docs/theming/css-variables#ionic-variables).
+The Ionic Framework components are themed using <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank" rel="noopener noreferrer">CSS properties (variables)</a>. CSS variables add dynamic values to an otherwise static language. This is something that has traditionally required a CSS preprocessor like Sass. The look of an application can easily be changed by changing the value of any of the [CSS Variables](/docs/theming/css-variables) Ionic Framework provides.
 
+
+## CSS Shadow Parts
+
+CSS Shadow Parts were added to make it easier to fully customize Ionic Framework Shadow components. In the past, components that use <a href="https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM" target="_blank" rel="noopener noreferrer">Shadow DOM</a> were unable to have elements inside of their shadow tree styled directly. With the addition of Shadow parts, there is no longer a need for CSS variables for every property on an inner element of a Shadow component. For more information on customizing Ionic Framework components using parts, see the [CSS Shadow Parts](/docs/theming/css-shadow-parts) guide.
 
 ## Branding
 

--- a/src/pages/theming/colors.md
+++ b/src/pages/theming/colors.md
@@ -1,8 +1,8 @@
 ---
 initialTab: 'preview'
 inlineHtmlPreviews: true
-previousText: 'CSS Variables'
-previousUrl: '/docs/theming/css-variables'
+previousText: 'CSS Shadow Parts'
+previousUrl: '/docs/theming/css-shadow-parts'
 nextText: 'Themes'
 nextUrl: '/docs/theming/themes'
 ---

--- a/src/pages/theming/css-shadow-parts.md
+++ b/src/pages/theming/css-shadow-parts.md
@@ -65,7 +65,7 @@ With these parts exposed, the element can now be styled directly using [::part](
 
 The <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank" rel="noopener noreferrer">`::part()`</a> pseudo-element allows developers to select elements inside of a shadow tree that have been exposed via a part attribute.
 
-Since we know that the `ion-select` exposes a `placeholder` part for styling the text when there is no value selected, we can customize it in the following way:
+Since we know that `ion-select` exposes a `placeholder` part for styling the text when there is no value selected, we can customize it in the following way:
 
 ```css
 ion-select::part(placeholder) {

--- a/src/pages/theming/css-shadow-parts.md
+++ b/src/pages/theming/css-shadow-parts.md
@@ -98,7 +98,7 @@ ion-item::part(native):hover {
 
 ## Ionic Framework Parts
 
-All exposed parts for an Ionic Framework component can be found under the CSS Shadow Parts heading on its API page. To view all components and their  API pages, see the <a href="/docs/components" target="_blank" rel="noopener noreferrer">Component documentation</a>.
+All exposed parts for an Ionic Framework component can be found under the CSS Shadow Parts heading on its API page. To view all components and their API pages, see the <a href="/docs/components" target="_blank" rel="noopener noreferrer">Component documentation</a>.
 
 In order to have parts a component must meet the following criteria:
 

--- a/src/pages/theming/css-shadow-parts.md
+++ b/src/pages/theming/css-shadow-parts.md
@@ -11,7 +11,7 @@ CSS Shadow Parts allow developers to style CSS properties on an element inside o
 
 ## Why Shadow Parts?
 
-Ionic Framework is a distributed set of <a href="https://www.webcomponents.org/introduction" target="_blank" rel="noopener noreferrer">Web Components</a>. Web Components follow the <a href="https://w3c.github.io/webcomponents/spec/shadow/" target="_blank" rel="noopener noreferrer">Shadow DOM specification</a> in order to encapsulate styles and markup.
+Ionic Framework is a distributed set of <a href="https://developer.mozilla.org/en-US/docs/Web/Web_Components" target="_blank" rel="noopener noreferrer">Web Components</a>. Web Components follow the <a href="https://w3c.github.io/webcomponents/spec/shadow/" target="_blank" rel="noopener noreferrer">Shadow DOM specification</a> in order to encapsulate styles and markup.
 
 > Ionic Framework components are **not all** Shadow DOM components. If the component is a Shadow DOM component, there will be a badge in the top right of its <a href="/docs/components" target="_blank" rel="noopener noreferrer">component documentation</a>. An example of a Shadow DOM component is the <a href="/docs/api/button" target="_blank" rel="noopener noreferrer">button component</a>.
 

--- a/src/pages/theming/css-shadow-parts.md
+++ b/src/pages/theming/css-shadow-parts.md
@@ -1,0 +1,153 @@
+---
+previousText: 'CSS Variables'
+previousUrl: '/docs/theming/css-variables'
+nextText: 'Colors'
+nextUrl: '/docs/theming/colors'
+---
+
+# CSS Shadow Parts
+
+CSS Shadow Parts allow developers to style CSS properties on an element inside of a shadow tree. This is extremely useful in customizing Ionic Framework <a href="https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM" target="_blank" rel="noopener noreferrer">Shadow DOM</a> components.
+
+## Why Shadow Parts?
+
+Ionic Framework is a distributed set of <a href="https://www.webcomponents.org/introduction" target="_blank" rel="noopener noreferrer">Web Components</a>. Web Components follow the <a href="https://w3c.github.io/webcomponents/spec/shadow/" target="_blank" rel="noopener noreferrer">Shadow DOM specification</a> in order to encapsulate styles and markup.
+
+> Ionic Framework components are **not all** Shadow DOM components. If the component is a Shadow DOM component, there will be a badge in the top right of its <a href="/docs/components" target="_blank" rel="noopener noreferrer">component documentation</a>. An example of a Shadow DOM component is the <a href="/docs/api/button" target="_blank" rel="noopener noreferrer">button component</a>.
+
+Shadow DOM is useful for preventing styles from leaking out of components and unintentionally applying to other elements. For example, we assign a `.button` class to our `ion-button` component. Without Shadow DOM encapsulation, if a user were to set the class `.button` on one of their own elements, it would inherit the Ionic Framework button styles. Since `ion-button` is a Shadow component, this is not a problem.
+
+However, due to this encapsulation, styles aren’t able to bleed into inner elements of Shadow components either. This means that if a Shadow component renders elements inside of its shadow tree, the inner elements cannot be targeted directly with CSS. Using the `ion-select` component as an example, it renders the following markup:
+
+```html
+<ion-select>
+  #shadow-root
+    <div class=”select-text select-placeholder”></div>
+    <div class=”select-icon”></div>
+</ion-select>
+```
+
+The placeholder text and icon elements are inside of the `#shadow-root`, which means the following CSS will **NOT** work to style the placeholder:
+
+```css
+/* Does NOT work */
+ion-select .select-placeholder {
+  color: blue;
+}
+```
+
+So how do we solve this? [CSS Shadow Parts](#shadow-parts-explained)!
+
+
+## Shadow Parts Explained
+
+Shadow parts allow developers to style inside a shadow tree, from outside of that shadow tree. In order to do so, the [part must be exposed](#exposing-a-part) and then it can be styled by using [::part](#how-part-works).
+
+### Exposing a part
+
+When creating a Shadow DOM component, a part can be added to an element inside of a shadow tree by assigning a `part` attribute on the element. This is added to the component in Ionic Framework and requires no action from an end user.
+
+Continuing to use the `ion-select` component as an example, the markup is updated to look like the following:
+
+```html
+<ion-select>
+  #shadow-root
+    <div part=”placeholder” class=”select-text select-placeholder”></div>
+    <div part=”icon” class=”select-icon”></div>
+</ion-select>
+```
+
+The above shows two parts: `placeholder` and `icon`. See the <a href="/docs/api/select#css-shadow-parts" target="_blank" rel="noopener noreferrer">select documentation</a> for all of its parts.
+
+With these parts exposed, the element can now be styled directly using [::part](#how-part-works).
+
+### How ::part works
+
+The <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank" rel="noopener noreferrer">`::part()`</a> pseudo-element allows developers to select elements inside of a shadow tree that have been exposed via a part attribute.
+
+Since we know that the `ion-select` exposes a `placeholder` part for styling the text when there is no value selected, we can customize it in the following way:
+
+```css
+ion-select::part(placeholder) {
+  color: blue;
+  opacity: 1;
+}
+```
+
+Styling using `::part` allows any CSS property that is accepted by that element to be changed.
+
+In addition to being able to target the part, <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements" target="_blank" rel="noopener noreferrer">pseudo-elements</a> can be styled without them being explicitly exposed:
+
+```css
+ion-select::part(placeholder)::first-letter {
+  font-size: 22px;
+  font-weight: 500;
+}
+```
+
+Parts work with most <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes" target="_blank" rel="noopener noreferrer">psuedo-classes</a>, as well:
+
+```css
+ion-item::part(native):hover {
+  color: green;
+}
+```
+
+> There are some known limitations with [vendor prefixed pseudo-elements](#vendor-prefixed-pseudo-elements) and [structural pseudo-classes](#structural-pseudo-classes).
+
+
+## Ionic Framework Parts
+
+All exposed parts for an Ionic Framework component can be found under the CSS Shadow Parts heading on its API page. To view all components and their  API pages, see the <a href="/docs/components" target="_blank" rel="noopener noreferrer">Component documentation</a>.
+
+In order to have parts a component must meet the following criteria:
+
+- It is a <a href="/docs/reference/glossary#shadow" target="_blank" rel="noopener noreferrer">Shadow DOM</a> component. If it is a <a href="/docs/reference/glossary#scoped" target="_blank" rel="noopener noreferrer">Scoped</a> or Light DOM component, the child elements can be targeted directly. If a component is Scoped or Shadow, it will be listed by its name on its <a href="/docs/components" target="_blank" rel="noopener noreferrer">component documentation page</a>.
+- It contains children elements. For example, `ion-card-header` is a Shadow component, but all styles are applied to the host element. Since it has no child elements, there’s no need for parts.
+- The children elements are not structural. In certain components, including `ion-title`, the child element is a structural element used to position the inner elements. We do not recommend customizing structural elements as this can have unexpected results.
+
+> We welcome recommendations for additional parts. Please create a <a href="https://github.com/ionic-team/ionic-framework/issues/new?assignees=&labels=&template=feature_request.md&title=feat%3A+" target="_blank" rel="noopener noreferrer">new GitHub issue</a> with as much information as possible when requesting a part.
+
+## Known Limitations
+
+### Browser Support
+
+CSS Shadow Parts are supported in the recent versions of all of the major browsers. However, some of the older versions do not support shadow parts. Verify the <a href="https://caniuse.com/#feat=mdn-css_selectors_part" target="_blank" rel="noopener noreferrer">browser support</a> meets the requirements before implementing parts in an app. If browser support for older versions is required, we recommend continuing to use <a href="/docs/theming/css-variables" target="_blank" rel="noopener noreferrer">CSS Variables</a> for styling.
+
+### Vendor Prefixed Pseudo-Elements
+
+<a href="https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix" target="_blank" rel="noopener noreferrer">Vendor prefixed</a> pseudo-elements are not supported at this time. An example of this would be any of the `::-webkit-scrollbar` pseudo-elements:
+
+```css
+/* Does NOT work */
+my-component::part(scroll)::-webkit-scrollbar {
+  background: green;
+}
+```
+
+See <a href="https://github.com/w3c/csswg-drafts/issues/4530" target="_blank" rel="noopener noreferrer">this issue on GitHub</a> for more information.
+
+
+### Structural Pseudo-Classes
+
+Most pseudo-classes are supported with parts, however, <a href="https://www.w3.org/TR/selectors-4/#structural-pseudos" target="_blank" rel="noopener noreferrer">structural pseudo-classes</a> are not. An example of structural pseudo-classes that do not work is below.
+
+```css
+/* Does NOT work */
+my-component::part(container):first-child {
+  background: green;
+}
+
+/* Does NOT work */
+my-component::part(container):last-child {
+  background: green;
+}
+```
+
+### Chaining Parts
+
+The `::part()` pseudo-element can not match additional `::part()`s.
+
+For example, `my-component::part(button)::part(label)` does not match anything. This is because doing so would expose more structural information than is intended.
+
+If the `<my-component>`’s internal button uses something like `part="label => button-label"` to forward the button’s internal parts up into the panel’s own part element map, then a selector like `my-component::part(button-label)` would select just the one button’s label, ignoring any other labels.

--- a/src/pages/theming/css-variables.md
+++ b/src/pages/theming/css-variables.md
@@ -1,8 +1,8 @@
 ---
 previousText: 'Platform Styles'
 previousUrl: '/docs/theming/platform-styles'
-nextText: 'Colors'
-nextUrl: '/docs/theming/colors'
+nextText: 'CSS Shadow Parts'
+nextUrl: '/docs/theming/css-shadow-parts'
 contributors:
   - brandyscarney
   - iget-master


### PR DESCRIPTION
Implements a guide for CSS Shadow Parts. Adapted from https://ionicframework.com/blog/customize-your-ionic-framework-app-with-css-shadow-parts/

Closes #1343 
