### PR TITLE
Update Firebase Crashlytics initialise method name

### DIFF
--- a/scripts/data/native.json
+++ b/scripts/data/native.json
@@ -1570,7 +1570,7 @@
     "packageName": "@ionic-native/firebase-crashlytics",
     "displayName": "Firebase Crashlytics",
     "description": "\nA Google Firebase Crashlytics plugin to enable capture of crash reports.\n",
-    "usage": "\n```typescript\nimport { FirebaseCrashlytics } from '@ionic-native/firebase-crashlytics/ngx';\n\n\nconstructor(private firebaseCrashlytics: FirebaseCrashlytics) { }\n\n...\n\n\nconst crashlytics = this.firebaseCrashlytics.initialize();\ncrashlytics.logException('my caught exception');\n\n```\n",
+    "usage": "\n```typescript\nimport { FirebaseCrashlytics } from '@ionic-native/firebase-crashlytics/ngx';\n\n\nconstructor(private firebaseCrashlytics: FirebaseCrashlytics) { }\n\n...\n\n\nconst crashlytics = this.firebaseCrashlytics.initialise();\ncrashlytics.logException('my caught exception');\n\n```\n",
     "platforms": [
       "Android",
       "iOS"


### PR DESCRIPTION
As updated at v5.6 of `@ionic-native/firebase-crashlytics`, the method `initialize()` does not exists any more it was renamed as `initialise()`.

See changelog:
https://github.com/ionic-team/ionic-native/blob/9f27d54f0eb359f5cd638a05de20c629b01deb56/CHANGELOG.md#560-2019-05-16