### PR TITLE
docs(navigation): add live example of angular routing

### DIFF
--- a/src/pages/angular/navigation.md
+++ b/src/pages/angular/navigation.md
@@ -161,6 +161,10 @@ import { LoginComponent } from './login.component';
 
 Here, we have a typical Angular Module setup, along with a RouterModule import, but we're now using `forChild` and declaring the component in that setup. With this setup, when we run our build, we will produce separate chunks for both the app component, the login component, and the detail component.
 
+## Live Example
+
+If you would prefer to get hands on with the concepts and code described above, please checkout our [live example](https://stackblitz.com/edit/ionic-angular-routing?file=src/app/app-routing.module.ts) of the topics above on StackBlitz.
+
 ## Working with Tabs
 
 With Tabs, the Angular Router provides Ionic the mechanism to know what components should be loaded, but the heavy lifting is actually done by the tabs component. Let's look at a simple example.


### PR DESCRIPTION
## Docs Addition
Add StackBlitz live example to Angular Navigation/Routing page to provide user with a playground to see routing in action.
The StackBlitz has some comments around lifecycle hooks also to help users understand when they are called.

Link to StackBlitz
https://stackblitz.com/edit/ionic-angular-routing

## Docs page screenshot
![image](https://user-images.githubusercontent.com/12140467/91309761-e7efdd00-e7a8-11ea-84ae-d0aff1525c36.png)

## Notes
The StackBlitz that is linked may need to be moved to an Ionic account on StackBlitz