### PR TITLE
docs(navigation): add live example for react routing

### DIFF
--- a/src/pages/react/navigation.md
+++ b/src/pages/react/navigation.md
@@ -186,6 +186,10 @@ The [`match`](https://reacttraining.com/react-router/web/api/match) prop contain
 
 Note how we use a TypeScript interface to strongly type the props object. The interface gives us type safety and code completion inside of the component.
 
+## Live Example
+
+If you would prefer to get hands on with the concepts and code described above, please checkout our [live example](https://stackblitz.com/edit/ionic-react-routing?file=src/index.tsx) of the topics above on StackBlitz.
+
 ### IonRouterOutlet in a Tabs View
 
 When working in a tabs view, Ionic React needs a way to determine what views belong to which tabs. We accomplish this by taking advantage of the fact that the paths provided to a `Route` are regular expressions.


### PR DESCRIPTION
## Docs Addition
Add StackBlitz live example to React Navigation/Routing page to provide user with a playground to see routing in action.

Link to StackBlitz
https://stackblitz.com/edit/ionic-react-routing

## Docs page screenshot
![image](https://user-images.githubusercontent.com/12140467/91327573-99990900-e7bd-11ea-96d1-2418a1511a26.png)


## Notes
The StackBlitz that is linked may need to be moved to an Ionic account on StackBlitz