### PR TITLE
docs(layout): add react live examples

### DIFF
--- a/src/pages/layout/structure.md
+++ b/src/pages/layout/structure.md
@@ -86,7 +86,7 @@ These can also be combined on one page to have a toolbar above *and* below the c
 
 ### Live examples
 
-You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-header-footer).
+You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-header-footer) and for React [here](https://stackblitz.com/edit/ionic-react-head-foot).
 
 ## Tabs Layout
 
@@ -118,7 +118,7 @@ A layout consisting of horizontal [tabs](/docs/api/tabs) can be used to let the 
 
 ### Live examples
 
-You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-tabs).
+You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-tabs) and for React [here](https://stackblitz.com/edit/ionic-react-tab-layout).
 
 ## Menu Layout
 
@@ -175,7 +175,7 @@ A standard layout among mobile apps includes the ability to toggle a side [menu]
 
 ### Live examples
 
-You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-menu-layout).
+You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-menu-layout) and for React [here](https://stackblitz.com/edit/ionic-react-menu).
 
 
 ## Split Pane Layout
@@ -238,4 +238,4 @@ It's important to note that the element with the `id` matching the `content-id` 
 
 ### Live examples
 
-You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-split-pane).
+You can view a live example of this setup in Angular [here](https://stackblitz.com/edit/ionic-ng-split-pane) and for React [here](https://stackblitz.com/edit/ionic-react-split-pane).


### PR DESCRIPTION
## Docs Addition
Add StackBlitz live example to Layout Structure page to provide user with a playground to see the different structures in action in React

Link to StackBlitz-s
https://stackblitz.com/edit/ionic-react-head-foot
https://stackblitz.com/edit/ionic-react-tab-layout
https://stackblitz.com/edit/ionic-react-menu
https://stackblitz.com/edit/ionic-react-split-pane

## Docs page screenshot
![image](https://user-images.githubusercontent.com/12140467/91546774-e514f980-e91a-11ea-909b-375746c985c0.png)

## Notes
The StackBlitz that is linked may need to be moved to an Ionic account on StackBlitz