### PR TITLE
docs(grid): add react live examples

### DIFF
--- a/src/pages/layout/grid.md
+++ b/src/pages/layout/grid.md
@@ -55,7 +55,7 @@ columns by adding the `ion-no-padding` class to the grid. See the [CSS Utilities
 
 ### Live Example
 
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-basic-grid).
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-basic-grid) and for React [here](https://stackblitz.com/edit/ionic-react-basic-grid).
 
 
 ## Grid size
@@ -73,7 +73,7 @@ By default, the grid will take up 100% width. To set a specific width based on t
 
 ### Live Example
 
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-fixed-width-grid).
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-fixed-width-grid) and for React [here](https://stackblitz.com/edit/ionic-react-fixed-width-grid).
 
 
 ## Grid attributes
@@ -183,7 +183,7 @@ Set the width of one column and the others will automatically resize around it. 
 
 #### Live Example
 
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-set-width-col).
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-set-width-col) and for React [here](https://stackblitz.com/edit/ionic-react-set-width-col).
 
 ### Variable-width
 
@@ -235,7 +235,7 @@ By setting the `size-{breakpoint}` properties to `"auto"` the column can size it
 
 #### Live Example
 
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-var-width-col).
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-var-width-col) and for React [here](https://stackblitz.com/edit/ionic-react-var-width-col).
 
 
 ## Responsive attributes
@@ -304,7 +304,7 @@ Use a combination of width and breakpoint attributes to create a grid that start
 
 #### Live Example
 
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-stacked-horizontal-grid).
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-stacked-horizontal-grid) and for React [here](https://stackblitz.com/edit/ionic-react-stacked-horizontal-grid).
 
 
 ## Reordering
@@ -356,7 +356,7 @@ Offsets can also be added based on screen breakpoints. Here's an example of a gr
 
 #### Live Example
 
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-offset-grid-cols).
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-offset-grid-cols) and for React [here](https://stackblitz.com/edit/ionic-react-offset-grid-cols).
 
 ### Push and pull
 
@@ -404,7 +404,8 @@ Push and pull can also be added based on screen breakpoints. In the following ex
 ```
 
 #### Live Example
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-grid-push-pull).
+
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-grid-push-pull) and for React [here](https://stackblitz.com/edit/ionic-react-grid-push-pull).
 
 
 ## Alignment
@@ -528,7 +529,8 @@ Columns can also align themselves differently than other columns by adding the a
 ```
 
 #### Live Example
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-grid-vertical-align).
+
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-grid-vertical-align) and for React [here](https://stackblitz.com/edit/ionic-react-grid-vertical-align).
 
 ### Horizontal alignment
 
@@ -605,7 +607,7 @@ All columns can be horizontally aligned inside of a row by adding different clas
 
 #### Live Example
 
-You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-grid-horizontal-align).
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-ng-grid-horizontal-align) and for React [here](https://stackblitz.com/edit/ionic-react-grid-horizontal-align).
 
 
 ## Customizing the grid


### PR DESCRIPTION
## Docs Addition
Add StackBlitz live example to Layout Grid page to provide user with a playground to see the different grid options in action in React

Link to StackBlitz-s
https://stackblitz.com/edit/ionic-react-basic-grid
https://stackblitz.com/edit/ionic-react-fixed-width-grid
https://stackblitz.com/edit/ionic-react-set-width-col
https://stackblitz.com/edit/ionic-react-var-width-col
https://stackblitz.com/edit/ionic-react-stacked-horizontal-grid
https://stackblitz.com/edit/ionic-react-offset-grid-cols
https://stackblitz.com/edit/ionic-react-grid-push-pull
https://stackblitz.com/edit/ionic-react-grid-vertical-align
https://stackblitz.com/edit/ionic-react-grid-horizontal-align

## Docs page screenshot
![image](https://user-images.githubusercontent.com/12140467/91546774-e514f980-e91a-11ea-909b-375746c985c0.png)

## Notes
The StackBlitz that is linked may need to be moved to an Ionic account on StackBlitz