### PR TITLE
fix(enterprise-plugins): wrong Capacitor install text after visiting some plugins

### DIFF
--- a/src/components/native-ent-install/native-ent-install.tsx
+++ b/src/components/native-ent-install/native-ent-install.tsx
@@ -27,7 +27,7 @@ export class NativeEnterpriseInstall {
         </command-line>
         <strong>Capacitor:</strong>
         {
-          typeof this.capacitorSlug !== 'undefined' ?
+          typeof this.capacitorSlug !== 'undefined' && this.capacitorSlug !== null ?
             <div>Available as a
               <a href={`https://capacitor.ionicframework.com/docs/apis/${this.capacitorSlug}`}> core Capacitor plugin</a>.
             </div>

--- a/src/components/native-ent-install/native-ent-install.tsx
+++ b/src/components/native-ent-install/native-ent-install.tsx
@@ -6,7 +6,7 @@ import { Component, Prop, h } from '@stencil/core';
 export class NativeEnterpriseInstall {
   @Prop() pluginId?: string;
   @Prop() variables?: string;
-  @Prop() capacitorSlug?: string;
+  @Prop() capacitorSlug?: string | null;
 
   render() {
     if (typeof this.pluginId === 'undefined') {


### PR DESCRIPTION
After visiting plugins that have capacitorSlug property (splashscreen, statusbar, filesystem or keyboard), the capacitorSlug becomes null instead of undefined and the link to a null capacitor alternative plugins appears.

This PR checks that capacitorSlug is also not null before printing the alternative Capacitor plugin.