### PR TITLE
Condense "Build Stacks" version table

### DIFF
--- a/src/pages/appflow/build-stacks.md
+++ b/src/pages/appflow/build-stacks.md
@@ -10,66 +10,19 @@ nextUrl: "/docs/appflow/web-previews"
 
 Below are the current versions used in Appflow for each build type.
 
-### iOS - Xcode 11 (Preferred)
+### Active Stack Versions
 
-| Software    | Version |
-| ----------- | ------- |
-| Cordova CLI | 9.0.3   |
-| Ionic CLI   | 6.9.2   |
-| Node.js     | 12.17.0 |
-| npm         | 6.14.4  |
-| Yarn        | 1.22.4  |
-| macOS       | 10.14.6 |
-| Carthage    | 0.34.0  |
-| CocoaPods   | 1.7.5   |
-| Xcode       | 11.5    |
-
-### iOS - Xcode 10
-
-| Software    | Version |
-| ----------- | ------- |
-| Cordova CLI | 9.0.3   |
-| Ionic CLI   | 6.2.2   |
-| Node.js     | 12.16.1 |
-| npm         | 6.13.4  |
-| Yarn        | 1.22.0  |
-| macOS       | 10.14.5 |
-| Carthage    | 0.34.0  |
-| CocoaPods   | 1.8.4   |
-| Xcode       | 10.2.1  |
-
-### iOS - v2020.08
-
-| Software    | Version |
-| ----------- | ------- |
-| Cordova CLI | 9.0.3   |
-| Ionic CLI   | 6.10.1  |
-| Node.js     | 12.18.3 |
-| npm         | 6.14.6  |
-| Yarn        | 1.22.4  |
-| macOS       | 10.15.6 |
-| Carthage    | 0.35.0  |
-| CocoaPods   | 1.9.3   |
-| Xcode       | 11.6    |
-
-### Android
-
-| Software    | Version   |
-| ----------- | --------- |
-| Cordova CLI | 9.0.3     |
-| Ionic CLI   | 6.2.2     |
-| Node.js     | 12.17.0   |
-| npm         | 6.14.4    |
-| Debian      | 9.11      |
-| Gradle      | 4.3.1     |
-| OpenJDK     | 1.8.0_252 |
-
-### Web Deploy
-
-| Software    | Version |
-| ----------- | ------- |
-| Cordova CLI | 9.0.3   |
-| Ionic CLI   | 6.2.2   |
-| Node.js     | 12.17.0 |
-| npm         | 6.14.4  |
-| Debian      | 9.11    |
+| Software    | iOS - Xcode 11 (Preferred) | iOS - Xcode 10 | iOS - v2020.08 | Android   | Web Deploy |
+| ----------- | -------------------------- | -------------- | -------------- | --------- | ---------- |
+| Cordova CLI | 9.0.3                      | 9.0.3          | 9.0.3          | 9.0.3     | 9.0.3      |
+| Ionic CLI   | 6.9.2                      | 6.2.2          | 6.10.1         | 6.2.2     | 6.2.2      |
+| Node.js     | 12.17.0                    | 12.16.1        | 12.18.3        | 12.17.0   | 12.17.0    |
+| npm         | 6.14.4                     | 6.13.4         | 6.14.6         | 6.14.4    | 6.14.4     |
+| Yarn        | 1.22.4                     | 1.22.0         | 1.22.4         | -         | -          |
+| macOS       | 10.14.6                    | 10.14.5        | 10.15.6        | -         | -          |
+| Carthage    | 0.34.0                     | 0.34.0         | 0.35.0         | -         | -          |
+| CocoaPods   | 1.7.5                      | 1.8.4          | 1.9.3          | -         | -          |
+| Xcode       | 11.5                       | 10.2.1         | 11.6           | -         | -          |
+| Debian      | -                          | -              | -              | 9.11      | 9.11       |
+| Gradle      | -                          | -              | -              | 4.3.1     | -          |
+| OpenJDK     | -                          | -              | -              | 1.8.0_252 | -          |


### PR DESCRIPTION
I found myself constantly scrolling down and up on this page, comparing different versions.. this change would simply make the page *easier* to read.

however, the validity of this change very much depends on the source for this file, is it generated by a script or updated manually each time there's a change?