### PR TITLE
docs(animations): add React and Angular example for overriding animations

### DIFF
--- a/src/pages/utilities/animations.md
+++ b/src/pages/utilities/animations.md
@@ -1019,7 +1019,7 @@ export class ModalExample {
 
 ```javascript
 import React, { useState } from 'react';
-import { CreateAnimation, IonModal, IonButton, IonContent } from '@ionic/react';
+import { createAnimation, IonModal, IonButton, IonContent } from '@ionic/react';
 
 export const ModalExample: React.FC = () => {
   const [showModal, setShowModal] = useState(false);
@@ -1060,6 +1060,8 @@ export const ModalExample: React.FC = () => {
 ```
 </docs-tab>
 </docs-tabs>
+
+You can view a live example of this in Angular [here](https://stackblitz.com/edit/ionic-angular-animation-override) and in React [here](https://stackblitz.com/edit/ionic-react-animation-overwride).
 
 <docs-codepen user="ionic" slug="ExapZBZ"></docs-codepen>
 


### PR DESCRIPTION
## Description

Add StackBlitz live example for [Overriding Ionic Components Animations](https://ionicframework.com/docs/utilities/animations#overriding-ionic-component-animations)

Also, fix missing import - `createAnimation`

## StackBlitz

Angular - https://stackblitz.com/edit/ionic-angular-animation-override
React - https://stackblitz.com/edit/ionic-react-animation-overwride