### PR TITLE
Update vue quickstart to include defineComponent

### DIFF
--- a/src/pages/vue/quickstart.md
+++ b/src/pages/vue/quickstart.md
@@ -73,7 +73,7 @@ If we open `App.vue` we should see the following:
 import { IonApp, IonRouterOutlet } from '@ionic/vue';
 import { defineComponent } from 'vue';
 
-export default {
+export default defineComponent({
   name: 'App',
   components: {
     IonApp,

--- a/src/pages/vue/quickstart.md
+++ b/src/pages/vue/quickstart.md
@@ -79,7 +79,7 @@ export default defineComponent({
     IonApp,
     IonRouterOutlet
   }
-};
+});
 </script>
 ```
 


### PR DESCRIPTION
`export default defineComponent({` was updated in other ares, this area still showed `export default {`