### PR TITLE
Import on a code example was using back-ticks

### DIFF
--- a/src/pages/react/quickstart.md
+++ b/src/pages/react/quickstart.md
@@ -210,7 +210,7 @@ From the Web Components side, we have a special attribute called `slot`. This is
 Let's look at another component from Ionic, FAB. Floating Action Buttons are a nice way to provide a main action that is elevated from the rest of an app. For this FAB, we'll need three components: a FAB, a FAB Button, and an Icon.
 
 ```typescript
-import { add } from ‘ionicons/icons’;
+import { add } from 'ionicons/icons';
 …
 
 <IonContent>


### PR DESCRIPTION
When I copied the import "import { add } from 'ionicons/icons';" it was using back-ticks and would cause the typescript linter in VScode to show an error. It is hard to notice that the example code wrote the import with back-ticks and changing them to single quotes fixes the issue.