### PR TITLE
Code example should show the new import

### DIFF
--- a/src/pages/react/quickstart.md
+++ b/src/pages/react/quickstart.md
@@ -232,7 +232,7 @@ On our main `IonFab`, we're setting its positioning with the vertical and horizo
 Now let's wire up a click handler to this. What we want to do is when we click the button, we'll navigate to a new page (which we'll create in a moment). To do this, we'll need to get access to React Router's navigation API. Thankfully since this is rendered in a Router/Route context, we have access to React Routers APIs via Props passed to our Home component.
 
 ```typescript
-import { add } from 'ionicons/icons';
+import { RouteComponentProps } from 'react-router';
 ...
 const Home: React.FC<RouteComponentProps> = (props) => {
   return (


### PR DESCRIPTION
In the code example, it needs to show the new import statement "import { RouteComponentProps } from 'react-router';" and remove the import statement that the previous code example had already introduced. This helps the user as they are following along so they can see how the import looks.