### PR TITLE
Update links for cdn version of ionicons

### DIFF
--- a/src/pages/intro/cdn.md
+++ b/src/pages/intro/cdn.md
@@ -158,8 +158,8 @@ From here, you can learn about how to develop with Ionic Framework in our [Ionic
 Ionicons is packaged by default with the Ionic Framework, so no installation is necessary if you're using Ionic. To use Ionicons without Ionic Framework, place the following `<script>` near the end of your page, right before the closing `</body>` tag.
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@4.7.4/dist/ionicons/ionicons.esm.js"></script>
-<script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@4.7.4/dist/ionicons/ionicons.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.esm.js"></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/ionicons/dist/ionicons/ionicons.js"></script>
 ```
 
 > See [Ionicons usage](https://ionicons.com/usage) for more information on using Ionicons.


### PR DESCRIPTION
The current links for cdn version of ionicons return 404 error so their links should be updated.