### PR TITLE
Fixed typo

### DIFF
--- a/src/pages/react/lifecycle.md
+++ b/src/pages/react/lifecycle.md
@@ -130,7 +130,7 @@ All the lifecycle methods in React (`componentDidMount`, `componentWillUnmount`,
 
 ## Guidance for Each LifeCycle Method
 
-Below are some tips on uses cases for each of the life cycle events.
+Below are some tips on use cases for each of the life cycle events.
 
 - `ionViewWillEnter` - Since `ionViewWillEnter` is called every time the view is navigated to (regardless if initialized or not), it's a good method to load data from services.
 - `ionViewDidEnter` - If you see performance problems from using `ionViewWillEnter` when loading data, you can do your data calls in `ionViewDidEnter` instead. This event won't fire until after the page is visible to the user, however, so you might want to use either a loading indicator or a skeleton screen, so content doesn't flash in un-naturally after the transition is complete.


### PR DESCRIPTION
uses->use

From 'Below are some tips on uses cases for each of the life cycle events.'
To 'Below are some tips on use cases for each of the life cycle events.'