### PR TITLE
Fix link to AdMobPro Free

### DIFF
--- a/scripts/data/native.json
+++ b/scripts/data/native.json
@@ -74,7 +74,7 @@
   {
     "packageName": "@ionic-native/admob-pro",
     "displayName": "AdMob Pro",
-    "description": "\nPlugin for Google Ads, including AdMob / DFP (DoubleClick for publisher) and mediations to other Ad networks.\n\nIMPORTANT NOTICE: this plugin takes a percentage out of your earnings if you profit more than $1,000. Read more about this on the plugin's repo. For a completely free alternative, see [AdMobPro Free](../admob-free).",
+    "description": "\nPlugin for Google Ads, including AdMob / DFP (DoubleClick for publisher) and mediations to other Ad networks.\n\nIMPORTANT NOTICE: this plugin takes a percentage out of your earnings if you profit more than $1,000. Read more about this on the plugin's repo. For a completely free alternative, see [AdMobPro Free](./admob-free).",
     "usage": "\n```typescript\nimport { AdMobPro } from '@ionic-native/admob-pro/ngx';\nimport { Platform } from '@ionic/angular';\n\nconstructor(private admob: AdMobPro, private platform: Platform ) { }\n\nionViewDidLoad() {\n  this.admob.onAdDismiss()\n    .subscribe(() => { console.log('User dismissed ad'); });\n}\n\nonClick() {\n  let adId;\n  if(this.platform.is('android')) {\n    adId = 'YOUR_ADID_ANDROID';\n  } else if (this.platform.is('ios')) {\n    adId = 'YOUR_ADID_IOS';\n  }\n  this.admob.prepareInterstitial({adId: adId})\n    .then(() => { this.admob.showInterstitial(); });\n}\n\n```\n",
     "platforms": [
       "Android",


### PR DESCRIPTION
In https://ionicframework.com/docs/native/admob-pro the link to AdMobPro Free returns a 404 as it links to https://ionicframework.com/docs/admob-free rather than https://ionicframework.com/docs/native/admob-free