### PR TITLE
add login note on angular pwa guide

### DIFF
--- a/src/pages/angular/pwa.md
+++ b/src/pages/angular/pwa.md
@@ -74,6 +74,8 @@ Next, in a Terminal, install the Firebase CLI:
 $ npm install -g firebase-tools
 ```
 
+> Note: If it's the first time you use firebase-tools, login to your Google account with `firebase login` command.
+
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
 
 **"Which Firebase CLI features do you want to set up for this folder?"**  Choose "Hosting: Configure and deploy Firebase Hosting sites."


### PR DESCRIPTION
It's the first time I use firebase-tools and `firebase init` command failed because I wasn't logged in. So I added a note about `firebase login` command.