### PR TITLE
Update debugging.md

### DIFF
--- a/src/pages/troubleshooting/debugging.md
+++ b/src/pages/troubleshooting/debugging.md
@@ -84,3 +84,16 @@ In the root of your Ionic project, create a folder called `.vscode` and inside t
 Next, launch the debugging process, selecting your device and Ionic app. VS Code will attach to both the Android device and Ionic app and you can now debug your app, which includes setting breakpoints.
 
 > If you are unable to set breakpoints and get an error saying, **"Breakpoint ignored because generated code not found (source map problem?)"** it means that the paths to the transpiled javascript files are incorrect. Use the `.scripts` command in the Debug console to see the loaded scripts. Make sure the paths of the scripts are correct  by experimenting with different values in the `sourceMapPathOverrides` key in your `launch.json` configuration file.
+
+> Debugging `Ionic Vue` projects? This is important for you!
+> 
+> `Vue` has its own way to config the `sourceMaps` and without it is not possible to get breakpoints to work with Visual Studio Code or even with Chrome or Firefox.
+> In order to properly obtain the source code inside final webpack, it is necessary to set `devtool` property inside `vue.config.js` file. This file doesn't exist in `Ionic Vue` templates, so go ahead and create it at the project root (same level as `package.json`). enter the following code to configure the plugin to debug `Ionic Vue` apps:
+> ```
+> module.exports = {
+>   configureWebpack: {
+>     devtool: 'source-map'
+>   }
+> }
+> ```
+


### PR DESCRIPTION
Added footnote for those trying to debug `Ionic Vue` apps. Differently from `Angular` or `React` apps, `Ionic Vue` apps cannot be properly debugged just following the instructions in this page as is. Following directions from official [https://vuejs.org/v2/cookbook/debugging-in-vscode.html](Vue.js Docs), I added the `vue.config.js` with `devtool` property settled to `source-map`. Now, I can debug inside VS Code properly. I'm suggesting to update docs in order to save some time from the Vue community.