### PR TITLE
chore(): bump framework dependency to v5.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ionic-internal/ionic-ds": "4.1.4",
-        "@ionic/core": "^5.6.4",
-        "@ionic/docs": "^5.6.4",
+        "@ionic/core": "^5.6.6",
+        "@ionic/docs": "^5.6.6",
         "@sentry/node": "^5.27.3",
         "@stencil/router": "^1.0.1",
         "@stencil/sass": "^1.3.2",
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.6.4.tgz",
-      "integrity": "sha512-fxCV/+0ibiaiBn1dsrrOmlLGJlTkqiG6IVXdLpPKimGdFLjy56olDvB5trlz9J5C/nHc7vR5MIiYC0qdTyX7og==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.6.6.tgz",
+      "integrity": "sha512-EbVIXOTVVPxBo7hsarBpRSFNsQ22wBFtWkKmrmliieknG5LUkf5WZBpj4EENQhzYA6c+//7/nfhcD9pWgtAofA==",
       "dependencies": {
         "@stencil/core": "^2.4.0",
         "ionicons": "^5.5.1",
@@ -220,9 +220,9 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@ionic/docs": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.6.4.tgz",
-      "integrity": "sha512-x3yDwdJ67qTMwFIels8MVRWOI97Q9NeNNSYOgIeVDrlJW+CDPxzoHxLvDX5SXLipeEqEmpTGCFjOonJ+CyHA0w=="
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.6.6.tgz",
+      "integrity": "sha512-LSTIdkSijb93E/lDyUXUntPnS8mjoLZNcKCGt5sYglQG7vwbxNPstALde0r/RT1iNsHFuGjWRufRc1T2cwE1tA=="
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -5193,9 +5193,9 @@
       }
     },
     "@ionic/core": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.6.4.tgz",
-      "integrity": "sha512-fxCV/+0ibiaiBn1dsrrOmlLGJlTkqiG6IVXdLpPKimGdFLjy56olDvB5trlz9J5C/nHc7vR5MIiYC0qdTyX7og==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.6.6.tgz",
+      "integrity": "sha512-EbVIXOTVVPxBo7hsarBpRSFNsQ22wBFtWkKmrmliieknG5LUkf5WZBpj4EENQhzYA6c+//7/nfhcD9pWgtAofA==",
       "requires": {
         "@stencil/core": "^2.4.0",
         "ionicons": "^5.5.1",
@@ -5210,9 +5210,9 @@
       }
     },
     "@ionic/docs": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.6.4.tgz",
-      "integrity": "sha512-x3yDwdJ67qTMwFIels8MVRWOI97Q9NeNNSYOgIeVDrlJW+CDPxzoHxLvDX5SXLipeEqEmpTGCFjOonJ+CyHA0w=="
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.6.6.tgz",
+      "integrity": "sha512-LSTIdkSijb93E/lDyUXUntPnS8mjoLZNcKCGt5sYglQG7vwbxNPstALde0r/RT1iNsHFuGjWRufRc1T2cwE1tA=="
     },
     "@kwsites/file-exists": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@ionic-internal/ionic-ds": "4.1.4",
-    "@ionic/core": "^5.6.4",
-    "@ionic/docs": "^5.6.4",
+    "@ionic/core": "^5.6.6",
+    "@ionic/docs": "^5.6.6",
     "@sentry/node": "^5.27.3",
     "@stencil/router": "^1.0.1",
     "@stencil/sass": "^1.3.2",

--- a/src/pages/utilities/animations.md
+++ b/src/pages/utilities/animations.md
@@ -1342,7 +1342,7 @@ export const ModalExample: React.FC = () => {
         :is-open="isModalOpen"
         :enter-animation="enterAnimation"
         :leave-animation="leaveAnimation"
-        @onDidDismiss="setModalOpen(false)"
+        @didDismiss="setModalOpen(false)"
       >
         Modal content goes here.
       </ion-modal>


### PR DESCRIPTION
v5.6.6 introduced a fix to what Ionic Vue recommends for listening to overlay component events: https://github.com/ionic-team/ionic-framework/releases/tag/v5.6.6

Need to update the docs so guidance is shown on there as well.