### PR TITLE
Replace deprecated API usage in dark mode documentation

### DIFF
--- a/src/pages/theming/dark-mode.md
+++ b/src/pages/theming/dark-mode.md
@@ -100,7 +100,7 @@ toggle.addEventListener('ionChange', (ev) => {
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
 // Listen for changes to the prefers-color-scheme media query
-prefersDark.addListener((e) => checkToggle(e.matches));
+prefersDark.addEventListener('change', (e) => checkToggle(e.matches));
 
 // Called when the app loads
 function loadApp() {


### PR DESCRIPTION
This change updates the proposed use of the [deprecated `MediaQueryList.addListener()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener) method with the standard `MediaQueryList.addEventListener()` method.