### PR TITLE
fix(react-first-app): typos update Info.plist

### DIFF
--- a/src/pages/angular/your-first-app/6-deploying-mobile.md
+++ b/src/pages/angular/your-first-app/6-deploying-mobile.md
@@ -1,8 +1,8 @@
 ---
-previousText: 'Adding Mobile'
-previousUrl: '/docs/angular/your-first-app/5-adding-mobile'
-nextText: 'Rapid App Dev with Live Reload'
-nextUrl: '/docs/angular/your-first-app/7-live-reload'
+previousText: "Adding Mobile"
+previousUrl: "/docs/angular/your-first-app/5-adding-mobile"
+nextText: "Rapid App Dev with Live Reload"
+nextUrl: "/docs/angular/your-first-app/7-live-reload"
 ---
 
 # Deploying to iOS and Android
@@ -56,12 +56,13 @@ In order for some native plugins to work, user permissions must be configured. I
 
 ![Xcode Custom iOS Target Properties](/docs/assets/img/guides/first-app-cap-ng/xcode-info-plist.png)
 
-
 Each setting in `Info.plist` has a low-level parameter name and a high-level name. By default, the property list editor shows the high-level names, but it's often useful to switch to showing the raw, low-level names. To do this, right-click anywhere in the property list editor and toggle "Raw Keys/Values."
 
-Locate the `NSCameraUsageDescription` Key (it should exist already if you followed along with this tutorial) and set the Value to something that describes why the app needs to use the camera, such as "To Take Photos." The Value field is displayed to the app user when the permission prompt opens.
+Add the `NSCameraUsageDescription` Key and set the Value to something that describes why the app needs to use the camera, such as "To Take Photos." The Value field is displayed to the app user when the permission prompt opens.
 
-Next, click on `App` in the Project Navigator on the left-hand side, then within the `Signing & Capabilities` section, select your Development Team. 
+Follow the same process to add the other two Keys required of the Camera plugin: `NSPhotoLibraryAddUsageDescription` and `NSPhotoLibraryUsageDescription`.
+
+Next, click on `App` in the Project Navigator on the left-hand side, then within the `Signing & Capabilities` section, select your Development Team.
 
 ![Xcode - Selecting Development Team](/docs/assets/img/guides/first-app-cap-ng/xcode-signing.png)
 

--- a/src/pages/react/your-first-app/2-taking-photos.md
+++ b/src/pages/react/your-first-app/2-taking-photos.md
@@ -1,8 +1,8 @@
 ---
-previousText: 'Your First App'
-previousUrl: '/docs/react/your-first-app'
-nextText: 'Saving Photos on Filesystem'
-nextUrl: '/docs/react/your-first-app/3-saving-photos'
+previousText: "Your First App"
+previousUrl: "/docs/react/your-first-app"
+nextText: "Saving Photos on Filesystem"
+nextUrl: "/docs/react/your-first-app/3-saving-photos"
 ---
 
 # Taking Photos with the Camera
@@ -18,29 +18,34 @@ Create a new file at `src/hooks/usePhotoGallery.ts` and open it up.
 A custom hook is just a function that uses other React hooks. And that's what we will be doing! We will start by importing the various hooks and utilities we will be using from React core, the Ionic React Hooks project, and Capacitor:
 
 ```typescript
-import { useState, useEffect } from 'react';
-import { isPlatform } from '@ionic/react';
+import { useState, useEffect } from "react";
+import { isPlatform } from "@ionic/react";
 
-import { Camera, CameraResultType, CameraSource, Photo, } from '@capacitor/camera';
-import { Filesystem, Directory } from '@capacitor/filesystem';
-import { Storage } from '@capacitor/storage';
-import { Capacitor } from '@capacitor/core';
+import {
+  Camera,
+  CameraResultType,
+  CameraSource,
+  Photo,
+} from "@capacitor/camera";
+import { Filesystem, Directory } from "@capacitor/filesystem";
+import { Storage } from "@capacitor/storage";
+import { Capacitor } from "@capacitor/core";
 ```
+
 Next, create a function named usePhotoGallery:
 
 ```typescript
 export function usePhotoGallery() {
-
   const takePhoto = async () => {
     const cameraPhoto = await Camera.getPhoto({
       resultType: CameraResultType.Uri,
       source: CameraSource.Camera,
-      quality: 100
+      quality: 100,
     });
   };
 
   return {
-    takePhoto
+    takePhoto,
   };
 }
 ```
@@ -52,7 +57,7 @@ Notice the magic here: there's no platform-specific code (web, iOS, or Android)!
 The last step we need to take is to use the new hook from the Tab2 page. Go back to Tab2.tsx and import the hook:
 
 ```typescript
-import { usePhotoGallery } from '../hooks/usePhotoGallery';
+import { usePhotoGallery } from "../hooks/usePhotoGallery";
 ```
 
 And right before the return statement in the functional component, get access to the `takePhoto` method by using the hook:
@@ -83,7 +88,7 @@ export interface UserPhoto {
 }
 ```
 
-Back at the top of the function (right after the call to `useCamera`, we will define a state variable to store the array of each photo captured with the Camera.
+Back at the top of the function (right after the call to `usePhotoGallery`, we will define a state variable to store the array of each photo captured with the Camera.
 
 ```typescript
 const [photos, setPhotos] = useState<UserPhoto[]>([]);
@@ -92,12 +97,15 @@ const [photos, setPhotos] = useState<UserPhoto[]>([]);
 When the camera is done taking a picture, the resulting CameraPhoto returned from Capacitor will be stored in the `photo` variable. We want to create a new photo object and add it to the photos state array. We make sure we don't accidently mutate the current photos array by making a new array, and then call `setPhotos` to store the array into state. Update the `takePhoto` method and add this code after the getPhoto call:
 
 ```typescript
-const fileName = new Date().getTime() + '.jpeg';
-const newPhotos = [{
-  filepath: fileName,
-  webviewPath: cameraPhoto.webPath
-}, ...photos];
-setPhotos(newPhotos)
+const fileName = new Date().getTime() + ".jpeg";
+const newPhotos = [
+  {
+    filepath: fileName,
+    webviewPath: cameraPhoto.webPath,
+  },
+  ...photos,
+];
+setPhotos(newPhotos);
 ```
 
 Next, let's expose the photos array from our hook. Update the return statement to include the photos:
@@ -105,7 +113,7 @@ Next, let's expose the photos array from our hook. Update the return statement t
 ```typescript
 return {
   photos,
-  takePhoto
+  takePhoto,
 };
 ```
 

--- a/src/pages/react/your-first-app/4-loading-photos.md
+++ b/src/pages/react/your-first-app/4-loading-photos.md
@@ -1,8 +1,8 @@
 ---
-previousText: 'Saving Photos on Filesystem'
-previousUrl: '/docs/react/your-first-app/3-saving-photos'
-nextText: 'Adding Mobile'
-nextUrl: '/docs/react/your-first-app/5-adding-mobile'
+previousText: "Saving Photos on Filesystem"
+previousUrl: "/docs/react/your-first-app/3-saving-photos"
+nextText: "Adding Mobile"
+nextUrl: "/docs/react/your-first-app/5-adding-mobile"
 ---
 
 # Loading Photos from the Filesystem
@@ -25,7 +25,7 @@ Then, use the `Storage` class to get access to the get and set methods for readi
 At the end of the `takePhoto` function, add a call to `Storage.set()` to save the Photos array. By adding it here, the Photos array is stored each time a new photo is taken. This way, it doesn’t matter when the app user closes or switches to a different app - all photo data is saved.
 
 ```typescript
-Storage.set({key: PHOTO_STORAGE,value: JSON.stringify(newPhotos)});
+Storage.set({ key: PHOTO_STORAGE, value: JSON.stringify(newPhotos) });
 ```
 
 With the photo array data saved, we will create a method that will retrieve the data when the hook loads. We will do so by using React's `useEffect` hook. Insert this above the `takePhoto` declaration. Here is the code, and we will break it down:
@@ -33,18 +33,18 @@ With the photo array data saved, we will create a method that will retrieve the 
 ```typescript
 useEffect(() => {
   const loadSaved = async () => {
-    const {value} = await Storage.get({key: PHOTO_STORAGE });
+    const { value } = await Storage.get({ key: PHOTO_STORAGE });
     const photosInStorage = (value ? JSON.parse(value) : []) as UserPhoto[];
 
     for (let photo of photosInStorage) {
       const file = await Filesystem.readFile({
         path: photo.filepath,
-        directory: Directory.Data
+        directory: Directory.Data,
       });
       // Web platform only: Load the photo as base64 data
       photo.webviewPath = `data:image/jpeg;base64,${file.data}`;
     }
-    setPhotos(photos);
+    setPhotos(photosInStorage);
   };
   loadSaved();
 }, []);

--- a/src/pages/react/your-first-app/6-deploying-mobile.md
+++ b/src/pages/react/your-first-app/6-deploying-mobile.md
@@ -1,8 +1,8 @@
 ---
-previousText: 'Adding Mobile'
-previousUrl: '/docs/react/your-first-app/5-adding-mobile'
-nextText: 'Rapid App Dev with Live Reload'
-nextUrl: '/docs/react/your-first-app/7-live-reload'
+previousText: "Adding Mobile"
+previousUrl: "/docs/react/your-first-app/5-adding-mobile"
+nextText: "Rapid App Dev with Live Reload"
+nextUrl: "/docs/react/your-first-app/7-live-reload"
 ---
 
 # Deploying to iOS and Android
@@ -56,26 +56,23 @@ In order for some native plugins to work, user permissions must be configured. I
 
 ![Xcode Custom iOS Target Properties](/docs/assets/img/guides/first-app-cap-ng/xcode-info-plist.png)
 
-
-
 Each setting in `Info.plist` has a low-level parameter name and a high-level name. By default, the property list editor shows the high-level names, but it's often useful to switch to showing the raw, low-level names. To do this, right-click anywhere in the property list editor and toggle "Raw Keys/Values."
 
-Locate the `NSCameraUsageDescription` Key (if should exist already if you followed along with this tutorial) and set the Value to something that describes why the app needs to use the camera, such as "To Take Photos." The Value field is displayed to the app user when the permission prompt opens.
+Add the `NSCameraUsageDescription` Key and set the Value to something that describes why the app needs to use the camera, such as "To Take Photos." The Value field is displayed to the app user when the permission prompt opens.
 
-Next, click on `App` in the Project Navigator on the left-hand side, then within the `Signing & Capabilities` section, select your Development Team. 
+Follow the same process to add the other two Keys required of the Camera plugin: `NSPhotoLibraryAddUsageDescription` and `NSPhotoLibraryUsageDescription`.
+
+Next, click on `App` in the Project Navigator on the left-hand side, then within the `Signing & Capabilities` section, select your Development Team.
 
 ![Xcode - Selecting Development Team](/docs/assets/img/guides/first-app-cap-ng/xcode-signing.png)
-
 
 With permissions in place and Development Team selected, we are ready to try out the app on a real device! Connect an iOS device to your Mac computer, select it (`App -> Matthew’s iPhone` for me) then click the "Build" button to build, install, and launch the app on your device:
 
 ![Xcode build button](/docs/assets/img/guides/first-app-cap-ng/xcode-build-button.png)
 
-
 Upon tapping the Camera button on the Photo Gallery tab, the permission prompt will display. Tap OK, then take a picture with the Camera. Afterward, the photo shows in the app!
 
 ![iOS Camera permissions](/docs/assets/img/guides/first-app-cap-ng/ios-permissions-photo.png)
-
 
 ## Android
 
@@ -91,7 +88,6 @@ Similar to iOS, we must enable the correct permissions to use the Camera. Config
 
 ![Android Manifest location](/docs/assets/img/guides/first-app-cap-ng/android-manifest.png)
 
-
 Scroll to the `Permissions` section and ensure these entries are included:
 
 ```xml
@@ -103,11 +99,9 @@ Save the file. With permissions in place, we are ready to try out the app on a r
 
 ![Launching app on Android](/docs/assets/img/guides/first-app-cap-ng/android-device.png)
 
-
 Once again, upon tapping the Camera button on the Photo Gallery tab, the permission prompt should be displayed. Tap OK, then take a picture with the Camera. Afterward, the photo should appear in the app.
 
 ![Android Camera permissions](/docs/assets/img/guides/first-app-cap-ng/android-permissions-photo.png)
-
 
 Our Photo Gallery app has just been deployed to Android and iOS devices. 🎉
 

--- a/src/pages/vue/your-first-app/6-deploying-mobile.md
+++ b/src/pages/vue/your-first-app/6-deploying-mobile.md
@@ -1,8 +1,8 @@
 ---
-previousText: 'Adding Mobile'
-previousUrl: '/docs/vue/your-first-app/5-adding-mobile'
-nextText: 'Rapid App Dev with Live Reload'
-nextUrl: '/docs/vue/your-first-app/7-live-reload'
+previousText: "Adding Mobile"
+previousUrl: "/docs/vue/your-first-app/5-adding-mobile"
+nextText: "Rapid App Dev with Live Reload"
+nextUrl: "/docs/vue/your-first-app/7-live-reload"
 ---
 
 # Deploying to iOS and Android
@@ -60,7 +60,9 @@ In order for some native plugins to work, user permissions must be configured. I
 
 Each setting in `Info.plist` has a low-level parameter name and a high-level name. By default, the property list editor shows the high-level names, but it's often useful to switch to showing the raw, low-level names. To do this, right-click anywhere in the property list editor and toggle "Raw Keys/Values."
 
-Locate the `NSCameraUsageDescription` Key (if should exist already if you followed along with this tutorial) and set the Value to something that describes why the app needs to use the camera, such as "To Take Photos." The Value field is displayed to the app user when the permission prompt opens.
+Add the `NSCameraUsageDescription` Key and set the Value to something that describes why the app needs to use the camera, such as "To Take Photos." The Value field is displayed to the app user when the permission prompt opens.
+
+Follow the same process to add the other two Keys required of the Camera plugin: `NSPhotoLibraryAddUsageDescription` and `NSPhotoLibraryUsageDescription`.
 
 Next, click on `App` in the Project Navigator on the left-hand side, then within the `Signing & Capabilities` section, select your Development Team.
 
@@ -87,7 +89,6 @@ $ ionic cap open android
 Similar to iOS, we must enable the correct permissions to use the Camera. Configure these in the `AndroidManifest.xml` file. Android Studio will likely open this file automatically, but in case it doesn't, locate it under `android/app/src/main/`.
 
 ![Android Manifest location](/docs/assets/img/guides/first-app-cap-ng/android-manifest.png)
-
 
 Scroll to the `Permissions` section and ensure these entries are included:
 


### PR DESCRIPTION
# Changes Made
## Your First Ionic App: React

- Step 2 Taking Photos: fixed typo where `useCamera` should be `usePhotoGallery`
- Step 4 Loading Photos: fixed typo where `setPhotos(photos)` should be `setPhotos(photosInStorage)`
- Step 6 Deploying Mobile: modified Info.plist instructions (must be manually added and includes 2 addt. permissions)

Regarding Step 6, this might need to be updated for Angular and Vue as well. I have not looked through those guides, but while walking through this guide during a training session it was discovered that the `Info.plist` entries are not added when adding/syncing the Cap project. 