### PR TITLE
docs(react): add IonPage to nested outlet example

### DIFF
--- a/src/pages/react/navigation.md
+++ b/src/pages/react/navigation.md
@@ -61,10 +61,12 @@ Inside the Dashboard page, we define more routes related to this specific sectio
 ```typescript
 const DashboardPage: React.FC = () => {
   return (
-    <IonRouterOutlet>
-      <Route exact path="/dashboard" component={UsersListPage} />
-      <Route path="/dashboard/users/:id" component={UserDetailPage} />
-    </IonRouterOutlet>
+    <IonPage>
+      <IonRouterOutlet>
+        <Route exact path="/dashboard" component={UsersListPage} />
+        <Route path="/dashboard/users/:id" component={UserDetailPage} />
+      </IonRouterOutlet>
+    </IonPage>
   );
 };
 ```
@@ -76,10 +78,12 @@ However, we can use the [`match`](https://reacttraining.com/react-router/web/api
 ```typescript
 const DashboardPage: React.FC<RouteComponentProps> = ({ match }) => {
   return (
-    <IonRouterOutlet>
-      <Route exact path={match.url} component={UsersListPage} />
-      <Route path={`${match.url}/users/:id`} component={UserDetailPage} />
-    </IonRouterOutlet>
+    <IonPage>
+      <IonRouterOutlet>
+        <Route exact path={match.url} component={UsersListPage} />
+        <Route path={`${match.url}/users/:id`} component={UserDetailPage} />
+      </IonRouterOutlet>
+    </IonPage>
   );
 };
 ```


### PR DESCRIPTION
All pages that can be navigated to need `IonPage`. This example works fine in non-Tabs examples but breaks when adding a nested router outlet inside of a Tab due to the views lack of an `IonPage`.

See: https://github.com/ionic-team/ionic-framework/issues/23418