### PR TITLE
docs(): add virtual scroll documentation

### DIFF
--- a/scripts/build-pages/markdown-renderer/code.ts
+++ b/scripts/build-pages/markdown-renderer/code.ts
@@ -27,7 +27,8 @@ loadLanguages([
   'json',
   'tsx',
   'typescript',
-  'scss'
+  'scss',
+  'diff'
 ]);
 
 // `shell` is an alias of `bash`, so we have to extend `bash`.

--- a/src/assets/locales/en/messages.json
+++ b/src/assets/locales/en/messages.json
@@ -99,6 +99,7 @@
   "menu-vue-lifecycle": "Lifecycle",
   "menu-vue-navigation": "Navigation/Routing",
   "menu-vue-config": "Config",
+  "menu-vue-virtual-scroll": "Virtual Scroll",
   "menu-vue-platform": "Platform",
   "menu-vue-pwa": "Progressive Web Apps",
   "menu-vue-storage": "Storage",

--- a/src/assets/locales/en/messages.json
+++ b/src/assets/locales/en/messages.json
@@ -78,6 +78,7 @@
   "menu-react-yfa-live-reload": "Live Reload",
   "menu-react-lifecycle": "Lifecycle",
   "menu-react-navigation": "Navigation/Routing",
+  "menu-react-virtual-scroll": "Virtual Scroll",
   "menu-react-config": "Config",
   "menu-react-platform": "Platform",
   "menu-react-pwa": "Progressive Web Apps",

--- a/src/assets/locales/en/messages.json
+++ b/src/assets/locales/en/messages.json
@@ -60,6 +60,7 @@
   "menu-angular-lifecycle": "Lifecycle",
   "menu-angular-navigation": "Navigation/Routing",
   "menu-angular-config": "Config",
+  "menu-angular-virtual-scroll": "Virtual Scroll",
   "menu-angular-platform": "Platform",
   "menu-angular-testing": "Testing",
   "menu-angular-storage": "Storage",

--- a/src/components/code/prismjs-theme.css
+++ b/src/components/code/prismjs-theme.css
@@ -88,6 +88,9 @@ pre[class*="language-"] {
 .token.inserted {
   color: #ff6810;
 }
+.token.inserted.inserted-sign {
+  color: green;
+}
 
 .token.operator,
 .token.string,

--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -51,6 +51,7 @@ const items = {
     'menu-angular-lifecycle': '/docs/angular/lifecycle',
     'menu-angular-navigation': '/docs/angular/navigation',
     'menu-angular-config': '/docs/angular/config',
+    'menu-angular-virtual-scroll': '/docs/angular/virtual-scroll',
     'menu-angular-platform': '/docs/angular/platform',
     'menu-angular-testing': '/docs/angular/testing',
     'menu-angular-storage': '/docs/angular/storage',

--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -72,6 +72,7 @@ const items = {
     'menu-react-lifecycle': '/docs/react/lifecycle',
     'menu-react-navigation': '/docs/react/navigation',
     'menu-react-config': '/docs/react/config',
+    'menu-react-virtual-scroll': '/docs/react/virtual-scroll',
     'menu-react-platform': '/docs/react/platform',
     'menu-react-pwa': '/docs/react/pwa',
     'menu-react-overlays': '/docs/react/overlays',

--- a/src/components/menu/templates/main.tsx
+++ b/src/components/menu/templates/main.tsx
@@ -94,6 +94,7 @@ const items = {
     'menu-vue-lifecycle': '/docs/vue/lifecycle',
     'menu-vue-navigation': '/docs/vue/navigation',
     'menu-vue-config': '/docs/vue/config',
+    'menu-vue-virtual-scroll': '/docs/vue/virtual-scroll',
     'menu-vue-platform': '/docs/vue/platform',
     'menu-vue-pwa': '/docs/vue/pwa',
     'menu-vue-storage': '/docs/vue/storage',

--- a/src/pages/angular/virtual-scroll.md
+++ b/src/pages/angular/virtual-scroll.md
@@ -1,0 +1,139 @@
+---
+title: 'Virtual Scroll'
+---
+
+In the past, we have provided an `ion-virtual-scroll` component in Ionic Framework to help with list virtualization. At the time this was not available in Angular, but recently Angular has provided its own solution via the `@angular/cdk` package.
+
+## Setup
+
+To setup the CDK Scroller, first install `@angular/cdk`:
+
+```shell
+npm add @angular/cdk
+```
+
+This provides a collection of different utilities, but we'll focus on `ScrollingModule` for now.
+
+When we want to use the CDK Scroller, we'll need to import the module in our component. For example, in a tabs starter project, we can add our import to the `tabs1.module.ts` file.
+
+```diff
+  import { IonicModule } from '@ionic/angular';
+  import { NgModule } from '@angular/core';
+  import { CommonModule } from '@angular/common';
+  import { FormsModule } from '@angular/forms';
+  import { Tab1Page } from './tab1.page';
+  import { ExploreContainerComponentModule } from '../explore-container/explore-container.module';
++ import { ScrollingModule } from '@angular/cdk/scrolling';
+  import { Tab1PageRoutingModule } from './tab1-routing.module';
+
+  @NgModule({
+    imports: [
+      IonicModule,
+      CommonModule,
+      FormsModule,
+      ExploreContainerComponentModule,
+      Tab1PageRoutingModule,
++     ScrollingModule
+    ],
+    declarations: [Tab1Page]
+  })
+  export class Tab1PageModule {}
+```
+
+With this added, we have access to the Virtual Scroller in the Tab1Page component.
+
+## Usage
+
+The CDK Virtual Scroller can be added to a component by adding the `cdk-virtual-scroll-viewport` to a component's template.
+
+```html
+<ion-content>
+  <cdk-virtual-scroll-viewport> </cdk-virtual-scroll-viewport>
+</ion-content>
+```
+
+`cdk-virtual-scroll-viewport` becomes the root of our scrollable content and is responsible for recycling DOM nodes as they scroll out of view.
+
+The DOM nodes at this point can be any content needed for an app. The difference is that when we want to iterate over a collection, `*cdkVirtualFor` is used instead of `*ngFor`.
+
+```html
+<ion-content>
+  <cdk-virtual-scroll-viewport>
+    <ion-list>
+      <ion-item *cdkVirtualFor="let item of items">
+        <ion-avatar slot="start">
+          <img src="https://loremflickr.com/40/40" />
+        </ion-avatar>
+        <ion-label>
+          {{item }}
+        </ion-label>
+      </ion-item>
+    </ion-list>
+  </cdk-virtual-scroll-viewport>
+</ion-content>
+```
+
+Here, `items` is an array, but it can be an array, `Observable<Array>`, or `DataSource`. `DataSource` is an abstract class that can provide the data needed as well as utility methods. For more details, check out the [CDK Virtual Scrolling docs](https://material.angular.io/cdk/scrolling/overview).
+
+The component is not complete yet as the `cdk-virtual-scroll-viewport` needs to know how big each node will be as well as the min/max buffer sizes.
+
+At the moment, CDK Virtual Scroller only supports fixed sized elements, but dynamic sized elements are planned for the future. For the `Tab1Page` component, since it is only rendering an item, it can be hard-coded to a fixed size.
+
+The min/max buffer size tells the scroller "render as many nodes as it takes to meet this minimum height, but not over this".
+
+```html
+<cdk-virtual-scroll-viewport
+  itemSize="56"
+  minBufferPx="900"
+  maxBufferPx="1350"
+></cdk-virtual-scroll-viewport>
+```
+
+For this case, the `cdk-virtual-scroll-viewport` will render cells at a height 56px until it reaches a height of 900px, but no more at 1350px. These numbers are arbitrary, so be sure to test out what values will work in a real use case.
+
+
+
+Putting everything together, the final HTML should look like:
+
+```html
+<ion-content>
+  <cdk-virtual-scroll-viewport
+    itemSize="56"
+    minBufferPx="900"
+    maxBufferPx="1350"
+  >
+    <ion-list>
+      <ion-item *cdkVirtualFor="let item of items">
+        <ion-avatar slot="start">
+          <img src="https://loremflickr.com/40/40" />
+        </ion-avatar>
+        <ion-label>
+          {{item }}
+        </ion-label>
+      </ion-item>
+    </ion-list>
+  </cdk-virtual-scroll-viewport>
+</ion-content>
+```
+
+
+The last piece needed is a some CSS to size the viewport correctly. In the `tab1.page.scss` file, add the following
+
+```scss
+cdk-virtual-scroll-viewport {
+  height: 100%;
+  width: 100%;
+}
+```
+
+Since the viewport is built to fit various use cases, the default sizing is not set and is up to developers to set.
+
+## A Note on Ionic Components
+
+Certain Ionic Framework functionality is currently not compatible with virtual scrolling. Features such as collapsible large titles, `ion-infinite-scroll`, and `ion-refresher` rely on being able to scroll on `ion-content` itself, and as a result will not work when using virtual scrolling.
+
+We are working to improve compatibility between these components and virtual scrolling solutions. You can follow progress and give feedback here: https://github.com/ionic-team/ionic-framework/issues/23437.
+
+## Further Reading
+
+This only covers a small portion of what the CDK Virtual Scroller is capable of. For more details, please see the [Angular CDK Virtual Scrolling docs](https://material.angular.io/cdk/scrolling/overview).

--- a/src/pages/react/virtual-scroll.md
+++ b/src/pages/react/virtual-scroll.md
@@ -1,0 +1,71 @@
+---
+title: 'Virtual Scroll'
+---
+
+One virtual scrolling solution to consider for your Ionic React app is [Virtuoso](https://virtuoso.dev/). This guide will go over how to install `Virtuoso` into your Ionic React application and use it with other Ionic components.
+
+## Installation
+
+To setup the virtual scroller, first install `react-virtuoso`:
+
+```shell
+npm install react-virtuoso
+```
+
+## Usage
+
+There are a few components that Virtuoso includes, but this example will use the `Virtuoso` component. This component should be added inside of your `IonContent` component:
+
+```typescript
+import React from 'react';
+import { Virtuoso } from 'react-virtuoso';
+import {
+  IonAvatar,
+  IonContent, 
+  IonItem,
+  IonLabel,
+  IonPage
+} from '@ionic/react';
+const Home: React.FC = () => (
+  <IonPage>
+    <IonContent>
+      <Virtuoso
+        style={{ height: '100%' }}
+        totalCount={100}
+        itemContent={(index) => {
+          return (
+            <div style={{ height: '56px' }}>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <img src="https://picsum.photos/seed/picsum/40/40" />
+                </IonAvatar>
+                <IonLabel>{ index }</IonLabel>
+              </IonItem>
+            </div>
+          )
+        }}
+      />
+    </IonContent>
+  </IonPage>
+)
+
+export default Home;
+```
+
+After adding the `Virtuoso` component to our page, we need to define the size of the virtual scroll container. In this case, we want the container to take up the full height of the screen which we can do by adding `style={{ height: '100%' }}`.
+
+Next, we want to define the total number of items to render via the `totalCount` property.
+
+From there, we can use the `itemContent` property to pass a function that will be called to render each item in our virtual scroll content.
+
+An important thing to note here is the `div` that wraps our `IonItem` component. When lazy loading Ionic components, there may be a few frames where the component is loaded but the styles have not loaded in. When this happens, the component's dimension will be `0`, and Virtuoso may throw an error. This is because Virtuoso needs distinct positions for each item it renders, and it cannot determine that when a component's dimension is `0`.
+
+## A Note on Ionic Components
+
+Certain Ionic Framework functionality is currently not compatible with virtual scrolling. Features such as collapsible large titles, `ion-infinite-scroll`, and `ion-refresher` rely on being able to scroll on `ion-content` itself, and as a result will not work when using virtual scrolling.
+
+We are working to improve compatibility between these components and virtual scrolling solutions. You can follow progress and give feedback here: https://github.com/ionic-team/ionic-framework/issues/23437.
+
+## Further Reading
+
+This guide only covers a small portion of what `Virtuoso` is capable of. For more details, please see the [Virtuoso documentation](https://virtuoso.dev/).

--- a/src/pages/vue/virtual-scroll.md
+++ b/src/pages/vue/virtual-scroll.md
@@ -1,0 +1,110 @@
+---
+title: 'Virtual Scroll'
+---
+
+One virtual scrolling solution to consider for your Ionic Vue app is [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller/blob/next/packages/vue-virtual-scroller/README.md). This guide will go over how to install `vue-virtual-scroller` into your Ionic Vue application and use it with other Ionic components.
+
+## Installation
+
+To setup the virtual scroller, first install `vue-virtual-scroll`:
+
+```shell
+npm install vue-virtual-scroll@next
+```
+
+> Be sure to use the `next` tag otherwise you will get a version of `vue-virtual-scroll` that is only compatible with Vue 2.
+
+From here, we need to import the virtual scroller's CSS into our app. In `main.ts`, add the following line:
+
+```js
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
+```
+
+## Registering Virtual Scroll Components
+
+Now that we have the package installed and the CSS imported, we can either import all virtual scroll components or only import the components we want to use. This guide will show how to do both.
+
+### Installing all Components
+
+To install all virtual scroll components for use your app, add the following import to `main.ts`:
+
+```js
+import VueVirtualScroller from 'vue-virtual-scroller';
+```
+
+Next, we need to install this in our Vue application:
+
+```js
+app.use(VueVirtualScroller);
+```
+
+After doing this, all virtual scroll components will be available for use in our app.
+
+> Note: Installing all components may result in unused virtual scroll components being added to your application bundle. See the [Installing Specific Components](#installing-specific-components) section below for an approach that works better with treeshaking.
+
+### Installing Specific Components
+
+To install specific virtual scroll components for use in your app, import the component you want to use in `main.ts`. In this example, we will be using the `RecycleScroller` component:
+
+```js
+import { RecycleScroller } from 'vue-virtual-scroller';
+```
+
+Next, we need to add the component to our Vue application:
+
+```js
+app.component('RecycleScroller', RecycleScroller);
+```
+
+After doing this, we will be able to use the `RecycleScroller` component in our app.
+
+## Usage
+
+This example will use the `RecycleScroller` component which only renders the visible items in your list. Other components such as `DynamicScroller` can be used when you do not know the size of the items in advance.
+
+The `RecycleScroller` component should be added inside of your `ion-content` component:
+
+```html
+<template>
+  <ion-page>
+    <ion-content>
+      <ion-list>
+        <RecycleScroller
+          class="scroller"
+          :items="list"
+          :item-size="56"
+        >
+          <template #default="{ item }">
+            <ion-item>
+              <ion-avatar slot="start">
+                <img src="https://picsum.photos/seed/picsum/40/40" />
+              </ion-avatar>
+              <ion-label>{{ item }}</ion-label>
+            </ion-item>
+          </template>
+        </RecycleScroller>
+      </ion-list>
+    </ion-content>
+  </ion-page>
+</template>
+```
+
+There are two important pieces we need to account for in order for `RecycleScroller` to work. First, we need to provide it with an array of data to iterate over via the `items` property. In this case, we have an array called `list` which provides our data. Second, we need to provide the size of each node via the `item-size` property. If you do not know the size of the node ahead of time, you should use the `DynamicScroller` component instead.
+
+Now that our template is setup, we need to add some CSS to size the virtual scrolling viewport correctly. In a `style` tag in your component, add the following:
+
+```css
+.scroller {
+  height: 100%;
+}
+```
+
+## A Note on Ionic Components
+
+Certain Ionic Framework functionality is currently not compatible with virtual scrolling. Features such as collapsible large title, `ion-infinite-scroll`, and `ion-refresher` rely on being able to scroll on `ion-content` itself, and as a result will not work when using virtual scrolling.
+
+We are working to improve compatibility between these components and virtual scrolling solutions. You can follow progress and give feedback here: https://github.com/ionic-team/ionic-framework/issues/23437.
+
+## Further Reading
+
+This guide only covers a small portion of what `vue-virtual-scroller` is capable of. For more details, please see the [vue-virtual-scroller documentation](https://github.com/Akryum/vue-virtual-scroller/blob/next/packages/vue-virtual-scroller/README.md).

--- a/src/pages/vue/virtual-scroll.md
+++ b/src/pages/vue/virtual-scroll.md
@@ -87,6 +87,32 @@ The `RecycleScroller` component should be added inside of your `ion-content` com
     </ion-content>
   </ion-page>
 </template>
+
+<script>
+  import { defineComponent, ref } from 'vue';
+  import {
+    IonAvatar,
+    IonContent,
+    IonItem,
+    IonLabel,
+    IonPage
+  } from '@ionic/vue';
+  
+  export default defineComponent({
+    components: {
+      IonAvatar,
+      IonContent,
+      IonItem,
+      IonLabel,
+      IonPage
+    },
+    setup() {
+      const list = ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      
+      return { list }
+    }
+  });
+</script>
 ```
 
 There are two important pieces we need to account for in order for `RecycleScroller` to work. First, we need to provide it with an array of data to iterate over via the `items` property. In this case, we have an array called `list` which provides our data. Second, we need to provide the size of each node via the `item-size` property. If you do not know the size of the node ahead of time, you should use the `DynamicScroller` component instead.
@@ -101,7 +127,7 @@ Now that our template is setup, we need to add some CSS to size the virtual scro
 
 ## A Note on Ionic Components
 
-Certain Ionic Framework functionality is currently not compatible with virtual scrolling. Features such as collapsible large title, `ion-infinite-scroll`, and `ion-refresher` rely on being able to scroll on `ion-content` itself, and as a result will not work when using virtual scrolling.
+Certain Ionic Framework functionality is currently not compatible with virtual scrolling. Features such as collapsible large titles, `ion-infinite-scroll`, and `ion-refresher` rely on being able to scroll on `ion-content` itself, and as a result will not work when using virtual scrolling.
 
 We are working to improve compatibility between these components and virtual scrolling solutions. You can follow progress and give feedback here: https://github.com/ionic-team/ionic-framework/issues/23437.
 


### PR DESCRIPTION
Related: https://github.com/ionic-team/ionic-framework/pull/23444

Adds virtual scroll recommendations for Angular, React, and Vue. Also provides steps for migrating `ion-virtual-scroll` to CDK Scroller.