### PR TITLE
chore(): add swiper 6 note

### DIFF
--- a/src/pages/angular/slides.md
+++ b/src/pages/angular/slides.md
@@ -11,12 +11,14 @@ We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener norefe
 
 This guide will go over how to get Swiper for Angular set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Angular integration.
 
+> This guide is only for Swiper v6. A guide for Swiper v7 is coming soon!
+
 ## Getting Started
 
 To get started, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@6
 ```
 
 ## Swiping with Style

--- a/src/pages/react/slides.md
+++ b/src/pages/react/slides.md
@@ -11,12 +11,14 @@ We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener norefe
 
 This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
+> This guide is only for Swiper v6. A guide for Swiper v7 is coming soon!
+
 ## Getting Started
 
 To get started, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@6
 ```
 
 ## Swiping with Style

--- a/src/pages/vue/slides.md
+++ b/src/pages/vue/slides.md
@@ -11,12 +11,14 @@ We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener norefe
 
 This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
 
+> This guide is only for Swiper v6. A guide for Swiper v7 is coming soon!
+
 ## Getting Started
 
 To get started, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@6
 ```
 
 ### Typescript (optional)


### PR DESCRIPTION
The current Slides migration guide only works with Swiper 6. Adding a note on this until we can figure out the Swiper 6 --> Swiper 7 changes that impact Ionic users