### PR TITLE
Update CONTRIBUTING.md update the branch name to `main` instead of `master` in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ If you're looking for issues to help out with, we'd recommend either asking abou
 
 ## Deploying
 
-The Ionic documentation's `master` branch is deployed automatically and separately from the [Ionic site](https://github.com/ionic-team/ionic-site) itself. The Ionic site then uses a proxy for paths under `/docs` to request the deployed documentation.
+The Ionic documentation's `main` branch is deployed automatically and separately from the [Ionic site](https://github.com/ionic-team/ionic-site) itself. The Ionic site then uses a proxy for paths under `/docs` to request the deployed documentation.
 
 ---
 


### PR DESCRIPTION
In the "Deploying" section it refers to "The Ionic documentation's `master` branch" but it looks like this is now renamed to `main`. I have edited it to use `main` instead.