### PR TITLE
chore(): bump Ionic dev build for infinite scroll examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ionic-docs",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ionic-internal/ionic-ds": "4.1.4",
-        "@ionic/core": "^5.7.0",
-        "@ionic/docs": "^5.7.0",
+        "@ionic/core": "5.9.0-dev.202111011809.3d377d7",
+        "@ionic/docs": "5.9.0-dev.202111011809.3d377d7",
         "@sentry/node": "^5.27.3",
         "@stencil/router": "^1.0.1",
         "@stencil/sass": "^1.3.2",
@@ -205,9 +206,9 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.7.0.tgz",
-      "integrity": "sha512-5GunAeZWDhjbo4/gFCYjA4vXP3V+8PEoGa9C+ZEojurpk7IBuAtI36KalCukrHLPoIbfUCywTXoZubfC1S6lHQ==",
+      "version": "5.9.0-dev.202111011809.3d377d7",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.9.0-dev.202111011809.3d377d7.tgz",
+      "integrity": "sha512-LNk596IwJl5951Z3NyTfdtEc9tnRFhkxEECFaCWGvwT3jh7z5EPweG6Orw43fp/gJGr0FAy9CfoUS8IsVnYjcA==",
       "dependencies": {
         "@stencil/core": "^2.4.0",
         "ionicons": "^5.5.3",
@@ -220,9 +221,9 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "node_modules/@ionic/docs": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.7.0.tgz",
-      "integrity": "sha512-x1TODT9cFT6FhCb+wF1uL9YKl0U/785Aum9ZPzBAyIm3jj3I8V4t3EnriyJOIS6ajqK+hJppK5P2pLcvMjmTng=="
+      "version": "5.9.0-dev.202111011809.3d377d7",
+      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.9.0-dev.202111011809.3d377d7.tgz",
+      "integrity": "sha512-A3QrYdU/cGn8dNycXkAJ9IFAlG3BBdvp2Cezvj3EADS6X3kEZzBhHAPrfy24zd8uoRbWRRP3roqzED/RQEDgyA=="
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -5257,9 +5258,9 @@
       }
     },
     "@ionic/core": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.7.0.tgz",
-      "integrity": "sha512-5GunAeZWDhjbo4/gFCYjA4vXP3V+8PEoGa9C+ZEojurpk7IBuAtI36KalCukrHLPoIbfUCywTXoZubfC1S6lHQ==",
+      "version": "5.9.0-dev.202111011809.3d377d7",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-5.9.0-dev.202111011809.3d377d7.tgz",
+      "integrity": "sha512-LNk596IwJl5951Z3NyTfdtEc9tnRFhkxEECFaCWGvwT3jh7z5EPweG6Orw43fp/gJGr0FAy9CfoUS8IsVnYjcA==",
       "requires": {
         "@stencil/core": "^2.4.0",
         "ionicons": "^5.5.3",
@@ -5274,9 +5275,9 @@
       }
     },
     "@ionic/docs": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.7.0.tgz",
-      "integrity": "sha512-x1TODT9cFT6FhCb+wF1uL9YKl0U/785Aum9ZPzBAyIm3jj3I8V4t3EnriyJOIS6ajqK+hJppK5P2pLcvMjmTng=="
+      "version": "5.9.0-dev.202111011809.3d377d7",
+      "resolved": "https://registry.npmjs.org/@ionic/docs/-/docs-5.9.0-dev.202111011809.3d377d7.tgz",
+      "integrity": "sha512-A3QrYdU/cGn8dNycXkAJ9IFAlG3BBdvp2Cezvj3EADS6X3kEZzBhHAPrfy24zd8uoRbWRRP3roqzED/RQEDgyA=="
     },
     "@kwsites/file-exists": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@ionic-internal/ionic-ds": "4.1.4",
-    "@ionic/core": "^5.7.0",
-    "@ionic/docs": "^5.7.0",
+    "@ionic/core": "5.9.0-dev.202111011809.3d377d7",
+    "@ionic/docs": "5.9.0-dev.202111011809.3d377d7",
     "@sentry/node": "^5.27.3",
     "@stencil/router": "^1.0.1",
     "@stencil/sass": "^1.3.2",


### PR DESCRIPTION
Would like to get the infinite scroll examples for React corrected sooner rather than later, so adding a temp dev build for now.