### PR TITLE
Renaming instances of Photo to UserPhoto and CameraPhoto to Photo

### DIFF
--- a/src/pages/angular/your-first-app/2-taking-photos.md
+++ b/src/pages/angular/your-first-app/2-taking-photos.md
@@ -74,10 +74,10 @@ After taking a photo, it disappears right away. We need to display it within our
 
 ## Displaying Photos
 
-Outside of the `PhotoService` class definition (the very bottom of the file), create a new interface, `Photo`, to hold our photo metadata:
+Outside of the `PhotoService` class definition (the very bottom of the file), create a new interface, `UserPhoto`, to hold our photo metadata:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath: string;
 }
@@ -87,7 +87,7 @@ Back at the top of the file, define an array of Photos, which will contain a ref
 
 ```typescript
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
 
   // other code
 }

--- a/src/pages/angular/your-first-app/3-saving-photos.md
+++ b/src/pages/angular/your-first-app/3-saving-photos.md
@@ -11,10 +11,10 @@ We’re now able to take multiple photos and display them in a photo gallery on 
 
 ## Filesystem API
 
-Fortunately, saving them to the filesystem only takes a few steps. Begin by creating a new class method, `savePicture()`, in the `PhotoService` class (`src/app/services/photo.service.ts`). We pass in the `cameraPhoto` object, which represents the newly captured device photo:
+Fortunately, saving them to the filesystem only takes a few steps. Begin by creating a new class method, `savePicture()`, in the `PhotoService` class (`src/app/services/photo.service.ts`). We pass in the `photo` object, which represents the newly captured device photo:
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) { }
+private async savePicture(photo: Photo) { }
 ```
 
 We can use this new method immediately in `addNewToGallery()`:
@@ -37,9 +37,9 @@ public async addNewToGallery() {
 We’ll use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. To start, convert the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function. As you’ll recall, we display each photo on the screen by setting each image’s source path (`src` attribute) in `tab2.page.html` to the webviewPath property. So, set it then return the new Photo object.
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) {
+private async savePicture(photo: Photo) {
   // Convert photo to base64 format, required by Filesystem API to save
-  const base64Data = await this.readAsBase64(cameraPhoto);
+  const base64Data = await this.readAsBase64(photo);
 
   // Write the file to the data directory
   const fileName = new Date().getTime() + '.jpeg';
@@ -53,7 +53,7 @@ private async savePicture(cameraPhoto: CameraPhoto) {
   // already loaded into memory
   return {
     filepath: fileName,
-    webviewPath: cameraPhoto.webPath
+    webviewPath: photo.webPath
   };
 }
 ```
@@ -61,9 +61,9 @@ private async savePicture(cameraPhoto: CameraPhoto) {
 `readAsBase64()` is a helper function we’ll define next. It's useful to organize via a separate method since it requires a small amount of platform-specific (web vs. mobile) logic - more on that in a bit. For now, implement the logic for running on the web:
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // Fetch the photo, read as a blob, then convert to base64 format
-  const response = await fetch(cameraPhoto.webPath!);
+  const response = await fetch(photo.webPath!);
   const blob = await response.blob();
 
   return await this.convertBlobToBase64(blob) as string;

--- a/src/pages/angular/your-first-app/4-loading-photos.md
+++ b/src/pages/angular/your-first-app/4-loading-photos.md
@@ -17,7 +17,7 @@ Begin by defining a constant variable that will act as the key for the store:
 
 ```typescript
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = "photos";
 
   // other code

--- a/src/pages/angular/your-first-app/5-adding-mobile.md
+++ b/src/pages/angular/your-first-app/5-adding-mobile.md
@@ -19,7 +19,7 @@ Import the Ionic [Platform API](https://ionicframework.com/docs/angular/platform
 import { Platform } from '@ionic/angular';
 
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = "photos";
   private platform: Platform;
 
@@ -36,19 +36,19 @@ export class PhotoService {
 First, we’ll update the photo saving functionality to support mobile. In the `readAsBase64()` function, check which platform the app is running on. If it’s “hybrid” (Capacitor or Cordova, two native runtimes), then read the photo file into base64 format using the Filesystem `readFile()` method. Otherwise, use the same logic as before when running the app on the web:
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // "hybrid" will detect Cordova or Capacitor
   if (this.platform.is('hybrid')) {
     // Read the file into base64 format
     const file = await Filesystem.readFile({
-      path: cameraPhoto.path
+      path: photo.path
     });
 
     return file.data;
   }
   else {
     // Fetch the photo, read as a blob, then convert to base64 format
-    const response = await fetch(cameraPhoto.webPath);
+    const response = await fetch(photo.webPath);
     const blob = await response.blob();
 
     return await this.convertBlobToBase64(blob) as string;
@@ -60,9 +60,9 @@ Next, update the `savePicture()` method. When running on mobile, set `filepath` 
 
 ```typescript
 // Save picture to file on device
-  private async savePicture(cameraPhoto: CameraPhoto) {
+  private async savePicture(photo: Photo) {
     // Convert photo to base64 format, required by Filesystem API to save
-    const base64Data = await this.readAsBase64(cameraPhoto);
+    const base64Data = await this.readAsBase64(photo);
 
     // Write the file to the data directory
     const fileName = new Date().getTime() + '.jpeg';
@@ -85,7 +85,7 @@ Next, update the `savePicture()` method. When running on mobile, set `filepath` 
       // already loaded into memory
       return {
         filepath: fileName,
-        webviewPath: cameraPhoto.webPath
+        webviewPath: photo.webPath
       };
     }
   }

--- a/src/pages/angular/your-first-app/7-live-reload.md
+++ b/src/pages/angular/your-first-app/7-live-reload.md
@@ -48,10 +48,10 @@ constructor(public photoService: PhotoService,
             public actionSheetController: ActionSheetController) {}
 ```
 
-Add `Photo` to the import statement.
+Add `UserPhoto` to the import statement.
 
 ```typescript
-import { Photo, PhotoService } from '../services/photo.service';
+import { UserPhoto, PhotoService } from '../services/photo.service';
 ```
 
 Next, implement the `showActionSheet()` function. We add two options: `Delete` that calls PhotoService’s `deletePicture()` function (to be added next) and `Cancel`, which when given the role of “cancel” will automatically close the action sheet:

--- a/src/pages/es/angular/your-first-app/2-taking-photos.md
+++ b/src/pages/es/angular/your-first-app/2-taking-photos.md
@@ -75,7 +75,7 @@ Después de tomar una foto, desaparece de inmediato. Necesitamos mostrarlo en nu
 
 ## Mostrando fotos
 
-Fuera de la definición de clase `Photo Service` (la parte inferior del archivo), crea una nueva interfaz, `Photo`para mantener nuestros metadatos fotográficos:
+Fuera de la definición de clase `Photo Service` (la parte inferior del archivo), crea una nueva interfaz, `UserPhoto` para mantener nuestros metadatos fotográficos:
 
 ```typescript
 export interface Photo {
@@ -88,7 +88,7 @@ Volver a la parte superior del archivo, definir una matriz de fotos, que contend
 
 ```typescript
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
 
   // otro código
 }

--- a/src/pages/es/angular/your-first-app/3-saving-photos.md
+++ b/src/pages/es/angular/your-first-app/3-saving-photos.md
@@ -11,10 +11,10 @@ Ahora podemos tomar varias fotos y mostrarlas en una galería de fotos en la seg
 
 ## API FileSystem
 
-Afortunadamente, guardarlos en el sistema de archivos sólo toma unos pocos pasos. Comencemos creando un nuevo método de clase, `savePicture()`, en la clase `PhotoService` (`src/app/services/photo.service.ts`). Pasamos al objeto `cameraPhoto`, que representa la foto del dispositivo recién capturado:
+Afortunadamente, guardarlos en el sistema de archivos sólo toma unos pocos pasos. Comencemos creando un nuevo método de clase, `savePicture()`, en la clase `PhotoService` (`src/app/services/photo.service.ts`). Pasamos al objeto `photo`, que representa la foto del dispositivo recién capturado:
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) { }
+private async savePicture(photo: Photo) { }
 ```
 
 Podemos usar éste nuevo método inmediatamente en `addNewToGallery()`:
@@ -37,9 +37,9 @@ public async addNewToGallery() {
 Utilizaremos el [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) de Capacitor, para guardar la foto en el sistema de archivos. Para empezar, convierte la foto en formato base64, luego envía los datos a la función `writeFile` del Filesystem. Como recordarás, mostramos cada foto en la pantalla configurando cada ruta origen de la imagen (atributo *src*) en `tab2.page.html` a la propiedad webviewPath. Entonces, configúrelo y luego devuelva el nuevo objeto Photo.
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) {
+private async savePicture(photo: Photo) {
   // Convierte photo al formato base64, requerido por el API de Filesystem para guardarlo
-  const base64Data = await this.readAsBase64(cameraPhoto);
+  const base64Data = await this.readAsBase64(photo);
 
   // Escribe el archivo a la carpeta Data
   const fileName = new Date().getTime() + '.jpeg';
@@ -53,7 +53,7 @@ private async savePicture(cameraPhoto: CameraPhoto) {
   // ya está cargada en memoria
   return {
     filepath: fileName,
-    webviewPath: cameraPhoto.webPath
+    webviewPath: photo.webPath
   };
 }
 ```
@@ -61,9 +61,9 @@ private async savePicture(cameraPhoto: CameraPhoto) {
 `readAsBase64()` es una función ayudante (helper), que definiremos a continuación. Es útil organizar a través de un método separado, ya que requiere una pequeña cantidad de lógica específica de la plataforma. (web vs. móvil) - más sobre esto en un momento. Por ahora, implementaremos la lógica para la plataforma web.
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // Obtener la foto, leer como un blob, luego convertir a formato base64
-  const response = await fetch(cameraPhoto.webPath!);
+  const response = await fetch(photo.webPath!);
  const blob = await response.blob();
 
   return await this.convertBlobToBase64(blob) as string;  

--- a/src/pages/es/angular/your-first-app/4-loading-photos.md
+++ b/src/pages/es/angular/your-first-app/4-loading-photos.md
@@ -17,7 +17,7 @@ Comience definiendo una variable constante que actuará como la clave para el al
 
 ```typescript
 export class PhotoService {
- public photos: Photo[] = [];
+ public photos: UserPhoto[] = [];
  private PHOTO_STORAGE: string = "photos";
 
   // otro código

--- a/src/pages/es/angular/your-first-app/5-adding-mobile.md
+++ b/src/pages/es/angular/your-first-app/5-adding-mobile.md
@@ -19,7 +19,7 @@ Importa el [API de Plataforma](https://ionicframework.com/docs/angular/platform)
 import { Platform } from '@ionic/angular';
 
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = "photos";
   private platform: Platform;
 
@@ -36,19 +36,19 @@ export class PhotoService {
 En primer lugar, actualizaremos la funcionalidad de guardar fotos para que sea compatible con dispositivos móviles. En la función `readAsBase64()`, compruebe en qué plataforma se está ejecutando la aplicación. Si es "híbrida" (Capacitor o Cordova, dos runtime nativos), entonces obtenga la foto en formato base64 utilizando el método de Filesystem `readFile()`. De lo contrario, utilice la misma lógica de antes cuando ejecute la aplicación en la web:
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // "hybrid" detectara si es Cordova o Capacitor
   if (this.platform.is('hybrid')) {
     // Lee el archivo en formato base64
     const file = await Filesystem.readFile({
-      path: cameraPhoto.path
+      path: photo.path
     });
 
     return file.data;
   }
   else {
     // Obtiene la foto, como blob, entonces la convierte en formato base64
-    const response = await fetch(cameraPhoto.webPath);
+    const response = await fetch(photo.webPath);
     const blob = await response.blob();
 
     return await this.convertBlobToBase64(blob) as string;
@@ -60,9 +60,9 @@ Next, update the `savePicture()` method. When running on mobile, set `filepath` 
 
 ```typescript
 // Save picture to file on device
-  private async savePicture(cameraPhoto: CameraPhoto) {
+  private async savePicture(photo: Photo) {
     // Convert photo to base64 format, required by Filesystem API to save
-    const base64Data = await this.readAsBase64(cameraPhoto);
+    const base64Data = await this.readAsBase64(photo);
 
     // Write the file to the data directory
     const fileName = new Date().getTime() + '.jpeg';
@@ -85,7 +85,7 @@ Next, update the `savePicture()` method. When running on mobile, set `filepath` 
       // already loaded into memory
       return {
         filepath: fileName,
-        webviewPath: cameraPhoto.webPath
+        webviewPath: photo.webPath
       };
     }
   }

--- a/src/pages/es/angular/your-first-app/7-live-reload.md
+++ b/src/pages/es/angular/your-first-app/7-live-reload.md
@@ -48,10 +48,10 @@ constructor(public photoService: PhotoService,
             public actionSheetController: ActionSheetController) {}
 ```
 
-Add `Photo` to the import statement.
+Add `UserPhoto` to the import statement.
 
 ```typescript
-import { Photo, PhotoService } from '../services/photo.service';
+import { UserPhoto, PhotoService } from '../services/photo.service';
 ```
 
 Next, implement the `showActionSheet()` function. We add two options: `Delete` that calls PhotoService’s `deletePicture()` function (to be added next) and `Cancel`, which when given the role of “cancel” will automatically close the action sheet:

--- a/src/pages/es/react/your-first-app/2-taking-photos.md
+++ b/src/pages/es/react/your-first-app/2-taking-photos.md
@@ -75,10 +75,10 @@ After taking a photo, it disappears. We still need to display it within our app 
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -87,7 +87,7 @@ export interface Photo {
 Back at the top of the function (right after the call to `useCamera`, we will define a state variable to store the array of each photo captured with the Camera.
 
 ```typescript
-const [photos, setPhotos] = useState<Photo[]>([]);
+const [photos, setPhotos] = useState<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting CameraPhoto returned from Capacitor will be stored in the `photo` variable. We want to create a new photo object and add it to the photos state array. We make sure we don't accidently mutate the current photos array by making a new array, and then call `setPhotos` to store the array into state. Update the `takePhoto` method and add this code after the getPhoto call:

--- a/src/pages/es/react/your-first-app/3-saving-photos.md
+++ b/src/pages/es/react/your-first-app/3-saving-photos.md
@@ -22,7 +22,7 @@ const { deleteFile, getUri, readFile, writeFile } = useFilesystem();
 Next, create a couple of new functions in `usePhotoGallery`:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   const base64Data = await base64FromPath(photo.webPath!);
   const savedFile = await writeFile({
     path: fileName,
@@ -41,22 +41,22 @@ const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo>
 
 > The base64FromPath method is a helper util imported from "@ionic/react-hooks/filesystem". It downloads a file from the supplied path and returns a base64 representation of that file.
 
-We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function.
 
-Last, call `savePicture` and pass in the cameraPhoto object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
+Last, call `savePicture` and pass in the photo object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await getPhoto({
+  const photo = await getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
   const newPhotos = [savedFileImage, ...photos];
   setPhotos(newPhotos);
 };

--- a/src/pages/es/react/your-first-app/4-loading-photos.md
+++ b/src/pages/es/react/your-first-app/4-loading-photos.md
@@ -38,7 +38,7 @@ With the photo array data saved, we will create a method that will retrieve the 
 useEffect(() => {
   const loadSaved = async () => {
     const photosString = await get(PHOTO_STORAGE);
-    const photos = (photosString ? JSON.parse(photosString) : []) as Photo[];
+    const photos = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
     for (let photo of photos) {
       const file = await readFile({
         path: photo.filepath,

--- a/src/pages/es/react/your-first-app/5-adding-mobile.md
+++ b/src/pages/es/react/your-first-app/5-adding-mobile.md
@@ -16,7 +16,7 @@ Let’s start with making some small code changes - then our app will “just wo
 First, we’ll update the photo saving functionality to support mobile. In the `savePicture` function, check which platform the app is running on. If it’s “hybrid” (Capacitor or Cordova, the two native runtimes), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://ionicframework.com/docs/core-concepts/webview#file-protocol)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect Cordova or Capacitor;
   if (isPlatform('hybrid')) {
@@ -57,7 +57,7 @@ Next, add a new bit of logic in the `loadSaved` function. On mobile, we can dire
 ```typescript
 const loadSaved = async () => {
   const photosString = await get('photos');
-  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as Photo[];
+  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
   // If running on the web...
   if (!isPlatform('hybrid')) {
     for (let photo of photosInStorage) {

--- a/src/pages/es/react/your-first-app/7-live-reload.md
+++ b/src/pages/es/react/your-first-app/7-live-reload.md
@@ -29,11 +29,11 @@ The Live Reload server will start up, and the native IDE of choice will open if 
 
 ## Deleting Photos
 
-With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `Photo` from the `usePhotoGallery` hook:
+With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `UserPhoto` from the `usePhotoGallery` hook:
 
 ```typescript
 import React, { useState } from 'react';
-import { usePhotoGallery, Photo } from '../hooks/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '../hooks/usePhotoGallery';
 // other imports
 ```
 
@@ -46,7 +46,7 @@ const { photos, takePhoto, deletePhoto } = usePhotoGallery();
 Next, add a state value to store information about the photo to delete:
 
 ```typescript
-const [photoToDelete, setPhotoToDelete] = useState<Photo>();
+const [photoToDelete, setPhotoToDelete] = useState<UserPhoto>();
 ```
 
 When a user clicks on an image, we will show the action sheet by changing the state value to the photo. Update the `<IonImg>` element to:

--- a/src/pages/es/vue/your-first-app/2-taking-photos.md
+++ b/src/pages/es/vue/your-first-app/2-taking-photos.md
@@ -90,10 +90,10 @@ After taking a photo, it disappears right away. We still need to display it with
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -102,7 +102,7 @@ export interface Photo {
 Back at the top of the function (right after referencing the Capacitor Camera plugin), define an array so we can store each photo captured with the Camera. Make it a reactive variable using Vue's [ref function](https://v3.vuejs.org/guide/composition-api-introduction.html#reactive-variables-with-ref).
 
 ```typescript
-const photos = ref<Photo[]>([]);
+const photos = ref<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting `CameraPhoto` returned from Capacitor will be added to the `photos` array. Update the `takePhoto` method, adding this code after the `Camera.getPhoto` line:
@@ -126,10 +126,10 @@ return {
 };
 ```
 
-Back in the Tab2 component, update the import statement to include the `Photo` interface:
+Back in the Tab2 component, update the import statement to include the `UserPhoto` interface:
 
 ```typescript
-import { usePhotoGallery, Photo } from '@/composables/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '@/composables/usePhotoGallery';
 ```
 
 Then, get access to the photos array:

--- a/src/pages/es/vue/your-first-app/3-saving-photos.md
+++ b/src/pages/es/vue/your-first-app/3-saving-photos.md
@@ -30,12 +30,12 @@ const convertBlobToBase64 = (blob: Blob) => new Promise((resolve, reject) => {
 });
 ```
 
-Next, add a function to save the photo to the filesystem. We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+Next, add a function to save the photo to the filesystem. We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   let base64Data: string;
 
   // Fetch the photo, read as a blob, then convert to base64 format
@@ -62,14 +62,14 @@ Last, update the `takePhoto` function to call `savePicture`. Once the photo has 
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await Camera.getPhoto({
+  const photo = await Camera.getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
 
   photos.value = [savedFileImage, ...photos.value];
 };

--- a/src/pages/es/vue/your-first-app/4-loading-photos.md
+++ b/src/pages/es/vue/your-first-app/4-loading-photos.md
@@ -24,7 +24,7 @@ Then, import the Storage API to get access to methods for reading and writing to
 ```typescript
 export function usePhotoGallery() {
   const { Camera, Filesystem, Storage } = Plugins;
-  const photos = ref<Photo[]>([]);
+  const photos = ref<UserPhoto[]>([]);
   const PHOTO_STORAGE = "photos";
 ```
 

--- a/src/pages/es/vue/your-first-app/5-adding-mobile.md
+++ b/src/pages/es/vue/your-first-app/5-adding-mobile.md
@@ -22,7 +22,7 @@ import { isPlatform } from '@ionic/vue';
 In the `savePicture` function, check which platform the app is running on. If it’s "hybrid" (Capacitor, the native runtime), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://capacitorjs.com/docs/basics/utilities#convertfilesrc)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect mobile - iOS or Android
   if (isPlatform('hybrid')) {

--- a/src/pages/fr/angular/your-first-app/2-taking-photos.md
+++ b/src/pages/fr/angular/your-first-app/2-taking-photos.md
@@ -75,10 +75,10 @@ Après avoir pris une photo, elle disparaît immédiatement. Nous devons l'affic
 
 ## Affichage des photos
 
-En dehors de la définition de classe `PhotoService` (le tout en bas du fichier), créer une nouvelle interface, `Photo`, pour tenir nos métadonnées photo:
+En dehors de la définition de classe `PhotoService` (le tout en bas du fichier), créer une nouvelle interface, `UserPhoto`, pour tenir nos métadonnées photo:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath: string;
 }
@@ -88,7 +88,7 @@ De retour en haut du fichier, définissez un tableau de Photos, qui contiendra u
 
 ```typescript
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
 
   // other code
 }

--- a/src/pages/fr/angular/your-first-app/3-saving-photos.md
+++ b/src/pages/fr/angular/your-first-app/3-saving-photos.md
@@ -11,10 +11,10 @@ Nous sommes maintenant en mesure de prendre plusieurs photos et de les afficher 
 
 ## API du système de fichiers
 
-Heureusement, les enregistrer dans le système de fichiers ne prend que quelques étapes. Commencez par créer une nouvelle méthode de classe, `savePicture()`, in the `PhotoService` class (`src/app/services/photo.service.ts`). Nous passons l'objet `cameraPhoto` , qui représente la photo du nouvel appareil capturé :
+Heureusement, les enregistrer dans le système de fichiers ne prend que quelques étapes. Commencez par créer une nouvelle méthode de classe, `savePicture()`, in the `PhotoService` class (`src/app/services/photo.service.ts`). Nous passons l'objet `photo` , qui représente la photo du nouvel appareil capturé :
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) { }
+private async savePicture(photo: Photo) { }
 ```
 
 Nous pouvons utiliser cette nouvelle méthode immédiatement dans `addNewToGallery()` :
@@ -37,9 +37,9 @@ public async addNewToGallery() {
 Nous utiliserons l'API du système de fichiers [Capacitor](https://capacitor.ionicframework.com/docs/apis/filesystem) pour enregistrer la photo dans le système de fichiers. Pour commencer, convertissez la photo au format base64, puis donnez les données à la fonction `writeFile` du système de fichiers. Comme vous vous en souvenez, nous affichons chaque photo à l'écran en définissant le chemin source de chaque image (`src` attribut) dans `tab2.page.html` à la propriété webviewPath. Donc, réglez-le puis rendez le nouvel objet Photo.
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) {
+private async savePicture(photo: Photo) {
   // Convert photo to base64 format, required by Filesystem API to save
-  const base64Data = await this.readAsBase64(cameraPhoto);
+  const base64Data = await this.readAsBase64(photo);
 
   // Write the file to the data directory
   const fileName = new Date().getTime() + '.jpeg';
@@ -53,7 +53,7 @@ private async savePicture(cameraPhoto: CameraPhoto) {
   // already loaded into memory
   return {
     filepath: fileName,
-    webviewPath: cameraPhoto.webPath
+    webviewPath: photo.webPath
   };
 }
 ```
@@ -61,9 +61,9 @@ private async savePicture(cameraPhoto: CameraPhoto) {
 `readAsBase64()` est une fonction d'aide que nous allons définir ensuite. Il est utile de s'organiser selon une méthode distincte car elle nécessite une petite quantité d'informations spécifiques à la plate-forme (web vs. mobile) - plus d'informations à ce sujet dans un instant. Pour l'instant, mettez en œuvre la logique de fonctionnement sur le web :
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // Fetch the photo, read as a blob, then convert to base64 format
-  const response = await fetch(cameraPhoto.webPath!);
+  const response = await fetch(photo.webPath!);
   const blob = await response.blob();
 
   return await this.convertBlobToBase64(blob) as string;  

--- a/src/pages/fr/angular/your-first-app/4-loading-photos.md
+++ b/src/pages/fr/angular/your-first-app/4-loading-photos.md
@@ -17,7 +17,7 @@ Commencez par définir une variable constante qui servira de clé pour le tablea
 
 ```typescript
 export class PhotoService {
-  public photos : Photo[] = [];
+  public photos : UserPhoto[] = [];
   private PHOTO_STORAGE: string = "photos";
 
   // autre code

--- a/src/pages/fr/angular/your-first-app/5-adding-mobile.md
+++ b/src/pages/fr/angular/your-first-app/5-adding-mobile.md
@@ -19,7 +19,7 @@ Importez l'API [Plateforme Ionic](https://ionicframework.com/docs/angular/platfo
 import { Platform } from '@ionic/angular';
 
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = "photos";
   private platform: Platform;
 
@@ -36,19 +36,19 @@ export class PhotoService {
 Tout d’abord, nous mettrons à jour la fonctionnalité d’enregistrement de photos pour prendre en charge le mobile. Dans la fonction `readAsBase64()` , vérifiez la plate-forme sur laquelle l'application s'exécute. Si c'est « hybride » (Capacitor ou Cordova, deux exécutions natives), alors lisez le fichier photo au format base64 en utilisant la méthode du système de fichiers `readFile()`. Sinon, utilisez la même logique qu'avant lors de l'exécution de l'application sur le web:
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // "hybrid" will detect Cordova or Capacitor
   if (this.platform.is('hybrid')) {
     // Read the file into base64 format
     const file = await Filesystem.readFile({
-      path: cameraPhoto.path
+      path: photo.path
     });
 
     return file.data;
   }
   else {
     // Fetch the photo, read as a blob, then convert to base64 format
-    const response = await fetch(cameraPhoto.webPath);
+    const response = await fetch(photo.webPath);
     const blob = await response.blob();
 
     return await this.convertBlobToBase64(blob) as string;
@@ -60,9 +60,9 @@ Ensuite, mettez à jour la méthode `savePicture()`. Lors de l'exécution sur mo
 
 ```typescript
 // Save picture to file on device
-  private async savePicture(cameraPhoto: CameraPhoto) {
+  private async savePicture(photo: Photo) {
     // Convert photo to base64 format, required by Filesystem API to save
-    const base64Data = await this.readAsBase64(cameraPhoto);
+    const base64Data = await this.readAsBase64(photo);
 
     // Write the file to the data directory
     const fileName = new Date().getTime() + '.jpeg';
@@ -85,7 +85,7 @@ Ensuite, mettez à jour la méthode `savePicture()`. Lors de l'exécution sur mo
       // already loaded into memory
       return {
         filepath: fileName,
-        webviewPath: cameraPhoto.webPath
+        webviewPath: photo.webPath
       };
     }
   }

--- a/src/pages/fr/angular/your-first-app/7-live-reload.md
+++ b/src/pages/fr/angular/your-first-app/7-live-reload.md
@@ -48,10 +48,10 @@ constructor(public photoService: PhotoService,
             public actionSheetController: ActionSheetController) {}
 ```
 
-Add `Photo` to the import statement.
+Add `UserPhoto` to the import statement.
 
 ```typescript
-import { Photo, PhotoService } from '../services/photo.service';
+import { UserPhoto, PhotoService } from '../services/photo.service';
 ```
 
 Next, implement the `showActionSheet()` function. We add two options: `Delete` that calls PhotoService’s `deletePicture()` function (to be added next) and `Cancel`, which when given the role of “cancel” will automatically close the action sheet:

--- a/src/pages/fr/react/your-first-app/2-taking-photos.md
+++ b/src/pages/fr/react/your-first-app/2-taking-photos.md
@@ -75,10 +75,10 @@ After taking a photo, it disappears. We still need to display it within our app 
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -87,7 +87,7 @@ export interface Photo {
 Back at the top of the function (right after the call to `useCamera`, we will define a state variable to store the array of each photo captured with the Camera.
 
 ```typescript
-const [photos, setPhotos] = useState<Photo[]>([]);
+const [photos, setPhotos] = useState<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting CameraPhoto returned from Capacitor will be stored in the `photo` variable. We want to create a new photo object and add it to the photos state array. We make sure we don't accidently mutate the current photos array by making a new array, and then call `setPhotos` to store the array into state. Update the `takePhoto` method and add this code after the getPhoto call:

--- a/src/pages/fr/react/your-first-app/3-saving-photos.md
+++ b/src/pages/fr/react/your-first-app/3-saving-photos.md
@@ -22,7 +22,7 @@ const { deleteFile, getUri, readFile, writeFile } = useFilesystem();
 Next, create a couple of new functions in `usePhotoGallery`:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   const base64Data = await base64FromPath(photo.webPath!);
   const savedFile = await writeFile({
     path: fileName,
@@ -41,22 +41,22 @@ const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo>
 
 > The base64FromPath method is a helper util imported from "@ionic/react-hooks/filesystem". It downloads a file from the supplied path and returns a base64 representation of that file.
 
-We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function.
 
-Last, call `savePicture` and pass in the cameraPhoto object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
+Last, call `savePicture` and pass in the photo object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await getPhoto({
+  const photo = await getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
   const newPhotos = [savedFileImage, ...photos];
   setPhotos(newPhotos);
 };

--- a/src/pages/fr/react/your-first-app/4-loading-photos.md
+++ b/src/pages/fr/react/your-first-app/4-loading-photos.md
@@ -38,7 +38,7 @@ With the photo array data saved, we will create a method that will retrieve the 
 useEffect(() => {
   const loadSaved = async () => {
     const photosString = await get(PHOTO_STORAGE);
-    const photos = (photosString ? JSON.parse(photosString) : []) as Photo[];
+    const photos = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
     for (let photo of photos) {
       const file = await readFile({
         path: photo.filepath,

--- a/src/pages/fr/react/your-first-app/5-adding-mobile.md
+++ b/src/pages/fr/react/your-first-app/5-adding-mobile.md
@@ -16,7 +16,7 @@ Let’s start with making some small code changes - then our app will “just wo
 First, we’ll update the photo saving functionality to support mobile. In the `savePicture` function, check which platform the app is running on. If it’s “hybrid” (Capacitor or Cordova, the two native runtimes), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://ionicframework.com/docs/core-concepts/webview#file-protocol)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect Cordova or Capacitor;
   if (isPlatform('hybrid')) {
@@ -57,7 +57,7 @@ Next, add a new bit of logic in the `loadSaved` function. On mobile, we can dire
 ```typescript
 const loadSaved = async () => {
   const photosString = await get('photos');
-  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as Photo[];
+  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
   // If running on the web...
   if (!isPlatform('hybrid')) {
     for (let photo of photosInStorage) {

--- a/src/pages/fr/react/your-first-app/7-live-reload.md
+++ b/src/pages/fr/react/your-first-app/7-live-reload.md
@@ -29,11 +29,11 @@ The Live Reload server will start up, and the native IDE of choice will open if 
 
 ## Deleting Photos
 
-With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `Photo` from the `usePhotoGallery` hook:
+With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `UserPhoto` from the `usePhotoGallery` hook:
 
 ```typescript
 import React, { useState } from 'react';
-import { usePhotoGallery, Photo } from '../hooks/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '../hooks/usePhotoGallery';
 // other imports
 ```
 
@@ -46,7 +46,7 @@ const { photos, takePhoto, deletePhoto } = usePhotoGallery();
 Next, add a state value to store information about the photo to delete:
 
 ```typescript
-const [photoToDelete, setPhotoToDelete] = useState<Photo>();
+const [photoToDelete, setPhotoToDelete] = useState<UserPhoto>();
 ```
 
 When a user clicks on an image, we will show the action sheet by changing the state value to the photo. Update the `<IonImg>` element to:

--- a/src/pages/fr/vue/your-first-app/2-taking-photos.md
+++ b/src/pages/fr/vue/your-first-app/2-taking-photos.md
@@ -90,10 +90,10 @@ After taking a photo, it disappears right away. We still need to display it with
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -102,7 +102,7 @@ export interface Photo {
 Back at the top of the function (right after referencing the Capacitor Camera plugin), define an array so we can store each photo captured with the Camera. Make it a reactive variable using Vue's [ref function](https://v3.vuejs.org/guide/composition-api-introduction.html#reactive-variables-with-ref).
 
 ```typescript
-const photos = ref<Photo[]>([]);
+const photos = ref<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting `CameraPhoto` returned from Capacitor will be added to the `photos` array. Update the `takePhoto` method, adding this code after the `Camera.getPhoto` line:
@@ -126,10 +126,10 @@ return {
 };
 ```
 
-Back in the Tab2 component, update the import statement to include the `Photo` interface:
+Back in the Tab2 component, update the import statement to include the `UserPhoto` interface:
 
 ```typescript
-import { usePhotoGallery, Photo } from '@/composables/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '@/composables/usePhotoGallery';
 ```
 
 Then, get access to the photos array:

--- a/src/pages/fr/vue/your-first-app/3-saving-photos.md
+++ b/src/pages/fr/vue/your-first-app/3-saving-photos.md
@@ -30,12 +30,12 @@ const convertBlobToBase64 = (blob: Blob) => new Promise((resolve, reject) => {
 });
 ```
 
-Next, add a function to save the photo to the filesystem. We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+Next, add a function to save the photo to the filesystem. We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   let base64Data: string;
 
   // Fetch the photo, read as a blob, then convert to base64 format
@@ -62,14 +62,14 @@ Last, update the `takePhoto` function to call `savePicture`. Once the photo has 
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await Camera.getPhoto({
+  const photo = await Camera.getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
 
   photos.value = [savedFileImage, ...photos.value];
 };

--- a/src/pages/fr/vue/your-first-app/4-loading-photos.md
+++ b/src/pages/fr/vue/your-first-app/4-loading-photos.md
@@ -24,7 +24,7 @@ Then, import the Storage API to get access to methods for reading and writing to
 ```typescript
 export function usePhotoGallery() {
   const { Camera, Filesystem, Storage } = Plugins;
-  const photos = ref<Photo[]>([]);
+  const photos = ref<UserPhoto[]>([]);
   const PHOTO_STORAGE = "photos";
 ```
 

--- a/src/pages/fr/vue/your-first-app/5-adding-mobile.md
+++ b/src/pages/fr/vue/your-first-app/5-adding-mobile.md
@@ -22,7 +22,7 @@ import { isPlatform } from '@ionic/vue';
 In the `savePicture` function, check which platform the app is running on. If it’s "hybrid" (Capacitor, the native runtime), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://capacitorjs.com/docs/basics/utilities#convertfilesrc)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect mobile - iOS or Android
   if (isPlatform('hybrid')) {

--- a/src/pages/pt/angular/your-first-app/2-taking-photos.md
+++ b/src/pages/pt/angular/your-first-app/2-taking-photos.md
@@ -75,7 +75,7 @@ Depois de tirar uma foto, ela desaparece imediatamente. Precisamos exibi-lo em n
 
 ## Mostrando Fotos
 
-Abaixo da classe `PhotoService` (porém fora dela), crie uma nova interface, chamada `Photo`, para guardar nossos metadados da foto:
+Abaixo da classe `PhotoService` (porém fora dela), crie uma nova interface, chamada `UserPhoto`, para guardar nossos metadados da foto:
 
 ```typescript
 exportar foto da interface {
@@ -88,7 +88,7 @@ Vá ao topo do arquivo e defina uma matriz de Fotos, que conterá uma referênci
 
 ```typescript
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
 
   // outro código
 }

--- a/src/pages/pt/angular/your-first-app/3-saving-photos.md
+++ b/src/pages/pt/angular/your-first-app/3-saving-photos.md
@@ -11,10 +11,10 @@ Agora podemos tirar várias fotos e exibí-las em uma galeria de fotos na segund
 
 ## Sistema de arquivos raiz
 
-Felizmente, salvá-los no sistema de arquivos só dá alguns passos. Comece criando uma nova função, `savePicture()`, na classe `PhotoService` (`src/app/services/photo.service.ts`). Passamos no objeto `cameraPhoto` , que representa a foto recém-capturada do dispositivo:
+Felizmente, salvá-los no sistema de arquivos só dá alguns passos. Comece criando uma nova função, `savePicture()`, na classe `PhotoService` (`src/app/services/photo.service.ts`). Passamos no objeto `photo` , que representa a foto recém-capturada do dispositivo:
 
 ```typescript
-salvamento assíncrono privado (imagem de câmera: CameraPhoto) { }
+salvamento assíncrono privado (imagem de câmera: Photo) { }
 ```
 
 Podemos usar esta nova função imediatamente em `addNewToGallery()`:
@@ -37,9 +37,9 @@ public async addNewToGallery() {
 Usaremos a Capacitor [API do sistema de arquivos](https://capacitor.ionicframework.com/docs/apis/filesystem) para salvar a foto no sistema de arquivos. Para começar, converta a foto para o formato base64 e, em seguida, utilize a função `writeFile` para alimentar os dados para a função </code>. Como deve se lembrar, nós exibimos cada foto na tela, definindo o caminho de origem de cada imagem (atributo`src` de imagem) em `tab2.page.html` para a propriedade webviewPath. Então, defina-o e retorne o novo objeto Foto.
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) {
+private async savePicture(photo: Photo) {
   // Converter a foto para formato base64, Necessário pela API do sistema de arquivos para salvar
-  const base64Data = await this.readAsBase64(cameraPhoto);
+  const base64Data = await this.readAsBase64(photo);
 
   // Escreva o arquivo para o diretório de dados
   const fileName = new Date().getTime() + '.jpeg';
@@ -53,7 +53,7 @@ private async savePicture(cameraPhoto: CameraPhoto) {
    // já carregada na memória
   return {
     filepath: fileName,
-    webviewPath: cameraPhoto.webPath
+    webviewPath: photo.webPath
   };
 }
 ```
@@ -61,9 +61,9 @@ private async savePicture(cameraPhoto: CameraPhoto) {
 `readAsBase64()` é uma função que vamos definir em seguida. É útil organizar através de um método separado, já que ele requer uma pequena quantidade de plataforma específica (web vs. móvel) - mais sobre isso um pouco. Por enquanto, implemente-os para serem executados na web:
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // Buscar a foto, leia como um blob, então converta em formato base64
-  const response = await fetch(cameraPhoto. ebPath!);
+  const response = await fetch(photo. ebPath!);
   const blob = await response.blob();
 
   return aguarda isso. onvertBlobToBase64(blob) como string;  

--- a/src/pages/pt/angular/your-first-app/4-loading-photos.md
+++ b/src/pages/pt/angular/your-first-app/4-loading-photos.md
@@ -17,7 +17,7 @@ Comece definindo uma variável constante que atuará como a chave para a loja:
 
 ```typescript
 export class PhotoService {
-  public fotos: Photo[] = [];
+  public fotos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = "fotos";
 
   // outro código

--- a/src/pages/pt/angular/your-first-app/5-adding-mobile.md
+++ b/src/pages/pt/angular/your-first-app/5-adding-mobile.md
@@ -36,19 +36,19 @@ export class PhotoService {
 Primeiro, vamos atualizar a funcionalidade de salvar fotos para dar suporte a dispositivos móveis. Na função `readAsBase64()`, verifica em qual plataforma a aplicação está a ser executada. Se for "híbrido" (Capacitor ou Cordova, dois runtimes nativos), então lê o arquivo de fotos no formato base64 usando o método de arquivo `readFile()`. Caso contrário, usa a mesma lógica como antes ao executar o aplicativo na web:
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // "hybrid" vai detetar Cordova ou Capacitor
   if (this.platform.is('hybrid')) {
     // Ler o ficheiro em formato base64 
     const file = await Filesystem.readFile({
-      path: cameraPhoto.path
+      path: photo.path
     });
 
     return file.data;
   }
   else {
     // Buscar a foto, ler como um "blob" e depois converter para formato base64
-    const response = await fetch(cameraPhoto.webPath);
+    const response = await fetch(photo.webPath);
     const blob = await response.blob();
 
     return await this.convertBlobToBase64(blob) as string;
@@ -60,9 +60,9 @@ A seguir, atualiza o método `savePicture()`. Quando executres em dispositivos m
 
 ```typescript
 // Guarda o fcheiro da imagem no dispositivo
-  private async savePicture(cameraPhoto: CameraPhoto) {
+  private async savePicture(photo: Photo) {
     // Converte a foto para formato base64, requerido para guardar pela Filesystem API
-    const base64Data = await this.readAsBase64(cameraPhoto);
+    const base64Data = await this.readAsBase64(photo);
 
     // Guarda o ficheiro no diretório de dados
     const fileName = new Date().getTime() + '.jpeg';
@@ -85,7 +85,7 @@ A seguir, atualiza o método `savePicture()`. Quando executres em dispositivos m
       // que esta já está gravada na memória
       return {
         filepath: fileName,
-        webviewPath: cameraPhoto.webPath
+        webviewPath: photo.webPath
       };
     }
   }

--- a/src/pages/pt/angular/your-first-app/7-live-reload.md
+++ b/src/pages/pt/angular/your-first-app/7-live-reload.md
@@ -48,10 +48,10 @@ constructor(public photoService: PhotoService,
             public actionSheetController: ActionSheetController) {}
 ```
 
-Add `Photo` to the import statement.
+Add `UserPhoto` to the import statement.
 
 ```typescript
-import { Photo, PhotoService } from '../services/photo.service';
+import { UserPhoto, PhotoService } from '../services/photo.service';
 ```
 
 Next, implement the `showActionSheet()` function. We add two options: `Delete` that calls PhotoService’s `deletePicture()` function (to be added next) and `Cancel`, which when given the role of “cancel” will automatically close the action sheet:

--- a/src/pages/pt/react/your-first-app/2-taking-photos.md
+++ b/src/pages/pt/react/your-first-app/2-taking-photos.md
@@ -75,10 +75,10 @@ After taking a photo, it disappears. We still need to display it within our app 
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -87,7 +87,7 @@ export interface Photo {
 Back at the top of the function (right after the call to `useCamera`, we will define a state variable to store the array of each photo captured with the Camera.
 
 ```typescript
-const [photos, setPhotos] = useState<Photo[]>([]);
+const [photos, setPhotos] = useState<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting CameraPhoto returned from Capacitor will be stored in the `photo` variable. We want to create a new photo object and add it to the photos state array. We make sure we don't accidently mutate the current photos array by making a new array, and then call `setPhotos` to store the array into state. Update the `takePhoto` method and add this code after the getPhoto call:

--- a/src/pages/pt/react/your-first-app/3-saving-photos.md
+++ b/src/pages/pt/react/your-first-app/3-saving-photos.md
@@ -22,7 +22,7 @@ const { deleteFile, getUri, readFile, writeFile } = useFilesystem();
 Next, create a couple of new functions in `usePhotoGallery`:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   const base64Data = await base64FromPath(photo.webPath!);
   const savedFile = await writeFile({
     path: fileName,
@@ -41,22 +41,22 @@ const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo>
 
 > The base64FromPath method is a helper util imported from "@ionic/react-hooks/filesystem". It downloads a file from the supplied path and returns a base64 representation of that file.
 
-We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function.
 
-Last, call `savePicture` and pass in the cameraPhoto object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
+Last, call `savePicture` and pass in the photo object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await getPhoto({
+  const photo = await getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
   const newPhotos = [savedFileImage, ...photos];
   setPhotos(newPhotos);
 };

--- a/src/pages/pt/react/your-first-app/4-loading-photos.md
+++ b/src/pages/pt/react/your-first-app/4-loading-photos.md
@@ -38,7 +38,7 @@ With the photo array data saved, we will create a method that will retrieve the 
 useEffect(() => {
   const loadSaved = async () => {
     const photosString = await get(PHOTO_STORAGE);
-    const photos = (photosString ? JSON.parse(photosString) : []) as Photo[];
+    const photos = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
     for (let photo of photos) {
       const file = await readFile({
         path: photo.filepath,

--- a/src/pages/pt/react/your-first-app/5-adding-mobile.md
+++ b/src/pages/pt/react/your-first-app/5-adding-mobile.md
@@ -16,7 +16,7 @@ Let’s start with making some small code changes - then our app will “just wo
 First, we’ll update the photo saving functionality to support mobile. In the `savePicture` function, check which platform the app is running on. If it’s “hybrid” (Capacitor or Cordova, the two native runtimes), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://ionicframework.com/docs/core-concepts/webview#file-protocol)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect Cordova or Capacitor;
   if (isPlatform('hybrid')) {
@@ -57,7 +57,7 @@ Next, add a new bit of logic in the `loadSaved` function. On mobile, we can dire
 ```typescript
 const loadSaved = async () => {
   const photosString = await get('photos');
-  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as Photo[];
+  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
   // If running on the web...
   if (!isPlatform('hybrid')) {
     for (let photo of photosInStorage) {

--- a/src/pages/pt/react/your-first-app/7-live-reload.md
+++ b/src/pages/pt/react/your-first-app/7-live-reload.md
@@ -29,11 +29,11 @@ The Live Reload server will start up, and the native IDE of choice will open if 
 
 ## Deleting Photos
 
-With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `Photo` from the `usePhotoGallery` hook:
+With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `UserPhoto` from the `usePhotoGallery` hook:
 
 ```typescript
 import React, { useState } from 'react';
-import { usePhotoGallery, Photo } from '../hooks/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '../hooks/usePhotoGallery';
 // other imports
 ```
 
@@ -46,7 +46,7 @@ const { photos, takePhoto, deletePhoto } = usePhotoGallery();
 Next, add a state value to store information about the photo to delete:
 
 ```typescript
-const [photoToDelete, setPhotoToDelete] = useState<Photo>();
+const [photoToDelete, setPhotoToDelete] = useState<UserPhoto>();
 ```
 
 When a user clicks on an image, we will show the action sheet by changing the state value to the photo. Update the `<IonImg>` element to:

--- a/src/pages/pt/vue/your-first-app/2-taking-photos.md
+++ b/src/pages/pt/vue/your-first-app/2-taking-photos.md
@@ -90,10 +90,10 @@ After taking a photo, it disappears right away. We still need to display it with
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -102,7 +102,7 @@ export interface Photo {
 Back at the top of the function (right after referencing the Capacitor Camera plugin), define an array so we can store each photo captured with the Camera. Make it a reactive variable using Vue's [ref function](https://v3.vuejs.org/guide/composition-api-introduction.html#reactive-variables-with-ref).
 
 ```typescript
-const photos = ref<Photo[]>([]);
+const photos = ref<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting `CameraPhoto` returned from Capacitor will be added to the `photos` array. Update the `takePhoto` method, adding this code after the `Camera.getPhoto` line:
@@ -126,10 +126,10 @@ return {
 };
 ```
 
-Back in the Tab2 component, update the import statement to include the `Photo` interface:
+Back in the Tab2 component, update the import statement to include the `UserPhoto` interface:
 
 ```typescript
-import { usePhotoGallery, Photo } from '@/composables/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '@/composables/usePhotoGallery';
 ```
 
 Then, get access to the photos array:

--- a/src/pages/pt/vue/your-first-app/3-saving-photos.md
+++ b/src/pages/pt/vue/your-first-app/3-saving-photos.md
@@ -30,12 +30,12 @@ const convertBlobToBase64 = (blob: Blob) => new Promise((resolve, reject) => {
 });
 ```
 
-Next, add a function to save the photo to the filesystem. We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+Next, add a function to save the photo to the filesystem. We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   let base64Data: string;
 
   // Fetch the photo, read as a blob, then convert to base64 format
@@ -62,14 +62,14 @@ Last, update the `takePhoto` function to call `savePicture`. Once the photo has 
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await Camera.getPhoto({
+  const photo = await Camera.getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
 
   photos.value = [savedFileImage, ...photos.value];
 };

--- a/src/pages/pt/vue/your-first-app/4-loading-photos.md
+++ b/src/pages/pt/vue/your-first-app/4-loading-photos.md
@@ -24,7 +24,7 @@ Then, import the Storage API to get access to methods for reading and writing to
 ```typescript
 export function usePhotoGallery() {
   const { Camera, Filesystem, Storage } = Plugins;
-  const photos = ref<Photo[]>([]);
+  const photos = ref<UserPhoto[]>([]);
   const PHOTO_STORAGE = "photos";
 ```
 

--- a/src/pages/pt/vue/your-first-app/5-adding-mobile.md
+++ b/src/pages/pt/vue/your-first-app/5-adding-mobile.md
@@ -22,7 +22,7 @@ import { isPlatform } from '@ionic/vue';
 In the `savePicture` function, check which platform the app is running on. If it’s "hybrid" (Capacitor, the native runtime), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://capacitorjs.com/docs/basics/utilities#convertfilesrc)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect mobile - iOS or Android
   if (isPlatform('hybrid')) {

--- a/src/pages/react/your-first-app/2-taking-photos.md
+++ b/src/pages/react/your-first-app/2-taking-photos.md
@@ -79,7 +79,7 @@ After taking a photo, it disappears. We still need to display it within our app 
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
 export interface UserPhoto {

--- a/src/pages/react/your-first-app/3-saving-photos.md
+++ b/src/pages/react/your-first-app/3-saving-photos.md
@@ -21,7 +21,7 @@ Next, create a couple of new functions in `usePhotoGallery`:
 export function usePhotoGallery() {
 
 
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   const base64Data = await base64FromPath(photo.webPath!);
   const savedFile = await FileSystem.writeFile({
     path: fileName,
@@ -60,22 +60,22 @@ export async function base64FromPath(path: string): Promise<string> {
 
 > The base64FromPath method is a helper util that downloads a file from the supplied path and returns a base64 representation of that file.
 
-We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function.
 
-Last, call `savePicture` and pass in the cameraPhoto object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
+Last, call `savePicture` and pass in the photo object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await Camera.getPhoto({
+  const photo = await Camera.getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
   const newPhotos = [savedFileImage, ...photos];
   setPhotos(newPhotos);
 };

--- a/src/pages/react/your-first-app/4-loading-photos.md
+++ b/src/pages/react/your-first-app/4-loading-photos.md
@@ -34,7 +34,7 @@ With the photo array data saved, we will create a method that will retrieve the 
 useEffect(() => {
   const loadSaved = async () => {
     const { value } = await Storage.get({ key: PHOTO_STORAGE });
-    const photosInStorage = (value ? JSON.parse(value) : []) as UserPhoto[];
+    const photosInStorage = (value ? JSON.parse(value) : []) as UserUserPhoto[];
 
     for (let photo of photosInStorage) {
       const file = await Filesystem.readFile({

--- a/src/pages/vue/your-first-app/2-taking-photos.md
+++ b/src/pages/vue/your-first-app/2-taking-photos.md
@@ -91,7 +91,7 @@ After taking a photo, it disappears right away. We still need to display it with
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
 export interface UserPhoto {
@@ -127,7 +127,7 @@ return {
 };
 ```
 
-Back in the Tab2 component, update the import statement to include the `Photo` interface:
+Back in the Tab2 component, update the import statement to include the `UserPhoto` interface:
 
 ```typescript
 import { usePhotoGallery, UserPhoto } from '@/composables/usePhotoGallery';

--- a/src/pages/vue/your-first-app/3-saving-photos.md
+++ b/src/pages/vue/your-first-app/3-saving-photos.md
@@ -27,12 +27,12 @@ const convertBlobToBase64 = (blob: Blob) => new Promise((resolve, reject) => {
 });
 ```
 
-Next, add a function to save the photo to the filesystem. We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+Next, add a function to save the photo to the filesystem. We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   let base64Data: string;
 
   // Fetch the photo, read as a blob, then convert to base64 format
@@ -59,14 +59,14 @@ Last, update the `takePhoto` function to call `savePicture`. Once the photo has 
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await Camera.getPhoto({
+  const photo = await Camera.getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
 
   photos.value = [savedFileImage, ...photos.value];
 };

--- a/src/pages/vue/your-first-app/5-adding-mobile.md
+++ b/src/pages/vue/your-first-app/5-adding-mobile.md
@@ -22,7 +22,7 @@ import { isPlatform } from '@ionic/vue';
 In the `savePicture` function, check which platform the app is running on. If it’s "hybrid" (Capacitor, the native runtime), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://capacitorjs.com/docs/basics/utilities#convertfilesrc)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<UserPhoto> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect mobile - iOS or Android
   if (isPlatform('hybrid')) {

--- a/src/pages/zh/angular/your-first-app/2-taking-photos.md
+++ b/src/pages/zh/angular/your-first-app/2-taking-photos.md
@@ -75,11 +75,11 @@ _（你的自怕可能会比我好看很多）_
 
 ## 展示照片
 
-在`PhotoService`文件里的最底部并且类的外边，创建一个名为`Photo`的interface，用于存放我们的照片数据：
+在`PhotoService`文件里的最底部并且类的外边，创建一个名为`UserPhoto`的interface，用于存放我们的照片数据：
 
 ```typescript
 // 导出接口照片
-export interface Photo{
+export interface UserPhoto{
   filepath: string;
   webviewPath: string;
 }
@@ -89,7 +89,7 @@ export interface Photo{
 
 ```typescript
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
 
   // 其他代码
 }

--- a/src/pages/zh/angular/your-first-app/3-saving-photos.md
+++ b/src/pages/zh/angular/your-first-app/3-saving-photos.md
@@ -11,10 +11,10 @@ nextUrl: '/docs/angular/your-first-app/4-loading-photos'
 
 ## 文件系统 API
 
-幸运的是，将它们保存到文件系统只需要几个步骤。 首先在` PhotoService `类(` src/app/services/photo.service.ts`)中创建一个新的类方法`savePicture()` 。 我们传入 `cameraPhoto` 对象，该对象代表新捕获的设备照片：
+幸运的是，将它们保存到文件系统只需要几个步骤。 首先在` PhotoService `类(` src/app/services/photo.service.ts`)中创建一个新的类方法`savePicture()` 。 我们传入 `photo` 对象，该对象代表新捕获的设备照片：
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) { }
+private async savePicture(photo: Photo) { }
 ```
 
 我们可以在 `addNewToGallery()` 中立即使用这个新函数：
@@ -37,9 +37,9 @@ public async addNewToGallery() {
 我们将使用 Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) 将照片保存到文件系统中。 首先，将照片转换为 base64 格式，然后将数据输入文件系统的 ` writeFile ` 函数。 你得记得，我们在`tab2.page.html`文件里，为每张显示的图片源路径（`src`属性）都设置了一个webviewPath的参数， 所以我们要返回一个照片的对象。
 
 ```typescript
-private async savePicture(cameraPhoto: CameraPhoto) {
+private async savePicture(photo: Photo) {
   // 要将照片转成base64格式，必须要通过文件系统保存
-  const base64Data = await this.readAsBase64(cameraPhoto);
+  const base64Data = await this.readAsBase64(photo);
 
   // 在数据文件夹中写入数据
   const fileName = new Date().getTime() + '.jpeg';
@@ -52,7 +52,7 @@ private async savePicture(cameraPhoto: CameraPhoto) {
   // 用webPath去显示图片，而不是用base64，因为base64需要在内存里加载
   return {
     filepath: fileName,
-    webviewPath: cameraPhoto.webPath
+    webviewPath: photo.webPath
   };
 }
 ```
@@ -60,9 +60,9 @@ private async savePicture(cameraPhoto: CameraPhoto) {
 接下来我们要定义一个很有用的函数`readAsBase64()`。 我们把他抽取成一个单独的方法，因为它的兼容性很不错（web、 移动）。 现在该实现在web上运行的业务：
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // 取得照片之后，将其读取成二进制大对象，然后转换成base64格式
-  const response = await fetch(cameraPhoto.webPath!);
+  const response = await fetch(photo.webPath!);
   const blob = await response.blob();
 
   return await this.convertBlobToBase64(blob) as string;  

--- a/src/pages/zh/angular/your-first-app/4-loading-photos.md
+++ b/src/pages/zh/angular/your-first-app/4-loading-photos.md
@@ -17,7 +17,7 @@ nextUrl: '/docs/angular/your-first app/5-adding-mobile'
 
 ```typescript
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = "photos";
 
   // 其他代码

--- a/src/pages/zh/angular/your-first-app/5-adding-mobile.md
+++ b/src/pages/zh/angular/your-first-app/5-adding-mobile.md
@@ -19,7 +19,7 @@ nextUrl: '/docs/angular/your-first-app/6-deploying-mobile'
 import { Platform } from '@ionic/angular';
 
 export class PhotoService {
-  public photos: Photo[] = [];
+  public photos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = "photos";
   private platform: Platform;
 
@@ -36,19 +36,19 @@ export class PhotoService {
 首先，我们将更新照片保存功能以支持移动设备。 在 `readAsBase64()` 函数中，检查应用程序正在运行哪个平台。 如果是“混合型”(Capacitor或Cordova，两个本机运行时)，则使用Filesystem ` readFile()`方法将照片文件读取为base64格式。 否则，在网络上运行应用程序时使用与以前相同的逻辑：
 
 ```typescript
-private async readAsBase64(cameraPhoto: CameraPhoto) {
+private async readAsBase64(photo: Photo) {
   // “hybrid”将检测Cordova或Capacitor
   if (this.platform.is('hybrid')) {
     // 将文件读取为base64格式
     const file = await Filesystem.readFile({
-      path: cameraPhoto.path
+      path: photo.path
     });
 
     return file.data;
   }
   else {
     // 提取照片，读取为blob，然后转换为base64格式
-    const response = await fetch(cameraPhoto.webPath);
+    const response = await fetch(photo.webPath);
     const blob = await response.blob();
 
     return await this.convertBlobToBase64(blob) as string;
@@ -60,9 +60,9 @@ private async readAsBase64(cameraPhoto: CameraPhoto) {
 
 ```typescript
 // 将图片保存到设备上的文件
-  private async savePicture(cameraPhoto: CameraPhoto) {
+  private async savePicture(photo: Photo) {
     // 将照片转换为Filesystem API要求保存的base64格式
-    const base64Data = await this.readAsBase64(cameraPhoto);
+    const base64Data = await this.readAsBase64(photo);
 
     // 将文件写入数据目录
     const fileName = new Date().getTime() + '.jpeg';
@@ -84,7 +84,7 @@ private async readAsBase64(cameraPhoto: CameraPhoto) {
       // 使用webPath来显示新图像而不是base64，因为它已经加载到内存中
       return {
         filepath: fileName,
-        webviewPath: cameraPhoto.webPath
+        webviewPath: photo.webPath
       };
     }
   }

--- a/src/pages/zh/angular/your-first-app/7-live-reload.md
+++ b/src/pages/zh/angular/your-first-app/7-live-reload.md
@@ -49,10 +49,10 @@ constructor(public photoService: PhotoService,
 
 ```
 
-在导入语句中添加 `Photo`
+在导入语句中添加 `UserPhoto`
 
 ```typescript
-import { Photo, PhotoService } from '../services/photo.service';
+import { UserPhoto, PhotoService } from '../services/photo.service';
 ```
 
 接下来，实现`showActionSheet()`函数。 我们往ActionSheet里面添加两个选项：`Delete`和`Cancel`，`Delete`选项可以调用照片服务的`deletePicture()`函数（我们后面要添加的功能），当按钮的`role`属性被赋值为"cancel"时，它将具有能关闭ActionSheet的功能。

--- a/src/pages/zh/react/your-first-app/2-taking-photos.md
+++ b/src/pages/zh/react/your-first-app/2-taking-photos.md
@@ -75,10 +75,10 @@ After taking a photo, it disappears. We still need to display it within our app 
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -87,7 +87,7 @@ export interface Photo {
 Back at the top of the function (right after the call to `useCamera`, we will define a state variable to store the array of each photo captured with the Camera.
 
 ```typescript
-const [photos, setPhotos] = useState<Photo[]>([]);
+const [photos, setPhotos] = useState<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting CameraPhoto returned from Capacitor will be stored in the `photo` variable. We want to create a new photo object and add it to the photos state array. We make sure we don't accidently mutate the current photos array by making a new array, and then call `setPhotos` to store the array into state. Update the `takePhoto` method and add this code after the getPhoto call:

--- a/src/pages/zh/react/your-first-app/3-saving-photos.md
+++ b/src/pages/zh/react/your-first-app/3-saving-photos.md
@@ -22,7 +22,7 @@ const { deleteFile, getUri, readFile, writeFile } = useFilesystem();
 Next, create a couple of new functions in `usePhotoGallery`:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   const base64Data = await base64FromPath(photo.webPath!);
   const savedFile = await writeFile({
     path: fileName,
@@ -41,22 +41,22 @@ const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo>
 
 > The base64FromPath method is a helper util imported from "@ionic/react-hooks/filesystem". It downloads a file from the supplied path and returns a base64 representation of that file.
 
-We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function.
 
-Last, call `savePicture` and pass in the cameraPhoto object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
+Last, call `savePicture` and pass in the photo object and filename directly underneath the call to `setPhotos` in the `takePhoto` method. Here is the full method:
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await getPhoto({
+  const photo = await getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
   const newPhotos = [savedFileImage, ...photos];
   setPhotos(newPhotos);
 };

--- a/src/pages/zh/react/your-first-app/4-loading-photos.md
+++ b/src/pages/zh/react/your-first-app/4-loading-photos.md
@@ -38,7 +38,7 @@ With the photo array data saved, we will create a method that will retrieve the 
 useEffect(() => {
   const loadSaved = async () => {
     const photosString = await get(PHOTO_STORAGE);
-    const photos = (photosString ? JSON.parse(photosString) : []) as Photo[];
+    const photos = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
     for (let photo of photos) {
       const file = await readFile({
         path: photo.filepath,

--- a/src/pages/zh/react/your-first-app/5-adding-mobile.md
+++ b/src/pages/zh/react/your-first-app/5-adding-mobile.md
@@ -16,7 +16,7 @@ Let’s start with making some small code changes - then our app will “just wo
 First, we’ll update the photo saving functionality to support mobile. In the `savePicture` function, check which platform the app is running on. If it’s “hybrid” (Capacitor or Cordova, the two native runtimes), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://ionicframework.com/docs/core-concepts/webview#file-protocol)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect Cordova or Capacitor;
   if (isPlatform('hybrid')) {
@@ -57,7 +57,7 @@ Next, add a new bit of logic in the `loadSaved` function. On mobile, we can dire
 ```typescript
 const loadSaved = async () => {
   const photosString = await get('photos');
-  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as Photo[];
+  const photosInStorage = (photosString ? JSON.parse(photosString) : []) as UserPhoto[];
   // If running on the web...
   if (!isPlatform('hybrid')) {
     for (let photo of photosInStorage) {

--- a/src/pages/zh/react/your-first-app/7-live-reload.md
+++ b/src/pages/zh/react/your-first-app/7-live-reload.md
@@ -29,11 +29,11 @@ The Live Reload server will start up, and the native IDE of choice will open if 
 
 ## Deleting Photos
 
-With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `Photo` from the `usePhotoGallery` hook:
+With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.tsx` then import `useState` from React and `UserPhoto` from the `usePhotoGallery` hook:
 
 ```typescript
 import React, { useState } from 'react';
-import { usePhotoGallery, Photo } from '../hooks/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '../hooks/usePhotoGallery';
 // other imports
 ```
 
@@ -46,7 +46,7 @@ const { photos, takePhoto, deletePhoto } = usePhotoGallery();
 Next, add a state value to store information about the photo to delete:
 
 ```typescript
-const [photoToDelete, setPhotoToDelete] = useState<Photo>();
+const [photoToDelete, setPhotoToDelete] = useState<UserPhoto>();
 ```
 
 When a user clicks on an image, we will show the action sheet by changing the state value to the photo. Update the `<IonImg>` element to:

--- a/src/pages/zh/vue/your-first-app/2-taking-photos.md
+++ b/src/pages/zh/vue/your-first-app/2-taking-photos.md
@@ -90,10 +90,10 @@ After taking a photo, it disappears right away. We still need to display it with
 
 ## Displaying Photos
 
-First we will create a new type to define our Photo, which will hold specific metadata. Add the following Photo interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
+First we will create a new type to define our Photo, which will hold specific metadata. Add the following UserPhoto interface to the `usePhotoGallery.ts` file, somewhere outside of the main function:
 
 ```typescript
-export interface Photo {
+export interface UserPhoto {
   filepath: string;
   webviewPath?: string;
 }
@@ -102,7 +102,7 @@ export interface Photo {
 Back at the top of the function (right after referencing the Capacitor Camera plugin), define an array so we can store each photo captured with the Camera. Make it a reactive variable using Vue's [ref function](https://v3.vuejs.org/guide/composition-api-introduction.html#reactive-variables-with-ref).
 
 ```typescript
-const photos = ref<Photo[]>([]);
+const photos = ref<UserPhoto[]>([]);
 ```
 
 When the camera is done taking a picture, the resulting `CameraPhoto` returned from Capacitor will be added to the `photos` array. Update the `takePhoto` method, adding this code after the `Camera.getPhoto` line:
@@ -126,10 +126,10 @@ return {
 };
 ```
 
-Back in the Tab2 component, update the import statement to include the `Photo` interface:
+Back in the Tab2 component, update the import statement to include the `UserPhoto` interface:
 
 ```typescript
-import { usePhotoGallery, Photo } from '@/composables/usePhotoGallery';
+import { usePhotoGallery, UserPhoto } from '@/composables/usePhotoGallery';
 ```
 
 Then, get access to the photos array:

--- a/src/pages/zh/vue/your-first-app/3-saving-photos.md
+++ b/src/pages/zh/vue/your-first-app/3-saving-photos.md
@@ -30,12 +30,12 @@ const convertBlobToBase64 = (blob: Blob) => new Promise((resolve, reject) => {
 });
 ```
 
-Next, add a function to save the photo to the filesystem. We pass in the `cameraPhoto` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
+Next, add a function to save the photo to the filesystem. We pass in the `photo` object, which represents the newly captured device photo, as well as the fileName, which will provide a path for the file to be stored to.
 
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function:
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
   let base64Data: string;
 
   // Fetch the photo, read as a blob, then convert to base64 format
@@ -62,14 +62,14 @@ Last, update the `takePhoto` function to call `savePicture`. Once the photo has 
 
 ```typescript
 const takePhoto = async () => {
-  const cameraPhoto = await Camera.getPhoto({
+  const photo = await Camera.getPhoto({
     resultType: CameraResultType.Uri,
     source: CameraSource.Camera,
     quality: 100
   });
 
   const fileName = new Date().getTime() + '.jpeg';
-  const savedFileImage = await savePicture(cameraPhoto, fileName);
+  const savedFileImage = await savePicture(photo, fileName);
 
   photos.value = [savedFileImage, ...photos.value];
 };

--- a/src/pages/zh/vue/your-first-app/4-loading-photos.md
+++ b/src/pages/zh/vue/your-first-app/4-loading-photos.md
@@ -24,7 +24,7 @@ Then, import the Storage API to get access to methods for reading and writing to
 ```typescript
 export function usePhotoGallery() {
   const { Camera, Filesystem, Storage } = Plugins;
-  const photos = ref<Photo[]>([]);
+  const photos = ref<UserPhoto[]>([]);
   const PHOTO_STORAGE = "photos";
 ```
 

--- a/src/pages/zh/vue/your-first-app/5-adding-mobile.md
+++ b/src/pages/zh/vue/your-first-app/5-adding-mobile.md
@@ -22,7 +22,7 @@ import { isPlatform } from '@ionic/vue';
 In the `savePicture` function, check which platform the app is running on. If it’s "hybrid" (Capacitor, the native runtime), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://capacitorjs.com/docs/basics/utilities#convertfilesrc)). Otherwise, use the same logic as before when running the app on the web.
 
 ```typescript
-const savePicture = async (photo: CameraPhoto, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
   // "hybrid" will detect mobile - iOS or Android
   if (isPlatform('hybrid')) {


### PR DESCRIPTION
Two issues were addressed (for _angular_, _vue_, and _react_ docs):

1. There were several references to a `Photo` interface that was renamed `UserPhoto` in the current version of the sample project downloads. 
2.  There were also references to the deprecated Capacitor Camera Plugin's `CameraPhoto` Class. Renamed the references to use the new value of `Photo`.