### PR TITLE
docs(slides): add Swiper 7 migration guide

### DIFF
--- a/src/pages/angular/slides.md
+++ b/src/pages/angular/slides.md
@@ -193,6 +193,10 @@ export class HomePage {
 }
 ```
 
+:::note
+The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+:::
+
 ## Properties
 
 Swiper options can be provided as individual properties directly on the `<swiper>` component or via the `config` property.

--- a/src/pages/angular/slides.md
+++ b/src/pages/angular/slides.md
@@ -11,34 +11,75 @@ We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener norefe
 
 This guide will go over how to get Swiper for Angular set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Angular integration.
 
-> This guide is only for Swiper v6. A guide for Swiper v7 is coming soon!
-
 ## Getting Started
 
-To get started, install the Swiper dependency in your project:
+First, update to the latest version of Ionic:
 
 ```shell
-npm install swiper@6
+npm install @ionic/angular@latest
+```
+
+Once that is done, install the Swiper dependency in your project:
+
+```shell
+npm install swiper
+```
+
+Once that is done, we need to import the `SwiperModule` module. This should be done in your component's module file:
+
+```typescript
+// home.module.ts
+import { SwiperModule } from 'swiper/angular';
+
+@NgModule({
+  imports: [..., SwiperModule]
+});
+...
 ```
 
 ## Swiping with Style
 
-Next, we need to import the base Swiper styles. We recommend importing the styles in the component in which Swiper is being used. This ensures that the styles are only loaded when needed:
+Next, we need to import the base Swiper styles. We are also going to import the styles that Ionic provides which will let us customize the Swiper styles using the same CSS Variables that we used with `ion-slides`.
 
-```javascript
-// slides.component.scss
-@import '~swiper/swiper';
-```
+You can import these files in `global.scss`:
 
-Ionic Framework also provides some default styles, as well as the CSS Variables that were used inside of the old `ion-slides`. If you would like to continue to use those styles and CSS Variables, be sure to import the `ionic-swiper.css` file:
-
-```javascript
-// slides.component.scss
-@import '~swiper/swiper';
+```scss
+// global.scss
+@import '~swiper/scss';
 @import '~@ionic/angular/css/ionic-swiper';
 ```
 
-You should also update any selectors to target the correct Swiper classes. If you were targeting `ion-slides`, you should target `.swiper-container`. If you were targeting `ion-slide`, you should target `.swiper-slide`.
+If you prefer to import these in the CSS file for your slides component, you will need to disable [ViewEncapsultion in Angular](https://angular.io/api/core/ViewEncapsulation), otherwise the styles will not apply:
+
+```typescript
+// home.page.ts
+import { Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: 'home.page.html',
+  styleUrls: ['home.page.scss'],
+  encapsulation: ViewEncapsulation.None
+})
+export class HomePage {
+  ...
+}
+```
+
+```scss
+// home.page.scss
+@import '~swiper/scss';
+@import '~@ionic/angular/css/ionic-swiper';
+```
+
+### Updating Selectors
+
+Previously, we were able to target `ion-slides` and `ion-slide` to apply any custom styling. The contents of those style blocks remain the same, but we need to update the selectors. Below is a list of selector changes when going from `ion-slides` to Swiper Angular:
+
+| ion-slides Selector | Swiper Selector |
+| ------------------- | --------------- |
+| `ion-slides`        | `.swiper`       |
+| `ion-slide`         | `.swiper-slide` |
 
 
 ### Vanilla CSS (Optional)
@@ -47,112 +88,114 @@ For developers not using a CSS pre-processor, Swiper also provides the styles bu
 
 ```javascript
 // slides.component.css
-@import '~swiper/swiper-bundle.min';
-@import '~@ionic/angular/css/ionic-swiper';
+@import 'swiper/css';
+@import '@ionic/angular/css/ionic-swiper';
 ```
 
 ## Using Components
 
-Swiper exports two components: `Swiper` and `SwiperSlide`. The `Swiper` component is the equivalent of `IonSlides`, and `SwiperSlide` is the equivalent of `IonSlide`.
-
-These components are registered by adding `SwiperModule` to the module of the component you wish to use Swiper in.
-
-```javascript
-// app.module.ts
-import { SwiperModule } from 'swiper/angular';
-@NgModule({
-  imports: [SwiperModule],
-})
-export class AppModule {}
-```
+Swiper Angular exports a `Swiper` component which is the equivalent of `ion-slides`. It also exports a `swiperSlide` directive which can be used on an `<ng-template>` for each slide:
 
 ```html
-<!-- swiper.component.html -->
-
-<swiper>
-  <swiper-slide>Slide 1</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-</swiper>
+<!-- home.page.html -->
+<ion-content>
+  <swiper>
+    <ng-template swiperSlide>Slide 1</ng-template>
+    <ng-template swiperSlide>Slide 3</ng-template>
+    <ng-template swiperSlide>Slide 3</ng-template>
+  </swiper>
+</ion-content>
 ```
 
-## The IonicSwiper Module
+## Using Modules
 
-There are a few edge cases in Ionic Framework where Swiper may not be able to compute the slider dimensions properly. As a result, we have created the `IonicSwiper` module to resolve some of these issues.
+By default, Swiper for Angular does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
 
-To install it, we first need to import the core Swiper library and the IonicSwiper module:
+`ion-slides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. This part of the guide will show you how to install these modules.
 
+To begin, we need to import the modules and provide them to Swiper:
 
-```javascript
-// slides.component.ts
-import SwiperCore from 'swiper';
-import { IonicSwiper } from '@ionic/angular';
-```
-
-Then we can install the module:
-
-```javascript
-// slides.component.ts
+```typescript
+// home.page.ts
 import { Component } from '@angular/core';
-import SwiperCore from 'swiper';
-import { IonicSwiper } from '@ionic/angular';
+import SwiperCore, { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
 
-SwiperCore.use([IonicSwiper]);
+SwiperCore.use([Autoplay, Keyboard, Pagination, Scrollbar, Zoom]);
 
 @Component({
-  selector: 'app-slides-example',
-  templateUrl: 'slides.component.html',
-  styleUrls: ['slides.component.scss']
+  selector: 'app-home',
+  templateUrl: 'home.page.html',
+  styleUrls: ['home.page.scss']
 })
-export class SlidesExample {
+export class HomePage {
   ...
 }
 ```
 
-## Additional Modules
-
-By default, Swiper for Angular uses the core version of Swiper and does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
-
-`ion-slides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. If you used any of these features, be sure to import them in your application.
-
-The following example shows how to install the Navigation and Pagination plugins:
-
-```javascript
-// slides.component.ts
-import { Component } from '@angular/core';
-import SwiperCore, { Navigation, Pagination } from 'swiper';
-import { IonicSwiper } from '@ionic/angular';
-
-SwiperCore.use([IonicSwiper, Navigation, Pagination]);
-
-@Component({
-  selector: 'app-slides-example',
-  templateUrl: 'slides.component.html',
-  styleUrls: ['slides.component.scss']
-})
-export class SlidesExample {
-  ...
-}
+Next, we need to import the stylesheets for each module:
+```scss
+// global.scss
+@import '~swiper/scss';
+@import '~swiper/scss/autoplay';
+@import '~swiper/scss/keyboard';
+@import '~swiper/scss/pagination';
+@import '~swiper/scss/scrollbar';
+@import '~swiper/scss/zoom';
+@import '~@ionic/angular/css/ionic-swiper';
 ```
 
+Finally, we can turn these features on by using the appropriate properties:
 ```html
-<!-- swiper.component.html -->
-<swiper
-  [pagination]="{ clickable: true }"
-  navigation
->
-  <swiper-slide>Slide 1</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-</swiper>
+<!-- home.page.html -->
+<ion-content>
+  <swiper
+    [autoplay]="true"
+    [keyboard]="true"
+    [pagination]="true"
+    [scrollbar]="true"
+    [zoom]="true"
+  >
+    <ng-template swiperSlide>Slide 1</ng-template>
+    <ng-template swiperSlide>Slide 3</ng-template>
+    <ng-template swiperSlide>Slide 3</ng-template>
+  </swiper>
+</ion-content>
 ```
+
+
 
 :::note
-Importing `swiper-bundle.min.css` imports styles for all modules. When using the SCSS or Less styles, you will need to import the styles for each module. See <a href="https://swiperjs.com/angular#styles" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#styles</a> for a full list of stylesheets.
+See <a href="https://swiperjs.com/angular#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#usage</a> for a full list of modules.
 :::
+
+
+## The IonSlides Module
+
+With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonSlides` module to ensure that these properties are also set when using Swiper directly.
+
+We can install the `IonSlides` module by importing it from `@ionic/angular` and passing it in as the last item in the array provided in `SwiperCore.use`:
+
+```javascript
+// home.page.ts
+import { Component } from '@angular/core';
+import SwiperCore, { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+import { IonSlides } from '@ionic/angular';
+
+SwiperCore.use([Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonSlides]);
+
+@Component({
+  selector: 'app-home',
+  templateUrl: 'home.page.html',
+  styleUrls: ['home.page.scss']
+})
+export class HomePage {
+  ...
+}
+```
+
 ## Properties
 
-Swiper options are provided as props directly on the `<swiper>` component rather than via the `options` object in `ion-slides`.
+Swiper options can be provided as individual properties directly on the `<swiper>` component or via the `config` property.
 
 Let's say in an app with `ion-slides` we had the `slidesPerView` and `loop` options set:
 
@@ -166,16 +209,28 @@ Let's say in an app with `ion-slides` we had the `slidesPerView` and `loop` opti
 </ion-slides>
 ```
 
-To migrate, we would move these options out of the `options` object and onto the `<swiper>` component directly as properties:
+To set these options as properties directly on `<swiper>` we would do the following:
 
 ```html
 <swiper
   [slidesPerView]="3"
   [loop]="true"
 >
-  <swiper-slide>Slide 1</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
+  <ng-template swiperSlide>Slide 1</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+</swiper>
+```
+
+To set these options using the `config` object, we would do:
+
+```html
+<swiper
+  [config]="{ slidesPerView: true, loop: true }"
+>
+  <ng-template swiperSlide>Slide 1</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
 </swiper>
 ```
 
@@ -183,12 +238,14 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 
 | Name      | Notes                                                        |
 | --------- | ------------------------------------------------------------ |
-| options   | Set each option as a property directly on the `<swiper>` component. |
-| mode      | For different styles based upon the mode, you can target the slides with `.ios .swiper-container` or `.md .swiper-container` |
+| options   | Use the `config` property instead or set each option as a property directly on the `<swiper>` component. |
+| mode      | For different styles based upon the mode, you can target the slides with `.ios .swiper` or `.md .swiper` in your CSS. |
 | pager     | Use the `pagination` property instead. Requires installation of the Pagination module. |
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first. |
 
-All properties available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-props</a>.
+:::note
+All properties available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-component-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-component-props</a>.
+:::
 
 ## Events
 
@@ -212,9 +269,9 @@ To migrate, we would change the name of the event to `slideChange`:
 <swiper
   (slideChange)="onSlideChange()"
 >
-  <swiper-slide>Slide 1</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
+  <ng-template swiperSlide>Slide 1</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
 </swiper>
 ```
 
@@ -240,8 +297,9 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | ionSlidesDidLoad        | init                       |
 
 
-All events available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-events</a>.
-
+:::note
+All events available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-component-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-component-events</a>.
+:::
 
 ## Methods
 
@@ -255,19 +313,15 @@ Accessing these properties can be tricky as you want to access the properties on
 <swiper
   (swiper)="setSwiperInstance($event)"
 >
-  <swiper-slide>Slide 1</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
+  <ng-template swiperSlide>Slide 1</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
 </swiper>
 ```
 
 ```javascript
 // slides.component.ts
 import { Component } from '@angular/core';
-import SwiperCore from 'swiper';
-import { IonicSwiper } from '@ionic/angular';
-
-SwiperCore.use([IonicSwiper]);
 
 @Component({
   selector: 'app-slides-example',
@@ -275,9 +329,10 @@ SwiperCore.use([IonicSwiper]);
   styleUrls: ['slides.component.scss']
 })
 export class SlidesExample {
-  private slides;
+  private slides: any;
+
   constructor() {}
-  setSwiperInstance(ev) {
+  setSwiperInstance(swiper: any) {
     this.slides = ev;
   }
 }
@@ -287,7 +342,7 @@ From here, if you wanted to access a property on the Swiper instance you would a
 
 Below is a full list of method changes when going from `ion-slides` to Swiper Angular:
 
-| Name               | Notes                                                        |
+| ion-slides Method  | Notes                                                        |
 | ------------------ | ------------------------------------------------------------ |
 | getActiveIndex()   | Use the `activeIndex` property instead.                      |
 | getPreviousIndex() | Use the `previousIndex` property instead.                    |
@@ -303,17 +358,15 @@ Below is a full list of method changes when going from `ion-slides` to Swiper An
 
 ## Effects
 
-If you are using effects such as Cube or Fade, you can install them similar to how you installed the other modules:
+If you are using effects such as Cube or Fade, you can install them just like we did with the other modules. In this example, we will use the fade effect. To start, we will import the `EffectFade` module and register it using `SwiperCore.use`:
 
 ```html
 <!-- slides.component.html -->
 
-<swiper
-  effect="fade"
->
-  <swiper-slide>Slide 1</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
-  <swiper-slide>Slide 3</swiper-slide>
+<swiper>
+  <ng-template swiperSlide>Slide 1</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
 </swiper>
 ```
 
@@ -321,9 +374,9 @@ If you are using effects such as Cube or Fade, you can install them similar to h
 // slides.component.ts
 import { Component } from '@angular/core';
 import SwiperCore, { EffectFade } from 'swiper';
-import { IonicSwiper } from '@ionic/angular';
+import { IonSlides } from '@ionic/angular';
 
-SwiperCore.use([IonicSwiper, EffectFade]);
+SwiperCore.use([EffectFade, EffectFade]);
 
 @Component({
   selector: 'app-slides-example',
@@ -331,24 +384,71 @@ SwiperCore.use([IonicSwiper, EffectFade]);
   styleUrls: ['slides.component.scss']
 })
 export class SlidesExample {
-  private slides;
   constructor() {}
-  setSwiperInstance(ev) {
-    this.slides = ev;
-  }
 }
 ```
 
+Next, we need to import the stylesheet associated with the effect:
+
+```scss
+// global.scss
+@import "~swiper/scss/effect-fade";
+```
+
+After that, we can activate it by setting the `effect` property on `swiper` to `"fade"`:
+
+```html
+<!-- slides.component.html -->
+
+<swiper
+  effect="fade"
+>
+  <ng-template swiperSlide>Slide 1</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+  <ng-template swiperSlide>Slide 3</ng-template>
+</swiper>
+```
+
+```javascript
+// slides.component.ts
+import { Component } from '@angular/core';
+import SwiperCore, { EffectFade } from 'swiper';
+import { IonSlides } from '@ionic/angular';
+
+SwiperCore.use([EffectFade, EffectFade]);
+
+@Component({
+  selector: 'app-slides-example',
+  templateUrl: 'slides.component.html',
+  styleUrls: ['slides.component.scss']
+})
+export class SlidesExample {
+  constructor() {}
+}
+```
+
+:::note
 For more information on effects in Swiper, please see <a href="https://swiperjs.com/angular#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#effects</a>.
+:::
 
 ## Wrap Up
 
 Now that you have Swiper installed, there is a whole set of new Swiper features for you to enjoy. We recommend starting with the <a href="https://swiperjs.com/angular" target="_blank" rel="noopener noreferrer">Swiper Angular Introduction</a> and then referencing <a href="https://swiperjs.com/swiper-api" target="_blank" rel="noopener noreferrer">the Swiper API docs</a>.
 
-### Where do I file issues?
+## FAQ
 
-Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a>) to see if your issue can be resolved by the community.
+### Where can I find an example of this migration?
+
+You can find a sample app with `ion-slides` and the equivalent Swiper usage at https://github.com/ionic-team/slides-migration-samples.
+
+### Where can I get help with this migration?
+
+If you are running into issues with the migration, please create a post on the [Ionic Forum](https://forum.ionicframework.com/).
+
+### Where do I file bug reports?
+
+Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
 If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
 
-If you are running into problems with the `IonicSwiper` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>

--- a/src/pages/angular/slides.md
+++ b/src/pages/angular/slides.md
@@ -169,19 +169,19 @@ See <a href="https://swiperjs.com/angular#usage" target="_blank" rel="noopener n
 :::
 
 
-## The IonSlides Module
+## The IonicSlides Module
 
-With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonSlides` module to ensure that these properties are also set when using Swiper directly.
+With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly.
 
-We can install the `IonSlides` module by importing it from `@ionic/angular` and passing it in as the last item in the array provided in `SwiperCore.use`:
+We can install the `IonicSlides` module by importing it from `@ionic/angular` and passing it in as the last item in the array provided in `SwiperCore.use`:
 
 ```javascript
 // home.page.ts
 import { Component } from '@angular/core';
 import SwiperCore, { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-import { IonSlides } from '@ionic/angular';
+import { IonicSlides } from '@ionic/angular';
 
-SwiperCore.use([Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonSlides]);
+SwiperCore.use([Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonicSlides]);
 
 @Component({
   selector: 'app-home',
@@ -374,9 +374,9 @@ If you are using effects such as Cube or Fade, you can install them just like we
 // slides.component.ts
 import { Component } from '@angular/core';
 import SwiperCore, { EffectFade } from 'swiper';
-import { IonSlides } from '@ionic/angular';
+import { IonicSlides } from '@ionic/angular';
 
-SwiperCore.use([EffectFade, EffectFade]);
+SwiperCore.use([EffectFade, IonicSlides]);
 
 @Component({
   selector: 'app-slides-example',
@@ -413,9 +413,9 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
 // slides.component.ts
 import { Component } from '@angular/core';
 import SwiperCore, { EffectFade } from 'swiper';
-import { IonSlides } from '@ionic/angular';
+import { IonicSlides } from '@ionic/angular';
 
-SwiperCore.use([EffectFade, EffectFade]);
+SwiperCore.use([EffectFade, IonicSlides]);
 
 @Component({
   selector: 'app-slides-example',
@@ -451,4 +451,4 @@ Before opening an issue, please consider creating a post on the <a href="https:/
 
 If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
 
-If you are running into problems with the `IonSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>

--- a/src/pages/react/slides.md
+++ b/src/pages/react/slides.md
@@ -11,131 +11,184 @@ We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener norefe
 
 This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
-> This guide is only for Swiper v6. A guide for Swiper v7 is coming soon!
-
 ## Getting Started
 
-To get started, install the Swiper dependency in your project:
+First, update to the latest version of Ionic:
 
 ```shell
-npm install swiper@6
+npm install @ionic/react@latest @ionic/react-router@latest
 ```
+
+Once that is done, install the Swiper dependency in your project:
+
+```shell
+npm install swiper
+```
+
+:::note
+Create React App does not support pure ESM packages yet. Developers can still use Swiper, but they will need to use Swiper 7.2.0+ and use direct file imports. This guide assumes you are using Create React App and will show you how to use these direct imports.
+:::
 
 ## Swiping with Style
 
-Next, we need to import the base Swiper styles. We recommend importing the styles in the component in which Swiper is being used. This ensures that the styles are only loaded when needed:
+Next, we need to import the base Swiper styles. We are also going to import the styles that Ionic provides which will let us customize the Swiper styles using the same CSS Variables that we used with `ion-slides`.
 
-```javascript
-import 'swiper/swiper-bundle.min.css';
-```
-
-Ionic Framework also provides some default styles, as well as the CSS Variables that were used inside of the old `IonSlides`. If you would like to continue to use those styles and CSS Variables, be sure to import the `ionic-swiper.css` file:
-
-```javascript
-import 'swiper/swiper-bundle.min.css';
-import '@ionic/react/css/ionic-swiper.css';
-```
-
-### Pre-processors (optional)
-
-For developers using SCSS or Less styles, Swiper also provides imports for those files. The difference here is that each Swiper module is broken out into its own file, so you may have to import multiple stylesheets if you are using modules such as transition effects, zoom, or pagination.
-
-If you wanted to import the base Swiper styles and the pagination styles, you would do the following:
-
-```javascript
-import 'swiper.scss';
-import 'swiper/components/pagination/pagination.scss';
-import '@ionic/react/css/ionic-swiper.css';
-```
-
-Swiper has a complete list of the stylesheets you can import here: <a href="https://swiperjs.com/react#styles" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#styles</a>.
-
-## Using Components
-
-Swiper exports two components: `Swiper` and `SwiperSlide`. The `Swiper` component is the equivalent of `IonSlides`, and `SwiperSlide` is the equivalent of `IonSlide`.
-
-These components are imported from `swiper/react`:
+We recommend importing the styles in the component in which Swiper is being used. This ensures that the styles are only loaded when needed:
 
 ```javascript
 import React from 'react';
 import { IonContent, IonPage } from '@ionic/react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
-import 'swiper/swiper-bundle.min.css';
+import 'swiper/swiper.min.css';
 import '@ionic/react/css/ionic-swiper.css';
 
 const Home: React.FC = () => {
   return (
-    <IonPage>
-      <IonContent>
-        <Swiper>
-          <SwiperSlide>Slide 1</SwiperSlide>
-          <SwiperSlide>Slide 2</SwiperSlide>
-          <SwiperSlide>Slide 3</SwiperSlide>
-        </Swiper>
-      </IonContent>
-    </IonPage>
+    ...
   );
 };
 export default Home;
 ```
 
-## The IonicSwiper Module
+> Not using Create React App? You can import the Swiper CSS from `swiper/css` instead.
 
-There are a few edge cases in Ionic Framework where Swiper may not be able to compute the slider dimensions properly. As a result, we have created the `IonicSwiper` module to resolve some of these issues.
+### Updating Selectors
 
-To install it, we first need to import the core Swiper library and the IonicSwiper module:
+Previously, we were able to target `ion-slides` and `ion-slide` to apply any custom styling. The contents of those style blocks remain the same, but we need to update the selectors. Below is a list of selector changes when going from `ion-slides` to Swiper React:
 
-```javascript
-import SwiperCore from 'swiper';
-import { IonicSwiper } from '@ionic/react';
-```
+| ion-slides Selector | Swiper Selector |
+| ------------------- | --------------- |
+| `ion-slides`        | `.swiper`       |
+| `ion-slide`         | `.swiper-slide` |
 
-Then we can install the module:
+### Pre-processors (optional)
 
-```javascript
-import React from 'react';
-import { IonContent, IonPage, IonicSwiper } from '@ionic/react';
-import SwiperCore from 'swiper';
+For developers using SCSS or Less styles, Swiper also provides imports for those files. 
 
-import 'swiper/swiper-bundle.min.css';
-import '@ionic/react/css/ionic-swiper.css';
-
-SwiperCore.use([IonicSwiper]);
-
-const Home: React.FC = () => {
-  return (
-    <IonPage>
-      <IonContent>
-        <Swiper>
-          <SwiperSlide>Slide 1</SwiperSlide>
-          <SwiperSlide>Slide 2</SwiperSlide>
-          <SwiperSlide>Slide 3</SwiperSlide>
-        </Swiper>
-      </IonContent>
-    </IonPage>
-  );
-};
-export default Home;
-```
-
-## Additional Modules
-
-By default, Swiper for React uses the core version of Swiper and does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
-
-`IonSlides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. If you used any of these features, be sure to import them in your application.
-
-The following example shows how to install the Navigation and Pagination plugins:
+For Less styles, replace `css` with `less` in the Swiper import path:
 
 ```javascript
 import React from 'react';
-import { IonContent, IonPage, IonicSwiper } from '@ionic/react';
-import SwiperCore, { Navigation, Pagination } from 'swiper';
+import { IonContent, IonPage } from '@ionic/react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
-Swiper.use([IonicSwiper, Navigation, Pagination]);
+import 'swiper/swiper.less';
+import '@ionic/react/css/ionic-swiper.css';
 
-import 'swiper/swiper-bundle.min.css';
+const Home: React.FC = () => {
+  return (
+    ...
+  );
+};
+export default Home;
+```
+
+For SCSS styles replace `css` with `scss` in the Swiper import path:
+
+```javascript
+import React from 'react';
+import { IonContent, IonPage } from '@ionic/react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+import 'swiper/swiper.scss';
+import '@ionic/react/css/ionic-swiper.css';
+
+const Home: React.FC = () => {
+  return (
+    ...
+  );
+};
+export default Home;
+```
+
+## Using Components
+
+Swiper exports two components: `Swiper` and `SwiperSlide`. The `Swiper` component is the equivalent of `IonSlides`, and `SwiperSlide` is the equivalent of `IonSlide`.
+
+These components are imported from `swiper/react/swiper-react.js`:
+
+```tsx
+import React from 'react';
+import { IonContent, IonPage } from '@ionic/react';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
+
+import 'swiper/swiper.min.css';
+import '@ionic/react/css/ionic-swiper.css';
+
+const Home: React.FC = () => {
+  return (
+    <IonPage>
+      <IonContent>
+        <Swiper>
+          <SwiperSlide>Slide 1</SwiperSlide>
+          <SwiperSlide>Slide 2</SwiperSlide>
+          <SwiperSlide>Slide 3</SwiperSlide>
+        </Swiper>
+      </IonContent>
+    </IonPage>
+  );
+};
+export default Home;
+```
+
+> Not using Create React App? You can import the Swiper components from `swiper/react` instead.
+
+
+## Using Modules
+
+By default, Swiper for React does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
+
+`ion-slides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. This part of the guide will show you how to install these modules.
+
+To begin, we need to import the modules and their corresponding CSS files from the `swiper` package:
+
+```tsx
+import React from 'react';
+import { IonContent, IonPage } from '@ionic/react';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
+import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+
+import 'swiper/swiper.min.css';
+import 'swiper/modules/autoplay/autoplay.min.css';
+import 'swiper/modules/keyboard/keyboard.min.css';
+import 'swiper/modules/pagination/pagination.min.css';
+import 'swiper/modules/scrollbar/scrollbar.min.css';
+import 'swiper/modules/zoom/zoom.min.css';
+import '@ionic/react/css/ionic-swiper.css';
+
+const Home: React.FC = () => {
+  return (
+    <IonPage>
+      <IonContent>
+        <Swiper>
+          <SwiperSlide>Slide 1</SwiperSlide>
+          <SwiperSlide>Slide 2</SwiperSlide>
+          <SwiperSlide>Slide 3</SwiperSlide>
+        </Swiper>
+      </IonContent>
+    </IonPage>
+  );
+};
+export default Home;
+```
+
+> Not using Create React App? You can import these modules from `swiper/css/[MODULE NAME]` instead (i.e. `swiper/css/autoplay`).
+
+From here, we need to provide these modules to Swiper by using the `modules` property on the `Swiper` component:
+
+```tsx
+import React from 'react';
+import { IonContent, IonPage } from '@ionic/react';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
+import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+
+import 'swiper/swiper.min.css';
+import 'swiper/modules/autoplay/autoplay.min.css';
+import 'swiper/modules/keyboard/keyboard.min.css';
+import 'swiper/modules/pagination/pagination.min.css';
+import 'swiper/modules/scrollbar/scrollbar.min.css';
+import 'swiper/modules/zoom/zoom.min.css';
 import '@ionic/react/css/ionic-swiper.css';
 
 const Home: React.FC = () => {
@@ -143,10 +196,46 @@ const Home: React.FC = () => {
     <IonPage>
       <IonContent>
         <Swiper
-          pagination={{
-            clickable: true
-          }}
-          navigation
+          modules={[Autoplay, Keyboard, Pagination, Scrollbar, Zoom]}
+        >
+          <SwiperSlide>Slide 1</SwiperSlide>
+          <SwiperSlide>Slide 2</SwiperSlide>
+          <SwiperSlide>Slide 3</SwiperSlide>
+        </Swiper>
+      </IonContent>
+    </IonPage>
+  );
+};
+export default Home;
+```
+
+Finally, we can turn these features on by using the appropriate properties:
+
+```tsx
+import React from 'react';
+import { IonContent, IonPage } from '@ionic/react';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
+import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+
+import 'swiper/swiper.min.css';
+import 'swiper/modules/autoplay/autoplay.min.css';
+import 'swiper/modules/keyboard/keyboard.min.css';
+import 'swiper/modules/pagination/pagination.min.css';
+import 'swiper/modules/scrollbar/scrollbar.min.css';
+import 'swiper/modules/zoom/zoom.min.css';
+import '@ionic/react/css/ionic-swiper.css';
+
+const Home: React.FC = () => {
+  return (
+    <IonPage>
+      <IonContent>
+        <Swiper
+          modules={[Autoplay, Keyboard, Pagination, Scrollbar, Zoom]}
+          autoplay={true}
+          keyboard={true}
+          pagination={true}
+          scrollbar={true}
+          zoom={true}
         >
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
@@ -160,38 +249,93 @@ export default Home;
 ```
 
 :::note
-Importing `swiper-bundle.min.css` imports styles for all modules. When using the SCSS or Less styles, you will need to import the styles for each module. See <a href="https://swiperjs.com/react#styles" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#styles</a> for a full list of stylesheets.
+See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#usage</a> for a full list of modules.
 :::
+
+
+
+## The IonSlides Module
+
+With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonSlides` module to ensure that these properties are also set when using Swiper directly.
+
+We can install the `IonSlides` module by importing it from `@ionic/react` and passing it in as the last item in the `modules` array:
+
+```tsx
+import React from 'react';
+import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
+import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+
+import 'swiper/swiper.min.css';
+import 'swiper/modules/autoplay/autoplay.min.css';
+import 'swiper/modules/keyboard/keyboard.min.css';
+import 'swiper/modules/pagination/pagination.min.css';
+import 'swiper/modules/scrollbar/scrollbar.min.css';
+import 'swiper/modules/zoom/zoom.min.css';
+import '@ionic/react/css/ionic-swiper.css';
+
+const Home: React.FC = () => {
+  return (
+    <IonPage>
+      <IonContent>
+        <Swiper
+          modules={[Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonSlides]}
+          autoplay={true}
+          keyboard={true}
+          pagination={true}
+          scrollbar={true}
+          zoom={true}
+        >
+          <SwiperSlide>Slide 1</SwiperSlide>
+          <SwiperSlide>Slide 2</SwiperSlide>
+          <SwiperSlide>Slide 3</SwiperSlide>
+        </Swiper>
+      </IonContent>
+    </IonPage>
+  );
+};
+export default Home;
+```
+
+
 ## Properties
 
 Swiper options are provided as props directly on the `<Swiper>` component rather than via the `options` object in `IonSlides`.
 
 Let's say in an app with `IonSlides` we had the `slidesPerView` and `loop` options set:
 
-```javascript
-<IonSlides
-  options={{
-    slidesPerView: 3,
-    loop: true
-  }}
-  >
-  <IonSlide>Slide 1</IonSlide>
-  <IonSlide>Slide 2</IonSlide>
-  <IonSlide>Slide 3</IonSlide>
-</IonSlides>
+```tsx
+const MyComponent: React.FC = () => {
+  return (
+    <IonSlides
+      options={{
+        slidesPerView: 3,
+        loop: true
+      }}
+      >
+      <IonSlide>Slide 1</IonSlide>
+      <IonSlide>Slide 2</IonSlide>
+      <IonSlide>Slide 3</IonSlide>
+    </IonSlides>
+  );
+};
 ```
 
 To migrate, we would move these options out of the `options` object and onto the `<Swiper>` component directly as properties:
 
-```javascript
-<Swiper
-  slidesPerView={3}
-  loop={true}
-  >
-  <SwiperSlide>Slide 1</SwiperSlide>
-  <SwiperSlide>Slide 2</SwiperSlide>
-  <SwiperSlide>Slide 3</SwiperSlide>
-</Swiper>
+```tsx
+const MyComponent: React.FC = () => {
+  return (
+    <Swiper
+      slidesPerView={3}
+      loop={true}
+      >
+      <SwiperSlide>Slide 1</SwiperSlide>
+      <SwiperSlide>Slide 2</SwiperSlide>
+      <SwiperSlide>Slide 3</SwiperSlide>
+    </Swiper>
+  );
+};
 ```
 
 Below is a full list of property changes when going from `IonSlides` to Swiper Rreact:
@@ -199,11 +343,13 @@ Below is a full list of property changes when going from `IonSlides` to Swiper R
 | Name      | Notes                                                        |
 | --------- | ------------------------------------------------------------ |
 | options   | Set each option as a property directly on the `<Swiper>` component. |
-| mode      | For different styles based upon the mode, you can target the slides with `.ios .swiper-container` or `.md .swiper-container` |
+| mode      | For different styles based upon the mode, you can target the slides with `.ios .swiper` or `.md .swiper` in your CSS. |
 | pager     | Use the `pagination` property instead. Requires installation of the Pagination module. |
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first. |
 
+:::note
 All properties available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-props</a>.
+:::
 
 ## Events
 
@@ -211,26 +357,34 @@ Since the `Swiper` component is not provided by Ionic Framework, event names wil
 
 Let's say in an app with `IonSlides` we used the `onIonSlideDidChange` event:
 
-```javascript
-<IonSlides
-  onIonSlideDidChange={() => onSlideChange()}
->
-  <IonSlide>Slide 1</IonSlide>
-  <IonSlide>Slide 2</IonSlide>
-  <IonSlide>Slide 3</IonSlide>
-</IonSlides>
+```tsx
+const MyComponent: React.FC = () => {
+  return (
+    <IonSlides
+      onIonSlideDidChange={() => onSlideChange()}
+    >
+      <IonSlide>Slide 1</IonSlide>
+      <IonSlide>Slide 2</IonSlide>
+      <IonSlide>Slide 3</IonSlide>
+    </IonSlides>
+  );
+};
 ```
 
 To migrate, we would change the name of the event to `onSlideChange`:
 
-```javascript
-<Swiper
-  onSlideChange={() => onSlideChange()}
->
-  <SwiperSlide>Slide 1</SwiperSlide>
-  <SwiperSlide>Slide 2</SwiperSlide>
-  <SwiperSlide>Slide 3</SwiperSlide>
-</Swiper>
+```tsx
+const MyComponent: React.FC = () => {
+  return (
+    <Swiper
+      onSlideChange={() => onSlideChange()}
+    >
+      <SwiperSlide>Slide 1</SwiperSlide>
+      <SwiperSlide>Slide 2</SwiperSlide>
+      <SwiperSlide>Slide 3</SwiperSlide>
+    </Swiper>
+  );
+};
 ```
 
 Below is a full list of event name changes when going from `IonSlides` to Swiper React:
@@ -254,7 +408,9 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | onIonSlideTransitionEnd   | onTransitionEnd              |
 | onIonSlidesDidLoad        | onInit                       |
 
+:::note
 All events available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-events</a>.
+:::
 
 ## Methods
 
@@ -262,11 +418,13 @@ Most methods have been removed in favor of accessing the `Swiper` props directly
 
 Accessing these properties can be tricky as you want to access the properties on the Swiper instance itself, not your React component. To do this, we recommend getting a reference to the `Swiper` instance via `onSwiper`:
 
-```javascript
+```tsx
 import React, { useState } from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
+import { Swiper as SwiperInterface } from 'swiper';
 ...
 const Home: React.FC = () => {
-  const [swiperInstance, setSwiperInstance] = useState();
+  const [swiperInstance, setSwiperInstance] = useState<SwiperInterface>();
   return (
     ...
     <Swiper
@@ -283,7 +441,7 @@ From here, if you wanted to access a property on the Swiper instance you would a
 
 Below is a full list of method changes when going from `IonSlides` to Swiper React:
 
-| Name               | Notes                                                        |
+| ion-slides Method  | Notes                                                        |
 | ------------------ | ------------------------------------------------------------ |
 | getActiveIndex()   | Use the `activeIndex` property instead.                      |
 | getPreviousIndex() | Use the `previousIndex` property instead.                    |
@@ -299,24 +457,24 @@ Below is a full list of method changes when going from `IonSlides` to Swiper Rea
 
 ## Effects
 
-If you are using effects such as Cube or Fade, you can install them similar to how you installed the other modules:
+If you are using effects such as Cube or Fade, you can install them just like we did with the other modules. In this example, we will use the fade effect. To start, we will import `EffectFade` from `swiper` and provide it in the `modules` array:
 
-```javascript
+```tsx
 import React from 'react';
-import { IonContent, IonPage, IonicSwiper } from '@ionic/react';
-import SwiperCore, { EffectFade } from 'swiper';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { EffectFade } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
 
-Swiper.use([IonicSwiper, EffectFade]);
-
-import 'swiper/swiper-bundle.min.css';
+import 'swiper/swiper.min.css';
 import '@ionic/react/css/ionic-swiper.css';
 
 const Home: React.FC = () => {
   return (
     <IonPage>
       <IonContent>
-        <Swiper effect="fade">
+        <Swiper
+          modules={[EffectFact, IonSlides]}
+        >
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
           <SwiperSlide>Slide 3</SwiperSlide>
@@ -328,16 +486,93 @@ const Home: React.FC = () => {
 export default Home;
 ```
 
+Next, we need to import the stylesheet associated with the effect:
+
+```tsx
+import React from 'react';
+import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { EffectFade } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
+
+import 'swiper/swiper.min.css';
+import 'swiper/modules/effect-fade/effect-fade.min.css';
+import '@ionic/react/css/ionic-swiper.css';
+
+const Home: React.FC = () => {
+  return (
+    <IonPage>
+      <IonContent>
+        <Swiper
+          modules={[EffectFact, IonSlides]}
+        >
+          <SwiperSlide>Slide 1</SwiperSlide>
+          <SwiperSlide>Slide 2</SwiperSlide>
+          <SwiperSlide>Slide 3</SwiperSlide>
+        </Swiper>
+      </IonContent>
+    </IonPage>
+  );
+};
+export default Home;
+```
+
+> Not using Create React App? You can import these effects from `swiper/css/[EFFECT NAME]` instead (i.e. `swiper/css/effect-fade`).
+
+After that, we can activate it by setting the `effect` property on `swiper` to `"fade"`:
+
+```tsx
+import React from 'react';
+import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { EffectFade } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';;
+
+import 'swiper/swiper.min.css';
+import 'swiper/modules/effect-fade/effect-fade.min.css';
+import '@ionic/react/css/ionic-swiper.css';
+
+const Home: React.FC = () => {
+  return (
+    <IonPage>
+      <IonContent>
+        <Swiper
+          modules={[EffectFact, IonSlides]}
+          swiper="fade"
+        >
+          <SwiperSlide>Slide 1</SwiperSlide>
+          <SwiperSlide>Slide 2</SwiperSlide>
+          <SwiperSlide>Slide 3</SwiperSlide>
+        </Swiper>
+      </IonContent>
+    </IonPage>
+  );
+};
+export default Home;
+```
+
+:::note
 For more information on effects in Swiper, please see <a href="https://swiperjs.com/react#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#effects</a>.
+:::
+
+
 
 ## Wrap Up
 
 Now that you have Swiper installed, there is a whole set of new Swiper features for you to enjoy. We recommend starting with the <a href="https://swiperjs.com/react" target="_blank" rel="noopener noreferrer">Swiper React Introduction</a> and then referencing <a href="https://swiperjs.com/swiper-api" target="_blank" rel="noopener noreferrer">the Swiper API docs</a>.
 
-### Where do I file issues?
+## FAQ
+
+### Where can I find an example of this migration?
+
+You can find a sample app with `ion-slides` and the equivalent Swiper usage at https://github.com/ionic-team/slides-migration-samples.
+
+### Where can I get help with this migration?
+
+If you are running into issues with the migration, please create a post on the [Ionic Forum](https://forum.ionicframework.com/).
+
+### Where do I file bug reports?
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
 If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
 
-If you are running into problems with the `IonicSwiper` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>

--- a/src/pages/react/slides.md
+++ b/src/pages/react/slides.md
@@ -297,6 +297,9 @@ const Home: React.FC = () => {
 export default Home;
 ```
 
+:::note
+The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+:::
 
 ## Properties
 

--- a/src/pages/react/slides.md
+++ b/src/pages/react/slides.md
@@ -254,15 +254,15 @@ See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener nor
 
 
 
-## The IonSlides Module
+## The IonicSlides Module
 
-With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonSlides` module to ensure that these properties are also set when using Swiper directly.
+With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly.
 
-We can install the `IonSlides` module by importing it from `@ionic/react` and passing it in as the last item in the `modules` array:
+We can install the `IonicSlides` module by importing it from `@ionic/react` and passing it in as the last item in the `modules` array:
 
 ```tsx
 import React from 'react';
-import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { IonContent, IonPage, IonicSlides } from '@ionic/react';
 import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
 import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
 
@@ -279,7 +279,7 @@ const Home: React.FC = () => {
     <IonPage>
       <IonContent>
         <Swiper
-          modules={[Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonSlides]}
+          modules={[Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonicSlides]}
           autoplay={true}
           keyboard={true}
           pagination={true}
@@ -338,7 +338,7 @@ const MyComponent: React.FC = () => {
 };
 ```
 
-Below is a full list of property changes when going from `IonSlides` to Swiper Rreact:
+Below is a full list of property changes when going from `IonSlides` to Swiper React:
 
 | Name      | Notes                                                        |
 | --------- | ------------------------------------------------------------ |
@@ -461,7 +461,7 @@ If you are using effects such as Cube or Fade, you can install them just like we
 
 ```tsx
 import React from 'react';
-import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { IonContent, IonPage, IonicSlides } from '@ionic/react';
 import { EffectFade } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
 
@@ -473,7 +473,7 @@ const Home: React.FC = () => {
     <IonPage>
       <IonContent>
         <Swiper
-          modules={[EffectFact, IonSlides]}
+          modules={[EffectFact, IonicSlides]}
         >
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
@@ -490,7 +490,7 @@ Next, we need to import the stylesheet associated with the effect:
 
 ```tsx
 import React from 'react';
-import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { IonContent, IonPage, IonicSlides } from '@ionic/react';
 import { EffectFade } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';
 
@@ -503,7 +503,7 @@ const Home: React.FC = () => {
     <IonPage>
       <IonContent>
         <Swiper
-          modules={[EffectFact, IonSlides]}
+          modules={[EffectFact, IonicSlides]}
         >
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
@@ -522,7 +522,7 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
 
 ```tsx
 import React from 'react';
-import { IonContent, IonPage, IonSlides } from '@ionic/react';
+import { IonContent, IonPage, IonicSlides } from '@ionic/react';
 import { EffectFade } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react/swiper-react.js';;
 
@@ -535,7 +535,7 @@ const Home: React.FC = () => {
     <IonPage>
       <IonContent>
         <Swiper
-          modules={[EffectFact, IonSlides]}
+          modules={[EffectFact, IonicSlides]}
           swiper="fade"
         >
           <SwiperSlide>Slide 1</SwiperSlide>
@@ -575,4 +575,4 @@ Before opening an issue, please consider creating a post on the <a href="https:/
 
 If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
 
-If you are running into problems with the `IonSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>

--- a/src/pages/vue/slides.md
+++ b/src/pages/vue/slides.md
@@ -11,55 +11,37 @@ We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener norefe
 
 This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
 
-> This guide is only for Swiper v6. A guide for Swiper v7 is coming soon!
-
 ## Getting Started
 
-To get started, install the Swiper dependency in your project:
+First, update to the latest version of Ionic:
 
 ```shell
-npm install swiper@6
+npm install @ionic/vue@latest @ionic/vue-router@latest
 ```
 
-### Typescript (optional)
+We recommend upgrading to Vue CLI 5 for better compatibility with Swiper:
 
-TypeScript users will need to add the following to their `shims-vue.d.ts` file:
-
-```tsx
-declare module 'swiper/vue' {
-  import _Vue from 'vue';
-  export class Swiper extends _Vue {}
-  export class SwiperSlide extends _Vue {}
-}
+```shell
+vue upgrade --next
 ```
 
-Swiper Vue does not have complete support for TypeScript, so this code bridges the gap. Follow https://github.com/nolimits4web/swiper/issues/3916 for updates on this issue.
+Once that is done, install the Swiper dependency in your project:
 
-You may need to restart your development server after adding this.
+```shell
+npm install swiper
+```
 
 ## Swiping with Style
 
-Next, we need to import the base Swiper styles. We recommend importing the styles in the component in which Swiper is being used. This ensures that the styles are only loaded when needed:
+Next, we need to import the base Swiper styles. We are also going to import the styles that Ionic provides which will let us customize the Swiper styles using the same CSS Variables that we used with `ion-slides`.
+
+We recommend importing the styles in the component in which Swiper is being used. This ensures that the styles are only loaded when needed:
 
 ```html
 <script>
   import { defineComponent } from 'vue';
 
-  import 'swiper/swiper-bundle.min.css';
-
-  export default defineComponent({
-    ...
-  });
-</script>
-```
-
-Ionic Framework also provides some default styles, as well as the CSS Variables that were used inside of the old `ion-slides`. If you would like to continue to use those styles and CSS Variables, be sure to import the `ionic-swiper.css` file:
-
-```html
-<script>
-  import { defineComponent } from 'vue';
-
-  import 'swiper/swiper-bundle.min.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -68,29 +50,32 @@ Ionic Framework also provides some default styles, as well as the CSS Variables 
 </script>
 ```
 
-You should also update any selectors to target the correct Swiper classes. If you were targeting `ion-slides`, you should target `.swiper-container`. If you were targeting `ion-slide`, you should target `.swiper-slide`.
+### Updating Selectors
+
+Previously, we were able to target `ion-slides` and `ion-slide` to apply any custom styling. The contents of those style blocks remain the same, but we need to update the selectors. Below is a list of selector changes when going from `ion-slides` to Swiper Vue:
+
+| ion-slides Selector | Swiper Selector |
+| ------------------- | --------------- |
+| `ion-slides`        | `.swiper`       |
+| `ion-slide`         | `.swiper-slide` |
 
 ### Pre-processors (optional)
 
-For developers using SCSS or Less styles, Swiper also provides imports for those files. The difference here is that each Swiper module is broken out into its own file, so you may have to import multiple stylesheets if you are using modules such as transition effects, zoom, or pagination.
+For developers using SCSS or Less styles, Swiper also provides imports for those files. 
 
-If you wanted to import the base Swiper styles and the pagination styles, you would do the following:
+For Less styles, replace `css` with `less` in the Swiper import path:
 
-```html
-<script>
-  import { defineComponent } from 'vue';
-
-  import 'swiper.scss';
-  import 'swiper/components/pagination/pagination.scss';
-  import '@ionic/vue/css/ionic-swiper.css';
-
-  export default defineComponent({
-    ...
-  });
-</script>
+```js
+import 'swiper/less';
+import '@ionic/vue/css/ionic-swiper.css';
 ```
 
-Swiper has a complete list of the stylesheets you can import here: <a href="https://swiperjs.com/vue#styles" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#styles</a>.
+For SCSS styles replace `css` with `scss` in the Swiper import path:
+
+```js
+import 'swiper/scss';
+import '@ionic/vue/css/ionic-swiper.css';
+```
 
 ## Using Components
 
@@ -116,7 +101,7 @@ These components are imported from `swiper/vue` and provided to your Vue compone
   import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper-bundle.min.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -130,55 +115,19 @@ These components are imported from `swiper/vue` and provided to your Vue compone
 </script>
 ```
 
-## The IonicSwiper Module
+## Using Modules
 
-There are a few edge cases in Ionic Framework where Swiper may not be able to compute the slider dimensions properly. As a result, we have created the `IonicSwiper` module to resolve some of these issues.
+By default, Swiper for Vue does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
 
-To install it, we first need to import the core Swiper library and the IonicSwiper module:
+`ion-slides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. This part of the guide will show you how to install these modules.
 
-```javascript
-import SwiperCore from 'swiper';
-import { IonicSwiper } from '@ionic/vue';
-```
-
-Then we can install the module:
-
-```html
-<script>
-  import { defineComponent } from 'vue';
-  import SwiperCore from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
-  import { IonContent, IonPage, IonicSwiper } from '@ionic/vue';
-
-  import 'swiper/swiper-bundle.min.css';
-  import '@ionic/vue/css/ionic-swiper.css';
-
-  SwiperCore.use([IonicSwiper]);
-
-  export default defineComponent({
-    components: {
-      Swiper,
-      SwiperSlide,
-      IonContent,
-      IonPage,
-    },
-  });
-</script>
-```
-
-## Additional Modules
-
-By default, Swiper for Vue uses the core version of Swiper and does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
-
-`ion-slides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. If you used any of these features, be sure to import them in your application.
-
-The following example shows how to install the Navigation and Pagination plugins:
+To begin, we need to import the modules and their corresponding CSS files from the `swiper` package:
 
 ```html
 <template>
   <ion-page>
     <ion-content>
-      <swiper :pagination="{ clickable: true }" navigation>
+      <swiper>
         <swiper-slide>Slide 1</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
@@ -188,14 +137,17 @@ The following example shows how to install the Navigation and Pagination plugins
 </template>
 <script>
   import { defineComponent } from 'vue';
-  import SwiperCore, { Navigation, Pagination } from 'swiper';
+  import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
   import { Swiper, SwiperSlide } from 'swiper/vue';
-  import { IonContent, IonPage, IonicSwiper } from '@ionic/vue';
+  import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper-bundle.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
-
-  SwiperCore.use([IonicSwiper, Navigation, Pagination]);
 
   export default defineComponent({
     components: { Swiper, SwiperSlide, IonContent, IonPage },
@@ -203,9 +155,153 @@ The following example shows how to install the Navigation and Pagination plugins
 </script>
 ```
 
+From here, we need to provide these modules to Swiper by using the `modules` property on the `swiper` component:
+```html
+<template>
+  <ion-page>
+    <ion-content>
+      <swiper
+        :modules="modules"
+      >
+        <swiper-slide>Slide 1</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+      </swiper>
+    </ion-content>
+  </ion-page>
+</template>
+<script>
+  import { defineComponent } from 'vue';
+  import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { IonContent, IonPage } from '@ionic/vue';
+
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
+  import '@ionic/vue/css/ionic-swiper.css';
+
+  export default defineComponent({
+    components: { Swiper, SwiperSlide, IonContent, IonPage },
+    setup() {
+      return {
+        modules: [Autoplay, Keyboard, Pagination, Scrollbar, Zoom]
+      }
+    }
+  });
+</script>
+```
+
+Finally, we can turn these features on by using the appropriate properties:
+```html
+<template>
+  <ion-page>
+    <ion-content>
+      <swiper
+        :modules="modules"
+        :autoplay="true"
+        :keyboard="true"
+        :pagination="true"
+        :scrollbar="true"
+        :zoom="true"
+      >
+        <swiper-slide>Slide 1</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+      </swiper>
+    </ion-content>
+  </ion-page>
+</template>
+<script>
+  import { defineComponent } from 'vue';
+  import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { IonContent, IonPage } from '@ionic/vue';
+
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
+  import '@ionic/vue/css/ionic-swiper.css';
+
+  export default defineComponent({
+    components: { Swiper, SwiperSlide, IonContent, IonPage },
+    setup() {
+      return {
+        modules: [Autoplay, Keyboard, Pagination, Scrollbar, Zoom]
+      }
+    }
+  });
+</script>
+```
+
+
+
 :::note
-Importing `swiper-bundle.min.css` imports styles for all modules. When using the SCSS or Less styles, you will need to import the styles for each module. See <a href="https://swiperjs.com/vue#styles" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#styles</a> for a full list of stylesheets.
+See <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#usage</a> for a full list of modules.
 :::
+
+
+## The IonSlides Module
+
+With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonSlides` module to ensure that these properties are also set when using Swiper directly.
+
+We can install the `IonSlides` module by importing it from `@ionic/vue` and passing it in as the last item in the `modules` array:
+
+```html
+<template>
+  <ion-page>
+    <ion-content>
+      <swiper
+        :modules="modules"
+        :autoplay="true"
+        :keyboard="true"
+        :pagination="true"
+        :scrollbar="true"
+        :zoom="true"
+      >
+        <swiper-slide>Slide 1</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+      </swiper>
+    </ion-content>
+  </ion-page>
+</template>
+<script>
+import { defineComponent } from 'vue';
+import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
+import { Swiper, SwiperSlide } from 'swiper/vue';
+import { IonContent, IonPage, IonSlides } from '@ionic/vue';
+
+import 'swiper/css';
+import 'swiper/css/autoplay';
+import 'swiper/css/keyboard';
+import 'swiper/css/pagination';
+import 'swiper/css/scrollbar';
+import 'swiper/css/zoom';
+import '@ionic/vue/css/ionic-swiper.css';
+
+export default defineComponent({
+  components: { Swiper, SwiperSlide, IonContent, IonPage },
+  setup() {
+    return {
+      modules: [Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonSlides]
+    }
+  }
+});
+</script>
+```
+
+:::note
+The `IonSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+:::
+
+
 
 ## Properties
 
@@ -240,11 +336,13 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | Name      | Notes                                                                                                                        |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | options   | Set each option as a property directly on the `<swiper>` component.                                                          |
-| mode      | For different styles based upon the mode, you can target the slides with `.ios .swiper-container` or `.md .swiper-container` |
+| mode      | For different styles based upon the mode, you can target the slides with `.ios .swiper` or `.md .swiper` in your CSS. |
 | pager     | Use the `pagination` property instead. Requires installation of the Pagination module.                                       |
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                        |
 
+:::note
 All properties available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-props</a>.
+:::
 
 ## Events
 
@@ -295,13 +393,15 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | ionSlideTransitionEnd   | transitionEnd              |
 | ionSlidesDidLoad        | init                       |
 
+:::note
 All events available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-events</a>.
+:::
 
 ## Methods
 
-Most methods have been removed in favor of accessing the `<swiper>` props directly. When calling methods, you no longer need to access `$el` first.
+Most methods have been removed in favor of accessing the `<swiper>` props directly. Additionally, you no longer need to access `$el` first when calling methods.
 
-Accessing these properties can be tricky as you want to access the properties on the Swiper instance itself, not your Vue component. To do this, we recommend getting a reference to the `Swiper` instance via `@swiper`:
+Accessing these properties can be tricky as you want to access the properties on the Swiper instance itself, not your Vue component. To do this, we recommend getting a reference to the Swiper instance via the `@swiper` event handler:
 
 ```html
 <template>
@@ -327,7 +427,7 @@ From here, if you wanted to access a property on the Swiper instance you would a
 
 Below is a full list of method changes when going from `ion-slides` to Swiper Vue:
 
-| Name               | Notes                                                                                |
+| ion-slides Method  | Notes                                                                                |
 | ------------------ | ------------------------------------------------------------------------------------ |
 | getActiveIndex()   | Use the `activeIndex` property instead.                                              |
 | getPreviousIndex() | Use the `previousIndex` property instead.                                            |
@@ -343,43 +443,139 @@ Below is a full list of method changes when going from `ion-slides` to Swiper Vu
 
 ## Effects
 
-If you are using effects such as Cube or Fade, you can install them similar to how you installed the other modules:
+If you are using effects such as Cube or Fade, you can install them just like we did with the other modules. In this example, we will use the fade effect. To start, we will import `EffectFade` from `swiper` and provide it in the `modules` array:
 
 ```html
 <template>
-  <swiper effect="fade">
-    <swiper-slide>Slide 1</swiper-slide>
-    <swiper-slide>Slide 2</swiper-slide>
-    <swiper-slide>Slide 3</swiper-slide>
-    ...
-  </swiper>
+  <ion-page>
+    <ion-content>
+      <swiper
+        :modules="modules"
+      >
+        <swiper-slide>Slide 1</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+      </swiper>
+    </ion-content>
+  </ion-page>
 </template>
 <script>
   import { defineComponent } from 'vue';
-  import SwiperCore, { EffectFade } from 'swiper';
+  import { EffectFade } from 'swiper';
   import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { IonContent, IonPage, IonSlides } from '@ionic/vue';
 
-  import 'swiper/swiper-bundle.min.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
-  SwiperCore.use([EffectFade]);
-
   export default defineComponent({
-    ...
+    components: { Swiper, SwiperSlide, IonContent, IonPage },
+    setup() {
+      return {
+        modules: [EffectFade, IonSlides]
+      }
+    }
   });
 </script>
 ```
 
+Next, we need to import the stylesheet associated with the effect:
+
+```html
+<template>
+  <ion-page>
+    <ion-content>
+      <swiper
+        :modules="modules"
+      >
+        <swiper-slide>Slide 1</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+      </swiper>
+    </ion-content>
+  </ion-page>
+</template>
+<script>
+  import { defineComponent } from 'vue';
+  import { EffectFade } from 'swiper';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { IonContent, IonPage, IonSlides } from '@ionic/vue';
+
+  import 'swiper/css';
+  import 'swiper/css/effect-fade';
+  import '@ionic/vue/css/ionic-swiper.css';
+
+  export default defineComponent({
+    components: { Swiper, SwiperSlide, IonContent, IonPage },
+    setup() {
+      return {
+        modules: [EffectFade, IonSlides]
+      }
+    }
+  });
+</script>
+```
+
+After that, we can activate it by setting the `effect` property on `swiper` to `"fade"`:
+
+```html
+<template>
+  <ion-page>
+    <ion-content>
+      <swiper
+        :modules="modules"
+        effect="fade"
+      >
+        <swiper-slide>Slide 1</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
+      </swiper>
+    </ion-content>
+  </ion-page>
+</template>
+<script>
+  import { defineComponent } from 'vue';
+  import { EffectFade } from 'swiper';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { IonContent, IonPage, IonSlides } from '@ionic/vue';
+
+  import 'swiper/css';
+  import 'swiper/css/effect-fade';
+  import '@ionic/vue/css/ionic-swiper.css';
+
+  export default defineComponent({
+    components: { Swiper, SwiperSlide, IonContent, IonPage },
+    setup() {
+      return {
+        modules: [EffectFade, IonSlides]
+      }
+    }
+  });
+</script>
+```
+
+:::note
 For more information on effects in Swiper, please see <a href="https://swiperjs.com/vue#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#effects</a>.
+:::
 
 ## Wrap Up
 
 Now that you have Swiper installed, there is a whole set of new Swiper features for you to enjoy. We recommend starting with the <a href="https://swiperjs.com/vue" target="_blank" rel="noopener noreferrer">Swiper Vue Introduction</a> and then referencing <a href="https://swiperjs.com/swiper-api" target="_blank" rel="noopener noreferrer">the Swiper API docs</a>.
 
-### Where do I file issues?
+## FAQ
+
+### Where can I find an example of this migration?
+
+You can find a sample app with `ion-slides` and the equivalent Swiper usage at https://github.com/ionic-team/slides-migration-samples.
+
+### Where can I get help with this migration?
+
+If you are running into issues with the migration, please create a post on the [Ionic Forum](https://forum.ionicframework.com/).
+
+### Where do I file bug reports?
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
 If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
 
-If you are running into problems with the `IonicSwiper` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>

--- a/src/pages/vue/slides.md
+++ b/src/pages/vue/slides.md
@@ -247,11 +247,11 @@ See <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noref
 :::
 
 
-## The IonSlides Module
+## The IonicSlides Module
 
-With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonSlides` module to ensure that these properties are also set when using Swiper directly.
+With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly.
 
-We can install the `IonSlides` module by importing it from `@ionic/vue` and passing it in as the last item in the `modules` array:
+We can install the `IonicSlides` module by importing it from `@ionic/vue` and passing it in as the last item in the `modules` array:
 
 ```html
 <template>
@@ -276,7 +276,7 @@ We can install the `IonSlides` module by importing it from `@ionic/vue` and pass
 import { defineComponent } from 'vue';
 import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/vue';
-import { IonContent, IonPage, IonSlides } from '@ionic/vue';
+import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
 import 'swiper/css';
 import 'swiper/css/autoplay';
@@ -290,7 +290,7 @@ export default defineComponent({
   components: { Swiper, SwiperSlide, IonContent, IonPage },
   setup() {
     return {
-      modules: [Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonSlides]
+      modules: [Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonicSlides]
     }
   }
 });
@@ -298,7 +298,7 @@ export default defineComponent({
 ```
 
 :::note
-The `IonSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
 :::
 
 
@@ -463,7 +463,7 @@ If you are using effects such as Cube or Fade, you can install them just like we
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
   import { Swiper, SwiperSlide } from 'swiper/vue';
-  import { IonContent, IonPage, IonSlides } from '@ionic/vue';
+  import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
   import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
@@ -472,7 +472,7 @@ If you are using effects such as Cube or Fade, you can install them just like we
     components: { Swiper, SwiperSlide, IonContent, IonPage },
     setup() {
       return {
-        modules: [EffectFade, IonSlides]
+        modules: [EffectFade, IonicSlides]
       }
     }
   });
@@ -499,7 +499,7 @@ Next, we need to import the stylesheet associated with the effect:
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
   import { Swiper, SwiperSlide } from 'swiper/vue';
-  import { IonContent, IonPage, IonSlides } from '@ionic/vue';
+  import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
   import 'swiper/css';
   import 'swiper/css/effect-fade';
@@ -509,7 +509,7 @@ Next, we need to import the stylesheet associated with the effect:
     components: { Swiper, SwiperSlide, IonContent, IonPage },
     setup() {
       return {
-        modules: [EffectFade, IonSlides]
+        modules: [EffectFade, IonicSlides]
       }
     }
   });
@@ -537,7 +537,7 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
   import { Swiper, SwiperSlide } from 'swiper/vue';
-  import { IonContent, IonPage, IonSlides } from '@ionic/vue';
+  import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
   import 'swiper/css';
   import 'swiper/css/effect-fade';
@@ -547,7 +547,7 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
     components: { Swiper, SwiperSlide, IonContent, IonPage },
     setup() {
       return {
-        modules: [EffectFade, IonSlides]
+        modules: [EffectFade, IonicSlides]
       }
     }
   });
@@ -578,4 +578,4 @@ Before opening an issue, please consider creating a post on the <a href="https:/
 
 If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
 
-If you are running into problems with the `IonSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>


### PR DESCRIPTION
Same thing as https://github.com/ionic-team/ionic-docs/pull/2094 but for the v5 docs. Do not merge until Ionic 5.9 ships.