### PR TITLE
fix(): remove :::note syntax for legacy docs

### DIFF
--- a/src/pages/angular/slides.md
+++ b/src/pages/angular/slides.md
@@ -164,9 +164,7 @@ Finally, we can turn these features on by using the appropriate properties:
 
 
 
-:::note
-See <a href="https://swiperjs.com/angular#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#usage</a> for a full list of modules.
-:::
+> See <a href="https://swiperjs.com/angular#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#usage</a> for a full list of modules.
 
 
 ## The IonicSlides Module
@@ -193,9 +191,7 @@ export class HomePage {
 }
 ```
 
-:::note
-The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
-:::
+> The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
 
 ## Properties
 
@@ -247,9 +243,7 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | pager     | Use the `pagination` property instead. Requires installation of the Pagination module. |
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first. |
 
-:::note
-All properties available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-component-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-component-props</a>.
-:::
+> All properties available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-component-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-component-props</a>.
 
 ## Events
 
@@ -301,9 +295,7 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | ionSlidesDidLoad        | init                       |
 
 
-:::note
-All events available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-component-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-component-events</a>.
-:::
+> All events available in Swiper Angular can be found at <a href="https://swiperjs.com/angular#swiper-component-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#swiper-component-events</a>.
 
 ## Methods
 
@@ -431,9 +423,7 @@ export class SlidesExample {
 }
 ```
 
-:::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/angular#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#effects</a>.
-:::
+> For more information on effects in Swiper, please see <a href="https://swiperjs.com/angular#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/angular#effects</a>.
 
 ## Wrap Up
 

--- a/src/pages/react/slides.md
+++ b/src/pages/react/slides.md
@@ -25,9 +25,7 @@ Once that is done, install the Swiper dependency in your project:
 npm install swiper
 ```
 
-:::note
-Create React App does not support pure ESM packages yet. Developers can still use Swiper, but they will need to use Swiper 7.2.0+ and use direct file imports. This guide assumes you are using Create React App and will show you how to use these direct imports.
-:::
+> Create React App does not support pure ESM packages yet. Developers can still use Swiper, but they will need to use Swiper 7.2.0+ and use direct file imports. This guide assumes you are using Create React App and will show you how to use these direct imports.
 
 ## Swiping with Style
 
@@ -248,9 +246,7 @@ const Home: React.FC = () => {
 export default Home;
 ```
 
-:::note
-See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#usage</a> for a full list of modules.
-:::
+> See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#usage</a> for a full list of modules.
 
 
 
@@ -297,9 +293,7 @@ const Home: React.FC = () => {
 export default Home;
 ```
 
-:::note
-The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
-:::
+> The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
 
 ## Properties
 
@@ -350,9 +344,7 @@ Below is a full list of property changes when going from `IonSlides` to Swiper R
 | pager     | Use the `pagination` property instead. Requires installation of the Pagination module. |
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first. |
 
-:::note
-All properties available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-props</a>.
-:::
+> All properties available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-props</a>.
 
 ## Events
 
@@ -411,9 +403,7 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | onIonSlideTransitionEnd   | onTransitionEnd              |
 | onIonSlidesDidLoad        | onInit                       |
 
-:::note
-All events available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-events</a>.
-:::
+> All events available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-events</a>.
 
 ## Methods
 
@@ -552,9 +542,7 @@ const Home: React.FC = () => {
 export default Home;
 ```
 
-:::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/react#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#effects</a>.
-:::
+> For more information on effects in Swiper, please see <a href="https://swiperjs.com/react#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#effects</a>.
 
 
 

--- a/src/pages/vue/slides.md
+++ b/src/pages/vue/slides.md
@@ -242,9 +242,7 @@ Finally, we can turn these features on by using the appropriate properties:
 
 
 
-:::note
-See <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#usage</a> for a full list of modules.
-:::
+> See <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#usage</a> for a full list of modules.
 
 
 ## The IonicSlides Module
@@ -297,9 +295,7 @@ export default defineComponent({
 </script>
 ```
 
-:::note
-The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
-:::
+> The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
 
 
 
@@ -340,9 +336,7 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | pager     | Use the `pagination` property instead. Requires installation of the Pagination module.                                       |
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                        |
 
-:::note
-All properties available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-props</a>.
-:::
+> All properties available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-props</a>.
 
 ## Events
 
@@ -393,9 +387,7 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | ionSlideTransitionEnd   | transitionEnd              |
 | ionSlidesDidLoad        | init                       |
 
-:::note
-All events available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-events</a>.
-:::
+> All events available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-events</a>.
 
 ## Methods
 
@@ -554,9 +546,7 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
 </script>
 ```
 
-:::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/vue#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#effects</a>.
-:::
+> For more information on effects in Swiper, please see <a href="https://swiperjs.com/vue#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#effects</a>.
 
 ## Wrap Up
 


### PR DESCRIPTION
The `:::note` syntax is a feature specific to Docusaurus and will not work on docs site built with Stencil.