### PR TITLE
docs(): deletes double 'the' typing

### DIFF
--- a/versioned_docs/version-v5/api/popover.md
+++ b/versioned_docs/version-v5/api/popover.md
@@ -13,7 +13,7 @@ A Popover is a dialog that appears on top of the current page. It can be used fo
 
 ## Presenting
 
-To present a popover, call the `present` method on a popover instance. In order to position the popover relative to the element clicked, a click event needs to be passed into the options of the the `present` method. If the event is not passed, the popover will be positioned in the center of the viewport.
+To present a popover, call the `present` method on a popover instance. In order to position the popover relative to the element clicked, a click event needs to be passed into the options of the `present` method. If the event is not passed, the popover will be positioned in the center of the viewport.
 
 ## Customization
 


### PR DESCRIPTION
Hello, this is my first PR and I saw some 'the' duplicates in the docs that would be fixed. Thanks in advance.