### PR TITLE
[WIP] docs(): fixed some mistakes in the docs

### DIFF
--- a/versioned_docs/version-v5/api/segment.md
+++ b/versioned_docs/version-v5/api/segment.md
@@ -647,8 +647,7 @@ export class SegmentExample {
 
 | Name                                                   | Description                                         |
 | ------------------------------------------------------ | --------------------------------------------------- |
-| `ionChange`                                            | Emitted when the value property has changed and any |
-| dragging pointer has been released from `ion-segment`. |
+| `ionChange`                                            | Emitted when the value property has changed and any dragging pointer has been released from `ion-segment`. |
 
 ## CSS Custom Properties
 


### PR DESCRIPTION
- Formatted the table design on the segment page

Screenshot:

Before:

![image](https://user-images.githubusercontent.com/41404838/145576416-f4013004-aa14-47c3-b807-b856f0c1bea8.png)

After:

![image](https://user-images.githubusercontent.com/41404838/145576451-3e064280-a0fe-40b2-9726-807dedbe0135.png)
