### PR TITLE
Update 2-taking-photos.md

### DIFF
--- a/versioned_docs/version-v5/angular/your-first-app/2-taking-photos.md
+++ b/versioned_docs/version-v5/angular/your-first-app/2-taking-photos.md
@@ -11,7 +11,7 @@ Now for the fun part - adding the ability to take photos with the device’s cam
 All Capacitor logic (Camera usage and other native features) will be encapsulated in a service class. Create `PhotoService` using the `ionic generate` command:
 
 ```bash
-$ ionic g service services/photo
+ionic g service services/photo
 ```
 
 Open the new `services/photo.service.ts` file, and let’s add the logic that will power the camera functionality. First, import Capacitor dependencies and get references to the Camera, Filesystem, and Storage plugins:


### PR DESCRIPTION
Removed the "$" from the shell commands, as the clipboard "copy" button ends up copying the terminal command with the "$" and this breaks the user experience and causes an error.