### PR TITLE
Return the correct type from `savePicture`

### DIFF
--- a/docs/vue/your-first-app/3-saving-photos.md
+++ b/docs/vue/your-first-app/3-saving-photos.md
@@ -29,7 +29,7 @@ Next, add a function to save the photo to the filesystem. We pass in the `photo`
 Next we use the Capacitor [Filesystem API](https://capacitor.ionicframework.com/docs/apis/filesystem) to save the photo to the filesystem. We start by converting the photo to base64 format, then feed the data to the Filesystem’s `writeFile` function:
 
 ```tsx
-const savePicture = async (photo: Photo, fileName: string): Promise<Photo> => {
+const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
   let base64Data: string;
 
   // Fetch the photo, read as a blob, then convert to base64 format


### PR DESCRIPTION
The return statement for `savePicture` doesn't match the interface it states it will return. It returns `UserPhoto` rather than `Photo` (the type is correct on later pages).