### PR TITLE
Adds Missing Instruction in Vue Start Step

### DIFF
--- a/docs/vue/quickstart.md
+++ b/docs/vue/quickstart.md
@@ -52,7 +52,7 @@ npm uninstall --save typescript @types/jest @typescript-eslint/eslint-plugin @ty
 
 3. Remove `@vue/typescript/recommended` and `@typescript-eslint/no-explicit-any: ‘off’, `from `.eslintrc.js`.
 
-4. Remove `Array<RouteRecordRaw>` from `router/index.js`.
+4. Remove `Array<RouteRecordRaw>` from `router/index.js`. Also remove the import `import { RouteRecordRaw } from 'vue-router';`.
 
 5. Delete the `shims-vue.d.ts` file.
 


### PR DESCRIPTION
Step 4 mentions that we have to remove `Array<RouteRecordRaw>` from `router/index.js`. After doing that, we also need to remove the import for `RouteRecordRaw` because that's not used anywhere else. Without that `ionic serve` will throw the following error:

```shell
[vue-cli-service] 
[vue-cli-service] /Users/luis/Programs/mechanical-b/src/router/index.js
[vue-cli-service]   2:10  error  'RouteRecordRaw' is defined but never used  no-unused-vars
[vue-cli-service] 
[vue-cli-service] ✖ 1 problem (1 error, 0 warnings)
```