### PR TITLE
docs(vue): fix typo in useIonRouter example

### DIFF
--- a/docs/vue/navigation.md
+++ b/docs/vue/navigation.md
@@ -162,7 +162,7 @@ export default defineComponent({
   setup() {
     const ionRouter = useIonRouter();
 
-    router.push('/page2', customAnimation);
+    ionRouter.push('/page2', customAnimation);
   }
 });
 ```
@@ -179,7 +179,7 @@ export default defineComponent({
   setup() {
     const ionRouter = useIonRouter();
 
-    router.navigate('/page2', 'forward', 'replace', customAnimation);
+    ionRouter.navigate('/page2', 'forward', 'replace', customAnimation);
   }
 });
 ```


### PR DESCRIPTION
---
name: Invalid variable name
about: Invalid variable name
title: The variable name for vue when using ionRouter is invalid
labels: doc, vue
assignees: ''

---

**URL**
[The URL at which the content is missing or inaccurate](https://ionicframework.com/docs/vue/navigation#navigating-using-useionrouter)

**What is missing or inaccurate about the content on this page?**

We import a `ionrouter` but then we use an hypothetical variable named `router`:
Initial :
```js
const ionRouter = useIonRouter();
router.navigate('...');
```
Fixed:
```js
const ionRouter = useIonRouter();
ionRouter.navigate('...');
```