### PR TITLE
docs(react): Clarify the Ionic Lifecycle Methods documentation

### DIFF
--- a/docs/react/lifecycle.md
+++ b/docs/react/lifecycle.md
@@ -20,9 +20,9 @@ Ionic provides a few lifecycle methods that you can use in your apps:
 | Event Name         | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
 | `ionViewWillEnter` | Fired when the component routing to is about to animate into view. |
-| `ionViewDidEnter`  | Fired when the component routing to has finished animating.        |
-| `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
-| `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
+| `ionViewDidEnter`  | Fired when the component routing to has *finished* animating.      |
+| `ionViewWillLeave` | Fired when the component routing *from* is about to animate.       |
+| `ionViewDidLeave`  | Fired when the component routing *from* has *finished* animating.  |
 
 The way you access these methods varies based on if you are using class-based components or functional components. We cover both methods below.
 


### PR DESCRIPTION
I think the ionViewDidLeave should state "from" not "to". Also added italics to make it clear what's different between the methods. 
Note - I'm reading the docs for a reason! :D if this change is wrong please someone correct me.