### PR TITLE
Fixing a mistake in the deletePicture definition

### DIFF
--- a/docs/angular/your-first-app/7-live-reload.md
+++ b/docs/angular/your-first-app/7-live-reload.md
@@ -86,7 +86,7 @@ Save both of the files we just edited. The Photo Gallery app will reload automat
 In `src/app/services/photo.service.ts`, add the `deletePicture()` function:
 
 ```tsx
-public async deletePicture(photo: Photo, position: number) {
+public async deletePicture(photo: UserPhoto, position: number) {
   // Remove this photo from the Photos reference data array
   this.photos.splice(position, 1);
 


### PR DESCRIPTION
There's a mistake in the **deletePicture** definition. 

We have to change the type of the **photo** argument from `photo: Photo`  to `photo: UserPhoto`