### PR TITLE
docs(rtl): remove unused page

### DIFF
--- a/docs/layout/rtl.md
+++ b/docs/layout/rtl.md
@@ -1,3 +1,0 @@
-# RTL Support
-
-TODO: add stuff here


### PR DESCRIPTION
This page just says "TODO" and is being indexed by our search component. Until we get a better RTL page up I would like to remove the placeholder content altogether so it's less confusing.