### PR TITLE
feat(docs): playground docs component

### DIFF
--- a/docs/playground/button.mdx
+++ b/docs/playground/button.mdx
@@ -5,7 +5,8 @@ import Playground from '../../src/components/global/Playground';
 Buttons provide a clickable element, which can be used in forms, or anywhere that needs simple, standard button functionality. They may display text, icons, or both. Buttons can be styled with several attributes to look a specific way.
 
 <Playground
-  src={{
+  src="/docs/code/button/usage/basic/index.html"
+  code={{
     basic: '/docs/code/button/usage/basic/javascript.md',
     angular: '/docs/code/button/usage/basic/angular.md',
     react: '/docs/code/button/usage/basic/react.md',
@@ -20,7 +21,8 @@ Buttons provide a clickable element, which can be used in forms, or anywhere tha
 The `color` attribute specifies the background color of the button.
 
 <Playground
-  src={{
+  src="/docs/code/button/usage/color/index.html"
+  code={{
     basic: '/docs/code/button/usage/color/javascript.md',
     angular: '/docs/code/button/usage/color/angular.md',
     react: '/docs/code/button/usage/color/react.md',
@@ -43,7 +45,8 @@ The `color` attribute specifies the background color of the button.
 The `expand` attribute will expand the button to fill the available space. Setting this attribute with `block` will create a full-width button with rounded corners. Setting this attribute with `full` will create a full-width button with square corners and no border on the left or right.
 
 <Playground
-  src={{
+  src="/docs/code/button/usage/expand/index.html"
+  code={{
     basic: '/docs/code/button/usage/expand/javascript.md',
   }}
 >
@@ -58,7 +61,8 @@ The `expand` attribute will expand the button to fill the available space. Setti
 The `fill` attribute determines the background and border color of the button. By default, buttons have a solid background unless the button is inside of a toolbar, in which case it has a transparent background.
 
 <Playground
-  src={{
+  src="/docs/code/button/usage/fill/index.html"
+  code={{
     basic: '/docs/code/button/usage/fill/javascript.md',
   }}
 >
@@ -72,7 +76,8 @@ The `fill` attribute determines the background and border color of the button. B
 This attribute specifies the size of the button. Setting this attribute will change the height and padding of a button.
 
 <Playground
-  src={{
+  src="/docs/code/button/usage/size/index.html"
+  code={{
     basic: '/docs/code/button/usage/size/javascript.md',
   }}
 >

--- a/docs/playground/button.mdx
+++ b/docs/playground/button.mdx
@@ -15,21 +15,9 @@ Buttons provide a clickable element, which can be used in forms, or anywhere tha
   <ion-button>Default</ion-button>
 </Playground>
 
-## Sizes
-
-This attribute specifies the size of the button. Setting this attribute will change the height and padding of a button.
-
-<Playground
-  src={{
-    html: '/docs/code/button/usage/size/javascript.md',
-  }}
->
-  <ion-button size="small">Small</ion-button>
-  <ion-button>Default</ion-button>
-  <ion-button size="large">Large</ion-button>
-</Playground>
-
 ## Colors
+
+The `color` attribute specifies the background color of the button.
 
 <Playground
   src={{
@@ -48,6 +36,49 @@ This attribute specifies the size of the button. Setting this attribute will cha
   <ion-button color="light">Light</ion-button>
   <ion-button color="medium">Medium</ion-button>
   <ion-button color="dark">Dark</ion-button>
+</Playground>
+
+## Expand
+
+The `expand` attribute will expand the button to fill the available space. Setting this attribute with `block` will create a full-width button with rounded corners. Setting this attribute with `full` will create a full-width button with square corners and no border on the left or right.
+
+<Playground
+  src={{
+    html: '/docs/code/button/usage/expand/javascript.md',
+  }}
+>
+  <div style={{ width: '100%' }}>
+    <ion-button expand="full">Full</ion-button>
+    <ion-button expand="block">Block</ion-button>
+  </div>
+</Playground>
+
+## Fill
+
+The `fill` attribute determines the background and border color of the button. By default, buttons have a solid background unless the button is inside of a toolbar, in which case it has a transparent background.
+
+<Playground
+  src={{
+    html: '/docs/code/button/usage/fill/javascript.md',
+  }}
+>
+  <ion-button fill="clear">Clear</ion-button>
+  <ion-button fill="outline">Outline</ion-button>
+  <ion-button fill="solid">Solid</ion-button>
+</Playground>
+
+## Size
+
+This attribute specifies the size of the button. Setting this attribute will change the height and padding of a button.
+
+<Playground
+  src={{
+    html: '/docs/code/button/usage/size/javascript.md',
+  }}
+>
+  <ion-button size="small">Small</ion-button>
+  <ion-button>Default</ion-button>
+  <ion-button size="large">Large</ion-button>
 </Playground>
 
 <!-- Auto Generated Below -->

--- a/docs/playground/button.mdx
+++ b/docs/playground/button.mdx
@@ -1,0 +1,147 @@
+import Playground from '../../src/components/global/Playground';
+
+# IonButton
+
+Buttons provide a clickable element, which can be used in forms, or anywhere that needs simple, standard button functionality. They may display text, icons, or both. Buttons can be styled with several attributes to look a specific way.
+
+<Playground
+  src={{
+    html: '/docs/code/button/usage/basic/javascript.md',
+    angular: '/docs/code/button/usage/basic/angular.md',
+    react: '/docs/code/button/usage/basic/react.md',
+    vue: '/docs/code/button/usage/basic/vue.md',
+  }}
+>
+  <ion-button>Default</ion-button>
+</Playground>
+
+## Sizes
+
+This attribute specifies the size of the button. Setting this attribute will change the height and padding of a button.
+
+<Playground
+  src={{
+    html: '/docs/code/button/usage/size/javascript.md',
+  }}
+>
+  <ion-button size="small">Small</ion-button>
+  <ion-button>Default</ion-button>
+  <ion-button size="large">Large</ion-button>
+</Playground>
+
+## Colors
+
+<Playground
+  src={{
+    html: '/docs/code/button/usage/color/javascript.md',
+    angular: '/docs/code/button/usage/color/angular.md',
+    react: '/docs/code/button/usage/color/react.md',
+    vue: '/docs/code/button/usage/color/vue.md',
+  }}
+>
+  <ion-button>Default</ion-button>
+  <ion-button color="secondary">Secondary</ion-button>
+  <ion-button color="tertiary">Tertiary</ion-button>
+  <ion-button color="success">Success</ion-button>
+  <ion-button color="warning">Warning</ion-button>
+  <ion-button color="danger">Danger</ion-button>
+  <ion-button color="light">Light</ion-button>
+  <ion-button color="medium">Medium</ion-button>
+  <ion-button color="dark">Dark</ion-button>
+</Playground>
+
+<!-- Auto Generated Below -->
+
+## Properties
+
+| Property          | Attribute          | Description                                                                                                                                                                                                                                                                               | Type                                                        | Default     |
+| ----------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------- |
+| `buttonType`      | `button-type`      | The type of button.                                                                                                                                                                                                                                                                       | `string`                                                    | `'button'`  |
+| `color`           | `color`            | The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).                    | `string \| undefined`                                       | `undefined` |
+| `disabled`        | `disabled`         | If `true`, the user cannot interact with the button.                                                                                                                                                                                                                                      | `boolean`                                                   | `false`     |
+| `download`        | `download`         | This attribute instructs browsers to download a URL instead of navigating to it, so the user will be prompted to save it as a local file. If the attribute has a value, it is used as the pre-filled file name in the Save prompt (the user can still change the file name if they want). | `string \| undefined`                                       | `undefined` |
+| `expand`          | `expand`           | Set to `"block"` for a full-width button or to `"full"` for a full-width button without left and right borders.                                                                                                                                                                           | `"block" \| "full" \| undefined`                            | `undefined` |
+| `fill`            | `fill`             | Set to `"clear"` for a transparent button, to `"outline"` for a transparent button with a border, or to `"solid"`. The default style is `"solid"` except inside of a toolbar, where the default is `"clear"`.                                                                             | `"clear" \| "default" \| "outline" \| "solid" \| undefined` | `undefined` |
+| `href`            | `href`             | Contains a URL or a URL fragment that the hyperlink points to. If this property is set, an anchor tag will be rendered.                                                                                                                                                                   | `string \| undefined`                                       | `undefined` |
+| `mode`            | `mode`             | The mode determines which platform styles to use.                                                                                                                                                                                                                                         | `"ios" \| "md"`                                             | `undefined` |
+| `rel`             | `rel`              | Specifies the relationship of the target object to the link object. The value is a space-separated list of [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types).                                                                                                    | `string \| undefined`                                       | `undefined` |
+| `routerAnimation` | --                 | When using a router, it specifies the transition animation when navigating to another page using `href`.                                                                                                                                                                                  | `((baseEl: any, opts?: any) => Animation) \| undefined`     | `undefined` |
+| `routerDirection` | `router-direction` | When using a router, it specifies the transition direction when navigating to another page using `href`.                                                                                                                                                                                  | `"back" \| "forward" \| "root"`                             | `'forward'` |
+| `shape`           | `shape`            | The button shape.                                                                                                                                                                                                                                                                         | `"round" \| undefined`                                      | `undefined` |
+| `size`            | `size`             | The button size.                                                                                                                                                                                                                                                                          | `"default" \| "large" \| "small" \| undefined`              | `undefined` |
+| `strong`          | `strong`           | If `true`, activates a button with a heavier font weight.                                                                                                                                                                                                                                 | `boolean`                                                   | `false`     |
+| `target`          | `target`           | Specifies where to display the linked URL. Only applies when an `href` is provided. Special keywords: `"_blank"`, `"_self"`, `"_parent"`, `"_top"`.                                                                                                                                       | `string \| undefined`                                       | `undefined` |
+| `type`            | `type`             | The type of the button.                                                                                                                                                                                                                                                                   | `"button" \| "reset" \| "submit"`                           | `'button'`  |
+
+## Events
+
+| Event      | Description                          | Type                |
+| ---------- | ------------------------------------ | ------------------- |
+| `ionBlur`  | Emitted when the button loses focus. | `CustomEvent<void>` |
+| `ionFocus` | Emitted when the button has focus.   | `CustomEvent<void>` |
+
+## Slots
+
+| Slot          | Description                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+|               | Content is placed between the named slots if provided without a slot.             |
+| `"end"`       | Content is placed to the right of the button text in LTR, and to the left in RTL. |
+| `"icon-only"` | Should be used on an icon in a button that has no text.                           |
+| `"start"`     | Content is placed to the left of the button text in LTR, and to the right in RTL. |
+
+## Shadow Parts
+
+| Part       | Description                                                             |
+| ---------- | ----------------------------------------------------------------------- |
+| `"native"` | The native HTML button or anchor element that wraps all child elements. |
+
+## CSS Custom Properties
+
+| Name                             | Description                                                                                               |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `--background`                   | Background of the button                                                                                  |
+| `--background-activated`         | Background of the button when pressed. Note: setting this will interfere with the Material Design ripple. |
+| `--background-activated-opacity` | Opacity of the button when pressed                                                                        |
+| `--background-focused`           | Background of the button when focused with the tab key                                                    |
+| `--background-focused-opacity`   | Opacity of the button when focused with the tab key                                                       |
+| `--background-hover`             | Background of the button on hover                                                                         |
+| `--background-hover-opacity`     | Opacity of the background on hover                                                                        |
+| `--border-color`                 | Border color of the button                                                                                |
+| `--border-radius`                | Border radius of the button                                                                               |
+| `--border-style`                 | Border style of the button                                                                                |
+| `--border-width`                 | Border width of the button                                                                                |
+| `--box-shadow`                   | Box shadow of the button                                                                                  |
+| `--color`                        | Text color of the button                                                                                  |
+| `--color-activated`              | Text color of the button when pressed                                                                     |
+| `--color-focused`                | Text color of the button when focused with the tab key                                                    |
+| `--color-hover`                  | Text color of the button when hover                                                                       |
+| `--opacity`                      | Opacity of the button                                                                                     |
+| `--padding-bottom`               | Bottom padding of the button                                                                              |
+| `--padding-end`                  | Right padding if direction is left-to-right, and left padding if direction is right-to-left of the button |
+| `--padding-start`                | Left padding if direction is left-to-right, and right padding if direction is right-to-left of the button |
+| `--padding-top`                  | Top padding of the button                                                                                 |
+| `--ripple-color`                 | Color of the button ripple effect                                                                         |
+| `--transition`                   | Transition of the button                                                                                  |
+
+## Dependencies
+
+### Used by
+
+- [ion-datetime](../datetime)
+
+### Depends on
+
+- [ion-ripple-effect](../ripple-effect)
+
+### Graph
+
+```mermaid
+graph TD;
+  ion-button --> ion-ripple-effect
+  ion-datetime --> ion-button
+  style ion-button fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+---
+
+_Built with [StencilJS](https://stenciljs.com/)_

--- a/docs/playground/button.mdx
+++ b/docs/playground/button.mdx
@@ -12,9 +12,7 @@ Buttons provide a clickable element, which can be used in forms, or anywhere tha
     react: '/docs/code/button/usage/basic/react.md',
     vue: '/docs/code/button/usage/basic/vue.md',
   }}
->
-  <ion-button>Default</ion-button>
-</Playground>
+/>
 
 ## Colors
 
@@ -28,17 +26,7 @@ The `color` attribute specifies the background color of the button.
     react: '/docs/code/button/usage/color/react.md',
     vue: '/docs/code/button/usage/color/vue.md',
   }}
->
-  <ion-button>Default</ion-button>
-  <ion-button color="secondary">Secondary</ion-button>
-  <ion-button color="tertiary">Tertiary</ion-button>
-  <ion-button color="success">Success</ion-button>
-  <ion-button color="warning">Warning</ion-button>
-  <ion-button color="danger">Danger</ion-button>
-  <ion-button color="light">Light</ion-button>
-  <ion-button color="medium">Medium</ion-button>
-  <ion-button color="dark">Dark</ion-button>
-</Playground>
+/>
 
 ## Expand
 
@@ -49,12 +37,7 @@ The `expand` attribute will expand the button to fill the available space. Setti
   code={{
     basic: '/docs/code/button/usage/expand/javascript.md',
   }}
->
-  <div style={{ width: '100%' }}>
-    <ion-button expand="full">Full</ion-button>
-    <ion-button expand="block">Block</ion-button>
-  </div>
-</Playground>
+/>
 
 ## Fill
 
@@ -65,11 +48,7 @@ The `fill` attribute determines the background and border color of the button. B
   code={{
     basic: '/docs/code/button/usage/fill/javascript.md',
   }}
->
-  <ion-button fill="clear">Clear</ion-button>
-  <ion-button fill="outline">Outline</ion-button>
-  <ion-button fill="solid">Solid</ion-button>
-</Playground>
+/>
 
 ## Size
 
@@ -80,11 +59,7 @@ This attribute specifies the size of the button. Setting this attribute will cha
   code={{
     basic: '/docs/code/button/usage/size/javascript.md',
   }}
->
-  <ion-button size="small">Small</ion-button>
-  <ion-button>Default</ion-button>
-  <ion-button size="large">Large</ion-button>
-</Playground>
+/>
 
 <!-- Auto Generated Below -->
 

--- a/docs/playground/button.mdx
+++ b/docs/playground/button.mdx
@@ -6,7 +6,7 @@ Buttons provide a clickable element, which can be used in forms, or anywhere tha
 
 <Playground
   src={{
-    html: '/docs/code/button/usage/basic/javascript.md',
+    basic: '/docs/code/button/usage/basic/javascript.md',
     angular: '/docs/code/button/usage/basic/angular.md',
     react: '/docs/code/button/usage/basic/react.md',
     vue: '/docs/code/button/usage/basic/vue.md',
@@ -21,7 +21,7 @@ The `color` attribute specifies the background color of the button.
 
 <Playground
   src={{
-    html: '/docs/code/button/usage/color/javascript.md',
+    basic: '/docs/code/button/usage/color/javascript.md',
     angular: '/docs/code/button/usage/color/angular.md',
     react: '/docs/code/button/usage/color/react.md',
     vue: '/docs/code/button/usage/color/vue.md',
@@ -44,7 +44,7 @@ The `expand` attribute will expand the button to fill the available space. Setti
 
 <Playground
   src={{
-    html: '/docs/code/button/usage/expand/javascript.md',
+    basic: '/docs/code/button/usage/expand/javascript.md',
   }}
 >
   <div style={{ width: '100%' }}>
@@ -59,7 +59,7 @@ The `fill` attribute determines the background and border color of the button. B
 
 <Playground
   src={{
-    html: '/docs/code/button/usage/fill/javascript.md',
+    basic: '/docs/code/button/usage/fill/javascript.md',
   }}
 >
   <ion-button fill="clear">Clear</ion-button>
@@ -73,7 +73,7 @@ This attribute specifies the size of the button. Setting this attribute will cha
 
 <Playground
   src={{
-    html: '/docs/code/button/usage/size/javascript.md',
+    basic: '/docs/code/button/usage/size/javascript.md',
   }}
 >
   <ion-button size="small">Small</ion-button>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -274,5 +274,4 @@ module.exports = {
     path.resolve(__dirname, './node_modules/@docusaurus/theme-search-algolia'),
   ],
   customFields: {},
-  stylesheets: ['https://cdn.jsdelivr.net/npm/@ionic/core/css/core.css'],
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -274,4 +274,5 @@ module.exports = {
     path.resolve(__dirname, './node_modules/@docusaurus/theme-search-algolia'),
   ],
   customFields: {},
+  stylesheets: ['https://cdn.jsdelivr.net/npm/@ionic/core/css/core.css'],
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@ionic-internal/ionic-ds": "^7.0.0",
     "@mdx-js/react": "^1.6.22",
     "@stackblitz/sdk": "^1.5.6",
+    "@tippyjs/react": "^4.2.6",
     "clsx": "^1.1.1",
     "concurrently": "^6.2.0",
     "crowdin": "^3.5.0",
@@ -66,7 +67,6 @@
     "@tsconfig/docusaurus": "^1.0.4",
     "@types/react": "^17.0.37",
     "prettier": "^2.5.0",
-    "react-script-hook": "^1.6.0",
     "typescript": "^4.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "dependencies": {
     "@docusaurus/core": "0.0.0-4192",
     "@docusaurus/mdx-loader": "0.0.0-4192",
+    "@docusaurus/plugin-client-redirects": "0.0.0-4192",
     "@docusaurus/plugin-content-docs": "0.0.0-4192",
     "@docusaurus/plugin-content-pages": "0.0.0-4192",
-    "@docusaurus/plugin-client-redirects": "0.0.0-4192",
     "@docusaurus/plugin-debug": "0.0.0-4192",
     "@docusaurus/plugin-google-analytics": "0.0.0-4192",
     "@docusaurus/plugin-google-gtag": "0.0.0-4192",
@@ -45,6 +45,7 @@
     "@ionic-internal/docusaurus-plugin-tag-manager": "^2.0.0",
     "@ionic-internal/ionic-ds": "^7.0.0",
     "@mdx-js/react": "^1.6.22",
+    "@stackblitz/sdk": "^1.5.6",
     "clsx": "^1.1.1",
     "concurrently": "^6.2.0",
     "crowdin": "^3.5.0",
@@ -65,6 +66,7 @@
     "@tsconfig/docusaurus": "^1.0.4",
     "@types/react": "^17.0.37",
     "prettier": "^2.5.0",
+    "react-script-hook": "^1.6.0",
     "typescript": "^4.5.2"
   }
 }

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -259,11 +259,12 @@ export default function Playground({ children, src, code, title, description }) 
   function openEditor(event) {
     const button = event.target.closest('button');
     // Outer text includes line breaks `\n` to maintain code formatting in editor examples.
-    const codeBlock = button.parentElement.parentElement.querySelector('.code-block pre code')?.outerText;
+    const codeBlock = button.closest('.playground').querySelector('.code-block pre code')?.outerText;
     const editorOptions = {
       title,
       description,
     };
+
     switch (selected) {
       case UsageTarget.Angular:
         openAngularEditor(codeBlock, editorOptions);

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -1,0 +1,362 @@
+import React, { useState, useEffect } from 'react';
+import useScript from 'react-script-hook';
+
+import sdk from '@stackblitz/sdk';
+
+import CodeBlock from '@theme/CodeBlock';
+
+import './playground.css';
+
+enum UsageTarget {
+  HTML = 'HTML',
+  Angular = 'Angular',
+  React = 'React',
+  Vue = 'Vue',
+}
+
+const UsageTargetList = Object.keys(UsageTarget);
+
+enum Theme {
+  Light = 'light',
+  Dark = 'dark',
+}
+
+enum Mode {
+  iOS = 'ios',
+  MD = 'md',
+}
+
+interface EditorOptions {
+  /**
+   * The title of the Stackblitz example.
+   */
+  title?: string;
+  /**
+   * The description of the Stackblitz example.
+   */
+  description?: string;
+}
+
+// The default title to use for Stackblitz examples (when not overwritten)
+const DEFAULT_EDITOR_TITLE = 'Ionic Docs Example';
+// The default description to use for Stackblitz examples (when not overwritten)
+const DEFAULT_EDITOR_DESCRIPTION = '';
+
+// Default package version to use for all @ionic/* packages.
+const DEFAULT_IONIC_VERSION = '^6.0.0';
+
+/**
+ * Playground component for live preview of Ionic doc examples.
+ * Allows developers to open individual examples in live code editor.
+ *
+ * @see https://developer.stackblitz.com/docs/platform/javascript-sdk
+ */
+
+const ToggleCodeButton = ({ expanded, setExpanded }) => {
+  return (
+    <button
+      type="button"
+      className="code-block-source__button"
+      aria-expanded={expanded ? 'true' : 'false'}
+      onClick={() => setExpanded(!expanded)}
+    >
+      {expanded ? 'Hide code' : 'Show code'}
+    </button>
+  );
+};
+
+const CodeBlockButton = ({ language, selected, setSelected }) => {
+  return (
+    <button
+      type="button"
+      title={`Show ${language} code`}
+      className={'playground__control-button ' + (selected === language ? 'playground__control-button--selected' : '')}
+      onClick={() => setSelected(language)}
+    >
+      {language}
+    </button>
+  );
+};
+
+/**
+ * Parses MDX formatted text and returns the inner
+ * contents of the block.
+ */
+function convertMdxToCode(text: string) {
+  const regexp = new RegExp(/`{3}([\S\s]*?)`{3}([^`]*)([\S\s]*?)/g);
+  const regexpResult = regexp.exec(text);
+  let sourceCode = '';
+  if (regexpResult) {
+    const sourceCodeLines = regexpResult[1].split('\n');
+    // Removes any language indicator for code formatting
+    sourceCodeLines.shift();
+    sourceCode = sourceCodeLines.join('\n');
+  }
+  return sourceCode;
+}
+
+export default function Playground({ children, src, title, description }) {
+  if (!src) {
+    console.warn('No src provided to Playground component');
+    return null;
+  }
+
+  const [selected, setSelected] = useState(UsageTarget.HTML);
+  const [theme, setTheme] = useState(Theme.Light);
+  const [mode, setMode] = useState(Mode.iOS);
+  const [expanded, setExpanded] = useState(false);
+  const [code, setCode] = useState({});
+
+  useEffect(() => {
+    const fetchCodeSnippets = Promise.all(
+      Object.keys(src).map((target) => {
+        return new Promise((resolve, reject) => {
+          fetch(src[target])
+            .then((res) =>
+              res.text().then((text) =>
+                resolve({
+                  [target]: text,
+                })
+              )
+            )
+            .catch((err) => {
+              console.error('Error loading source file for ' + target, err);
+              reject();
+            });
+        });
+      })
+    );
+
+    fetchCodeSnippets.then((res) => {
+      const snippets = Object.assign({}, ...res);
+      Object.keys(snippets).forEach((key) => {
+        snippets[key] = convertMdxToCode(snippets[key]);
+      });
+      setCode(snippets);
+    });
+  }, []);
+
+  const [loading, error] = useScript({
+    src: 'https://cdn.jsdelivr.net/npm/@ionic/core@latest/dist/ionic/ionic.js',
+    checkForExisting: true,
+  });
+
+  async function openHtmlEditor(codeBlock: string, options?: EditorOptions) {
+    const indexTs = convertMdxToCode(await (await fetch('/docs/code/stackblitz/html/index.ts.md')).text());
+    const indexHtml = convertMdxToCode(await (await fetch('/docs/code/stackblitz/html/index.html.md')).text());
+
+    sdk.openProject({
+      template: 'typescript',
+      title: options?.title ?? DEFAULT_EDITOR_TITLE,
+      description: options?.description ?? DEFAULT_EDITOR_DESCRIPTION,
+      files: {
+        // Injects our code sample into the body of the HTML document
+        'index.html': indexHtml.replace(/<body><\/body>/g, `<body>\n` + codeBlock + '</body>'),
+        'index.ts': indexTs,
+      },
+      dependencies: {
+        '@ionic/core': DEFAULT_IONIC_VERSION,
+      },
+    });
+  }
+
+  async function openAngularEditor(codeBlock: string, options?: EditorOptions) {
+    const main_ts = convertMdxToCode(await (await fetch('/docs/code/stackblitz/angular/main.md')).text());
+    const app_module_ts = convertMdxToCode(await (await fetch('/docs/code/stackblitz/angular/app.module.md')).text());
+    const app_component_ts = convertMdxToCode(
+      await (await fetch('/docs/code/stackblitz/angular/app.component.md')).text()
+    );
+    const styles_css = convertMdxToCode(await (await fetch('/docs/code/stackblitz/angular/styles.md')).text());
+    const angular_json = await (await fetch('/docs/code/stackblitz/angular/angular.json')).text();
+
+    sdk.openProject({
+      template: 'angular-cli',
+      title: options?.title ?? DEFAULT_EDITOR_TITLE,
+      description: options?.description ?? DEFAULT_EDITOR_DESCRIPTION,
+      files: {
+        'src/main.ts': main_ts,
+        'src/polyfills.ts': `import 'zone.js/dist/zone';`,
+        'src/app/app.module.ts': app_module_ts,
+        'src/app/app.component.ts': app_component_ts,
+        'src/app/app.component.html': codeBlock,
+        'src/index.html': '<app-root></app-root>',
+        'src/styles.css': styles_css,
+        'angular.json': angular_json,
+      },
+      dependencies: {
+        '@ionic/angular': DEFAULT_IONIC_VERSION,
+      },
+    });
+  }
+
+  async function openReactEditor(codeBlock: string, options?: EditorOptions) {
+    // Matches the name after `export default` to use as the component tag.
+    const componentTagName = new RegExp(/function([\S\s]*?)\(/g).exec(codeBlock)[1].trim();
+
+    const index_js = convertMdxToCode(await (await fetch('/docs/code/stackblitz/react/index.md')).text());
+    const app_tsx = convertMdxToCode(await (await fetch('/docs/code/stackblitz/react/app.md')).text())
+      // Inserts the component name from the sample into the <IonApp> tag.
+      .replace(/<IonApp><\/IonApp>/g, `<IonApp><${componentTagName} /></IonApp>`)
+      // Imports the component from our `main` example file.
+      .replace(/setupIonicReact\(\);/g, `import ${componentTagName} from "./main";\n\n` + 'setupIonicReact();');
+
+    sdk.openProject({
+      template: 'create-react-app',
+      title: options?.title ?? DEFAULT_EDITOR_TITLE,
+      description: options?.description ?? DEFAULT_EDITOR_DESCRIPTION,
+      files: {
+        'index.html': `<div id="root"></div>`,
+        'index.js': index_js,
+        'App.js': app_tsx,
+        'main.js': codeBlock,
+      },
+      dependencies: {
+        react: 'latest',
+        'react-dom': 'latest',
+        '@ionic/react': DEFAULT_IONIC_VERSION,
+        // Stackblitz requires this dependency to run
+        '@stencil/core': '^2.13.0',
+      },
+    });
+  }
+
+  async function openVueEditor(codeBlock: string, options?: EditorOptions) {
+    const main_js = convertMdxToCode(await (await fetch('/docs/code/stackblitz/vue/main.md')).text());
+    const app_vue = convertMdxToCode(await (await fetch('/docs/code/stackblitz/vue/app.md')).text());
+
+    sdk.openProject({
+      template: 'vue',
+      title: options?.title ?? DEFAULT_EDITOR_TITLE,
+      description: options?.description ?? DEFAULT_EDITOR_DESCRIPTION,
+      files: {
+        'src/main.js': main_js,
+        'src/App.vue': app_vue,
+        'src/components/Example.vue': codeBlock,
+        'public/index.html': '<div id="app"></div>',
+      },
+      dependencies: {
+        vue: '^3.0.0',
+        'vue-router': '^4.0.12',
+        '@ionic/vue': DEFAULT_IONIC_VERSION,
+        // Stackblitz requires this dependency to run
+        '@stencil/core': '^2.13.0',
+      },
+    });
+  }
+
+  function openEditor(event) {
+    const button = event.target.closest('button');
+    // Outer text includes line breaks `\n` to maintain code formatting in editor examples.
+    const codeBlock = button.parentElement.parentElement.querySelector('.code-block pre code')?.outerText;
+    const editorOptions = {
+      title,
+      description,
+    };
+    switch (selected) {
+      case UsageTarget.Angular:
+        openAngularEditor(codeBlock, editorOptions);
+        break;
+      case UsageTarget.HTML:
+        openHtmlEditor(codeBlock, editorOptions);
+        break;
+      case UsageTarget.React:
+        openReactEditor(codeBlock, editorOptions);
+        break;
+      case UsageTarget.Vue:
+        openVueEditor(codeBlock, editorOptions);
+        break;
+    }
+  }
+
+  const languages = UsageTargetList.filter((lang) => Object.keys(code).includes(lang.toLowerCase()));
+
+  return (
+    <div className={`playground playground--theme-${theme} playground--mode-${mode}`}>
+      <div className="playground__control-toolbar">
+        <div className="playground__control-group">
+          {languages.map((language) => (
+            <CodeBlockButton key={language} language={language} selected={selected} setSelected={setSelected} />
+          ))}
+        </div>
+        <div className="playground__control-group">
+          <button
+            type="button"
+            className={
+              'playground__control-button ' + (mode === Mode.iOS ? 'playground__control-button--selected' : '')
+            }
+            onClick={() => setMode(Mode.iOS)}
+          >
+            iOS
+          </button>
+          <button
+            type="button"
+            className={'playground__control-button ' + (mode === Mode.MD ? 'playground__control-button--selected' : '')}
+            onClick={() => setMode(Mode.MD)}
+          >
+            MD
+          </button>
+        </div>
+        <div className="playground__control-group">
+          <button
+            className={
+              'playground__control-button ' + (theme === Theme.Light ? 'playground__control-button--selected' : '')
+            }
+            type="button"
+            title="Enable Light Theme"
+            onClick={() => setTheme(Theme.Light)}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+              <path d="M256,118a22,22,0,0,1-22-22V48a22,22,0,0,1,44,0V96A22,22,0,0,1,256,118Z" />
+              <path d="M256,486a22,22,0,0,1-22-22V416a22,22,0,0,1,44,0v48A22,22,0,0,1,256,486Z" />
+              <path d="M369.14,164.86a22,22,0,0,1-15.56-37.55l33.94-33.94a22,22,0,0,1,31.11,31.11l-33.94,33.94A21.93,21.93,0,0,1,369.14,164.86Z" />
+              <path d="M108.92,425.08a22,22,0,0,1-15.55-37.56l33.94-33.94a22,22,0,1,1,31.11,31.11l-33.94,33.94A21.94,21.94,0,0,1,108.92,425.08Z" />
+              <path d="M464,278H416a22,22,0,0,1,0-44h48a22,22,0,0,1,0,44Z" />
+              <path d="M96,278H48a22,22,0,0,1,0-44H96a22,22,0,0,1,0,44Z" />
+              <path d="M403.08,425.08a21.94,21.94,0,0,1-15.56-6.45l-33.94-33.94a22,22,0,0,1,31.11-31.11l33.94,33.94a22,22,0,0,1-15.55,37.56Z" />
+              <path d="M142.86,164.86a21.89,21.89,0,0,1-15.55-6.44L93.37,124.48a22,22,0,0,1,31.11-31.11l33.94,33.94a22,22,0,0,1-15.56,37.55Z" />
+              <path d="M256,358A102,102,0,1,1,358,256,102.12,102.12,0,0,1,256,358Z" />
+            </svg>
+          </button>
+          <button
+            className={
+              'playground__control-button ' + (theme === Theme.Dark ? 'playground__control-button--selected' : '')
+            }
+            type="button"
+            title="Enable Dark Theme"
+            onClick={() => setTheme(Theme.Dark)}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+              <path d="M264,480A232,232,0,0,1,32,248C32,154,86,69.72,169.61,33.33a16,16,0,0,1,21.06,21.06C181.07,76.43,176,104.66,176,136c0,110.28,89.72,200,200,200,31.34,0,59.57-5.07,81.61-14.67a16,16,0,0,1,21.06,21.06C442.28,426,358,480,264,480Z" />
+            </svg>
+          </button>
+        </div>
+        <button
+          className="playground__control-button playground__control-button--editor"
+          title="Edit on Stackblitz"
+          onClick={openEditor}
+        >
+          Open Editor
+        </button>
+      </div>
+      {/* Applying `mode` at this node will update the playground example to mode="md" or mode="ios". */}
+      <div className={`playground__preview playground__preview-theme--${theme}`} key={mode} {...{ mode }}>
+        {children}
+      </div>
+      <div className={'playground__code-block ' + (expanded ? 'playground__code-block--expanded' : '')}>
+        {selected === UsageTarget.HTML && (
+          <CodeBlock className="code-block code--html language-html">{code['html'] ?? ''}</CodeBlock>
+        )}
+        {selected === UsageTarget.Angular && (
+          <CodeBlock className="code-block code--angular language-html">{code['angular']}</CodeBlock>
+        )}
+        {selected === UsageTarget.React && (
+          <CodeBlock className="code-block code--react language-jsx">{code['react']}</CodeBlock>
+        )}
+        {selected === UsageTarget.Vue && (
+          <CodeBlock className="code-block code--vue language-jsx">{code['vue']}</CodeBlock>
+        )}
+      </div>
+      <ToggleCodeButton expanded={expanded} setExpanded={setExpanded} />
+    </div>
+  );
+}

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -65,6 +65,15 @@ const ToggleCodeButton = ({ expanded, setExpanded }) => {
   );
 };
 
+const FeedbackButton = () => {
+  // TODO: Open github issue in new tab for the example
+  return (
+    <a href="#" className="code-block-feedback__button">
+      Report an issue
+    </a>
+  );
+};
+
 const CodeBlockButton = ({ language, selected, setSelected }) => {
   return (
     <button
@@ -341,6 +350,7 @@ export default function Playground({ children, src, title, description }) {
       {/* Applying `mode` at this node will update the playground example to mode="md" or mode="ios". */}
       <div className={`playground__preview playground__preview-theme--${theme}`} key={mode} {...{ mode }}>
         {children}
+        <FeedbackButton />
         <ToggleCodeButton expanded={expanded} setExpanded={setExpanded} />
       </div>
       <div className={'playground__code-block ' + (expanded ? 'playground__code-block--expanded' : '')}>

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -8,7 +8,7 @@ import CodeBlock from '@theme/CodeBlock';
 import './playground.css';
 
 enum UsageTarget {
-  HTML = 'HTML',
+  Basic = 'Basic',
   Angular = 'Angular',
   React = 'React',
   Vue = 'Vue',
@@ -101,7 +101,7 @@ export default function Playground({ children, src, title, description }) {
     return null;
   }
 
-  const [selected, setSelected] = useState(UsageTarget.HTML);
+  const [selected, setSelected] = useState(UsageTarget.Basic);
   const [theme, setTheme] = useState(Theme.Light);
   const [mode, setMode] = useState(Mode.iOS);
   const [expanded, setExpanded] = useState(false);
@@ -256,7 +256,7 @@ export default function Playground({ children, src, title, description }) {
       case UsageTarget.Angular:
         openAngularEditor(codeBlock, editorOptions);
         break;
-      case UsageTarget.HTML:
+      case UsageTarget.Basic:
         openHtmlEditor(codeBlock, editorOptions);
         break;
       case UsageTarget.React:
@@ -341,10 +341,11 @@ export default function Playground({ children, src, title, description }) {
       {/* Applying `mode` at this node will update the playground example to mode="md" or mode="ios". */}
       <div className={`playground__preview playground__preview-theme--${theme}`} key={mode} {...{ mode }}>
         {children}
+        <ToggleCodeButton expanded={expanded} setExpanded={setExpanded} />
       </div>
       <div className={'playground__code-block ' + (expanded ? 'playground__code-block--expanded' : '')}>
-        {selected === UsageTarget.HTML && (
-          <CodeBlock className="code-block code--html language-html">{code['html'] ?? ''}</CodeBlock>
+        {selected === UsageTarget.Basic && (
+          <CodeBlock className="code-block code--html language-html">{code['basic'] ?? ''}</CodeBlock>
         )}
         {selected === UsageTarget.Angular && (
           <CodeBlock className="code-block code--angular language-html">{code['angular']}</CodeBlock>
@@ -356,7 +357,6 @@ export default function Playground({ children, src, title, description }) {
           <CodeBlock className="code-block code--vue language-jsx">{code['vue']}</CodeBlock>
         )}
       </div>
-      <ToggleCodeButton expanded={expanded} setExpanded={setExpanded} />
     </div>
   );
 }

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -225,8 +225,7 @@
   fill: #428cff;
 }
 
-.playground--theme-dark .code-block-source__button {
-  cursor: pointer;
+.playground--theme-dark .code-block-source__button, .playground--theme-dark .code-block-feedback__button {
   background: #34302f;
 }
 
@@ -242,7 +241,21 @@
   padding: 4px 8px;
   font-size: 12px;
   letter-spacing: -.02em;
+  cursor: pointer;
+}
 
+.code-block-feedback__button {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  border: none;
+
+  background: #fbfbfd;
+  color: var(--playground-btn-color);
+  border-radius: 0 12px 0 12px;
+  padding: 4px 8px;
+  font-size: 12px;
+  letter-spacing: -.02em;
 }
 
 .playground__control-button--editor {

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -1,308 +1,183 @@
 
+[data-theme="dark"] .playground {
+  --playground-btn-color: var(--c-carbon-20);
+  --playground-btn-selected-color: #fff;
+  --playground-btn-selected-background: var(--c-carbon-70);
+
+  --playground-btn-icon-color: var(--c-carbon-20);
+  --playground-btn-icon-hover-background: rgba(67, 79, 93, 0.5);
+
+  --playground-separator-color: var(--c-carbon-70);
+
+}
+
+[data-theme="light"] {
+  --playground-tooltip-background: var(--c-carbon-70);
+}
+
+[data-theme="dark"] {
+  --playground-tooltip-background: var(--c-carbon-90);
+}
+
 .playground {
-  --playground-btn-color: #92a1b3;
-  --playground-btn-background: #000;
-  --playground-btn-selected-color: #428cff;
-  --playground-btn-selected-background: #fff;
+  /**
+   * @prop --playground-btn-color The text color of the button in the toolbar.
+   */
+  --playground-btn-color: #2D4665;
+  --playground-btn-selected-color: var(--c-blue-90);
+  --playground-btn-selected-background: var(--c-blue-10);
+
+  --playground-btn-icon-hover-background: var(--c-indigo-20);
+  --playground-btn-icon-color: var(--c-indigo-80);
+
+  --playground-separator-color: var(--c-indigo-30);
+
 
   overflow: hidden;
 }
 
-.playground--theme-dark {
-  --code-block-bg-c: #1e2a3a;
-  --ifm-pre-color: white;
-
-  --ion-color-primary: #428cff;
-  --ion-color-primary-rgb: 66,140,255;
-  --ion-color-primary-contrast: #ffffff;
-  --ion-color-primary-contrast-rgb: 255,255,255;
-  --ion-color-primary-shade: #3a7be0;
-  --ion-color-primary-tint: #5598ff;
-  --ion-color-secondary: #50c8ff;
-  --ion-color-secondary-rgb: 80,200,255;
-  --ion-color-secondary-contrast: #ffffff;
-  --ion-color-secondary-contrast-rgb: 255,255,255;
-  --ion-color-secondary-shade: #46b0e0;
-  --ion-color-secondary-tint: #62ceff;
-  --ion-color-tertiary: #6a64ff;
-  --ion-color-tertiary-rgb: 106,100,255;
-  --ion-color-tertiary-contrast: #ffffff;
-  --ion-color-tertiary-contrast-rgb: 255,255,255;
-  --ion-color-tertiary-shade: #5d58e0;
-  --ion-color-tertiary-tint: #7974ff;
-  --ion-color-success: #2fdf75;
-  --ion-color-success-rgb: 47,223,117;
-  --ion-color-success-contrast: #000000;
-  --ion-color-success-contrast-rgb: 0,0,0;
-  --ion-color-success-shade: #29c467;
-  --ion-color-success-tint: #44e283;
-  --ion-color-warning: #ffd534;
-  --ion-color-warning-rgb: 255,213,52;
-  --ion-color-warning-contrast: #000000;
-  --ion-color-warning-contrast-rgb: 0,0,0;
-  --ion-color-warning-shade: #e0bb2e;
-  --ion-color-warning-tint: #ffd948;
-  --ion-color-danger: #ff4961;
-  --ion-color-danger-rgb: 255,73,97;
-  --ion-color-danger-contrast: #ffffff;
-  --ion-color-danger-contrast-rgb: 255,255,255;
-  --ion-color-danger-shade: #e04055;
-  --ion-color-danger-tint: #ff5b71;
-  --ion-color-dark: #f4f5f8;
-  --ion-color-dark-rgb: 244,245,248;
-  --ion-color-dark-contrast: #000000;
-  --ion-color-dark-contrast-rgb: 0,0,0;
-  --ion-color-dark-shade: #d7d8da;
-  --ion-color-dark-tint: #f5f6f9;
-  --ion-color-medium: #989aa2;
-  --ion-color-medium-rgb: 152,154,162;
-  --ion-color-medium-contrast: #000000;
-  --ion-color-medium-contrast-rgb: 0,0,0;
-  --ion-color-medium-shade: #86888f;
-  --ion-color-medium-tint: #a2a4ab;
-  --ion-color-light: #222428;
-  --ion-color-light-rgb: 34,36,40;
-  --ion-color-light-contrast: #ffffff;
-  --ion-color-light-contrast-rgb: 255,255,255;
-  --ion-color-light-shade: #1e2023;
-  --ion-color-light-tint: #383a3e;
-}
-
-.playground--theme-dark.playground--mode-ios {
-  --ion-background-color: #000000;
-  --ion-background-color-rgb: 0,0,0;
-  --ion-text-color: #ffffff;
-  --ion-text-color-rgb: 255,255,255;
-  --ion-color-step-50: #0d0d0d;
-  --ion-color-step-100: #1a1a1a;
-  --ion-color-step-150: #262626;
-  --ion-color-step-200: #333333;
-  --ion-color-step-250: #404040;
-  --ion-color-step-300: #4d4d4d;
-  --ion-color-step-350: #595959;
-  --ion-color-step-400: #666666;
-  --ion-color-step-450: #737373;
-  --ion-color-step-500: #808080;
-  --ion-color-step-550: #8c8c8c;
-  --ion-color-step-600: #999999;
-  --ion-color-step-650: #a6a6a6;
-  --ion-color-step-700: #b3b3b3;
-  --ion-color-step-750: #bfbfbf;
-  --ion-color-step-800: #cccccc;
-  --ion-color-step-850: #d9d9d9;
-  --ion-color-step-900: #e6e6e6;
-  --ion-color-step-950: #f2f2f2;
-  --ion-toolbar-background: #0d0d0d;
-  --ion-item-background: #000000;
-  --ion-card-background: #1c1c1d;
-}
-
-.playground--theme-dark.playground--mode-md {
-  --ion-background-color: #121212;
-  --ion-background-color-rgb: 18,18,18;
-  --ion-text-color: #ffffff;
-  --ion-text-color-rgb: 255,255,255;
-  --ion-border-color: #222222;
-  --ion-color-step-50: #1e1e1e;
-  --ion-color-step-100: #2a2a2a;
-  --ion-color-step-150: #363636;
-  --ion-color-step-200: #414141;
-  --ion-color-step-250: #4d4d4d;
-  --ion-color-step-300: #595959;
-  --ion-color-step-350: #656565;
-  --ion-color-step-400: #717171;
-  --ion-color-step-450: #7d7d7d;
-  --ion-color-step-500: #898989;
-  --ion-color-step-550: #949494;
-  --ion-color-step-600: #a0a0a0;
-  --ion-color-step-650: #acacac;
-  --ion-color-step-700: #b8b8b8;
-  --ion-color-step-750: #c4c4c4;
-  --ion-color-step-800: #d0d0d0;
-  --ion-color-step-850: #dbdbdb;
-  --ion-color-step-900: #e7e7e7;
-  --ion-color-step-950: #f3f3f3;
-  --ion-item-background: #1e1e1e;
-  --ion-toolbar-background: #1f1f1f;
-  --ion-tab-bar-background: #1f1f1f;
-  --ion-card-background: #1e1e1e;
-}
-
-.playground__preview {
-  position: relative;
-  margin: 18px 0;
-  background-image: radial-gradient(#f1f2f6 2px, #fbfbfd 2px);
-  background-size: 12px 12px;
-  border: 2px solid #dee3ea;
+/* Playground container includes the toolbar and preview container */
+.playground__container {
+  border: 1px solid var(--playground-separator-color);
   border-radius: 16px;
-  min-height: 200px;
+}
 
+/* Playground preview contains the demo example*/
+.playground__preview {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  align-content: center;
   justify-content: center;
-}
 
-.playground--theme-dark .playground__preview {
-  background-image: radial-gradient(var(--ion-color-step-50) 2px, var(--ion-background-color) 2px);
-  border-color: var(--ion-color-step-150);
-}
-
-.playground__control-group {
-  display: flex;
-  border-right: 2px solid #dee3ea;
-  padding-left: 6px;
-  min-height: 26px;
-}
-
-.playground__control-group .playground__control-button:last-child {
-  margin-right: 6px;
-}
-
-.playground__code-block {
-  height: 0px;
-  overflow: hidden;
-}
-
-.playground__code-block--expanded {
-  height: initial;
+  margin: 18px 0;
+  padding: 16px 0;
 }
 
 .playground__control-toolbar {
   display: flex;
-  border-top: 2px solid #e9edf3;
   align-items: center;
-  padding-right: 6px;
-  padding-top: 12px;
-  padding-bottom: 6px;
+
+  padding: 8px 12px;
+
+  border-bottom: 1px solid var(--playground-separator-color);
+
   overflow-y: auto;
   scrollbar-width: none;
-  transition: background .2s;
 }
 
+/* Hides the horizontal scrollbar when the toolbar has horizontal overflow */
 .playground__control-toolbar::-webkit-scrollbar {
   width: 0;
   background: transparent;
   height: 0;
 }
 
-.playground__control-button {
-  color: var(--playground-btn-color);
+/* Playground control group contains a section of buttons in the toolbar */
+.playground__control-group {
+  display: flex;
+  min-height: 24px;
+}
 
-  appearance: none;
-  text-transform: uppercase;;
-  background-color: transparent;
-  border: none;
-  border-radius: 16px;
-  cursor: pointer;
-  font-family: var(--font-family);
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: .08em;
-  min-width: 44px;
-  transition: background-color .2s, color .2s;
-  padding: 0 12px 0;
+.playground__control-group + .playground__control-group {
+  padding-left: 12px;
+}
+
+.playground__control-group + .playground__control-group:not(.playground__control-group--end) {
+  /* Only render the separator between sections when there is an accompanying section */
+  border-left: 1px solid var(--playground-separator-color);
+}
+
+.playground__control-group .playground__control-button:last-child {
+  margin-right: 12px;
+}
+
+.playground__control-group--end {
+  margin-left: auto;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(4, auto);
+}
+
+.playground__control-button {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-}
+  padding: 6px 10px;
 
-.playground__control-button svg {
-  height: 100%;
-  max-height: 12px;
-  width: auto;
-  fill: var(--playground-btn-color);
-  transition: fill .2s;
+  color: var(--playground-btn-color);
+  background-color: transparent;
+  border: none;
+  border-radius: 100px;
+
+  font-size: 12px;
+
+  appearance: none;
+  cursor: pointer;
+  transition: background-color .2s, color .2s;
 }
 
 .playground__control-button--selected {
   background-color: var(--playground-btn-selected-background);
   color: var(--playground-btn-selected-color);
+  font-weight: 500;
 }
 
-.playground__control-button--selected svg {
-  fill: #428cff;
-}
+/* Icon buttons at the end of the toolbar */
 
-.playground--theme-dark .code-block-source__button, .playground--theme-dark .code-block-feedback__button {
-  background: #34302f;
-}
+.playground__icon-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;;
 
-.code-block-source__button {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  border: none;
+  stroke: var(--playground-btn-icon-color);
+  background: transparent;
 
-  background: #fbfbfd;
-  color: var(--playground-btn-color);
-  border-radius: 12px 0 12px 0;
-  padding: 4px 8px;
-  font-size: 12px;
-  letter-spacing: -.02em;
+  width: 24px;
+  height: 24px;
+  padding: 8px 5px;
+
+  border: 0;
+  border-radius: 100px;
+
   cursor: pointer;
-}
-
-.code-block-feedback__button {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  border: none;
-
-  background: #fbfbfd;
-  color: var(--playground-btn-color);
-  border-radius: 0 12px 0 12px;
-  padding: 4px 8px;
-  font-size: 12px;
-  letter-spacing: -.02em;
-}
-
-.playground__control-button--editor {
-  padding: 0.5rem 1rem;
-  color: #428cff;
-  background:#5598ff29;
-  font-weight: 600;
-  letter-spacing: .08em;
-
-  margin-left: auto;
-  border: none;
-  cursor: pointer;
-
+  appearance: none;
   transition: background .2s;
 }
 
-.playground__control-button--editor:hover {
-  background:#5598ff38;
+.playground__icon-button:hover {
+  background: var(--playground-btn-icon-hover-background);
 }
 
-/* Disable Docusaurus style conflicts */
+/* The code block example that users can copy to clipboard */
+.playground__code-block {
+  /* Height is set to zero instead of display: none so that outerText includes line breaks */
+  height: 0px;
+  overflow: hidden;
+}
 
+.playground__code-block--expanded {
+  height: initial;
+  margin-top: 16px;
+}
+
+/* Overrides Docusaurus codeblock styles */
 pre[class*=language-] {
   border-radius: 16px;
 }
 
-.button {
-  padding: initial;
-  text-align: initial;
-  vertical-align: initial;
-  display: inline-block;
-  white-space: initial;
+/* Disable Docusaurus style conflicts */
+.playground iframe {
+  box-shadow: none;
+  background-color: transparent;
+}
+
+/* Tooltip styling */
+.tippy-box {
+  background-color: var(--playground-tooltip-background);
+  border-radius: 8px;
   line-height: initial;
-  background-color: initial;
-  border-color: initial;
-  border-radius: initial;
-  border-style: initial;
-  font-size: initial;
-  color: var(--color);
-  font-weight: initial;
+  font-size: 11px;
 }
 
-/* Fixes ion-button expand conflict */
-.button.button-full, .button.button-block {
-  display: block;
-}
-
-.button:hover {
-  color: initial;
+.tippy-box .tippy-content {
+  padding: 8px 10px;
 }

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -1,0 +1,245 @@
+
+.playground {
+  padding: 0.75rem;
+  border: 1px solid #dee3ea;
+  border-radius: 12px;
+  position: relative;
+  overflow: hidden;
+  background: var(--ion-background-color);
+}
+
+.playground--theme-dark {
+  --ion-color-primary: #428cff;
+  --ion-color-primary-rgb: 66,140,255;
+  --ion-color-primary-contrast: #ffffff;
+  --ion-color-primary-contrast-rgb: 255,255,255;
+  --ion-color-primary-shade: #3a7be0;
+  --ion-color-primary-tint: #5598ff;
+  --ion-color-secondary: #50c8ff;
+  --ion-color-secondary-rgb: 80,200,255;
+  --ion-color-secondary-contrast: #ffffff;
+  --ion-color-secondary-contrast-rgb: 255,255,255;
+  --ion-color-secondary-shade: #46b0e0;
+  --ion-color-secondary-tint: #62ceff;
+  --ion-color-tertiary: #6a64ff;
+  --ion-color-tertiary-rgb: 106,100,255;
+  --ion-color-tertiary-contrast: #ffffff;
+  --ion-color-tertiary-contrast-rgb: 255,255,255;
+  --ion-color-tertiary-shade: #5d58e0;
+  --ion-color-tertiary-tint: #7974ff;
+  --ion-color-success: #2fdf75;
+  --ion-color-success-rgb: 47,223,117;
+  --ion-color-success-contrast: #000000;
+  --ion-color-success-contrast-rgb: 0,0,0;
+  --ion-color-success-shade: #29c467;
+  --ion-color-success-tint: #44e283;
+  --ion-color-warning: #ffd534;
+  --ion-color-warning-rgb: 255,213,52;
+  --ion-color-warning-contrast: #000000;
+  --ion-color-warning-contrast-rgb: 0,0,0;
+  --ion-color-warning-shade: #e0bb2e;
+  --ion-color-warning-tint: #ffd948;
+  --ion-color-danger: #ff4961;
+  --ion-color-danger-rgb: 255,73,97;
+  --ion-color-danger-contrast: #ffffff;
+  --ion-color-danger-contrast-rgb: 255,255,255;
+  --ion-color-danger-shade: #e04055;
+  --ion-color-danger-tint: #ff5b71;
+  --ion-color-dark: #f4f5f8;
+  --ion-color-dark-rgb: 244,245,248;
+  --ion-color-dark-contrast: #000000;
+  --ion-color-dark-contrast-rgb: 0,0,0;
+  --ion-color-dark-shade: #d7d8da;
+  --ion-color-dark-tint: #f5f6f9;
+  --ion-color-medium: #989aa2;
+  --ion-color-medium-rgb: 152,154,162;
+  --ion-color-medium-contrast: #000000;
+  --ion-color-medium-contrast-rgb: 0,0,0;
+  --ion-color-medium-shade: #86888f;
+  --ion-color-medium-tint: #a2a4ab;
+  --ion-color-light: #222428;
+  --ion-color-light-rgb: 34,36,40;
+  --ion-color-light-contrast: #ffffff;
+  --ion-color-light-contrast-rgb: 255,255,255;
+  --ion-color-light-shade: #1e2023;
+  --ion-color-light-tint: #383a3e;
+}
+
+.playground--theme-dark.playground--mode-ios {
+  --ion-background-color: #000000;
+  --ion-background-color-rgb: 0,0,0;
+  --ion-text-color: #ffffff;
+  --ion-text-color-rgb: 255,255,255;
+  --ion-color-step-50: #0d0d0d;
+  --ion-color-step-100: #1a1a1a;
+  --ion-color-step-150: #262626;
+  --ion-color-step-200: #333333;
+  --ion-color-step-250: #404040;
+  --ion-color-step-300: #4d4d4d;
+  --ion-color-step-350: #595959;
+  --ion-color-step-400: #666666;
+  --ion-color-step-450: #737373;
+  --ion-color-step-500: #808080;
+  --ion-color-step-550: #8c8c8c;
+  --ion-color-step-600: #999999;
+  --ion-color-step-650: #a6a6a6;
+  --ion-color-step-700: #b3b3b3;
+  --ion-color-step-750: #bfbfbf;
+  --ion-color-step-800: #cccccc;
+  --ion-color-step-850: #d9d9d9;
+  --ion-color-step-900: #e6e6e6;
+  --ion-color-step-950: #f2f2f2;
+  --ion-toolbar-background: #0d0d0d;
+  --ion-item-background: #000000;
+  --ion-card-background: #1c1c1d;
+}
+
+.playground--theme-dark.playground--mode-md {
+  --ion-background-color: #121212;
+  --ion-background-color-rgb: 18,18,18;
+  --ion-text-color: #ffffff;
+  --ion-text-color-rgb: 255,255,255;
+  --ion-border-color: #222222;
+  --ion-color-step-50: #1e1e1e;
+  --ion-color-step-100: #2a2a2a;
+  --ion-color-step-150: #363636;
+  --ion-color-step-200: #414141;
+  --ion-color-step-250: #4d4d4d;
+  --ion-color-step-300: #595959;
+  --ion-color-step-350: #656565;
+  --ion-color-step-400: #717171;
+  --ion-color-step-450: #7d7d7d;
+  --ion-color-step-500: #898989;
+  --ion-color-step-550: #949494;
+  --ion-color-step-600: #a0a0a0;
+  --ion-color-step-650: #acacac;
+  --ion-color-step-700: #b8b8b8;
+  --ion-color-step-750: #c4c4c4;
+  --ion-color-step-800: #d0d0d0;
+  --ion-color-step-850: #dbdbdb;
+  --ion-color-step-900: #e7e7e7;
+  --ion-color-step-950: #f3f3f3;
+  --ion-item-background: #1e1e1e;
+  --ion-toolbar-background: #1f1f1f;
+  --ion-tab-bar-background: #1f1f1f;
+  --ion-card-background: #1e1e1e;
+}
+
+.playground__preview {
+  margin: 18px 0;
+}
+
+.playground__control-group {
+  display: flex;
+  border-right: 2px solid #dee3ea;
+  padding-left: 6px;
+}
+
+.playground__control-group .playground__control-button:last-child {
+  margin-right: 6px;
+}
+
+.playground__code-block {
+  height: 0px;
+  overflow: hidden;
+}
+
+.playground__code-block--expanded {
+  height: initial;
+}
+
+.playground__control-toolbar {
+  background: #ecf0f5;
+  display: flex;
+  align-items: center;
+  border-radius: 16px;
+  padding-right: 6px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  height: 34px;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.playground__control-toolbar::-webkit-scrollbar {
+  width: 0;
+  background: transparent;
+  height: 0;
+}
+
+.playground__control-button {
+  appearance: none;
+  background-color: transparent;
+  border: none;
+  border-radius: 16px;
+  color: #5b708b;
+  cursor: pointer;
+  font-family: var(--font-family);
+  font-size: 11px;
+  letter-spacing: -.02em;
+  min-width: 44px;
+  height: 22px;
+  line-height: 21px;
+  transition: background-color .2s,color .2s;
+  padding: 0 12px 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.playground__control-button svg {
+  height: 100%;
+  max-height: 12px;
+  width: auto;
+}
+
+.playground__control-button--selected {
+  background-color: #fff;
+  box-shadow: 0 2px 3px rgb(0 16 46 / 15%);
+  color: #000;
+  font-weight: 600;
+}
+
+.code-block-source__button {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  border: none;
+
+  background-color: #dee3ea;
+  color: #5b708b;
+  border-radius: 6px 0 0 0px;
+  padding: 4px 8px;
+  font-size: 12px;
+  letter-spacing: -.02em;
+
+}
+
+.playground__control-button--editor {
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+
+/* Disable Docusaurus style conflicts */
+
+.button {
+  padding: initial;
+  text-align: initial;
+  vertical-align: initial;
+  white-space: initial;
+  line-height: initial;
+  background-color: initial;
+  border-color: initial;
+  border-radius: initial;
+  border-style: initial;
+  color: initial;
+  font-size: initial;
+  font-weight: initial;
+}
+
+.button:hover {
+  color: initial;
+}

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -1,22 +1,14 @@
 
 .playground {
-  overflow: hidden;
-
-  --playground-toolbar-background: #ecf0f5;
-
-  --playground-btn-color: #5b708b;
+  --playground-btn-color: #92a1b3;
   --playground-btn-background: #000;
-  --playground-btn-selected-color: #000;
+  --playground-btn-selected-color: #428cff;
   --playground-btn-selected-background: #fff;
 
+  overflow: hidden;
 }
 
 .playground--theme-dark {
-  --playground-toolbar-background: #34302f;
-  --playground-btn-color: #fff;
-  --playground-btn-selected-background: #424241;
-  --playground-btn-selected-color: #fff;
-
   --code-block-bg-c: #1e2a3a;
   --ifm-pre-color: white;
 
@@ -161,6 +153,7 @@
   display: flex;
   border-right: 2px solid #dee3ea;
   padding-left: 6px;
+  min-height: 26px;
 }
 
 .playground__control-group .playground__control-button:last-child {
@@ -177,14 +170,12 @@
 }
 
 .playground__control-toolbar {
-  background: var(--playground-toolbar-background);
   display: flex;
+  border-top: 2px solid #e9edf3;
   align-items: center;
-  border-radius: 16px;
   padding-right: 6px;
-  padding-top: 6px;
+  padding-top: 12px;
   padding-bottom: 6px;
-  height: 34px;
   overflow-y: auto;
   scrollbar-width: none;
   transition: background .2s;
@@ -197,18 +188,19 @@
 }
 
 .playground__control-button {
+  color: var(--playground-btn-color);
+
   appearance: none;
+  text-transform: uppercase;;
   background-color: transparent;
   border: none;
   border-radius: 16px;
-  color: var(--playground-btn-color);
   cursor: pointer;
   font-family: var(--font-family);
-  font-size: 11px;
-  letter-spacing: -.02em;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: .08em;
   min-width: 44px;
-  height: 22px;
-  line-height: 21px;
   transition: background-color .2s, color .2s;
   padding: 0 12px 0;
   display: inline-flex;
@@ -227,12 +219,15 @@
 .playground__control-button--selected {
   background-color: var(--playground-btn-selected-background);
   color: var(--playground-btn-selected-color);
-  box-shadow: 0 2px 3px rgb(0 16 46 / 15%);
-  font-weight: 600;
+}
+
+.playground__control-button--selected svg {
+  fill: #428cff;
 }
 
 .playground--theme-dark .code-block-source__button {
-  background: var(--playground-toolbar-background);
+  cursor: pointer;
+  background: #34302f;
 }
 
 .code-block-source__button {
@@ -251,12 +246,22 @@
 }
 
 .playground__control-button--editor {
+  padding: 0.5rem 1rem;
+  color: #428cff;
+  background:#5598ff29;
+  font-weight: 600;
+  letter-spacing: .08em;
+
   margin-left: auto;
   border: none;
-  background: transparent;
   cursor: pointer;
+
+  transition: background .2s;
 }
 
+.playground__control-button--editor:hover {
+  background:#5598ff38;
+}
 
 /* Disable Docusaurus style conflicts */
 

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -6,6 +6,9 @@
   position: relative;
   overflow: hidden;
   background: var(--ion-background-color);
+
+  --code-block-bg-c: #1e2a3a;
+  --ifm-pre-color: white;
 }
 
 .playground--theme-dark {
@@ -127,6 +130,22 @@
 
 .playground__preview {
   margin: 18px 0;
+  background-image: radial-gradient(#f1f2f6 2px, #fbfbfd 2px);
+  background-size: 12px 12px;
+  border: 2px solid #dee3ea;
+  border-radius: 16px;
+  min-height: 200px;
+
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+
+.playground--theme-dark .playground__preview {
+  background-image: radial-gradient(var(--ion-color-step-50) 2px, var(--ion-background-color) 2px);
+  border-color: var(--ion-color-step-150);
 }
 
 .playground__control-group {
@@ -229,6 +248,7 @@
   padding: initial;
   text-align: initial;
   vertical-align: initial;
+  display: inline-block;
   white-space: initial;
   line-height: initial;
   background-color: initial;
@@ -238,6 +258,11 @@
   color: initial;
   font-size: initial;
   font-weight: initial;
+}
+
+/* Fixes ion-button expand conflict */
+.button.button-full, .button.button-block {
+  display: block;
 }
 
 .button:hover {

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -1,17 +1,25 @@
 
 .playground {
-  padding: 0.75rem;
-  border: 1px solid #dee3ea;
-  border-radius: 12px;
-  position: relative;
   overflow: hidden;
-  background: var(--ion-background-color);
 
-  --code-block-bg-c: #1e2a3a;
-  --ifm-pre-color: white;
+  --playground-toolbar-background: #ecf0f5;
+
+  --playground-btn-color: #5b708b;
+  --playground-btn-background: #000;
+  --playground-btn-selected-color: #000;
+  --playground-btn-selected-background: #fff;
+
 }
 
 .playground--theme-dark {
+  --playground-toolbar-background: #34302f;
+  --playground-btn-color: #fff;
+  --playground-btn-selected-background: #424241;
+  --playground-btn-selected-color: #fff;
+
+  --code-block-bg-c: #1e2a3a;
+  --ifm-pre-color: white;
+
   --ion-color-primary: #428cff;
   --ion-color-primary-rgb: 66,140,255;
   --ion-color-primary-contrast: #ffffff;
@@ -129,6 +137,7 @@
 }
 
 .playground__preview {
+  position: relative;
   margin: 18px 0;
   background-image: radial-gradient(#f1f2f6 2px, #fbfbfd 2px);
   background-size: 12px 12px;
@@ -168,7 +177,7 @@
 }
 
 .playground__control-toolbar {
-  background: #ecf0f5;
+  background: var(--playground-toolbar-background);
   display: flex;
   align-items: center;
   border-radius: 16px;
@@ -178,6 +187,7 @@
   height: 34px;
   overflow-y: auto;
   scrollbar-width: none;
+  transition: background .2s;
 }
 
 .playground__control-toolbar::-webkit-scrollbar {
@@ -191,7 +201,7 @@
   background-color: transparent;
   border: none;
   border-radius: 16px;
-  color: #5b708b;
+  color: var(--playground-btn-color);
   cursor: pointer;
   font-family: var(--font-family);
   font-size: 11px;
@@ -199,7 +209,7 @@
   min-width: 44px;
   height: 22px;
   line-height: 21px;
-  transition: background-color .2s,color .2s;
+  transition: background-color .2s, color .2s;
   padding: 0 12px 0;
   display: inline-flex;
   justify-content: center;
@@ -210,13 +220,19 @@
   height: 100%;
   max-height: 12px;
   width: auto;
+  fill: var(--playground-btn-color);
+  transition: fill .2s;
 }
 
 .playground__control-button--selected {
-  background-color: #fff;
+  background-color: var(--playground-btn-selected-background);
+  color: var(--playground-btn-selected-color);
   box-shadow: 0 2px 3px rgb(0 16 46 / 15%);
-  color: #000;
   font-weight: 600;
+}
+
+.playground--theme-dark .code-block-source__button {
+  background: var(--playground-toolbar-background);
 }
 
 .code-block-source__button {
@@ -225,9 +241,9 @@
   right: 0;
   border: none;
 
-  background-color: #dee3ea;
-  color: #5b708b;
-  border-radius: 6px 0 0 0px;
+  background: #fbfbfd;
+  color: var(--playground-btn-color);
+  border-radius: 12px 0 12px 0;
   padding: 4px 8px;
   font-size: 12px;
   letter-spacing: -.02em;
@@ -244,6 +260,10 @@
 
 /* Disable Docusaurus style conflicts */
 
+pre[class*=language-] {
+  border-radius: 16px;
+}
+
 .button {
   padding: initial;
   text-align: initial;
@@ -255,8 +275,8 @@
   border-color: initial;
   border-radius: initial;
   border-style: initial;
-  color: initial;
   font-size: initial;
+  color: var(--color);
   font-weight: initial;
 }
 

--- a/static/code/button/usage/basic/angular.md
+++ b/static/code/button/usage/basic/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-button>Default</ion-button>
+```

--- a/static/code/button/usage/basic/index.html
+++ b/static/code/button/usage/basic/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button</title>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-button>Default</ion-button>
+
+  <script>
+    window.addEventListener('load', function () {
+      let height = document.getElementsByTagName('html')[0].scrollHeight;
+      window.top.postMessage(JSON.stringify({
+        type: 'height',
+        data: height
+      }), '*');
+    });
+  </script>
+</body>
+
+</html>

--- a/static/code/button/usage/basic/javascript.md
+++ b/static/code/button/usage/basic/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-button>Default</ion-button>
+```

--- a/static/code/button/usage/basic/react.md
+++ b/static/code/button/usage/basic/react.md
@@ -1,0 +1,10 @@
+```tsx
+import React from "react";
+import { IonButton } from "@ionic/react";
+
+function Example() {
+  return <IonButton>Default</IonButton>;
+}
+
+export default Example;
+```

--- a/static/code/button/usage/basic/vue.md
+++ b/static/code/button/usage/basic/vue.md
@@ -1,0 +1,13 @@
+```html
+<template>
+  <ion-button>Default</ion-button>
+</template>
+
+<script>
+  import { IonButton } from "@ionic/vue";
+
+  export default defineComponent({
+    components: { IonButton },
+  });
+</script>
+```

--- a/static/code/button/usage/color/angular.md
+++ b/static/code/button/usage/color/angular.md
@@ -1,0 +1,11 @@
+```html
+<ion-button>Default</ion-button>
+<ion-button color="secondary">Secondary</ion-button>
+<ion-button color="tertiary">Tertiary</ion-button>
+<ion-button color="success">Success</ion-button>
+<ion-button color="warning">Warning</ion-button>
+<ion-button color="danger">Danger</ion-button>
+<ion-button color="light">Light</ion-button>
+<ion-button color="medium">Medium</ion-button>
+<ion-button color="dark">Dark</ion-button>
+```

--- a/static/code/button/usage/color/index.html
+++ b/static/code/button/usage/color/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button: Color</title>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-button>Default</ion-button>
+  <ion-button color="secondary">Secondary</ion-button>
+  <ion-button color="tertiary">Tertiary</ion-button>
+  <ion-button color="success">Success</ion-button>
+  <ion-button color="warning">Warning</ion-button>
+  <ion-button color="danger">Danger</ion-button>
+  <ion-button color="light">Light</ion-button>
+  <ion-button color="medium">Medium</ion-button>
+  <ion-button color="dark">Dark</ion-button>
+
+  <script>
+    window.addEventListener('load', function () {
+      let height = document.getElementsByTagName('html')[0].scrollHeight;
+      window.top.postMessage(JSON.stringify({
+        type: 'height',
+        data: height
+      }), '*');
+    });
+  </script>
+</body>
+
+</html>

--- a/static/code/button/usage/color/javascript.md
+++ b/static/code/button/usage/color/javascript.md
@@ -1,0 +1,11 @@
+```html
+<ion-button>Default</ion-button>
+<ion-button color="secondary">Secondary</ion-button>
+<ion-button color="tertiary">Tertiary</ion-button>
+<ion-button color="success">Success</ion-button>
+<ion-button color="warning">Warning</ion-button>
+<ion-button color="danger">Danger</ion-button>
+<ion-button color="light">Light</ion-button>
+<ion-button color="medium">Medium</ion-button>
+<ion-button color="dark">Dark</ion-button>
+```

--- a/static/code/button/usage/color/react.md
+++ b/static/code/button/usage/color/react.md
@@ -1,0 +1,22 @@
+```tsx
+import React from "react";
+import { IonButton } from "@ionic/react";
+
+function Example() {
+  return (
+    <>
+      <IonButton>Default</IonButton>
+      <IonButton color="secondary">Secondary</IonButton>
+      <IonButton color="tertiary">Tertiary</IonButton>
+      <IonButton color="success">Success</IonButton>
+      <IonButton color="warning">Warning</IonButton>
+      <IonButton color="danger">Danger</IonButton>
+      <IonButton color="light">Light</IonButton>
+      <IonButton color="medium">Medium</IonButton>
+      <IonButton color="dark">Dark</IonButton>
+    </>
+  );
+}
+
+export default Example;
+```

--- a/static/code/button/usage/color/vue.md
+++ b/static/code/button/usage/color/vue.md
@@ -1,0 +1,21 @@
+```html
+<template>
+  <ion-button>Default</ion-button>
+  <ion-button color="secondary">Secondary</ion-button>
+  <ion-button color="tertiary">Tertiary</ion-button>
+  <ion-button color="success">Success</ion-button>
+  <ion-button color="warning">Warning</ion-button>
+  <ion-button color="danger">Danger</ion-button>
+  <ion-button color="light">Light</ion-button>
+  <ion-button color="medium">Medium</ion-button>
+  <ion-button color="dark">Dark</ion-button>
+</template>
+
+<script>
+  import { IonButton } from "@ionic/vue";
+
+  export default defineComponent({
+    components: { IonButton },
+  });
+</script>
+```

--- a/static/code/button/usage/expand/index.html
+++ b/static/code/button/usage/expand/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button: Expand</title>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-button expand="full">Full</ion-button>
+  <ion-button expand="block">Block</ion-button>
+
+  <script>
+    window.addEventListener('load', function () {
+      let height = document.getElementsByTagName('html')[0].scrollHeight;
+      window.top.postMessage(JSON.stringify({
+        type: 'height',
+        data: height
+      }), '*');
+    });
+  </script>
+</body>
+
+</html>

--- a/static/code/button/usage/expand/javascript.md
+++ b/static/code/button/usage/expand/javascript.md
@@ -1,0 +1,4 @@
+```html
+<ion-button expand="full">Full</ion-button>
+<ion-button expand="block">Block</ion-button>
+```

--- a/static/code/button/usage/fill/index.html
+++ b/static/code/button/usage/fill/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button: Fill</title>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-button fill="clear">Clear</ion-button>
+  <ion-button fill="outline">Outline</ion-button>
+  <ion-button fill="solid">Solid</ion-button>
+
+  <script>
+    window.addEventListener('load', function () {
+      let height = document.getElementsByTagName('html')[0].scrollHeight;
+      window.top.postMessage(JSON.stringify({
+        type: 'height',
+        data: height
+      }), '*');
+    });
+  </script>
+</body>
+
+</html>

--- a/static/code/button/usage/fill/javascript.md
+++ b/static/code/button/usage/fill/javascript.md
@@ -1,0 +1,5 @@
+```html
+<ion-button fill="clear">Clear</ion-button>
+<ion-button fill="outline">Outline</ion-button>
+<ion-button fill="solid">Solid</ion-button>
+```

--- a/static/code/button/usage/size/index.html
+++ b/static/code/button/usage/size/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Button: Size</title>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-button size="small">Small</ion-button>
+  <ion-button>Default</ion-button>
+  <ion-button size="large">Large</ion-button>
+
+  <script>
+    window.addEventListener('load', function () {
+      let height = document.getElementsByTagName('html')[0].scrollHeight;
+      window.top.postMessage(JSON.stringify({
+        type: 'height',
+        data: height
+      }), '*');
+    });
+  </script>
+</body>
+
+</html>

--- a/static/code/button/usage/size/javascript.md
+++ b/static/code/button/usage/size/javascript.md
@@ -1,0 +1,5 @@
+```html
+<ion-button size="small">Small</ion-button>
+<ion-button>Default</ion-button>
+<ion-button size="large">Large</ion-button>
+```

--- a/static/code/stackblitz/angular.md
+++ b/static/code/stackblitz/angular.md
@@ -1,0 +1,28 @@
+```ts
+// app.js
+const { Component, VERSION } = ng.core;
+
+@Component({
+  selector: "app-root",
+  template: `{{ template }}`,
+})
+class AppComponent {}
+
+// main.js
+const { BrowserModule } = ng.platformBrowser;
+const { NgModule } = ng.core;
+const { CommonModule } = ng.common;
+
+@NgModule({
+  imports: [BrowserModule, CommonModule],
+  declarations: [AppComponent],
+  bootstrap: [AppComponent],
+})
+class AppModule {}
+
+const { platformBrowserDynamic } = ng.platformBrowserDynamic;
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));
+```

--- a/static/code/stackblitz/angular/angular.json
+++ b/static/code/stackblitz/angular/angular.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "app": {
+      "root": "",
+      "sourceRoot": "src",
+      "projectType": "application",
+      "prefix": "app",
+      "schematics": {},
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "src/tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "app:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "app:build:production"
+            }
+          }
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "app:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "src/tsconfig.spec.json",
+            "karmaConfig": "src/karma.conf.js",
+            "styles": ["src/styles.css"],
+            "scripts": [],
+            "assets": ["src/favicon.ico", "src/assets"]
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": ["src/tsconfig.app.json", "src/tsconfig.spec.json"],
+            "exclude": ["**/node_modules/**"]
+          }
+        }
+      }
+    },
+    "app-e2e": {
+      "root": "e2e/",
+      "projectType": "application",
+      "prefix": "",
+      "architect": {
+        "e2e": {
+          "builder": "@angular-devkit/build-angular:protractor",
+          "options": {
+            "protractorConfig": "e2e/protractor.conf.js",
+            "devServerTarget": "app:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "app:serve:production"
+            }
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": "e2e/tsconfig.e2e.json",
+            "exclude": ["**/node_modules/**"]
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "app"
+}

--- a/static/code/stackblitz/angular/app.component.md
+++ b/static/code/stackblitz/angular/app.component.md
@@ -1,0 +1,9 @@
+```ts
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-root",
+  templateUrl: "app.component.html",
+})
+export class AppComponent {}
+```

--- a/static/code/stackblitz/angular/app.module.md
+++ b/static/code/stackblitz/angular/app.module.md
@@ -1,0 +1,15 @@
+```ts
+import { NgModule } from "@angular/core";
+import { BrowserModule } from "@angular/platform-browser";
+
+import { IonicModule } from "@ionic/angular";
+
+import { AppComponent } from "./app.component";
+
+@NgModule({
+  imports: [BrowserModule, IonicModule.forRoot({})],
+  declarations: [AppComponent],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```

--- a/static/code/stackblitz/angular/main.md
+++ b/static/code/stackblitz/angular/main.md
@@ -1,0 +1,9 @@
+```ts
+import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
+
+import { AppModule } from "./app/app.module";
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));
+```

--- a/static/code/stackblitz/angular/styles.md
+++ b/static/code/stackblitz/angular/styles.md
@@ -1,0 +1,16 @@
+```css
+/* Core CSS required for Ionic components to work properly */
+@import "~@ionic/angular/css/core.css";
+
+/* Basic CSS for apps built with Ionic */
+@import "~@ionic/angular/css/normalize.css";
+@import "~@ionic/angular/css/structure.css";
+@import "~@ionic/angular/css/typography.css";
+
+/* Optional CSS utils that can be commented out */
+@import "~@ionic/angular/css/padding.css";
+@import "~@ionic/angular/css/float-elements.css";
+@import "~@ionic/angular/css/text-alignment.css";
+@import "~@ionic/angular/css/text-transformation.css";
+@import "~@ionic/angular/css/flex-utils.css";
+```

--- a/static/code/stackblitz/html/index.html.md
+++ b/static/code/stackblitz/html/index.html.md
@@ -1,0 +1,12 @@
+```html
+<html>
+  <head>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.skypack.dev/@ionic/core/css/core.css"
+    />
+  </head>
+  <body></body>
+</html>
+```

--- a/static/code/stackblitz/html/index.ts.md
+++ b/static/code/stackblitz/html/index.ts.md
@@ -1,0 +1,5 @@
+```ts
+import { defineCustomElements } from "@ionic/core/loader";
+
+defineCustomElements();
+```

--- a/static/code/stackblitz/react/app.md
+++ b/static/code/stackblitz/react/app.md
@@ -1,0 +1,18 @@
+```tsx
+import React from "react";
+import { setupIonicReact, IonApp } from "@ionic/react";
+
+/* Core CSS required for Ionic components to work properly */
+import "@ionic/react/css/core.css";
+
+/* Basic CSS for apps built with Ionic */
+import "@ionic/react/css/normalize.css";
+import "@ionic/react/css/structure.css";
+import "@ionic/react/css/typography.css";
+
+setupIonicReact();
+
+export default function App() {
+  return <IonApp></IonApp>;
+}
+```

--- a/static/code/stackblitz/react/index.md
+++ b/static/code/stackblitz/react/index.md
@@ -1,0 +1,13 @@
+```tsx
+import React from "react";
+import ReactDOM from "react-dom";
+
+import App from "./App";
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById("root")
+);
+```

--- a/static/code/stackblitz/vue/app.md
+++ b/static/code/stackblitz/vue/app.md
@@ -1,0 +1,22 @@
+```vue
+<template>
+  <ion-app>
+    <Example />
+  </ion-app>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { IonApp } from "@ionic/vue";
+
+import Example from "./components/Example.vue";
+
+export default defineComponent({
+  name: "App",
+  components: {
+    IonApp,
+    Example,
+  },
+});
+</script>
+```

--- a/static/code/stackblitz/vue/main.md
+++ b/static/code/stackblitz/vue/main.md
@@ -1,0 +1,24 @@
+```js
+const { createApp } = require("vue");
+const { IonicVue } = require("@ionic/vue");
+
+import App from "./App";
+
+/* Core CSS required for Ionic components to work properly */
+import "@ionic/vue/css/core.css";
+
+/* Basic CSS for apps built with Ionic */
+import "@ionic/vue/css/normalize.css";
+import "@ionic/vue/css/structure.css";
+import "@ionic/vue/css/typography.css";
+
+/* Optional CSS utils that can be commented out */
+import "@ionic/vue/css/padding.css";
+import "@ionic/vue/css/float-elements.css";
+import "@ionic/vue/css/text-alignment.css";
+import "@ionic/vue/css/text-transformation.css";
+import "@ionic/vue/css/flex-utils.css";
+import "@ionic/vue/css/display.css";
+
+const app = createApp(App).use(IonicVue).mount("#app");
+```


### PR DESCRIPTION
Introduces the new `<Playground />` component for documenting Ionic Framework components in the docs site.

```jsx
import Playground from '../../src/components/global/Playground';

<Playground 
  src="/patch/to/demo/index.html"
  code={{
    basic: '/docs/path/to/html-code.md'
}} />
```

Supports:
- Source targets for: `basic` (HTML), `angular`, `react` and `vue`. 
- Toggling iOS/MD mode preview for Ionic component
- Generating Stackblitz example for HTML, Angular and React (still outstanding issue with Vue)

Preview path: [`/docs/playground/button`](https://ionic-docs-git-fw-714-ionic1.vercel.app/docs/playground/button)

Code within `/static/code/stackblitz` is required to generate a working Stackblitz app in the selected target. All other directories (i.e. `/static/code/button`) would be the replacement for our existing usage examples. 
## Other information

- Did not commit `package-lock.json` file, need to connect with the team to see what version of npm they are using (appears to be an outdated version)
- Had to downgrade prototype example from Docusaurus v2-beta to v1 to support ionic-docs example (main differences are how we handle code language formatting and static asset paths)
- Network requests aren't batched for usage examples, this would be a worthy optimization in the future.