### PR TITLE
feat(playground): set-up playground component

### DIFF
--- a/docs/playground/button.mdx
+++ b/docs/playground/button.mdx
@@ -1,0 +1,7 @@
+import Playground from '../../src/components/global/Playground';
+
+# IonButton
+
+Buttons provide a clickable element, which can be used in forms, or anywhere that needs simple, standard button functionality. They may display text, icons, or both. Buttons can be styled with several attributes to look a specific way.
+
+<Playground />

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -14,7 +14,7 @@ export default function Playground() {
 
   return (
     <div className="playground">
-      <div className="playground-container">
+      <div className="playground__container">
         <div className="playground__control-toolbar">
           {/* TODO FW:-742: Code language switcher */}
           <div className="playground__control-group">

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -10,6 +10,9 @@ enum Mode {
 export default function Playground() {
   const [mode, setMode] = useState(Mode.iOS);
 
+  const isIOS = mode === Mode.iOS;
+  const isMD = mode === Mode.MD;
+
   // TODO FW-741: Load code snippets remotely
 
   return (
@@ -20,18 +23,14 @@ export default function Playground() {
           <div className="playground__control-group">
             <button
               type="button"
-              className={
-                'playground__control-button ' + (mode === Mode.iOS ? 'playground__control-button--selected' : '')
-              }
+              className={'playground__control-button ' + (isIOS ? 'playground__control-button--selected' : '')}
               onClick={() => setMode(Mode.iOS)}
             >
               iOS
             </button>
             <button
               type="button"
-              className={
-                'playground__control-button ' + (mode === Mode.MD ? 'playground__control-button--selected' : '')
-              }
+              className={'playground__control-button ' + (isMD ? 'playground__control-button--selected' : '')}
               onClick={() => setMode(Mode.MD)}
             >
               MD

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+
+import './playground.css';
+
+enum Mode {
+  iOS = 'ios',
+  MD = 'md',
+}
+
+export default function Playground() {
+  const [mode, setMode] = useState(Mode.iOS);
+
+  // TODO FW-741: Load code snippets remotely
+
+  return (
+    <div className="playground">
+      <div className="playground-container">
+        <div className="playground__control-toolbar">
+          {/* TODO FW:-742: Code language switcher */}
+          <div className="playground__control-group">
+            <button
+              type="button"
+              className={
+                'playground__control-button ' + (mode === Mode.iOS ? 'playground__control-button--selected' : '')
+              }
+              onClick={() => setMode(Mode.iOS)}
+            >
+              iOS
+            </button>
+            <button
+              type="button"
+              className={
+                'playground__control-button ' + (mode === Mode.MD ? 'playground__control-button--selected' : '')
+              }
+              onClick={() => setMode(Mode.MD)}
+            >
+              MD
+            </button>
+          </div>
+          <div className="playground__control-group playground__control-group--end">
+            {/* TODO FW-737: Toggle/Collapse Button */}
+            {/* TODO FW-738: Report an Issue Button */}
+            {/* TODO FW-739: Copy Source Code Button */}
+            {/* TODO FW-740: Open Stackblitz Button */}
+          </div>
+        </div>
+        <div className="playground__preview">{/* TODO FW-743: iframe Preview */}</div>
+      </div>
+      <div className="playground__code-block">{/* TODO FW-744: Code blocks per language */}</div>
+    </div>
+  );
+}

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -19,7 +19,7 @@ export default function Playground() {
     <div className="playground">
       <div className="playground__container">
         <div className="playground__control-toolbar">
-          {/* TODO FW:-742: Code language switcher */}
+          {/* TODO FW-742: Code language switcher */}
           <div className="playground__control-group">
             <button
               type="button"

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -69,9 +69,8 @@
 
 .playground__control-group--end {
   margin-left: auto;
-  display: grid;
+  display: flex;
   gap: 4px;
-  grid-template-columns: repeat(4, auto);
 }
 
 .playground__control-button {

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -1,0 +1,106 @@
+/* Dark theme overrides */
+[data-theme="dark"] .playground {
+  --playground-btn-color: var(--c-carbon-20);
+  --playground-btn-selected-color: #fff;
+  --playground-btn-selected-background: var(--c-carbon-70);
+
+  --playground-separator-color: var(--c-carbon-70);
+}
+
+.playground {
+  /**
+   * @prop --playground-btn-color The text color of the button in the toolbar.
+   */
+   --playground-btn-color: var(--c-indigo-90);
+   --playground-btn-selected-color: var(--c-blue-90);
+   --playground-btn-selected-background: var(--c-blue-10);
+
+  --playground-separator-color: var(--c-indigo-30);
+
+  overflow: hidden;
+}
+
+/* Playground container includes the toolbar and preview container */
+.playground__container {
+  border: 1px solid var(--playground-separator-color);
+  border-radius: 16px;
+}
+
+/* Playground preview contains the demo example*/
+.playground__preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin: 18px 0;
+  padding: 16px 0;
+}
+
+.playground__control-toolbar {
+  display: flex;
+  align-items: center;
+
+  padding: 8px 12px;
+
+  border-bottom: 1px solid var(--playground-separator-color);
+
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+/* Hides the horizontal scrollbar when the toolbar has horizontal overflow */
+.playground__control-toolbar::-webkit-scrollbar {
+  width: 0;
+  background: transparent;
+  height: 0;
+}
+
+/* Playground control group contains a section of buttons in the toolbar */
+.playground__control-group {
+  display: flex;
+  min-height: 24px;
+}
+
+.playground__control-group + .playground__control-group {
+  padding-left: 12px;
+}
+
+.playground__control-group + .playground__control-group:not(.playground__control-group--end) {
+  /* Only render the separator between sections when there is an accompanying section */
+  border-left: 1px solid var(--playground-separator-color);
+}
+
+.playground__control-group .playground__control-button:last-child {
+  margin-right: 12px;
+}
+
+.playground__control-group--end {
+  margin-left: auto;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(4, auto);
+}
+
+.playground__control-button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 6px 10px;
+
+  color: var(--playground-btn-color);
+  background-color: transparent;
+  border: none;
+  border-radius: 100px;
+
+  font-size: 12px;
+
+  appearance: none;
+  cursor: pointer;
+  transition: background-color .2s, color .2s;
+}
+
+.playground__control-button--selected {
+  background-color: var(--playground-btn-selected-background);
+  color: var(--playground-btn-selected-color);
+  font-weight: 500;
+}

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -46,8 +46,7 @@
 
   border-bottom: 1px solid var(--playground-separator-color);
 
-  overflow-y: auto;
-  scrollbar-width: none;
+  overflow-x: auto;
 }
 
 /* Playground control group contains a section of buttons in the toolbar */

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -48,13 +48,6 @@
   scrollbar-width: none;
 }
 
-/* Hides the horizontal scrollbar when the toolbar has horizontal overflow */
-.playground__control-toolbar::-webkit-scrollbar {
-  width: 0;
-  background: transparent;
-  height: 0;
-}
-
 /* Playground control group contains a section of buttons in the toolbar */
 .playground__control-group {
   display: flex;

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -12,9 +12,17 @@
    * @prop --playground-btn-color The text color of the button in the toolbar.
    */
    --playground-btn-color: var(--c-indigo-90);
-   --playground-btn-selected-color: var(--c-blue-90);
-   --playground-btn-selected-background: var(--c-blue-10);
-
+  /**
+   * @prop --playground-btn-selected-color The text color of the button in the toolbar when selected.
+   */
+  --playground-btn-selected-color: var(--c-blue-90);
+  /**
+   * @prop --playground-btn-selected-background The background color of the button in the toolbar when selected.
+   */
+  --playground-btn-selected-background: var(--c-blue-10);
+  /**
+   * @prop --playground-separator-color The color of the separator/border in the toolbar.
+   */
   --playground-separator-color: var(--c-indigo-30);
 
   overflow: hidden;
@@ -23,7 +31,7 @@
 /* Playground container includes the toolbar and preview container */
 .playground__container {
   border: 1px solid var(--playground-separator-color);
-  border-radius: 16px;
+  border-radius: var(--ifm-code-border-radius);
 }
 
 /* Playground preview contains the demo example*/
@@ -58,8 +66,9 @@
   padding-left: 12px;
 }
 
+/** Vertical divider between control groups */
 .playground__control-group + .playground__control-group:not(.playground__control-group--end) {
-  /* Only render the separator between sections when there is an accompanying section */
+  /* Only show the vertical divider when there is a control group after it */
   border-left: 1px solid var(--playground-separator-color);
 }
 

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -10,19 +10,13 @@
 .playground {
   /**
    * @prop --playground-btn-color The text color of the button in the toolbar.
-   */
-   --playground-btn-color: var(--c-indigo-90);
-  /**
    * @prop --playground-btn-selected-color The text color of the button in the toolbar when selected.
-   */
-  --playground-btn-selected-color: var(--c-blue-90);
-  /**
    * @prop --playground-btn-selected-background The background color of the button in the toolbar when selected.
-   */
-  --playground-btn-selected-background: var(--c-blue-10);
-  /**
    * @prop --playground-separator-color The color of the separator/border in the toolbar.
    */
+  --playground-btn-color: var(--c-indigo-90);
+  --playground-btn-selected-color: var(--c-blue-90);
+  --playground-btn-selected-background: var(--c-blue-10);
   --playground-separator-color: var(--c-indigo-30);
 
   overflow: hidden;


### PR DESCRIPTION
Introduces the new `<Playground />` component for documenting Ionic Framework components in the docs site.

Displays the initial design with partial dark-mode support.


|Light Theme|Dark Theme|
|---|---|
|![Screen Shot 2022-02-08 at 5 30 42 PM](https://user-images.githubusercontent.com/13732623/153086606-243af567-5121-4d39-8c58-c6a246348f7f.png)|![Screen Shot 2022-02-08 at 5 31 06 PM](https://user-images.githubusercontent.com/13732623/153086653-e42d9361-c3f4-4753-8548-19586f397cef.png)|


Split from #2185