### PR TITLE
Update ios.md

### DIFF
--- a/docs/developing/ios.md
+++ b/docs/developing/ios.md
@@ -114,7 +114,7 @@ In this workflow, Xcode can automatically fix common compilation and signing iss
 
    ```shell
    $ ionic capacitor copy ios
-   $ ionic capactior update
+   $ ionic capacitor update
    ```
 
    For Cordova, run the following:

--- a/docs/developing/ios.md
+++ b/docs/developing/ios.md
@@ -114,6 +114,7 @@ In this workflow, Xcode can automatically fix common compilation and signing iss
 
    ```shell
    $ ionic capacitor copy ios
+   $ ionic capactior update
    ```
 
    For Cordova, run the following:


### PR DESCRIPTION
Following these steps cause an error where the podsfile has not been created nor installed. after copy ios, capacitor update is required to setup the podsfile and native dependencies.