### PR TITLE
fix(): bump to latest ionic 6

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -8,7 +8,7 @@ const DEMOS_PATH = path.resolve('static/demos');
 let COMPONENT_LINK_REGEXP;
 
 (async function () {
-  const response = await fetch('https://unpkg.com/@ionic/docs@6.0.10-dev.1645800478.beaed6d/core.json');
+  const response = await fetch('https://unpkg.com/@ionic/docs@6.0.10-dev.11645801048.2804c20/core.json');
   const { components } = await response.json();
 
   const names = components.map((component) => component.tag.slice(4));

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -8,7 +8,7 @@ const DEMOS_PATH = path.resolve('static/demos');
 let COMPONENT_LINK_REGEXP;
 
 (async function () {
-  const response = await fetch('https://unpkg.com/@ionic/docs@6.0.1-dev.1639592631.ce89cfa/core.json');
+  const response = await fetch('https://unpkg.com/@ionic/docs@6/core.json');
   const { components } = await response.json();
 
   const names = components.map((component) => component.tag.slice(4));

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -8,7 +8,7 @@ const DEMOS_PATH = path.resolve('static/demos');
 let COMPONENT_LINK_REGEXP;
 
 (async function () {
-  const response = await fetch('https://unpkg.com/@ionic/docs@6/core.json');
+  const response = await fetch('https://unpkg.com/@ionic/docs@6.0.10-dev.1645800478.beaed6d/core.json');
   const { components } = await response.json();
 
   const names = components.map((component) => component.tag.slice(4));


### PR DESCRIPTION
I wanted to bump this to the `6` tag on npm, but there was a problem with the deploy scripts for @ionic/docs. This dev build has a fix for that. Once 6.0.10 ships we can safely change this to use the `6` npm tag.

See https://github.com/ionic-team/ionic-framework/pull/24850