### PR TITLE
feat(playground): create stackblitz examples for vue/vite

### DIFF
--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -118,8 +118,35 @@ const openReactEditor = async (code: string, options?: EditorOptions) => {
 }
 
 const openVueEditor = async (code: string, options?: EditorOptions) => {
-  // TODO FW-715: Open Vue editor
-  console.warn('Not implemented');
+  const [package_json, index_html, vite_config_js, main_js, app_vue] = await loadSourceFiles([
+    'vue/package.json',
+    'vue/index.html',
+    'vue/vite.config.js',
+    'vue/main.js',
+    'vue/App.vue'
+  ]);
+  /**
+   * We have to use Stackblitz web containers here (node template), due
+   * to multiple issues with Vite, Vue/Vue Router and Vue 3's script setup.
+   *
+   * https://github.com/stackblitz/core/issues/1308
+   */
+  sdk.openProject({
+    template: 'node',
+    title: options?.title ?? DEFAULT_EDITOR_TITLE,
+    description: options?.description ?? DEFAULT_EDITOR_DESCRIPTION,
+    files: {
+      'src/App.vue': app_vue,
+      'src/components/Example.vue': code,
+      'src/main.js': main_js,
+      'index.html': index_html,
+      'vite.config.js': vite_config_js,
+      'package.json': package_json,
+      '.stackblitzrc': `{
+        "startCommand": "yarn run dev"
+      }`
+    }
+  });
 }
 
 export { openAngularEditor, openHtmlEditor, openReactEditor, openVueEditor };

--- a/static/code/stackblitz/README.md
+++ b/static/code/stackblitz/README.md
@@ -28,4 +28,10 @@ This directory contains the source files for generating the individual framework
 
 ## Vue
 
-- Coming soon
+| File             | Description                                                   |
+| ---------------- | ------------------------------------------------------------- |
+| `App.vue`        | Main Vue component that wraps each example in `ion-app`.      |
+| `index.html`     | The HTML template to create an element to mount Vue to.       |
+| `main.js`        | Initializes Ionic Vue and imports global styles.              |
+| `package.json`   | Project specific dependencies to create an example with Vite. |
+| `vite.config.js` | Vite configuration file.                                      |

--- a/static/code/stackblitz/vue/App.vue
+++ b/static/code/stackblitz/vue/App.vue
@@ -1,0 +1,18 @@
+<template>
+  <ion-app>
+    <Example />
+  </ion-app>
+</template>
+
+<script>
+import { IonApp } from '@ionic/vue';
+
+import { defineComponent } from 'vue';
+
+import Example from './components/Example.vue';
+
+export default defineComponent({
+  name: 'App',
+  components: { IonApp, Example },
+});
+</script>

--- a/static/code/stackblitz/vue/index.html
+++ b/static/code/stackblitz/vue/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vite App</title>
+</head>
+
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+
+</html>

--- a/static/code/stackblitz/vue/index.html
+++ b/static/code/stackblitz/vue/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" href="/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Vite App</title>
+  <title>Ionic App</title>
 </head>
 
 <body>

--- a/static/code/stackblitz/vue/main.js
+++ b/static/code/stackblitz/vue/main.js
@@ -1,0 +1,22 @@
+import { createApp } from 'vue';
+import { IonicVue } from '@ionic/vue';
+
+import App from './App.vue';
+
+/* Core CSS required for Ionic components to work properly */
+import '@ionic/vue/css/core.css';
+
+/* Basic CSS for apps built with Ionic */
+import '@ionic/vue/css/normalize.css';
+import '@ionic/vue/css/structure.css';
+import '@ionic/vue/css/typography.css';
+
+/* Optional CSS utils that can be commented out */
+import '@ionic/vue/css/padding.css';
+import '@ionic/vue/css/float-elements.css';
+import '@ionic/vue/css/text-alignment.css';
+import '@ionic/vue/css/text-transformation.css';
+import '@ionic/vue/css/flex-utils.css';
+import '@ionic/vue/css/display.css';
+
+createApp(App).use(IonicVue).mount('#app');

--- a/static/code/stackblitz/vue/package.json
+++ b/static/code/stackblitz/vue/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ionic/vue": "latest",
+    "@ionic/vue": "^6.0.0",
     "vue": "^3.2.25",
     "vue-router": "4.0.13"
   },

--- a/static/code/stackblitz/vue/package.json
+++ b/static/code/stackblitz/vue/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vite-vue-starter",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@ionic/vue": "latest",
+    "vue": "^3.2.25",
+    "vue-router": "4.0.13"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^2.2.0",
+    "vite": "^2.8.0"
+  }
+}

--- a/static/code/stackblitz/vue/vite.config.js
+++ b/static/code/stackblitz/vue/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [vue()],
+});


### PR DESCRIPTION
Introduces the ability to generate Stackblitz examples for Vue (using Vite). 

This implementation required a little more customization than the others, since Stackblitz does not have a template starter that works with Vue & Vue Router. There is also an active issue open for their template starters with Vue 3 and `script setup`. This uses web containers for now, which is a beta feature from Stackblitz.