### PR TITLE
feat(playground): load code usage snippets

### DIFF
--- a/docs/playground/button.mdx
+++ b/docs/playground/button.mdx
@@ -4,4 +4,11 @@ import Playground from '../../src/components/global/Playground';
 
 Buttons provide a clickable element, which can be used in forms, or anywhere that needs simple, standard button functionality. They may display text, icons, or both. Buttons can be styled with several attributes to look a specific way.
 
-<Playground />
+<Playground
+  code={{
+    html: 'button/basic/javascript.md',
+    angular: 'button/basic/angular.md',
+    react: 'button/basic/react.md',
+    vue: 'button/basic/vue.md',
+  }}
+></Playground>

--- a/src/components/global/Playground/code.utils.ts
+++ b/src/components/global/Playground/code.utils.ts
@@ -1,0 +1,46 @@
+
+/**
+ * Loads the contents of a file remotely. Loads all code snippet files
+ * from `/docs/usage/**` directory.
+ *
+ * loadCodeSnippet('/button/basic/javascript.md');
+ *
+ * @param path The relative path to the code snippet file from /docs/usage/.
+ * @returns The parsed code block from the markdown code snippet file.
+ */
+const loadCodeSnippet = async (path: string) => {
+  const res = await fetch(`/docs/usage/${path}`);
+  const text = await res.text();
+  return convertMdxToCode(text);
+}
+
+/**
+ * Parses MDX formatted text and returns the inner
+ * contents of the block.
+ */
+const convertMdxToCode = (text: string) => {
+  /**
+   * The regex below matches the following:
+   *
+   * ```typescript
+   * const foo = 'bar';
+   * ```
+   *
+   * - The first group is the markdown lint language.
+   * - The second group is the code contents.
+   * - The third group the closing markdown tag.
+   *
+   */
+  const regexp = new RegExp(/`{3}([\S\s]*?)`{3}([^`]*)([\S\s]*?)/g);
+  const regexpResult = regexp.exec(text);
+  let sourceCode = '';
+  if (regexpResult) {
+    const sourceCodeLines = regexpResult[1].split('\n');
+    // Removes any language indicator for code formatting
+    sourceCodeLines.shift();
+    sourceCode = sourceCodeLines.join('\n');
+  }
+  return sourceCode;
+}
+
+export { loadCodeSnippet };

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -1,19 +1,25 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import CodeBlock from '@theme/CodeBlock';
 
 import './playground.css';
+import { loadCodeSnippet } from './code.utils';
 
 enum Mode {
   iOS = 'ios',
   MD = 'md',
 }
 
-export default function Playground() {
+export default function Playground({ code }) {
+  if (!code) {
+    console.warn('No code usage examples provided for this Playground example.');
+    return;
+  }
   const codeRef = useRef(null);
 
   const [mode, setMode] = useState(Mode.iOS);
   const [codeExpanded, setCodeExpanded] = useState(false);
+  const [codeSnippet, setCodeSnippet] = useState({});
 
   const isIOS = mode === Mode.iOS;
   const isMD = mode === Mode.MD;
@@ -24,6 +30,23 @@ export default function Playground() {
     const copyButton = codeRef.current.querySelector('button');
     copyButton.click();
   }
+
+  useEffect(() => {
+    /**
+     * TODO FW-877: Lazy load code snippets with the same solution for preview examples.
+     *
+     * We could also consider only loading code snippets for the active framework button.
+     */
+    Promise.all(Object.keys(code).map((key) => loadCodeSnippet(code[key])))
+      .then((codeSnippetContent) => {
+        const codeSnippet = {};
+        Object.keys(code).forEach((lang) => {
+          codeSnippet[lang] = codeSnippetContent[lang];
+        });
+        setCodeSnippet(codeSnippet);
+      })
+      .catch((err) => console.error('Error loading code snippets', err));
+  }, []);
 
   return (
     <div className="playground">

--- a/static/usage/button/basic/angular.md
+++ b/static/usage/button/basic/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-button>Default</ion-button>
+```

--- a/static/usage/button/basic/javascript.md
+++ b/static/usage/button/basic/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-button>Default</ion-button>
+```

--- a/static/usage/button/basic/react.md
+++ b/static/usage/button/basic/react.md
@@ -1,0 +1,8 @@
+```tsx
+import React from 'react';
+import { IonButton } from '@ionic/react';
+function Example() {
+  return <IonButton>Default</IonButton>;
+}
+export default Example;
+```

--- a/static/usage/button/basic/vue.md
+++ b/static/usage/button/basic/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-button>Default</ion-button>
+</template>
+
+<script>
+  import { IonButton } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton },
+  });
+</script>
+```


### PR DESCRIPTION
Supports loading the code usage example files (markdown files) for specified languages (framework targets). It will parse the inner contents of the MD file and set the code snippet value to the React component state.

Usage:
```tsx
<Playground code={{
  html: 'button/basic/javascript.md',
  angular: 'button/basic/angular.md',
  react: 'button/basic/react.md',
  vue: 'button/basic/vue.md'
}}></Playground>
```

The object keys aren't important with this PR and will be finally decided with FW-742.