### PR TITLE
fix(scripts): always load latest core.json

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -8,7 +8,7 @@ const DEMOS_PATH = path.resolve('static/demos');
 let COMPONENT_LINK_REGEXP;
 
 (async function () {
-  const response = await fetch('https://unpkg.com/@ionic/docs@6.0.10-dev.11645801048.2804c20/core.json');
+  const response = await fetch('https://unpkg.com/@ionic/doc/core.json');
   const { components } = await response.json();
 
   const names = components.map((component) => component.tag.slice(4));

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -8,7 +8,7 @@ const DEMOS_PATH = path.resolve('static/demos');
 let COMPONENT_LINK_REGEXP;
 
 (async function () {
-  const response = await fetch('https://unpkg.com/@ionic/doc/core.json');
+  const response = await fetch('https://unpkg.com/@ionic/docs/core.json');
   const { components } = await response.json();
 
   const names = components.map((component) => component.tag.slice(4));


### PR DESCRIPTION
Updates the API script to always point to the latest published release (semantic release) for the `core.json` asset. Unpkg is smart enough that when you do not specify a version, it will pull the latest.