### PR TITLE
feat(playground): add language toggle buttons, populate selected code

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -4,6 +4,17 @@ import './playground.css';
 import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, openVueEditor } from './stackblitz.utils';
 import { Mode, UsageTarget } from './playground.types';
 
+const CodeBlockButton = ({ language, usageTarget, setUsageTarget }) => {
+  return (
+    <button
+      type="button"
+      title={`Show ${language} code`}
+      className={`playground__control-button ${usageTarget === language ? "playground__control-button--selected" : ""}`}
+      onClick={() => setUsageTarget(language)}
+    >{language}</button>
+  );
+};
+
 /**
  * @param code The code snippets for each supported framework target.
  * @param title Optional title of the generated playground example. Specify to customize the Stackblitz title.
@@ -23,7 +34,7 @@ export default function Playground({
     return;
   }
   const codeRef = useRef(null);
-  
+
   const [usageTarget, setUsageTarget] = useState(UsageTarget.Html);
   const [mode, setMode] = useState(Mode.iOS);
   const [codeExpanded, setCodeExpanded] = useState(false);
@@ -74,7 +85,11 @@ export default function Playground({
     <div className="playground">
       <div className="playground__container">
         <div className="playground__control-toolbar">
-          {/* TODO FW-742: Code language switcher */}
+          <div className="playground__control-group">
+            {Object.values(UsageTarget).map(lang => (
+              <CodeBlockButton language={lang} usageTarget={usageTarget} setUsageTarget={setUsageTarget} />
+            ))}
+          </div>
           <div className="playground__control-group">
             <button
               type="button"

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -4,15 +4,27 @@ import './playground.css';
 import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, openVueEditor } from './stackblitz.utils';
 import { Mode, UsageTarget } from './playground.types';
 
-const CodeBlockButton = ({ language, usageTarget, setUsageTarget }) => {
-  const langValue = UsageTarget[language];
+const ControlButton = ({ isSelected, handleClick, title, label }) => {
   return (
     <button
       type="button"
+      title={title}
+      className={`playground__control-button ${isSelected ? "playground__control-button--selected" : ""}`}
+      onClick={handleClick}
+      data-text={label}
+    >{label}</button>
+  );
+};
+
+const CodeBlockButton = ({ language, usageTarget, setUsageTarget }) => {
+  const langValue = UsageTarget[language];
+  return (
+    <ControlButton
+      isSelected={usageTarget === langValue}
+      handleClick={() => setUsageTarget(langValue)}
       title={`Show ${language} code`}
-      className={`playground__control-button ${usageTarget === langValue ? "playground__control-button--selected" : ""}`}
-      onClick={() => setUsageTarget(langValue)}
-    >{language}</button>
+      label={language}
+    />
   );
 };
 
@@ -93,20 +105,18 @@ export default function Playground({
             ))}
           </div>
           <div className="playground__control-group">
-            <button
-              type="button"
-              className={'playground__control-button ' + (isIOS ? 'playground__control-button--selected' : '')}
-              onClick={() => setMode(Mode.iOS)}
-            >
-              iOS
-            </button>
-            <button
-              type="button"
-              className={'playground__control-button ' + (isMD ? 'playground__control-button--selected' : '')}
-              onClick={() => setMode(Mode.MD)}
-            >
-              MD
-            </button>
+            <ControlButton
+              isSelected={isIOS}
+              handleClick={() => setMode(Mode.iOS)}
+              title="iOS mode"
+              label="iOS"
+            />
+            <ControlButton
+              isSelected={isMD}
+              handleClick={() => setMode(Mode.MD)}
+              title="MD mode"
+              label="MD"
+            />
           </div>
           <div className="playground__control-group playground__control-group--end">
             <button

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -36,7 +36,7 @@ export default function Playground({
   }
   const codeRef = useRef(null);
 
-  const [usageTarget, setUsageTarget] = useState(UsageTarget.Basic);
+  const [usageTarget, setUsageTarget] = useState(UsageTarget.JavaScript);
   const [mode, setMode] = useState(Mode.iOS);
   const [codeExpanded, setCodeExpanded] = useState(false);
   const [codeSnippets, setCodeSnippets] = useState({});
@@ -62,7 +62,7 @@ export default function Playground({
       case UsageTarget.Angular:
         openAngularEditor(codeBlock, editorOptions);
         break;
-      case UsageTarget.Basic:
+      case UsageTarget.JavaScript:
         openHtmlEditor(codeBlock, editorOptions);
         break;
       case UsageTarget.React:

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import './playground.css';
 import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, openVueEditor } from './stackblitz.utils';
-import { Mode, SupportedFrameworks, UsageTarget } from './playground.types';
+import { Mode, UsageTarget } from './playground.types';
 
 /**
  * @param code The code snippets for each supported framework target.
@@ -14,7 +14,7 @@ export default function Playground({
   title,
   description,
 }: {
-  code: { [key in SupportedFrameworks]?: () => {} };
+  code: { [key in UsageTarget]?: () => {} };
   title?: string;
   description?: string;
 }) {
@@ -23,7 +23,7 @@ export default function Playground({
     return;
   }
   const codeRef = useRef(null);
-
+  
   const [usageTarget, setUsageTarget] = useState(UsageTarget.Html);
   const [mode, setMode] = useState(Mode.iOS);
   const [codeExpanded, setCodeExpanded] = useState(false);
@@ -31,8 +31,6 @@ export default function Playground({
 
   const isIOS = mode === Mode.iOS;
   const isMD = mode === Mode.MD;
-
-  const activeCodeSnippet: SupportedFrameworks = 'react';
 
   function copySourceCode() {
     const copyButton = codeRef.current.querySelector('button');
@@ -168,7 +166,7 @@ export default function Playground({
         className={'playground__code-block ' + (codeExpanded ? 'playground__code-block--expanded' : '')}
         aria-expanded={codeExpanded ? 'true' : 'false'}
       >
-        {codeSnippets[activeCodeSnippet]}
+        {codeSnippets[usageTarget]}
       </div>
     </div>
   );

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -5,12 +5,13 @@ import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, open
 import { Mode, UsageTarget } from './playground.types';
 
 const CodeBlockButton = ({ language, usageTarget, setUsageTarget }) => {
+  const langValue = UsageTarget[language];
   return (
     <button
       type="button"
       title={`Show ${language} code`}
-      className={`playground__control-button ${usageTarget === language ? "playground__control-button--selected" : ""}`}
-      onClick={() => setUsageTarget(language)}
+      className={`playground__control-button ${usageTarget === langValue ? "playground__control-button--selected" : ""}`}
+      onClick={() => setUsageTarget(langValue)}
     >{language}</button>
   );
 };
@@ -35,7 +36,7 @@ export default function Playground({
   }
   const codeRef = useRef(null);
 
-  const [usageTarget, setUsageTarget] = useState(UsageTarget.Html);
+  const [usageTarget, setUsageTarget] = useState(UsageTarget.Basic);
   const [mode, setMode] = useState(Mode.iOS);
   const [codeExpanded, setCodeExpanded] = useState(false);
   const [codeSnippets, setCodeSnippets] = useState({});
@@ -60,7 +61,7 @@ export default function Playground({
       case UsageTarget.Angular:
         openAngularEditor(codeBlock, editorOptions);
         break;
-      case UsageTarget.Html:
+      case UsageTarget.Basic:
         openHtmlEditor(codeBlock, editorOptions);
         break;
       case UsageTarget.React:
@@ -86,7 +87,7 @@ export default function Playground({
       <div className="playground__container">
         <div className="playground__control-toolbar">
           <div className="playground__control-group">
-            {Object.values(UsageTarget).map(lang => (
+            {Object.keys(UsageTarget).map(lang => (
               <CodeBlockButton language={lang} usageTarget={usageTarget} setUsageTarget={setUsageTarget} />
             ))}
           </div>

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -50,8 +50,9 @@ export default function Playground({
   }
 
   function openEditor(event) {
-    // TODO assign code block value based on active framework button and loaded code snippets
-    const codeBlock = '';
+    // codeSnippets are React components, so we need to get their rendered text
+    // using outerText will preserve line breaks for formatting in Stackblitz editor
+    const codeBlock = codeRef.current.querySelector('code').outerText;
     const editorOptions: EditorOptions = {
       title,
       description,

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -88,6 +88,7 @@
 
 .playground__control-button {
   display: inline-flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   padding: 6px 10px;
@@ -102,6 +103,25 @@
   appearance: none;
   cursor: pointer;
   transition: background-color .2s, color .2s;
+}
+
+/* fix layout shifting when button is bolded on select */
+/* has the same text as the button, but bolded in advance to nudge the width */
+.playground__control-button::after {
+  content: attr(data-text);
+  font-weight: 500;
+  overflow: hidden;
+  pointer-events: none;
+  user-select: none;
+  visibility: hidden;
+
+  height: 0;
+}
+
+@media speech {
+  .playground__control-button::after {
+    display: none;
+  }
 }
 
 .playground__control-button--selected {

--- a/src/components/global/Playground/playground.types.ts
+++ b/src/components/global/Playground/playground.types.ts
@@ -5,8 +5,6 @@ export enum UsageTarget {
   Vue = 'Vue',
 }
 
-export const UsageTargetList = Object.keys(UsageTarget);
-
 export enum Mode {
   iOS = 'ios',
   MD = 'md',

--- a/src/components/global/Playground/playground.types.ts
+++ b/src/components/global/Playground/playground.types.ts
@@ -1,5 +1,5 @@
 export enum UsageTarget {
-  Basic = 'javascript',
+  JavaScript = 'javascript',
   Angular = 'angular',
   React = 'react',
   Vue = 'vue',

--- a/src/components/global/Playground/playground.types.ts
+++ b/src/components/global/Playground/playground.types.ts
@@ -11,5 +11,3 @@ export enum Mode {
   iOS = 'ios',
   MD = 'md',
 }
-
-export type SupportedFrameworks = 'angular' | 'react' | 'vue' | 'javascript';

--- a/src/components/global/Playground/playground.types.ts
+++ b/src/components/global/Playground/playground.types.ts
@@ -1,8 +1,8 @@
 export enum UsageTarget {
-  Html = 'Basic',
-  Angular = 'Angular',
-  React = 'React',
-  Vue = 'Vue',
+  Basic = 'javascript',
+  Angular = 'angular',
+  React = 'react',
+  Vue = 'vue',
 }
 
 export enum Mode {


### PR DESCRIPTION
- Adds the buttons for switching between languages.
- Populates the code block and Stackblitz editor with the code for your selected language.
- Cleans up some redundant code.
- Fixes the layout shifting when control buttons are selected, including a slight refactor of all control buttons to clean things up.