### PR TITLE
feat(playground): populate code block and Stackblitz with code for selected framework

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -49,8 +49,10 @@ export default function Playground({
   }
 
   function openEditor(event) {
-    // TODO assign code block value based on active framework button and loaded code snippets
-    const codeBlock = '';
+    // codeSnippets are React components, so we need to get their rendered text
+    // outerText preserves line breaks for formatting in Stackblitz editor
+    const codeBlock = codeRef.current.querySelector('code').outerText;
+    
     const editorOptions: EditorOptions = {
       title,
       description,

--- a/static/usage/button/basic/index.md
+++ b/static/usage/button/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} />
+<Playground code={{
+  Basic: javascript,
+  React: react,
+  Vue: vue,
+  Angular: angular
+}} />


### PR DESCRIPTION
The code block will now show the imported example code for each framework, and the Stackblitz examples are populated as well.

This builds off of https://github.com/ionic-team/ionic-docs/pull/2228, which notably removes some redundant type declarations so `UsageTarget` is the one source of truth. This meant the keys in the `code` prop needed to be updated to match.