### PR TITLE
feat(playground): buttons now show tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@ionic-internal/ionic-ds": "^7.0.0",
         "@mdx-js/react": "^1.6.22",
         "@stackblitz/sdk": "^1.6.0",
+        "@tippyjs/react": "^4.2.6",
         "clsx": "^1.1.1",
         "concurrently": "^6.2.0",
         "crowdin": "^3.5.0",
@@ -2997,6 +2998,15 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
       "integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA=="
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
+      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -3312,6 +3322,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@tippyjs/react": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
+      "integrity": "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==",
+      "dependencies": {
+        "tippy.js": "^6.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@trysound/sax": {
@@ -12802,6 +12824,14 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "node_modules/tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.0"
+      }
+    },
     "node_modules/title-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
@@ -16210,6 +16240,11 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.15.tgz",
       "integrity": "sha512-15spi3V28QdevleWBNXE4pIls3nFZmBbUGrW9IVPwiQczuSb9n76TCB4bsk8TSel+I1OkHEdPhu5QKMfY6rQHA=="
     },
+    "@popperjs/core": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.4.tgz",
+      "integrity": "sha512-q/ytXxO5NKvyT37pmisQAItCFqA7FD/vNb8dgaJy3/630Fsc+Mz9/9f2SziBoIZ30TJooXyTwZmhi1zjXmObYg=="
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -16403,6 +16438,14 @@
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@tippyjs/react": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@tippyjs/react/-/react-4.2.6.tgz",
+      "integrity": "sha512-91RicDR+H7oDSyPycI13q3b7o4O60wa2oRbjlz2fyRLmHImc4vyDwuUP8NtZaN0VARJY5hybvDYrFzhY9+Lbyw==",
+      "requires": {
+        "tippy.js": "^6.3.1"
       }
     },
     "@trysound/sax": {
@@ -23530,6 +23573,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "tippy.js": {
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
+      "requires": {
+        "@popperjs/core": "^2.9.0"
+      }
     },
     "title-case": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@ionic-internal/ionic-ds": "^7.0.0",
     "@mdx-js/react": "^1.6.22",
     "@stackblitz/sdk": "^1.6.0",
+    "@tippyjs/react": "^4.2.6",
     "clsx": "^1.1.1",
     "concurrently": "^6.2.0",
     "crowdin": "^3.5.0",

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -155,7 +155,7 @@ export default function Playground({
             />
           </div>
           <div className="playground__control-group playground__control-group--end">
-            <Tippy content={codeExpanded ? 'Hide source code' : 'Show full source'}>
+            <Tippy arrow={false} placement="bottom" content={codeExpanded ? 'Hide source code' : 'Show full source'}>
               <button
               className="playground__icon-button playground__icon-button--primary"
               aria-label={codeExpanded ? 'Hide source code' : 'Show full source'}
@@ -174,7 +174,7 @@ export default function Playground({
               </svg>
             </button>
             </Tippy>
-            <Tippy content="Report an issue">
+            <Tippy arrow={false} placement="bottom" content="Report an issue">
               <a
               className="playground__icon-button"
               href="https://github.com/ionic-team/ionic-docs/issues/new/choose"
@@ -190,7 +190,7 @@ export default function Playground({
               </svg>
             </a>
             </Tippy>
-            <Tippy content="Copy source code">
+            <Tippy arrow={false} placement="bottom" content="Copy source code">
               <button className="playground__icon-button playground__icon-button--primary" onClick={copySourceCode}>
               <svg
                 aria-hidden="true"
@@ -208,7 +208,7 @@ export default function Playground({
               </svg>
             </button>
             </Tippy>
-            <Tippy content="Open in StackBlitz">
+            <Tippy arrow={false} placement="bottom" content="Open in StackBlitz">
               <button className="playground__icon-button playground__icon-button--primary" onClick={openEditor}>
               <svg
                 aria-hidden="true"

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -5,6 +5,8 @@ import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, open
 import { Mode, UsageTarget } from './playground.types';
 import useThemeContext from '@theme/hooks/useThemeContext';
 
+import Tippy from '@tippyjs/react';
+import 'tippy.js/dist/tippy.css';
 
 const ControlButton = ({ isSelected, handleClick, title, label }) => {
   return (
@@ -153,7 +155,8 @@ export default function Playground({
             />
           </div>
           <div className="playground__control-group playground__control-group--end">
-            <button
+            <Tippy content={codeExpanded ? 'Hide source code' : 'Show full source'}>
+              <button
               className="playground__icon-button playground__icon-button--primary"
               aria-label={codeExpanded ? 'Hide source code' : 'Show full source'}
               onClick={() => setCodeExpanded(!codeExpanded)}
@@ -170,7 +173,9 @@ export default function Playground({
                 <path d="M11 9L15 5L11 1" stroke="current" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             </button>
-            <a
+            </Tippy>
+            <Tippy content="Report an issue">
+              <a
               className="playground__icon-button"
               href="https://github.com/ionic-team/ionic-docs/issues/new/choose"
               aria-label="Report an issue"
@@ -184,7 +189,9 @@ export default function Playground({
                 />
               </svg>
             </a>
-            <button className="playground__icon-button playground__icon-button--primary" onClick={copySourceCode}>
+            </Tippy>
+            <Tippy content="Copy source code">
+              <button className="playground__icon-button playground__icon-button--primary" onClick={copySourceCode}>
               <svg
                 aria-hidden="true"
                 xmlns="http://www.w3.org/2000/svg"
@@ -200,7 +207,9 @@ export default function Playground({
                 <rect x="3" y="3" width="8" height="8" rx="1.5" stroke="current" />
               </svg>
             </button>
-            <button className="playground__icon-button playground__icon-button--primary" onClick={openEditor}>
+            </Tippy>
+            <Tippy content="Open in StackBlitz">
+              <button className="playground__icon-button playground__icon-button--primary" onClick={openEditor}>
               <svg
                 aria-hidden="true"
                 width="12"
@@ -218,6 +227,7 @@ export default function Playground({
                 />
               </svg>
             </button>
+            </Tippy>
           </div>
         </div>
         <div className="playground__preview">

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -155,7 +155,7 @@ export default function Playground({
             />
           </div>
           <div className="playground__control-group playground__control-group--end">
-            <Tippy arrow={false} placement="bottom" content={codeExpanded ? 'Hide source code' : 'Show full source'}>
+            <Tippy theme="playground" arrow={false} placement="bottom" content={codeExpanded ? 'Hide source code' : 'Show full source'}>
               <button
               className="playground__icon-button playground__icon-button--primary"
               aria-label={codeExpanded ? 'Hide source code' : 'Show full source'}
@@ -174,7 +174,7 @@ export default function Playground({
               </svg>
             </button>
             </Tippy>
-            <Tippy arrow={false} placement="bottom" content="Report an issue">
+            <Tippy theme="playground" arrow={false} placement="bottom" content="Report an issue">
               <a
               className="playground__icon-button"
               href="https://github.com/ionic-team/ionic-docs/issues/new/choose"
@@ -190,7 +190,7 @@ export default function Playground({
               </svg>
             </a>
             </Tippy>
-            <Tippy arrow={false} placement="bottom" content="Copy source code">
+            <Tippy theme="playground" arrow={false} placement="bottom" content="Copy source code">
               <button className="playground__icon-button playground__icon-button--primary" onClick={copySourceCode}>
               <svg
                 aria-hidden="true"
@@ -208,7 +208,7 @@ export default function Playground({
               </svg>
             </button>
             </Tippy>
-            <Tippy arrow={false} placement="bottom" content="Open in StackBlitz">
+            <Tippy theme="playground" arrow={false} placement="bottom" content="Open in StackBlitz">
               <button className="playground__icon-button playground__icon-button--primary" onClick={openEditor}>
               <svg
                 aria-hidden="true"

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -29,6 +29,7 @@
   --playground-btn-icon-color: var(--c-indigo-80);
   --playground-separator-color: var(--c-indigo-30);
   --playground-code-background: var(--c-indigo-10);
+  --playground-tooltip-background: var(--c-indigo-90);
 
   overflow: hidden;
 }
@@ -193,13 +194,13 @@
 }
 
 /* Tooltip styling */
-.tippy-box {
-  background-color: var(--playground-tooltip-background);
+.tippy-box[data-theme="playground"] {
+  background-color: var(--c-carbon-90);
   border-radius: 8px;
   line-height: initial;
-  font-size: 11px;
+  font-size: 12px;
 }
 
-.tippy-box .tippy-content {
-  padding: 8px 10px;
+.tippy-box[data-theme="playground"] .tippy-content {
+  padding: 6px 10px;
 }

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -29,7 +29,6 @@
   --playground-btn-icon-color: var(--c-indigo-80);
   --playground-separator-color: var(--c-indigo-30);
   --playground-code-background: var(--c-indigo-10);
-  --playground-tooltip-background: var(--c-indigo-90);
 
   overflow: hidden;
 }

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -191,3 +191,15 @@
 .playground iframe.frame-hidden {
   display: none;
 }
+
+/* Tooltip styling */
+.tippy-box {
+  background-color: var(--playground-tooltip-background);
+  border-radius: 8px;
+  line-height: initial;
+  font-size: 11px;
+}
+
+.tippy-box .tippy-content {
+  padding: 8px 10px;
+}


### PR DESCRIPTION
Hovering over the source code, github, copy code, and stackblitz buttons now show tooltips.