### PR TITLE
Update 3-saving-photos.md

### DIFF
--- a/docs/angular/your-first-app/3-saving-photos.md
+++ b/docs/angular/your-first-app/3-saving-photos.md
@@ -49,8 +49,8 @@ private async savePicture(photo: Photo) {
   // Use webPath to display the new image instead of base64 since it's
   // already loaded into memory
   return {
-    filepath: fileName,
-    webviewPath: photo.webPath
+    filePath: fileName,
+    webViewPath: photo.webPath
   };
 }
 ```


### PR DESCRIPTION
Fixed variable names to fix error: 

Argument of type '{ filepath: string; webviewPath: string; }' is not assignable to parameter of type 'UserPhoto'. [ng] Type '{ filepath: string; webviewPath: string; }' is missing the following properties from type 'UserPhoto': filePath, webViewPath