### PR TITLE
docs(support): update v5 and v6 support policy

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -22,11 +22,12 @@ The current status of each Ionic Framework version is:
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
-|   V5    |      **Active**       | Feb 11, 2020 |       TBD        |        TBD        |
-|   V4    |      Maintenance      | Jan 23, 2019 |   Aug 11, 2020   |        TBD        |
-|   V3    | Extended Support Only | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
-|   V2    |    End of Support     | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
-|   V1    |    End of Support     | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
+| V6      | **Active**            | Dec 8, 2021  | TBD              | TBD               |
+| V5      | Maintenance           | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
+| V4      | End of Support        | Jan 23, 2019 | Aug 11, 2020     | Feb 11, 2021      |
+| V3      | End of Support        | Apr 5, 2017  | Oct 30, 2019     | Aug 11, 2020      |
+| V2      | End of Support        | Jan 25, 2017 | Apr 5, 2017      | Apr 5, 2017       |
+| V1      | End of Support        | May 12, 2015 | Jan 25, 2017     | Jan 25, 2017      |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
 - **Extended Support**: For teams and organizations that require additional long term support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -24,7 +24,7 @@ The current status of each Ionic Framework version is:
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
 | V6      | **Active**            | Dec 8, 2021  | TBD              | TBD               |
 | V5      | Maintenance           | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
-| V4      | Extended Support Only | Jan 23, 2019 | Aug 11, 2020     | TBD               |
+| V4      | Extended Support Only | Jan 23, 2019 | Aug 11, 2020     | Sept 30, 2022     |
 | V3      | End of Support        | Apr 5, 2017  | Oct 30, 2019     | Aug 11, 2020      |
 | V2      | End of Support        | Jan 25, 2017 | Apr 5, 2017      | Apr 5, 2017       |
 | V1      | End of Support        | May 12, 2015 | Jan 25, 2017     | Jan 25, 2017      |

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -24,7 +24,7 @@ The current status of each Ionic Framework version is:
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
 | V6      | **Active**            | Dec 8, 2021  | TBD              | TBD               |
 | V5      | Maintenance           | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
-| V4      | End of Support        | Jan 23, 2019 | Aug 11, 2020     | Feb 11, 2021      |
+| V4      | Extended Support Only | Jan 23, 2019 | Aug 11, 2020     | TBD               |
 | V3      | End of Support        | Apr 5, 2017  | Oct 30, 2019     | Aug 11, 2020      |
 | V2      | End of Support        | Jan 25, 2017 | Apr 5, 2017      | Apr 5, 2017       |
 | V1      | End of Support        | May 12, 2015 | Jan 25, 2017     | Jan 25, 2017      |


### PR DESCRIPTION
This PR does the following:

1. Adds a new row to the support table for v6.
2. Indicates that v6 is the active version.
3. Moves v5 from "Active" to "Maintenance".
4. Defines "Maintenance Ends" and "Extended Support Ends" dates for v5.
5. Defines the "Extended Support Ends" date for v4.