### PR TITLE
docs(slides): set swiper instance in angular

### DIFF
--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -308,7 +308,7 @@ export class SlidesExample {
 
   constructor() {}
   setSwiperInstance(swiper: any) {
-    this.slides = ev;
+    this.slides = swiper;
   }
 }
 ```


### PR DESCRIPTION
Fixes a typo in the swiper example code snippet for Angular. 