### PR TITLE
docs(picker): angular usage example

### DIFF
--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -113,7 +113,58 @@ interface PickerAttributes extends JSXBase.HTMLAttributes<HTMLElement> {}
 
 ## Usage
 
-<Tabs groupId="framework" defaultValue="react" values={[{ value: 'react', label: 'React' }, { value: 'vue', label: 'Vue' }]}>
+<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'react', label: 'React' }, { value: 'vue', label: 'Vue' }]}>
+
+
+<TabItem value="angular">
+
+```html
+<ion-button expand="block" (click)="presentPicker()">Show Picker</ion-button>
+```
+
+```ts
+import { Component } from '@angular/core';
+import { PickerController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-picker-example',
+  template: 'picker-example.component.html'
+})
+export class PickerExample {
+
+  private selectedAnimal: string;
+
+  constructor(private pickerController: PickerController) { }
+  
+  async presentPicker() {
+    const picker = await this.pickerController.create({
+      buttons: [
+        {
+          text: 'Confirm',
+          handler: (selected) => {
+            this.selectedAnimal = selected.animal.value;
+          },
+        }
+      ],
+      columns: [
+        {
+          name: 'animal',
+          options: [
+            { text: 'Dog', value: 'dog' },
+            { text: 'Cat', value: 'cat' },
+            { text: 'Bird', value: 'bird' },
+          ]
+        }
+      ]
+    });
+    await picker.present();
+  }
+
+}
+
+```
+
+</TabItem>
 
 <TabItem value="react">
 


### PR DESCRIPTION
Adds usage example for Angular to the `ion-picker`. 

Quick link for effected section: https://ionic-docs-git-docs-picker-usage-angular-ionic1.vercel.app/docs/api/picker#usage