### PR TITLE
docs(react): v6 migrating controller import path

### DIFF
--- a/docs/intro/upgrading-to-ionic-6.md
+++ b/docs/intro/upgrading-to-ionic-6.md
@@ -75,6 +75,18 @@ Developers must import and call `setupIonicReact` even if they are not setting c
 
 See the [React Config Documentation](../react/config) for more examples.
 
+5. Update all controller imports from `@ionic/core` to `@ionic/core/components`. As an example, here is a migration for `menuController`:
+
+**Before**
+```tsx
+import { menuController } from '@ionic/core';
+```
+
+**After**
+```tsx
+import { menuController } from '@ionic/core/components';
+```
+
 ### Vue
 
 1. Ionic 6 supports Vue 3.0.6+. Update to the latest version of Vue:


### PR DESCRIPTION
Discovered in this framework issue: https://github.com/ionic-team/ionic-framework/issues/24497, React developers migrating from Ionic v5 to v6 will need to update controller imports to reference `@ionic/core/components`.

Without this change, they will create multiple instances of the menu controller and be unable to control their `ion-menu` through the menu controller. 