### PR TITLE
feat(component-playground): use devicePreview to render phone wrappers

### DIFF
--- a/src/components/global/Playground/device-preview.js
+++ b/src/components/global/Playground/device-preview.js
@@ -151,11 +151,7 @@ class DevicePreview extends HTMLElement {
     this.modeChanged();
   }
 
-  attributeChangedCallback(
-    name: string,
-    _previousValue: string,
-    _nextValue: string
-  ) {
+  attributeChangedCallback(name, _previousValue, _nextValue) {
     if (name === 'mode') {
       this.modeChanged();
     }

--- a/src/components/global/Playground/device-preview.js
+++ b/src/components/global/Playground/device-preview.js
@@ -123,6 +123,26 @@ class DevicePreview extends HTMLElement {
      height: 100%;
    }
 
+   @media only screen and (max-width: 600px) {
+    :host(.ios) .ios-notch,
+    :host(.md) .md-bar,
+    :host(.ios) figure::after {
+      display: none;
+    }
+
+    :host(.ios) figure,
+    :host(.md) figure {
+      border: 0;
+      border-radius: 0;
+      box-shadow: none;
+    }
+
+    :host(.ios) .content {
+      border-radius: 0;
+    }
+
+   }
+
  `;
 
       const _template = document.createElement('template');

--- a/src/components/global/Playground/device-preview.js
+++ b/src/components/global/Playground/device-preview.js
@@ -124,6 +124,9 @@ class DevicePreview extends HTMLElement {
    }
 
    @media only screen and (max-width: 600px) {
+    :host {
+      --device-width: 100%;
+    }
     :host(.ios) .ios-notch,
     :host(.md) .md-bar,
     :host(.ios) figure::after {

--- a/src/components/global/Playground/device-preview.ts
+++ b/src/components/global/Playground/device-preview.ts
@@ -1,0 +1,177 @@
+class DevicePreview extends HTMLElement {
+  static get observedAttributes() {
+    return ['mode'];
+  }
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+
+    if (this.shadowRoot) {
+      const _style = document.createElement('style');
+      _style.innerHTML = `
+   :host {
+     --device-padding: 1rem;
+     --device-width: 344px;
+     --device-height: 704px;
+     --device-frame-width: 12px;
+
+
+     display: flex;
+
+     align-items: center;
+     justify-content: center;
+   }
+
+   figure {
+     margin: 0;
+
+     background-size: contain;
+     background-repeat: no-repeat;
+
+     box-shadow: 0px 2px 8px rgba(2, 8, 20, 0.1), 0px 8px 16px rgba(2, 8, 20, 0.08);
+
+     width: var(--device-width);
+     height: var(--device-height);
+
+     overflow: hidden;
+
+     position: relative;
+
+     z-index: 1;
+   }
+
+   .content {
+    position: absolute;
+
+    top: 0;
+    left: 0;
+
+    width: 100%;
+    height: 100%;
+
+    border: none;
+
+    overflow: hidden;
+
+    -webkit-mask-image: -webkit-radial-gradient(white, black);
+
+    z-index: 1;
+   }
+
+   :host(.ios) figure {
+    border: 12px solid black;
+    border-radius: 54px;
+   }
+
+   :host(.ios) .content {
+     border-radius: 38px;
+   }
+
+   :host(.ios) figure:after {
+     background-color: rgba(0, 0, 0, 0.5);
+     border-radius: 2px;
+     bottom: 8px;
+     content: '';
+     height: 4px;
+     left: 50%;
+     position: absolute;
+     transform: translateX(-50%);
+     width: 35%;
+     z-index: 1;
+   }
+
+   :host(.md) figure {
+     border: 12px solid black;
+     border-radius: 44px;
+   }
+
+   :host(.md) .content {
+     border-radius: 32px;
+   }
+
+   .ios-notch {
+     display: none;
+     fill: #090a0d;
+     left: 50%;
+     position: absolute;
+     top: 0px;
+     transform: translateX(-50%);
+     width: 165px;
+     z-index: 2;
+   }
+
+   .md-bar {
+     display: none;
+     fill: rgba(125, 125, 125, 0.3);
+     padding: 0.5rem 2.2rem;
+     position: relative;
+     width: calc(100% - 64px);
+     z-index: 2;
+     top: 0px;
+   }
+
+   :host(.ios) .ios-notch {
+     display: block;
+   }
+
+   :host(.md) .md-bar {
+     display: block;
+   }
+
+   ::slotted(iframe) {
+     height: 100%;
+   }
+
+ `;
+
+      const _template = document.createElement('template');
+      _template.innerHTML = `
+        <figure>
+          <svg class="md-bar" viewBox="0 0 1384.3 40.3">
+            <path class="st0" d="M1343 5l18.8 32.3c.8 1.3 2.7 1.3 3.5 0L1384 5c.8-1.3-.2-3-1.7-3h-37.6c-1.5 0-2.5 1.7-1.7 3z"></path>
+            <circle class="st0" cx="1299" cy="20.2" r="20"></circle>
+            <path class="st0" d="M1213 1.2h30c2.2 0 4 1.8 4 4v30c0 2.2-1.8 4-4 4h-30c-2.2 0-4-1.8-4-4v-30c0-2.3 1.8-4 4-4zM16 4.2h64c8.8 0 16 7.2 16 16s-7.2 16-16 16H16c-8.8 0-16-7.2-16-16s7.2-16 16-16z"></path>
+          </svg>
+          <svg class="ios-notch" viewBox="0 0 219 31">
+            <path d="M0 1V0h219v1a5 5 0 0 0-5 5v3c0 12.15-9.85 22-22 22H27C14.85 31 5 21.15 5 9V6a5 5 0 0 0-5-5z" fill-rule="evenodd"></path>
+          </svg>
+          <div class="content">
+            <slot></slot>
+          </div>
+        </figure>
+      `;
+
+      this.shadowRoot.appendChild(_style);
+      this.shadowRoot.appendChild(_template.content.cloneNode(true));
+    }
+  }
+
+  connectedCallback() {
+    this.modeChanged();
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _previousValue: string,
+    _nextValue: string
+  ) {
+    if (name === 'mode') {
+      this.modeChanged();
+    }
+  }
+
+  modeChanged() {
+    const mode = this.getAttribute('mode');
+    if (this.shadowRoot) {
+      this.shadowRoot.host.classList.toggle('ios', mode === 'ios');
+      this.shadowRoot.host.classList.toggle('md', mode === 'md');
+    }
+  }
+}
+
+export function defineCustomElement() {
+  if (window.customElements.get('device-preview') === undefined) {
+    window.customElements.define('device-preview', DevicePreview);
+  }
+}

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -7,6 +7,7 @@ import { Mode, UsageTarget } from './playground.types';
 import useThemeContext from '@theme/hooks/useThemeContext';
 
 import Tippy from '@tippyjs/react';
+import { defineCustomElement } from './device-preview';
 import 'tippy.js/dist/tippy.css';
 
 const ControlButton = ({ isSelected, handleClick, title, label }) => {
@@ -49,10 +50,12 @@ export default function Playground({
   description,
   src,
   size = 'small',
+  devicePreview,
 }: {
   code: { [key in UsageTarget]?: () => {} };
   title?: string;
   description?: string;
+  devicePreview?: boolean;
 }) {
   if (!code || Object.keys(code).length === 0) {
     console.warn('No code usage examples provided for this Playground example.');
@@ -88,6 +91,10 @@ export default function Playground({
       frameMD.current.contentWindow.postMessage(message);
     }
   }, [isDarkTheme]);
+
+  useEffect(() => {
+    defineCustomElement();
+  });
 
   const isIOS = mode === Mode.iOS;
   const isMD = mode === Mode.MD;
@@ -241,8 +248,33 @@ export default function Playground({
             show the other. This is done to avoid flickering
             and doing unnecessary reloads when switching modes.
           */}
-          <iframe height={frameSize} className={!isIOS ? 'frame-hidden' : ''} ref={frameiOS} src={sourceiOS}></iframe>
-          <iframe height={frameSize} className={!isMD ? 'frame-hidden' : ''} ref={frameMD} src={sourceMD}></iframe>
+          {devicePreview
+            ? [
+                <div className={!isIOS ? 'frame-hidden' : ''}>
+                  <device-preview mode="ios">
+                    <iframe height={frameSize} ref={frameiOS} src={sourceiOS}></iframe>
+                  </device-preview>
+                </div>,
+                <div className={!isMD ? 'frame-hidden' : ''}>
+                  <device-preview mode="md">
+                    <iframe height={frameSize} ref={frameMD} src={sourceMD}></iframe>
+                  </device-preview>
+                </div>,
+              ]
+            : [
+                <iframe
+                  height={frameSize}
+                  className={!isIOS ? 'frame-hidden' : ''}
+                  ref={frameiOS}
+                  src={sourceiOS}
+                ></iframe>,
+                <iframe
+                  height={frameSize}
+                  className={!isMD ? 'frame-hidden' : ''}
+                  ref={frameMD}
+                  src={sourceMD}
+                ></iframe>,
+              ]}
         </div>
       </div>
       <div

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -251,12 +251,12 @@ export default function Playground({
           */}
           {devicePreview
             ? [
-                <div className={!isIOS ? 'frame-hidden' : ''}>
+                <div className={!isIOS ? 'frame-hidden' : 'frame-visible'}>
                   <device-preview mode="ios">
                     <iframe height={frameSize} ref={frameiOS} src={sourceiOS}></iframe>
                   </device-preview>
                 </div>,
-                <div className={!isMD ? 'frame-hidden' : ''}>
+                <div className={!isMD ? 'frame-hidden' : 'frame-visible'}>
                   <device-preview mode="md">
                     <iframe height={frameSize} ref={frameMD} src={sourceMD}></iframe>
                   </device-preview>

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -5,6 +5,7 @@ import './playground.css';
 import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, openVueEditor } from './stackblitz.utils';
 import { Mode, UsageTarget } from './playground.types';
 import useThemeContext from '@theme/hooks/useThemeContext';
+import { defineCustomElement } from './device-preview';
 
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
@@ -94,7 +95,7 @@ export default function Playground({
   }, [isDarkTheme]);
 
   useEffect(() => {
-    import('./device-preview.js').then((comp) => comp.defineCustomElement());
+    defineCustomElement();
   });
 
   const isIOS = mode === Mode.iOS;

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -7,7 +7,6 @@ import { Mode, UsageTarget } from './playground.types';
 import useThemeContext from '@theme/hooks/useThemeContext';
 
 import Tippy from '@tippyjs/react';
-import { defineCustomElement } from './device-preview';
 import 'tippy.js/dist/tippy.css';
 
 const ControlButton = ({ isSelected, handleClick, title, label }) => {
@@ -54,6 +53,8 @@ export default function Playground({
 }: {
   code: { [key in UsageTarget]?: () => {} };
   title?: string;
+  src: string;
+  size: string;
   description?: string;
   devicePreview?: boolean;
 }) {
@@ -93,7 +94,7 @@ export default function Playground({
   }, [isDarkTheme]);
 
   useEffect(() => {
-    defineCustomElement();
+    import('./device-preview.js').then((comp) => comp.defineCustomElement());
   });
 
   const isIOS = mode === Mode.iOS;

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -5,7 +5,6 @@ import './playground.css';
 import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, openVueEditor } from './stackblitz.utils';
 import { Mode, UsageTarget } from './playground.types';
 import useThemeContext from '@theme/hooks/useThemeContext';
-import { defineCustomElement } from './device-preview';
 
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
@@ -95,7 +94,11 @@ export default function Playground({
   }, [isDarkTheme]);
 
   useEffect(() => {
-    defineCustomElement();
+    /**
+     * Using a dynamic import here to avoid SSR errors when trying to extend `HTMLElement`
+     * to create the custom element.
+     */
+    import('./device-preview.js').then((comp) => comp.defineCustomElement());
   });
 
   const isIOS = mode === Mode.iOS;

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -188,7 +188,7 @@
   width: 100%;
 }
 
-.playground iframe.frame-hidden {
+.playground .frame-hidden {
   display: none;
 }
 

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -47,6 +47,8 @@
 
   margin: 18px 0;
   padding: 16px 0;
+
+  overflow: auto;
 }
 
 .playground__control-toolbar {

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -194,6 +194,10 @@
   display: none;
 }
 
+.playground .frame-visible {
+  width: 100%;
+}
+
 /* Tooltip styling */
 .tippy-box[data-theme="playground"] {
   background-color: var(--c-carbon-90);

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,5 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    'device-preview': any;
+  }
+}

--- a/static/usage/button/basic/index.md
+++ b/static/usage/button/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/button/basic/demo.html" />
+<Playground code={{ javascript, react, vue, angular }} src="usage/button/basic/demo.html" devicePreview />

--- a/static/usage/common.css
+++ b/static/usage/common.css
@@ -237,3 +237,8 @@
 
   height: 100%;
 }
+
+:root {
+  --ion-safe-area-top: 26px;
+  --ion-safe-area-bottom: 20px;
+}


### PR DESCRIPTION
Introduces new `devicePreview` option that can be enabled per-playground example to render a "device chrome" around the example iframe for iOS vs. MD. Copies the implementation styles close to the existing Ionic Docs, but uses an SVG instead of a PNG asset.

The inner `device-preview` is a web component with shadow-dom, to prevent style conflicts with the device wrapper.

Updated the button example (in our temporary playground doc), to show the device emulation. 

Live preview (Chrome will likely say it is a dangerous site): https://ionic-docs-git-feat-device-preview-ionic1.vercel.app/docs/playground/button

iOS:

<img src="https://user-images.githubusercontent.com/13732623/163846903-d20fc688-29f1-44eb-850a-7420463d8e39.png" width="500px" />

MD:

<img src="https://user-images.githubusercontent.com/13732623/163846898-09612d2c-8ea6-4167-afa9-475efb747f53.png" width="500px" />
