### PR TITLE
fix(stackblitz): ionic core types in angular examples

### DIFF
--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -92,6 +92,14 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
     },
     dependencies: {
       '@ionic/angular': DEFAULT_IONIC_VERSION,
+      /**
+       * Stackblitz doesn't install the underlying `@ionic/core` package type declarations.
+       * This can lead to issues with extended type declarations, such as our proxies
+       * that extend the JSX component type.
+       *
+       * We manually install this dependency to avoid this issue in Stackblitz.
+       */
+      '@ionic/core': DEFAULT_IONIC_VERSION,
     },
   });
 }


### PR DESCRIPTION
Stackblitz doesn't appear to install the whole `@ionic/core` package to allow the extended JSX types to populate in the examples. This change manually installs `@ionic/core` at the same version as the `@ionic/angular` package, which resolves this problem.

An example where this occurred was doing this:
```html
<ion-modal #modal>
  <ng-template>
    <ion-button (click)="modal.dismiss()">Dismiss</ion-buton>
  </ng-template>
</ion-modal>
```

`dismiss` would not exist on `IonModal` type.