### PR TITLE
fix(stackblitz/react): global classes in example

### DIFF
--- a/static/code/stackblitz/react/app.tsx
+++ b/static/code/stackblitz/react/app.tsx
@@ -6,6 +6,12 @@ import '@ionic/react/css/core.css';
 import '@ionic/react/css/normalize.css';
 import '@ionic/react/css/structure.css';
 import '@ionic/react/css/typography.css';
+/* Optional CSS utils that can be commented out */
+import '@ionic/react/css/padding.css';
+import '@ionic/react/css/float-elements.css';
+import '@ionic/react/css/text-alignment.css';
+import '@ionic/react/css/text-transformation.css';
+import '@ionic/react/css/flex-utils.css';
 
 setupIonicReact();
 


### PR DESCRIPTION
Adds the stylesheets to the react Stackblitz examples for many of our commonly used helper global classes (i.e.: `ion-text-center`).