### PR TITLE
fix(stackblitz): tsconfig file output in live example

### DIFF
--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -61,7 +61,6 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
     'angular/app.component.ts',
     'angular/styles.css',
     'angular/angular.json',
-    'angular/package.json',
     'angular/tsconfig.json'
   ])
 


### PR DESCRIPTION
Fixes the Stackblitz output for Angular examples. Previously we were passing a custom `package.json` to Stackblitz, but do not need that currently. Since that file is not fetched anymore, but is referenced in the code that maps the fetched code to a file path, it was mapping incorrectly. Removing the file path from the mapping logic resolves the issue.