### PR TITLE
docs(picker): component playground examples

### DIFF
--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -36,6 +36,23 @@ import APITOCInline from '@components/page/api/APITOCInline';
 
 A Picker is a dialog that displays a row of buttons and columns underneath. It appears on top of the app's content, and at the bottom of the viewport.
 
+## Single Column
+
+Display a list of options in a single, scrollable column.
+
+import SingleColumn from '@site/static/usage/picker/single-column/index.md';
+
+<SingleColumn />
+
+
+## Multiple Columns
+
+Display multiple columns of different options.
+
+import MultipleColumn from '@site/static/usage/picker/multiple-column/index.md';
+
+<MultipleColumn />
+
 ## Interfaces
 
 ### PickerButton

--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -1,8 +1,6 @@
 ---
 title: "ion-picker"
 hide_table_of_contents: true
-demoUrl: "/docs/demos/api/picker/index.html"
-demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/picker/index.html"
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -47,6 +47,7 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
       // Injects our code sample into the body of the HTML document
       'index.html': index_html.replace(/<body><\/body>/g, `<body>\n` + code + '</body>'),
       'index.ts': index_ts,
+      ...options?.files
     },
     dependencies: {
       '@ionic/core': DEFAULT_IONIC_VERSION,

--- a/static/code/stackblitz/html/index.ts
+++ b/static/code/stackblitz/html/index.ts
@@ -1,3 +1,7 @@
 import { defineCustomElements } from '@ionic/core/loader';
 
+import { pickerController } from '@ionic/core';
+
 defineCustomElements();
+
+(window as any).pickerController = pickerController;

--- a/static/usage/picker/multiple-column/angular/app_component_html.md
+++ b/static/usage/picker/multiple-column/angular/app_component_html.md
@@ -1,0 +1,5 @@
+```html
+<ion-content [fullscreen]="true">
+  <ion-button (click)="openPicker()">Open</ion-button>
+</ion-content>
+```

--- a/static/usage/picker/multiple-column/angular/app_component_html.md
+++ b/static/usage/picker/multiple-column/angular/app_component_html.md
@@ -1,5 +1,5 @@
 ```html
-<ion-content [fullscreen]="true">
+<ion-content class="ion-padding">
   <ion-button (click)="openPicker()">Open</ion-button>
 </ion-content>
 ```

--- a/static/usage/picker/multiple-column/angular/app_component_ts.md
+++ b/static/usage/picker/multiple-column/angular/app_component_ts.md
@@ -71,7 +71,9 @@ export class AppComponent {
         },
         {
           text: 'Confirm',
-          handler: (value) => {},
+          handler: (value) => {
+            window.alert(`You selected a ${value.crust.text} pizza with ${value.meat.text} and ${value.veggies.text}`);
+          },
         },
       ],
     });

--- a/static/usage/picker/multiple-column/angular/app_component_ts.md
+++ b/static/usage/picker/multiple-column/angular/app_component_ts.md
@@ -1,0 +1,82 @@
+```ts
+import { Component } from '@angular/core';
+import { PickerController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  constructor(private pickerCtrl: PickerController) {}
+
+  async openPicker() {
+    const picker = await this.pickerCtrl.create({
+      columns: [
+        {
+          name: 'meat',
+          options: [
+            {
+              text: 'Pepperoni',
+              value: 'pepperoni',
+            },
+            {
+              text: 'Smoked Ham',
+              value: 'smoked-ham',
+            },
+            {
+              text: 'Crispy Bacon',
+              value: 'bacon',
+            },
+          ],
+        },
+        {
+          name: 'veggies',
+          options: [
+            {
+              text: 'Red onion',
+              value: 'red-onion',
+            },
+            {
+              text: 'Peppers',
+              value: 'peppers',
+            },
+            {
+              text: 'Black olives',
+              value: 'black-olives',
+            },
+          ],
+        },
+        {
+          name: 'crust',
+          options: [
+            {
+              text: 'Pan style',
+              value: 'pan',
+            },
+            {
+              text: 'Hand tossed',
+              value: 'hand-tossed',
+            },
+            {
+              text: 'Stuffed crust',
+              value: 'stuffed-crust',
+            },
+          ],
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Confirm',
+          handler: (value) => {},
+        },
+      ],
+    });
+
+    await picker.present();
+  }
+}
+```

--- a/static/usage/picker/multiple-column/demo.html
+++ b/static/usage/picker/multiple-column/demo.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Picker | Multiple Columns</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module">
+    import { pickerController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
+    window.pickerController = pickerController;
+  </script>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content fullscreen>
+      <div class="container">
+        <ion-button onclick="openPicker()">Open</ion-button>
+      </div>
+    </ion-content>
+  </ion-app>
+  <script>
+    async function openPicker() {
+      const picker = await pickerController.create({
+        columns: [{
+          name: 'meat',
+          options: [
+            {
+              text: 'Pepperoni',
+              value: 'pepperoni'
+            }, {
+              text: 'Smoked Ham',
+              value: 'smoked-ham'
+            }, {
+              text: 'Crispy Bacon',
+              value: 'bacon'
+            }
+          ]
+        }, {
+          name: 'veggies',
+          options: [
+            {
+              text: 'Red onion',
+              value: 'red-onion'
+            }, {
+              text: 'Peppers',
+              value: 'peppers'
+            }, {
+              text: 'Black olives',
+              value: 'black-olives'
+            }
+          ]
+        }, {
+          name: 'crust',
+          options: [
+            {
+              text: 'Pan style',
+              value: 'pan'
+            }, {
+              text: 'Hand tossed',
+              value: 'hand-tossed'
+            }, {
+              text: 'Stuffed crust',
+              value: 'stuffed-crust'
+            }
+          ]
+        }],
+        buttons: [
+          {
+            text: 'Cancel',
+            role: 'cancel'
+          },
+          {
+            text: 'Confirm',
+            handler: (value) => {
+
+            }
+          }
+        ]
+      });
+      await picker.present();
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/picker/multiple-column/demo.html
+++ b/static/usage/picker/multiple-column/demo.html
@@ -17,7 +17,7 @@
 
 <body>
   <ion-app>
-    <ion-content fullscreen>
+    <ion-content>
       <div class="container">
         <ion-button onclick="openPicker()">Open</ion-button>
       </div>
@@ -77,7 +77,7 @@
           {
             text: 'Confirm',
             handler: (value) => {
-
+              window.alert(`You selected a ${value.crust.text} pizza with ${value.meat.text} and ${value.veggies.text}`);
             }
           }
         ]

--- a/static/usage/picker/multiple-column/index.md
+++ b/static/usage/picker/multiple-column/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+      },
+    },
+  }}
+  src="usage/picker/multiple-column/demo.html"
+  size="medium"
+/>

--- a/static/usage/picker/multiple-column/javascript.md
+++ b/static/usage/picker/multiple-column/javascript.md
@@ -1,9 +1,7 @@
 ```html
 <ion-app>
-  <ion-content fullscreen>
-    <div class="container">
-      <ion-button onclick="openPicker()">Open</ion-button>
-    </div>
+  <ion-content class="ion-padding">
+    <ion-button onclick="openPicker()">Open</ion-button>
   </ion-content>
 </ion-app>
 <script>
@@ -69,7 +67,9 @@
         },
         {
           text: 'Confirm',
-          handler: (value) => {},
+          handler: (value) => {
+            window.alert(`You selected a ${value.crust.text} pizza with ${value.meat.text} and ${value.veggies.text}`);
+          },
         },
       ],
     });

--- a/static/usage/picker/multiple-column/javascript.md
+++ b/static/usage/picker/multiple-column/javascript.md
@@ -1,0 +1,79 @@
+```html
+<ion-app>
+  <ion-content fullscreen>
+    <div class="container">
+      <ion-button onclick="openPicker()">Open</ion-button>
+    </div>
+  </ion-content>
+</ion-app>
+<script>
+  async function openPicker() {
+    const picker = await pickerController.create({
+      columns: [
+        {
+          name: 'meat',
+          options: [
+            {
+              text: 'Pepperoni',
+              value: 'pepperoni',
+            },
+            {
+              text: 'Smoked Ham',
+              value: 'smoked-ham',
+            },
+            {
+              text: 'Crispy Bacon',
+              value: 'bacon',
+            },
+          ],
+        },
+        {
+          name: 'veggies',
+          options: [
+            {
+              text: 'Red onion',
+              value: 'red-onion',
+            },
+            {
+              text: 'Peppers',
+              value: 'peppers',
+            },
+            {
+              text: 'Black olives',
+              value: 'black-olives',
+            },
+          ],
+        },
+        {
+          name: 'crust',
+          options: [
+            {
+              text: 'Pan style',
+              value: 'pan',
+            },
+            {
+              text: 'Hand tossed',
+              value: 'hand-tossed',
+            },
+            {
+              text: 'Stuffed crust',
+              value: 'stuffed-crust',
+            },
+          ],
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Confirm',
+          handler: (value) => {},
+        },
+      ],
+    });
+    await picker.present();
+  }
+</script>
+```

--- a/static/usage/picker/multiple-column/react.md
+++ b/static/usage/picker/multiple-column/react.md
@@ -1,0 +1,86 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, IonPage, useIonPicker } from '@ionic/react';
+
+function Example() {
+  const [present] = useIonPicker();
+
+  const openPicker = async () => {
+    present({
+      columns: [
+        {
+          name: 'meat',
+          options: [
+            {
+              text: 'Pepperoni',
+              value: 'pepperoni',
+            },
+            {
+              text: 'Smoked Ham',
+              value: 'smoked-ham',
+            },
+            {
+              text: 'Crispy Bacon',
+              value: 'bacon',
+            },
+          ],
+        },
+        {
+          name: 'veggies',
+          options: [
+            {
+              text: 'Red onion',
+              value: 'red-onion',
+            },
+            {
+              text: 'Peppers',
+              value: 'peppers',
+            },
+            {
+              text: 'Black olives',
+              value: 'black-olives',
+            },
+          ],
+        },
+        {
+          name: 'crust',
+          options: [
+            {
+              text: 'Pan style',
+              value: 'pan',
+            },
+            {
+              text: 'Hand tossed',
+              value: 'hand-tossed',
+            },
+            {
+              text: 'Stuffed crust',
+              value: 'stuffed-crust',
+            },
+          ],
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Confirm',
+          handler: (value) => {},
+        },
+      ],
+    });
+  };
+
+  return (
+    <IonPage>
+      <IonContent className="ion-padding">
+        <IonButton onClick={openPicker}>Open</IonButton>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/picker/multiple-column/react.md
+++ b/static/usage/picker/multiple-column/react.md
@@ -67,7 +67,9 @@ function Example() {
         },
         {
           text: 'Confirm',
-          handler: (value) => {},
+          handler: (value) => {
+            window.alert(`You selected a ${value.crust.text} pizza with ${value.meat.text} and ${value.veggies.text}`);
+          },
         },
       ],
     });

--- a/static/usage/picker/multiple-column/vue.md
+++ b/static/usage/picker/multiple-column/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-content fullscreen>
+  <ion-content class="ion-padding">
     <ion-button @click="openPicker()">Open</ion-button>
   </ion-content>
 </template>
@@ -79,7 +79,11 @@
             },
             {
               text: 'Confirm',
-              handler: (value) => {},
+              handler: (value) => {
+                window.alert(
+                  `You selected a ${value.crust.text} pizza with ${value.meat.text} and ${value.veggies.text}`
+                );
+              },
             },
           ],
         });

--- a/static/usage/picker/multiple-column/vue.md
+++ b/static/usage/picker/multiple-column/vue.md
@@ -1,0 +1,91 @@
+```html
+<template>
+  <ion-content fullscreen>
+    <ion-button @click="openPicker()">Open</ion-button>
+  </ion-content>
+</template>
+
+<script>
+  import { IonButton, IonContent, pickerController } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonContent },
+    data() {
+      return {
+        message: '',
+      };
+    },
+    methods: {
+      async openPicker() {
+        const picker = await pickerController.create({
+          columns: [
+            {
+              name: 'meat',
+              options: [
+                {
+                  text: 'Pepperoni',
+                  value: 'pepperoni',
+                },
+                {
+                  text: 'Smoked Ham',
+                  value: 'smoked-ham',
+                },
+                {
+                  text: 'Crispy Bacon',
+                  value: 'bacon',
+                },
+              ],
+            },
+            {
+              name: 'veggies',
+              options: [
+                {
+                  text: 'Red onion',
+                  value: 'red-onion',
+                },
+                {
+                  text: 'Peppers',
+                  value: 'peppers',
+                },
+                {
+                  text: 'Black olives',
+                  value: 'black-olives',
+                },
+              ],
+            },
+            {
+              name: 'crust',
+              options: [
+                {
+                  text: 'Pan style',
+                  value: 'pan',
+                },
+                {
+                  text: 'Hand tossed',
+                  value: 'hand-tossed',
+                },
+                {
+                  text: 'Stuffed crust',
+                  value: 'stuffed-crust',
+                },
+              ],
+            },
+          ],
+          buttons: [
+            {
+              text: 'Cancel',
+              role: 'cancel',
+            },
+            {
+              text: 'Confirm',
+              handler: (value) => {},
+            },
+          ],
+        });
+        await picker.present();
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/picker/single-column/angular/app_component_html.md
+++ b/static/usage/picker/single-column/angular/app_component_html.md
@@ -1,0 +1,5 @@
+```html
+<ion-content [fullscreen]="true">
+  <ion-button (click)="openPicker()">Open</ion-button>
+</ion-content>
+```

--- a/static/usage/picker/single-column/angular/app_component_html.md
+++ b/static/usage/picker/single-column/angular/app_component_html.md
@@ -1,5 +1,5 @@
 ```html
-<ion-content [fullscreen]="true">
+<ion-content class="ion-padding">
   <ion-button (click)="openPicker()">Open</ion-button>
 </ion-content>
 ```

--- a/static/usage/picker/single-column/angular/app_component_ts.md
+++ b/static/usage/picker/single-column/angular/app_component_ts.md
@@ -13,7 +13,7 @@ export class AppComponent {
     const picker = await this.pickerCtrl.create({
       columns: [
         {
-          name: 'programming-languages',
+          name: 'languages',
           options: [
             {
               text: 'JavaScript',
@@ -41,7 +41,9 @@ export class AppComponent {
         },
         {
           text: 'Confirm',
-          handler: (value) => {},
+          handler: (value) => {
+            window.alert(`You selected: ${value.languages.value}`);
+          },
         },
       ],
     });

--- a/static/usage/picker/single-column/angular/app_component_ts.md
+++ b/static/usage/picker/single-column/angular/app_component_ts.md
@@ -1,0 +1,52 @@
+```ts
+import { Component } from '@angular/core';
+import { PickerController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  constructor(private pickerCtrl: PickerController) {}
+
+  async openPicker() {
+    const picker = await this.pickerCtrl.create({
+      columns: [
+        {
+          name: 'programming-languages',
+          options: [
+            {
+              text: 'JavaScript',
+              value: 'javascript',
+            },
+            {
+              text: 'TypeScript',
+              value: 'typescript',
+            },
+            {
+              text: 'Rust',
+              value: 'rust',
+            },
+            {
+              text: 'C#',
+              value: 'c#',
+            },
+          ],
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Confirm',
+          handler: (value) => {},
+        },
+      ],
+    });
+
+    await picker.present();
+  }
+}
+```

--- a/static/usage/picker/single-column/demo.html
+++ b/static/usage/picker/single-column/demo.html
@@ -17,7 +17,7 @@
 
 <body>
   <ion-app>
-    <ion-content fullscreen>
+    <ion-content>
       <div class="container">
         <ion-button onclick="openPicker()">Open</ion-button>
       </div>
@@ -27,7 +27,7 @@
     async function openPicker() {
       const picker = await pickerController.create({
         columns: [{
-          name: 'programming-languages',
+          name: 'languages',
           options: [
             {
               text: 'JavaScript',
@@ -52,7 +52,7 @@
           {
             text: 'Confirm',
             handler: (value) => {
-
+              window.alert(`You selected: ${value.languages.value}`);
             }
           }
         ]

--- a/static/usage/picker/single-column/demo.html
+++ b/static/usage/picker/single-column/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Picker | Single Column</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module">
+    import { pickerController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
+    window.pickerController = pickerController;
+  </script>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content fullscreen>
+      <div class="container">
+        <ion-button onclick="openPicker()">Open</ion-button>
+      </div>
+    </ion-content>
+  </ion-app>
+  <script>
+    async function openPicker() {
+      const picker = await pickerController.create({
+        columns: [{
+          name: 'programming-languages',
+          options: [
+            {
+              text: 'JavaScript',
+              value: 'javascript'
+            }, {
+              text: 'TypeScript',
+              value: 'typescript'
+            }, {
+              text: 'Rust',
+              value: 'rust'
+            }, {
+              text: 'C#',
+              value: 'c#'
+            }
+          ]
+        }],
+        buttons: [
+          {
+            text: 'Cancel',
+            role: 'cancel'
+          },
+          {
+            text: 'Confirm',
+            handler: (value) => {
+
+            }
+          }
+        ]
+      });
+      await picker.present();
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/picker/single-column/index.md
+++ b/static/usage/picker/single-column/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+      },
+    },
+  }}
+  src="usage/picker/single-column/demo.html"
+  size="medium"
+/>

--- a/static/usage/picker/single-column/javascript.md
+++ b/static/usage/picker/single-column/javascript.md
@@ -1,0 +1,49 @@
+```html
+<ion-app>
+  <ion-content fullscreen>
+    <div class="container">
+      <ion-button onclick="openPicker()">Open</ion-button>
+    </div>
+  </ion-content>
+</ion-app>
+<script>
+  async function openPicker() {
+    const picker = await pickerController.create({
+      columns: [
+        {
+          name: 'programming-languages',
+          options: [
+            {
+              text: 'JavaScript',
+              value: 'javascript',
+            },
+            {
+              text: 'TypeScript',
+              value: 'typescript',
+            },
+            {
+              text: 'Rust',
+              value: 'rust',
+            },
+            {
+              text: 'C#',
+              value: 'c#',
+            },
+          ],
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Confirm',
+          handler: (value) => {},
+        },
+      ],
+    });
+    await picker.present();
+  }
+</script>
+```

--- a/static/usage/picker/single-column/javascript.md
+++ b/static/usage/picker/single-column/javascript.md
@@ -1,9 +1,7 @@
 ```html
 <ion-app>
   <ion-content class="ion-padding">
-    <div class="container">
-      <ion-button onclick="openPicker()">Open</ion-button>
-    </div>
+    <ion-button onclick="openPicker()">Open</ion-button>
   </ion-content>
 </ion-app>
 <script>

--- a/static/usage/picker/single-column/javascript.md
+++ b/static/usage/picker/single-column/javascript.md
@@ -1,6 +1,6 @@
 ```html
 <ion-app>
-  <ion-content fullscreen>
+  <ion-content class="ion-padding">
     <div class="container">
       <ion-button onclick="openPicker()">Open</ion-button>
     </div>
@@ -11,7 +11,7 @@
     const picker = await pickerController.create({
       columns: [
         {
-          name: 'programming-languages',
+          name: 'languages',
           options: [
             {
               text: 'JavaScript',
@@ -39,7 +39,9 @@
         },
         {
           text: 'Confirm',
-          handler: (value) => {},
+          handler: (value) => {
+            window.alert(`You selected: ${value.languages.value}`);
+          },
         },
       ],
     });

--- a/static/usage/picker/single-column/react.md
+++ b/static/usage/picker/single-column/react.md
@@ -9,7 +9,7 @@ function Example() {
     present({
       columns: [
         {
-          name: 'programming-languages',
+          name: 'languages',
           options: [
             {
               text: 'JavaScript',
@@ -37,7 +37,9 @@ function Example() {
         },
         {
           text: 'Confirm',
-          handler: (value) => {},
+          handler: (value) => {
+            window.alert(`You selected: ${value.languages.value}`);
+          },
         },
       ],
     });

--- a/static/usage/picker/single-column/react.md
+++ b/static/usage/picker/single-column/react.md
@@ -1,0 +1,56 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, IonPage, useIonPicker } from '@ionic/react';
+
+function Example() {
+  const [present] = useIonPicker();
+
+  const openPicker = async () => {
+    present({
+      columns: [
+        {
+          name: 'programming-languages',
+          options: [
+            {
+              text: 'JavaScript',
+              value: 'javascript',
+            },
+            {
+              text: 'TypeScript',
+              value: 'typescript',
+            },
+            {
+              text: 'Rust',
+              value: 'rust',
+            },
+            {
+              text: 'C#',
+              value: 'c#',
+            },
+          ],
+        },
+      ],
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+        },
+        {
+          text: 'Confirm',
+          handler: (value) => {},
+        },
+      ],
+    });
+  };
+
+  return (
+    <IonPage>
+      <IonContent className="ion-padding">
+        <IonButton onClick={openPicker}>Open</IonButton>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/picker/single-column/vue.md
+++ b/static/usage/picker/single-column/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-content fullscreen>
+  <ion-content class="ion-padding">
     <ion-button @click="openPicker()">Open</ion-button>
   </ion-content>
 </template>
@@ -21,7 +21,7 @@
         const picker = await pickerController.create({
           columns: [
             {
-              name: 'programming-languages',
+              name: 'languages',
               options: [
                 {
                   text: 'JavaScript',
@@ -49,7 +49,9 @@
             },
             {
               text: 'Confirm',
-              handler: (value) => {},
+              handler: (value) => {
+                window.alert(`You selected: ${value.languages.value}`);
+              },
             },
           ],
         });

--- a/static/usage/picker/single-column/vue.md
+++ b/static/usage/picker/single-column/vue.md
@@ -1,0 +1,61 @@
+```html
+<template>
+  <ion-content fullscreen>
+    <ion-button @click="openPicker()">Open</ion-button>
+  </ion-content>
+</template>
+
+<script>
+  import { IonButton, IonContent, pickerController } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonContent },
+    data() {
+      return {
+        message: '',
+      };
+    },
+    methods: {
+      async openPicker() {
+        const picker = await pickerController.create({
+          columns: [
+            {
+              name: 'programming-languages',
+              options: [
+                {
+                  text: 'JavaScript',
+                  value: 'javascript',
+                },
+                {
+                  text: 'TypeScript',
+                  value: 'typescript',
+                },
+                {
+                  text: 'Rust',
+                  value: 'rust',
+                },
+                {
+                  text: 'C#',
+                  value: 'c#',
+                },
+              ],
+            },
+          ],
+          buttons: [
+            {
+              text: 'Cancel',
+              role: 'cancel',
+            },
+            {
+              text: 'Confirm',
+              handler: (value) => {},
+            },
+          ],
+        });
+        await picker.present();
+      },
+    },
+  });
+</script>
+```


### PR DESCRIPTION
Introduces component playground examples for `ion-picker` for the single and multi-column examples. 

Verified each usage target example in Stackblitz, with both single and multiple columns.

Quick link to `ion-picker` page: https://ionic-docs-git-fw-1278-ionic1.vercel.app/docs/api/picker