### PR TITLE
docs(modal): presenting inline modals

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -42,13 +42,13 @@ A Modal is a dialog that appears on top of the app's content, and must be dismis
 
 When using `ion-modal` with Angular, React, or Vue, the component you pass in will be destroyed when the modal is dismissed. As this functionality is provided by the JavaScript framework, using `ion-modal` without a JavaScript framework will not destroy the component you passed in. If this is a needed functionality, we recommend using the `modalController` instead.
 
-TODO: Playground Example
-
 #### Using triggers
 
 A trigger is an element reference, that when selected will automatically open a modal. Triggers are useful when presenting a modal from a button or similar interaction.
 
-TODO: Playground Example
+import PresentTriggerExample from '@site/static/usage/modal/presenting/inline/trigger/index.md';
+
+<PresentTriggerExample />
 
 #### Using `isOpen`
 
@@ -56,7 +56,9 @@ The `isOpen` property on `ion-modal` allows developers to control the presentati
 
 `isOpen` uses one-way data binding, meaning it will not automatically be set to `false` when the modal is dismissed. To keep the state of `isOpen` in sync with your UI state, listen for either `ionModalDidDismiss` or `didDismiss` and set the variable to `false`.
 
-TODO: Playground Example
+import PresentIsOpenExample from '@site/static/usage/modal/presenting/inline/is-open/index.md'; 
+
+<PresentIsOpenExample />
 
 ### Controller Modals
 

--- a/static/usage/modal/presenting/inline/is-open/angular.md
+++ b/static/usage/modal/presenting/inline/is-open/angular.md
@@ -1,0 +1,20 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Inline Modal</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-modal [isOpen]="true">
+    <ng-template>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">This is an example of an inline full-height modal.</ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>
+```

--- a/static/usage/modal/presenting/inline/is-open/demo.html
+++ b/static/usage/modal/presenting/inline/is-open/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Inline</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Inline Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <ion-modal is-open="true">
+        <ion-header>
+          <ion-toolbar>
+            <ion-title>Modal</ion-title>
+          </ion-toolbar>
+        </ion-header>
+        <ion-content class="ion-padding">
+          This is an example of an inline full-height modal.
+        </ion-content>
+      </ion-modal>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/modal/presenting/inline/is-open/index.md
+++ b/static/usage/modal/presenting/inline/is-open/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{ javascript, react, vue, angular }}
+  src="usage/modal/presenting/inline/is-open/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/presenting/inline/is-open/javascript.md
+++ b/static/usage/modal/presenting/inline/is-open/javascript.md
@@ -1,0 +1,19 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-modal is-open="true">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding"> This is an example of an inline full-height modal. </ion-content>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+```

--- a/static/usage/modal/presenting/inline/is-open/react.md
+++ b/static/usage/modal/presenting/inline/is-open/react.md
@@ -1,0 +1,28 @@
+```tsx
+import React from 'react';
+import { IonModal, IonHeader, IonContent, IonToolbar, IonTitle, IonPage } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Inline Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <IonModal isOpen={true}>
+          <IonHeader>
+            <IonToolbar>
+              <IonTitle>Modal</IonTitle>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent className="ion-padding">This is an example of an inline full-height modal.</IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/presenting/inline/is-open/vue.md
+++ b/static/usage/modal/presenting/inline/is-open/vue.md
@@ -1,0 +1,28 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-modal :is-open="true">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding"> This is an example of an inline full-height modal. </ion-content>
+    </ion-modal>
+  </ion-content>
+</template>
+
+<script>
+  import { IonButton, IonModal, IonHeader, IonToolbar, IonTitle } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonModal, IonHeader, IonToolbar, IonTitle },
+  });
+</script>
+```

--- a/static/usage/modal/presenting/inline/trigger/angular.md
+++ b/static/usage/modal/presenting/inline/trigger/angular.md
@@ -1,0 +1,22 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Inline Modal</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-button id="open-modal">Open Modal</ion-button>
+
+  <ion-modal trigger="open-modal">
+    <ng-template>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">This is an example of an inline full-height modal.</ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>
+```

--- a/static/usage/modal/presenting/inline/trigger/demo.html
+++ b/static/usage/modal/presenting/inline/trigger/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Inline</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Inline Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <div class="container">
+        <ion-button id="open-modal">Open Modal</ion-button>
+      </div>
+      <ion-modal trigger="open-modal">
+        <ion-header>
+          <ion-toolbar>
+            <ion-title>Modal</ion-title>
+          </ion-toolbar>
+        </ion-header>
+        <ion-content class="ion-padding">
+          This is an example of an inline full-height modal.
+        </ion-content>
+      </ion-modal>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/modal/presenting/inline/trigger/index.md
+++ b/static/usage/modal/presenting/inline/trigger/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{ javascript, react, vue, angular }}
+  src="usage/modal/presenting/inline/trigger/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/presenting/inline/trigger/javascript.md
+++ b/static/usage/modal/presenting/inline/trigger/javascript.md
@@ -1,0 +1,22 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-button id="open-modal">Open Modal</ion-button>
+
+    <ion-modal trigger="open-modal">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">This is an example of an inline full-height modal.</ion-content>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+```

--- a/static/usage/modal/presenting/inline/trigger/react.md
+++ b/static/usage/modal/presenting/inline/trigger/react.md
@@ -1,0 +1,29 @@
+```tsx
+import React from 'react';
+import { IonButton, IonModal, IonHeader, IonContent, IonToolbar, IonTitle, IonPage } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Inline Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <IonButton id="open-modal">Open Modal</IonButton>
+        <IonModal trigger="open-modal">
+          <IonHeader>
+            <IonToolbar>
+              <IonTitle>Modal</IonTitle>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent className="ion-padding">This is an example of an inline full-height modal.</IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/presenting/inline/trigger/vue.md
+++ b/static/usage/modal/presenting/inline/trigger/vue.md
@@ -1,0 +1,29 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content>
+    <ion-button id="open-modal">Open Modal</ion-button>
+    <ion-modal trigger="open-modal">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding"> This is an example of an inline full-height modal. </ion-content>
+    </ion-modal>
+  </ion-content>
+</template>
+
+<script>
+  import { IonButton, IonModal, IonHeader, IonToolbar, IonTitle } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonModal, IonHeader, IonToolbar, IonTitle },
+  });
+</script>
+```


### PR DESCRIPTION
This PR adds the component playground examples for presenting inline modals.