### PR TITLE
docs(modal): presenting controller modals

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -62,7 +62,9 @@ TODO: Playground Example
 
 With the `modalController` developers can present an `ion-modal` programmatically. Developers will have complete control over when a modal is presented and dismissed.
 
-TODO: Playground Example
+import PresentControllerExample from '@site/static/usage/modal/presenting/controller/index.md';
+
+<PresentControllerExample />
 
 ## Dismissing
 

--- a/static/code/stackblitz/angular/app.module.ts
+++ b/static/code/stackblitz/angular/app.module.ts
@@ -5,9 +5,11 @@ import { IonicModule } from '@ionic/angular';
 
 import { AppComponent } from './app.component';
 
+const DECLARATIONS = [/* CUSTOM_DECLARATIONS */];
+
 @NgModule({
   imports: [BrowserModule, IonicModule.forRoot({})],
-  declarations: [AppComponent],
+  declarations: [AppComponent, ...DECLARATIONS],
   bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/static/usage/modal/presenting/controller/angular/app_component_html.md
+++ b/static/usage/modal/presenting/controller/angular/app_component_html.md
@@ -1,0 +1,5 @@
+```html
+<ion-content class="ion-padding">
+  <ion-button (click)="openModal()">Open Modal</ion-button>
+</ion-content>
+```

--- a/static/usage/modal/presenting/controller/angular/app_component_ts.md
+++ b/static/usage/modal/presenting/controller/angular/app_component_ts.md
@@ -1,0 +1,21 @@
+```ts
+import { Component } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+import { ModalExampleComponent } from './modal-example.component';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  constructor(private modalCtrl: ModalController) {}
+
+  async openModal() {
+    const modal = await this.modalCtrl.create({
+      component: ModalExampleComponent,
+    });
+    modal.present();
+  }
+}
+```

--- a/static/usage/modal/presenting/controller/angular/modal-example_component_html.md
+++ b/static/usage/modal/presenting/controller/angular/modal-example_component_html.md
@@ -1,0 +1,9 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Modal</ion-title>
+    <ion-button slot="end" fill="clear" (click)="dismiss()">Dismiss</ion-button>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding"> This is an example of a controller full-height modal. </ion-content>
+```

--- a/static/usage/modal/presenting/controller/angular/modal-example_component_ts.md
+++ b/static/usage/modal/presenting/controller/angular/modal-example_component_ts.md
@@ -1,0 +1,17 @@
+```ts
+import { Component } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-modal-example',
+  templateUrl: 'modal-example.component.html',
+})
+export class ModalExampleComponent {
+  constructor(private modalCtrl: ModalController) {}
+
+  dismiss() {
+    return this.modalCtrl.dismiss();
+  }
+}
+```

--- a/static/usage/modal/presenting/controller/demo.html
+++ b/static/usage/modal/presenting/controller/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Controller</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <script type="module">
+    import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
+    window.modalController = modalController;
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <div class="container">
+        <ion-button onclick="openModal()">Open Modal</ion-button>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+
+    const openModal = async () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+            <ion-title>Modal</ion-title>
+            <ion-button slot="end" fill="clear" onclick="dismiss()">Dismiss</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        This is an example of a controller full-height modal.
+      </ion-content>
+      `;
+
+      const modal = await modalController.create({
+        component: div,
+      });
+
+      modal.present();
+    }
+
+    const dismiss = () => {
+      const modal = document.querySelector('ion-modal');
+      modal.dismiss();
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/presenting/controller/index.md
+++ b/static/usage/modal/presenting/controller/index.md
@@ -1,0 +1,39 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_modal_example_component_html from './angular/modal-example_component_html.md';
+import angular_modal_example_component_ts from './angular/modal-example_component_ts.md';
+
+import vue_example from './vue/example_vue.md';
+import vue_modal from './vue/modal_vue.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue: {
+      files: {
+        'src/components/Example.vue': vue_example,
+        'src/components/Modal.vue': vue_modal,
+      },
+    },
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+        'src/app/modal-example.component.html': angular_modal_example_component_html,
+        'src/app/modal-example.component.ts': angular_modal_example_component_ts,
+      },
+      angularModuleOptions: {
+        imports: [`import { ModalExampleComponent } from './modal-example.component';`],
+        declarations: ['ModalExampleComponent'],
+      },
+    },
+  }}
+  src="usage/modal/presenting/controller/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/presenting/controller/javascript.md
+++ b/static/usage/modal/presenting/controller/javascript.md
@@ -1,0 +1,40 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Controller Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button onclick="openModal()">Open Modal</ion-button>
+  </ion-content>
+</ion-app>
+
+<script>
+  var openModal = async () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+            <ion-title>Modal</ion-title>
+            <ion-button slot="end" fill="clear" onclick="dismiss()">Dismiss</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        This is an example of a controller full-height modal.
+      </ion-content>
+      `;
+
+    let modal = await modalController.create({
+      component: div,
+    });
+
+    modal.present();
+  };
+
+  var dismiss = () => {
+    const modal = document.querySelector('ion-modal');
+    modal.dismiss();
+  };
+</script>
+```

--- a/static/usage/modal/presenting/controller/react.md
+++ b/static/usage/modal/presenting/controller/react.md
@@ -1,0 +1,39 @@
+```tsx
+import React from 'react';
+import { IonButton, IonHeader, IonContent, IonToolbar, IonTitle, IonPage, useIonModal } from '@ionic/react';
+
+const ModalExample = ({ onDismiss }) => (
+  <div>
+    <IonHeader>
+      <IonToolbar>
+        <IonTitle>Modal</IonTitle>
+        <IonButton slot="end" fill="clear" onClick={() => onDismiss()}>
+          Dismiss
+        </IonButton>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent class="ion-padding">This is an example of an controller full-height modal.</IonContent>
+  </div>
+);
+
+function Example() {
+  const [present, dismiss] = useIonModal(ModalExample, {
+    onDismiss: () => dismiss(),
+  });
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Controller Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonButton onClick={() => present()}>Open Modal</IonButton>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/presenting/controller/vue/example_vue.md
+++ b/static/usage/modal/presenting/controller/vue/example_vue.md
@@ -1,0 +1,31 @@
+```html
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button @click="openModal">Open Modal</ion-button>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script>
+  import { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle, modalController } from '@ionic/vue';
+  import Modal from './Modal.vue';
+
+  export default {
+    components: { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle },
+    methods: {
+      async openModal() {
+        const modal = await modalController.create({
+          component: Modal,
+        });
+        return modal.present();
+      },
+    },
+  };
+</script>
+```

--- a/static/usage/modal/presenting/controller/vue/modal_vue.md
+++ b/static/usage/modal/presenting/controller/vue/modal_vue.md
@@ -1,0 +1,26 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Modal</ion-title>
+      <ion-button slot="end" fill="clear" @click="dismiss">Dismiss</ion-button>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding"> This is an example of a controller full-height modal. </ion-content>
+</template>
+
+<script>
+  import { IonContent, IonHeader, IonTitle, IonToolbar, IonButton, modalController } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    name: 'Modal',
+    components: { IonContent, IonHeader, IonTitle, IonToolbar, IonButton },
+    methods: {
+      dismiss() {
+        return modalController.dismiss();
+      },
+    },
+  });
+</script>
+```


### PR DESCRIPTION
This PR adds the component playground example for presenting a controller modal.