### PR TITLE
docs(modal): dismissing controller modals

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -101,20 +101,25 @@ TODO: Playground Example
 
 Since controller modals open a new component outside of the scope of the current template, that component will need the ability to dismiss itself and return context to the presenting view.
 
-TODO: Playground Example
+import ControllerDismissExample from '@site/static/usage/modal/dismissing/controller/dismiss/index.md';
+
+<ControllerDismissExample />
 
 #### Returning data when dismissed
 
 When dismissing a modal, you can optionally send data back to the presenting view.
 
-TODO: Playground Example
+import ControllerDismissDataExample from '@site/static/usage/modal/dismissing/controller/data/index.md';
+
+<ControllerDismissDataExample />
 
 #### Using roles to distinguish dismiss actions
 
 When dismissing a modal, you can optionally specify the `role` responsible for dismissing the modal. Roles are used to differentiate the operation that dismissed the modal, such as a cancel or confirm action.
 
-TODO: Playground Example
+import ControllerDismissRoleExample from '@site/static/usage/modal/dismissing/controller/role/index.md';
 
+<ControllerDismissRoleExample />
 
 ### Preventing a modal from dismissing
 

--- a/static/code/stackblitz/angular/app.module.ts
+++ b/static/code/stackblitz/angular/app.module.ts
@@ -5,9 +5,11 @@ import { IonicModule } from '@ionic/angular';
 
 import { AppComponent } from './app.component';
 
+const DECLARATIONS = [/* CUSTOM_DECLARATIONS */];
+
 @NgModule({
   imports: [BrowserModule, IonicModule.forRoot({})],
-  declarations: [AppComponent],
+  declarations: [AppComponent, ...DECLARATIONS],
   bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/static/usage/modal/dismissing/controller/data/angular/app_component_html.md
+++ b/static/usage/modal/dismissing/controller/data/angular/app_component_html.md
@@ -1,0 +1,10 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Controller Modal</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <div>{{ message }}</div>
+</ion-content>
+```

--- a/static/usage/modal/dismissing/controller/data/angular/app_component_ts.md
+++ b/static/usage/modal/dismissing/controller/data/angular/app_component_ts.md
@@ -1,0 +1,30 @@
+```ts
+import { Component, OnInit } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+import { ModalExampleComponent } from './modal-example.component';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent implements OnInit {
+  message: string;
+
+  constructor(private modalCtrl: ModalController) {}
+
+  ngOnInit() {
+    this.openModal();
+  }
+
+  async openModal() {
+    const modal = await this.modalCtrl.create({
+      component: ModalExampleComponent,
+    });
+    modal.present();
+
+    const { data } = await modal.onDidDismiss();
+    this.message = `Hello, ${data}!`;
+  }
+}
+```

--- a/static/usage/modal/dismissing/controller/data/angular/modal-example_component_html.md
+++ b/static/usage/modal/dismissing/controller/data/angular/modal-example_component_html.md
@@ -1,0 +1,14 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Modal</ion-title>
+    <ion-button slot="end" fill="clear" (click)="dismiss(input.value)">Dismiss</ion-button>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <ion-item>
+    <ion-label>Enter your name</ion-label>
+    <ion-input #input type="text" placeholder="Your name"></ion-input>
+  </ion-item>
+</ion-content>
+```

--- a/static/usage/modal/dismissing/controller/data/angular/modal-example_component_ts.md
+++ b/static/usage/modal/dismissing/controller/data/angular/modal-example_component_ts.md
@@ -1,0 +1,17 @@
+```ts
+import { Component } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-modal-example',
+  templateUrl: 'modal-example.component.html',
+})
+export class ModalExampleComponent {
+  constructor(private modalCtrl: ModalController) {}
+
+  dismiss(value: string | number) {
+    return this.modalCtrl.dismiss(value);
+  }
+}
+```

--- a/static/usage/modal/dismissing/controller/data/demo.html
+++ b/static/usage/modal/dismissing/controller/data/demo.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Controller</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <script type="module">
+    import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
+    window.modalController = modalController;
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <div class="container">
+        <div id="message"></div>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const openModal = async () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+            <ion-title>Modal</ion-title>
+            <ion-button slot="end" fill="clear" onclick="dismiss()">Dismiss</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <ion-item>
+          <ion-label>Enter your name</ion-label>
+          <ion-input type="text" placeholder="Your name"></ion-input>
+        </ion-item>
+      </ion-content>
+      `;
+
+      const modal = await modalController.create({
+        component: div,
+      });
+
+      modal.present();
+
+      const { data } = await modal.onDidDismiss();
+
+      document.querySelector('#message').innerHTML = `Hello, ${data}!`;
+    }
+
+    const dismiss = () => {
+      const input = document.querySelector('ion-input');
+      modalController.dismiss(input.value);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      openModal();
+    });
+
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/dismissing/controller/data/index.md
+++ b/static/usage/modal/dismissing/controller/data/index.md
@@ -1,0 +1,39 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_modal_example_component_html from './angular/modal-example_component_html.md';
+import angular_modal_example_component_ts from './angular/modal-example_component_ts.md';
+
+import vue_example from './vue/example_vue.md';
+import vue_modal from './vue/modal_vue.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue: {
+      files: {
+        'src/components/Example.vue': vue_example,
+        'src/components/Modal.vue': vue_modal,
+      },
+    },
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+        'src/app/modal-example.component.html': angular_modal_example_component_html,
+        'src/app/modal-example.component.ts': angular_modal_example_component_ts,
+      },
+      angularModuleOptions: {
+        imports: [`import { ModalExampleComponent } from './modal-example.component';`],
+        declarations: ['ModalExampleComponent'],
+      },
+    },
+  }}
+  src="usage/modal/dismissing/controller/data/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/dismissing/controller/data/javascript.md
+++ b/static/usage/modal/dismissing/controller/data/javascript.md
@@ -1,0 +1,51 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Controller Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <div class="container">
+      <div id="message"></div>
+    </div>
+  </ion-content>
+</ion-app>
+
+<script>
+  var openModal = async () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+            <ion-title>Modal</ion-title>
+            <ion-button slot="end" fill="clear" onclick="dismiss()">Dismiss</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <ion-item>
+          <ion-label>Enter your name</ion-label>
+          <ion-input type="text" placeholder="Your name"></ion-input>
+        </ion-item>
+      </ion-content>
+      `;
+
+    const modal = await modalController.create({
+      component: div,
+    });
+
+    modal.present();
+
+    const { data } = await modal.onDidDismiss();
+
+    document.querySelector('#message').innerHTML = `Hello, ${data}!`;
+  };
+
+  var dismiss = () => {
+    const input = document.querySelector('ion-input');
+    modalController.dismiss(input.value);
+  };
+
+  openModal();
+</script>
+```

--- a/static/usage/modal/dismissing/controller/data/react.md
+++ b/static/usage/modal/dismissing/controller/data/react.md
@@ -1,0 +1,68 @@
+```tsx
+import React, { useEffect, useState, useRef } from 'react';
+import {
+  IonButton,
+  IonHeader,
+  IonContent,
+  IonToolbar,
+  IonTitle,
+  IonPage,
+  IonItem,
+  IonLabel,
+  IonInput,
+  useIonModal,
+} from '@ionic/react';
+
+const ModalExample = ({ onDismiss }) => {
+  const inputRef = useRef(null);
+  return (
+    <div>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Modal</IonTitle>
+          <IonButton slot="end" fill="clear" onClick={() => onDismiss(inputRef.current?.value)}>
+            Dismiss
+          </IonButton>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent class="ion-padding">
+        <IonItem>
+          <IonLabel>Enter your name</IonLabel>
+          <IonInput ref={inputRef} placeholder="Your name" />
+        </IonItem>
+      </IonContent>
+    </div>
+  );
+};
+
+function Example() {
+  const [present, dismiss] = useIonModal(ModalExample, {
+    onDismiss: () => dismiss(),
+  });
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    present({
+      onDidDismiss: (ev) => {
+        const name = ev.detail.data;
+        setMessage(`Hello, ${name}!`);
+      },
+    });
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Controller Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <p className="ion-text-center">{message}</p>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/dismissing/controller/data/vue/example_vue.md
+++ b/static/usage/modal/dismissing/controller/data/vue/example_vue.md
@@ -1,0 +1,43 @@
+```html
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <div>{{ message }}</div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script>
+  import { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle, modalController } from '@ionic/vue';
+  import Modal from './Modal.vue';
+
+  export default {
+    components: { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle },
+    data() {
+      return {
+        message: '',
+      };
+    },
+    methods: {
+      async openModal() {
+        const modal = await modalController.create({
+          component: Modal,
+        });
+        modal.present();
+
+        const { data } = await modal.onDidDismiss();
+
+        this.message = `Hello, ${data}!`;
+      },
+    },
+    mounted() {
+      this.openModal();
+    },
+  };
+</script>
+```

--- a/static/usage/modal/dismissing/controller/data/vue/modal_vue.md
+++ b/static/usage/modal/dismissing/controller/data/vue/modal_vue.md
@@ -1,0 +1,40 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Modal</ion-title>
+      <ion-button slot="end" fill="clear" @click="dismiss">Dismiss</ion-button>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-item>
+      <ion-label>Enter your name</ion-label>
+      <ion-input ref="input" type="text" placeholder="Your name"></ion-input>
+    </ion-item>
+  </ion-content>
+</template>
+
+<script>
+  import {
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonButton,
+    IonItem,
+    IonInput,
+    modalController,
+  } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    name: 'Modal',
+    components: { IonContent, IonHeader, IonTitle, IonToolbar, IonButton, IonItem, IonInput },
+    methods: {
+      dismiss() {
+        return modalController.dismiss(this.$refs.input.$el.value);
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/modal/dismissing/controller/dismiss/angular/app_component_html.md
+++ b/static/usage/modal/dismissing/controller/dismiss/angular/app_component_html.md
@@ -1,0 +1,10 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Controller Modal</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <ion-button (click)="openModal()">Open Modal</ion-button>
+</ion-content>
+```

--- a/static/usage/modal/dismissing/controller/dismiss/angular/app_component_ts.md
+++ b/static/usage/modal/dismissing/controller/dismiss/angular/app_component_ts.md
@@ -1,0 +1,21 @@
+```ts
+import { Component } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+import { ModalExampleComponent } from './modal-example.component';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  constructor(private modalCtrl: ModalController) {}
+
+  async openModal() {
+    const modal = await this.modalCtrl.create({
+      component: ModalExampleComponent,
+    });
+    modal.present();
+  }
+}
+```

--- a/static/usage/modal/dismissing/controller/dismiss/angular/modal-example_component_html.md
+++ b/static/usage/modal/dismissing/controller/dismiss/angular/modal-example_component_html.md
@@ -1,0 +1,9 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Modal</ion-title>
+    <ion-button slot="end" fill="clear" (click)="dismiss()">Dismiss</ion-button>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding"> This is an example of a controller full-height modal. </ion-content>
+```

--- a/static/usage/modal/dismissing/controller/dismiss/angular/modal-example_component_ts.md
+++ b/static/usage/modal/dismissing/controller/dismiss/angular/modal-example_component_ts.md
@@ -1,0 +1,17 @@
+```ts
+import { Component } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-modal-example',
+  templateUrl: 'modal-example.component.html',
+})
+export class ModalExampleComponent {
+  constructor(private modalCtrl: ModalController) {}
+
+  dismiss() {
+    return this.modalCtrl.dismiss();
+  }
+}
+```

--- a/static/usage/modal/dismissing/controller/dismiss/demo.html
+++ b/static/usage/modal/dismissing/controller/dismiss/demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Controller</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <script type="module">
+    import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
+    window.modalController = modalController;
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <div class="container">
+        <ion-button onclick="openModal()">Open Modal</ion-button>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const openModal = async () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+            <ion-title>Modal</ion-title>
+            <ion-button slot="end" fill="clear" onclick="dismiss()">Dismiss</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        This is an example of a controller full-height modal.
+      </ion-content>
+      `;
+
+      const modal = await modalController.create({
+        component: div,
+      });
+
+      modal.present();
+    }
+
+    const dismiss = () => {
+      modalController.dismiss();
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/dismissing/controller/dismiss/index.md
+++ b/static/usage/modal/dismissing/controller/dismiss/index.md
@@ -1,0 +1,39 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_modal_example_component_html from './angular/modal-example_component_html.md';
+import angular_modal_example_component_ts from './angular/modal-example_component_ts.md';
+
+import vue_example from './vue/example_vue.md';
+import vue_modal from './vue/modal_vue.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue: {
+      files: {
+        'src/components/Example.vue': vue_example,
+        'src/components/Modal.vue': vue_modal,
+      },
+    },
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+        'src/app/modal-example.component.html': angular_modal_example_component_html,
+        'src/app/modal-example.component.ts': angular_modal_example_component_ts,
+      },
+      angularModuleOptions: {
+        imports: [`import { ModalExampleComponent } from './modal-example.component';`],
+        declarations: ['ModalExampleComponent'],
+      },
+    },
+  }}
+  src="usage/modal/dismissing/controller/dismiss/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/dismissing/controller/dismiss/javascript.md
+++ b/static/usage/modal/dismissing/controller/dismiss/javascript.md
@@ -1,0 +1,39 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Controller Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button onclick="openModal()">Open Modal</ion-button>
+  </ion-content>
+</ion-app>
+
+<script>
+  var openModal = async () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+            <ion-title>Modal</ion-title>
+            <ion-button slot="end" fill="clear" onclick="dismiss()">Dismiss</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        This is an example of a controller full-height modal.
+      </ion-content>
+      `;
+
+    const modal = await modalController.create({
+      component: div,
+    });
+
+    modal.present();
+  };
+
+  var dismiss = () => {
+    modalController.dismiss();
+  };
+</script>
+```

--- a/static/usage/modal/dismissing/controller/dismiss/react.md
+++ b/static/usage/modal/dismissing/controller/dismiss/react.md
@@ -1,0 +1,39 @@
+```tsx
+import React from 'react';
+import { IonButton, IonHeader, IonContent, IonToolbar, IonTitle, IonPage, useIonModal } from '@ionic/react';
+
+const ModalExample = ({ onDismiss }) => (
+  <div>
+    <IonHeader>
+      <IonToolbar>
+        <IonTitle>Modal</IonTitle>
+        <IonButton slot="end" fill="clear" onClick={() => onDismiss()}>
+          Dismiss
+        </IonButton>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent class="ion-padding">This is an example of an controller full-height modal.</IonContent>
+  </div>
+);
+
+function Example() {
+  const [present, dismiss] = useIonModal(ModalExample, {
+    onDismiss: () => dismiss(),
+  });
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Controller Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonButton onClick={() => present()}>Open Modal</IonButton>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/dismissing/controller/dismiss/vue/example_vue.md
+++ b/static/usage/modal/dismissing/controller/dismiss/vue/example_vue.md
@@ -1,0 +1,31 @@
+```html
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button @click="openModal">Open Modal</ion-button>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script>
+  import { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle, modalController } from '@ionic/vue';
+  import Modal from './Modal.vue';
+
+  export default {
+    components: { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle },
+    methods: {
+      async openModal() {
+        const modal = await modalController.create({
+          component: Modal,
+        });
+        return modal.present();
+      },
+    },
+  };
+</script>
+```

--- a/static/usage/modal/dismissing/controller/dismiss/vue/modal_vue.md
+++ b/static/usage/modal/dismissing/controller/dismiss/vue/modal_vue.md
@@ -1,0 +1,26 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Modal</ion-title>
+      <ion-button slot="end" fill="clear" @click="dismiss">Dismiss</ion-button>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding"> This is an example of a controller full-height modal. </ion-content>
+</template>
+
+<script>
+  import { IonContent, IonHeader, IonTitle, IonToolbar, IonButton, modalController } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    name: 'Modal',
+    components: { IonContent, IonHeader, IonTitle, IonToolbar, IonButton },
+    methods: {
+      dismiss() {
+        return modalController.dismiss();
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/modal/dismissing/controller/role/angular/app_component_html.md
+++ b/static/usage/modal/dismissing/controller/role/angular/app_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-content class="ion-padding"> {{ message }} </ion-content>
+```

--- a/static/usage/modal/dismissing/controller/role/angular/app_component_ts.md
+++ b/static/usage/modal/dismissing/controller/role/angular/app_component_ts.md
@@ -1,0 +1,30 @@
+```ts
+import { Component, OnInit } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+import { ModalExampleComponent } from './modal-example.component';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent implements OnInit {
+  message: string;
+
+  constructor(private modalCtrl: ModalController) {}
+
+  ngOnInit() {
+    this.openModal();
+  }
+
+  async openModal() {
+    const modal = await this.modalCtrl.create({
+      component: ModalExampleComponent,
+    });
+    modal.present();
+
+    const { role } = await modal.onDidDismiss();
+    this.message = `Modal was dismissed with role: ${role}`;
+  }
+}
+```

--- a/static/usage/modal/dismissing/controller/role/angular/modal-example_component_html.md
+++ b/static/usage/modal/dismissing/controller/role/angular/modal-example_component_html.md
@@ -1,0 +1,12 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-button slot="start" fill="clear" (click)="dismiss('cancel')">Cancel</ion-button>
+    <ion-title>Modal</ion-title>
+    <ion-button slot="end" fill="clear" (click)="dismiss('confirm')">Confirm</ion-button>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <p>Select a button to dismiss the modal.</p>
+</ion-content>
+```

--- a/static/usage/modal/dismissing/controller/role/angular/modal-example_component_ts.md
+++ b/static/usage/modal/dismissing/controller/role/angular/modal-example_component_ts.md
@@ -1,0 +1,17 @@
+```ts
+import { Component } from '@angular/core';
+
+import { ModalController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-modal-example',
+  templateUrl: 'modal-example.component.html',
+})
+export class ModalExampleComponent {
+  constructor(private modalCtrl: ModalController) {}
+
+  dismiss(role: string) {
+    return this.modalCtrl.dismiss(null, role);
+  }
+}
+```

--- a/static/usage/modal/dismissing/controller/role/demo.html
+++ b/static/usage/modal/dismissing/controller/role/demo.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Controller</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <script type="module">
+    import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
+    window.modalController = modalController;
+  </script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <div class="container">
+        <div id="message"></div>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const openModal = async () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+          <ion-button slot="start" fill="clear" onclick="modalController.dismiss(null, 'cancel')">Cancel</ion-button>
+          <ion-title>Modal</ion-title>
+          <ion-button slot="end" fill="clear" onclick="modalController.dismiss(null, 'confirm')">Confirm</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <p>Select a button to dismiss the modal.</p>
+      </ion-content>`;
+
+      const modal = await modalController.create({
+        component: div,
+      });
+
+      modal.present();
+
+      const { role } = await modal.onDidDismiss();
+
+      document.querySelector('#message').innerHTML = `Modal was dismissed with role: ${role}`;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      openModal();
+    });
+
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/dismissing/controller/role/index.md
+++ b/static/usage/modal/dismissing/controller/role/index.md
@@ -1,0 +1,39 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_modal_example_component_html from './angular/modal-example_component_html.md';
+import angular_modal_example_component_ts from './angular/modal-example_component_ts.md';
+
+import vue_example from './vue/example_vue.md';
+import vue_modal from './vue/modal_vue.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue: {
+      files: {
+        'src/components/Example.vue': vue_example,
+        'src/components/Modal.vue': vue_modal,
+      },
+    },
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+        'src/app/modal-example.component.html': angular_modal_example_component_html,
+        'src/app/modal-example.component.ts': angular_modal_example_component_ts,
+      },
+      angularModuleOptions: {
+        imports: [`import { ModalExampleComponent } from './modal-example.component';`],
+        declarations: ['ModalExampleComponent'],
+      },
+    },
+  }}
+  src="usage/modal/dismissing/controller/role/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/dismissing/controller/role/javascript.md
+++ b/static/usage/modal/dismissing/controller/role/javascript.md
@@ -1,0 +1,41 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Controller Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <div id="message"></div>
+  </ion-content>
+</ion-app>
+
+<script>
+  var openModal = async () => {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <ion-header>
+        <ion-toolbar>
+          <ion-button slot="start" fill="clear" onclick="modalController.dismiss(null, 'cancel')">Cancel</ion-button>
+          <ion-title>Modal</ion-title>
+          <ion-button slot="end" fill="clear" onclick="modalController.dismiss(null, 'confirm')">Confirm</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <p>Select a button to dismiss the modal.</p>
+      </ion-content>`;
+
+    const modal = await modalController.create({
+      component: div,
+    });
+
+    modal.present();
+
+    const { role } = await modal.onDidDismiss();
+
+    document.querySelector('#message').innerHTML = `Modal was dismissed with role: ${role}`;
+  };
+
+  openModal();
+</script>
+```

--- a/static/usage/modal/dismissing/controller/role/react.md
+++ b/static/usage/modal/dismissing/controller/role/react.md
@@ -1,0 +1,51 @@
+```tsx
+import React, { useEffect, useState } from 'react';
+import { IonButton, IonHeader, IonContent, IonToolbar, IonTitle, IonPage, useIonModal } from '@ionic/react';
+
+const ModalExample = ({ onDismiss }) => (
+  <div>
+    <IonHeader>
+      <IonToolbar>
+        <IonButton slot="start" fill="clear" onClick={() => onDismiss('cancel')}>
+          Cancel
+        </IonButton>
+        <IonTitle>Modal</IonTitle>
+        <IonButton slot="end" fill="clear" onClick={() => onDismiss('confirm')}>
+          Confirm
+        </IonButton>
+      </IonToolbar>
+    </IonHeader>
+    <IonContent class="ion-padding">Select a button to dismiss the modal.</IonContent>
+  </div>
+);
+
+function Example() {
+  const [present, dismiss] = useIonModal(ModalExample, {
+    onDismiss: (role) => dismiss(null, role),
+  });
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    present({
+      onDidDismiss: ({ detail }) => {
+        setMessage(`Modal was dismissed with role: ${detail?.role}`);
+      },
+    });
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Controller Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <div>{message}</div>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/dismissing/controller/role/vue/example_vue.md
+++ b/static/usage/modal/dismissing/controller/role/vue/example_vue.md
@@ -1,0 +1,43 @@
+```html
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Controller Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <div>{{ message }}</div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script>
+  import { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle, modalController } from '@ionic/vue';
+  import Modal from './Modal.vue';
+
+  export default {
+    components: { IonButton, IonContent, IonPage, IonHeader, IonToolbar, IonTitle },
+    data() {
+      return {
+        message: '',
+      };
+    },
+    methods: {
+      async openModal() {
+        const modal = await modalController.create({
+          component: Modal,
+        });
+        modal.present();
+
+        const { role } = await modal.onDidDismiss();
+
+        this.message = `Modal was dismissed with role: ${role}`;
+      },
+    },
+    mounted() {
+      this.openModal();
+    },
+  };
+</script>
+```

--- a/static/usage/modal/dismissing/controller/role/vue/modal_vue.md
+++ b/static/usage/modal/dismissing/controller/role/vue/modal_vue.md
@@ -1,0 +1,38 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-button slot="start" fill="clear" @click="() => dismiss('cancel')">Cancel</ion-button>
+      <ion-title>Modal</ion-title>
+      <ion-button slot="end" fill="clear" @click="() => dismiss('confirm')">Dismiss</ion-button>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <p>Select a button to dismiss the modal.</p>
+  </ion-content>
+</template>
+
+<script>
+  import {
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonButton,
+    IonItem,
+    IonInput,
+    modalController,
+  } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    name: 'Modal',
+    components: { IonContent, IonHeader, IonTitle, IonToolbar, IonButton },
+    methods: {
+      dismiss(role) {
+        return modalController.dismiss(null, role);
+      },
+    },
+  });
+</script>
+```


### PR DESCRIPTION
This PR adds the component playground examples for dismissing controller modals.

Note: The React examples for dismissing data and roles will not function properly until this week's release of Ionic. I left the examples in this PR to demonstrate how the implementation should look, once that fix is released. I think it is unlikely this is all going to be merged before the release, but on the off chance it is, I can remove react from those examples and create a ticket to re-introduce it after the release. 