### PR TITLE
docs(modal): inline playground

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -33,7 +33,7 @@ import APITOCInline from '@components/page/api/APITOCInline';
 A Modal is a dialog that appears on top of the app's content, and must be dismissed by the app before interaction can resume. It is useful as a select component when there are a lot of options to choose from, or when filtering items in a list, as well as many other use cases.
 
 
-## Inline Modals
+## Inline Modals (Recommended)
 
 `ion-modal` can be used by writing the component directly in your template. This reduces the number of handlers you need to wire up in order to present the modal.
 

--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -39,9 +39,9 @@ A Modal is a dialog that appears on top of the app's content, and must be dismis
 
 When using `ion-modal` with Angular, React, or Vue, the component you pass in will be destroyed when the modal is dismissed. As this functionality is provided by the JavaScript framework, using `ion-modal` without a JavaScript framework will not destroy the component you passed in. If this is a needed functionality, we recommend using the `modalController` instead.
 
-It is recommended to using triggers to open inline modals. A trigger is an element reference, that when selected will automatically open a modal. Triggers are useful when presenting a modal from a button or similar interaction.
+import InlineModalTriggerExample from '@site/static/usage/modal/inline/basic/index.md';
 
-TODO: Playground Example
+<InlineModalTriggerExample />
 
 ### Using `isOpen`
 
@@ -49,7 +49,9 @@ The `isOpen` property on `ion-modal` allows developers to control the presentati
 
 `isOpen` uses one-way data binding, meaning it will not automatically be set to `false` when the modal is dismissed. To keep the state of `isOpen` in sync with your UI state, listen for either `ionModalDidDismiss` or `didDismiss` and set the variable to `false`.
 
-TODO: Playground Example
+import InlineModalIsOpenExample from '@site/static/usage/modal/inline/is-open/index.md';
+
+<InlineModalIsOpenExample />
 
 ## Controller Modals
 

--- a/static/usage/modal/inline/basic/angular/app_component_html.md
+++ b/static/usage/modal/inline/basic/angular/app_component_html.md
@@ -8,7 +8,7 @@
   <ion-content class="ion-padding">
     <ion-button id="open-modal" expand="block">Open</ion-button>
     <p>{{ message }}</p>
-    <ion-modal trigger="open-modal" (didDismiss)="onDidDismiss($event)">
+    <ion-modal trigger="open-modal" (willDismiss)="onWillDismiss($event)">
       <ng-template>
         <ion-header>
           <ion-toolbar>

--- a/static/usage/modal/inline/basic/angular/app_component_html.md
+++ b/static/usage/modal/inline/basic/angular/app_component_html.md
@@ -1,0 +1,30 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open</ion-button>
+    <p>{{ message }}</p>
+    <ion-modal trigger="open-modal" (didDismiss)="onDidDismiss($event)">
+      <ng-template>
+        <ion-header>
+          <ion-toolbar>
+            <ion-button slot="start" fill="clear" (click)="cancel()" color="medium">Cancel</ion-button>
+            <ion-title>Welcome</ion-title>
+            <ion-button slot="end" fill="clear" (click)="confirm()">Confirm</ion-button>
+          </ion-toolbar>
+        </ion-header>
+        <ion-content class="ion-padding">
+          <ion-item>
+            <ion-label position="stacked">Enter your name</ion-label>
+            <ion-input type="text" placeholder="Your name" [(ngModel)]="name"></ion-input>
+          </ion-item>
+        </ion-content>
+      </ng-template>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+```

--- a/static/usage/modal/inline/basic/angular/app_component_html.md
+++ b/static/usage/modal/inline/basic/angular/app_component_html.md
@@ -12,9 +12,9 @@
       <ng-template>
         <ion-header>
           <ion-toolbar>
-            <ion-button slot="start" fill="clear" (click)="cancel()" color="medium">Cancel</ion-button>
+            <ion-button slot="start" fill="clear" (click)="cancel()">Cancel</ion-button>
             <ion-title>Welcome</ion-title>
-            <ion-button slot="end" fill="clear" (click)="confirm()">Confirm</ion-button>
+            <ion-button slot="end" fill="clear" (click)="confirm()" [strong]="true">Confirm</ion-button>
           </ion-toolbar>
         </ion-header>
         <ion-content class="ion-padding">

--- a/static/usage/modal/inline/basic/angular/app_component_ts.md
+++ b/static/usage/modal/inline/basic/angular/app_component_ts.md
@@ -1,0 +1,29 @@
+```ts
+import { Component, ViewChild } from '@angular/core';
+import { IonModal } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  @ViewChild(IonModal) modal: IonModal;
+
+  message = 'This modal example uses triggers to automatically open a modal when the button is clicked.';
+  name: string;
+
+  cancel() {
+    this.modal.dismiss(null, 'cancel');
+  }
+
+  confirm() {
+    this.modal.dismiss(this.name, 'confirm');
+  }
+
+  onDidDismiss(ev: any) {
+    if (ev.detail.role === 'confirm') {
+      this.message = `Hello, ${ev.detail.data}!`;
+    }
+  }
+}
+```

--- a/static/usage/modal/inline/basic/angular/app_component_ts.md
+++ b/static/usage/modal/inline/basic/angular/app_component_ts.md
@@ -1,6 +1,7 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
 import { IonModal } from '@ionic/angular';
+import { OverlayEventDetail } from '@ionic/core/components';
 
 @Component({
   selector: 'app-root',
@@ -20,7 +21,8 @@ export class AppComponent {
     this.modal.dismiss(this.name, 'confirm');
   }
 
-  onDidDismiss(ev: any) {
+  onWillDismiss(event: Event) {
+    const ev = event as CustomEvent<OverlayEventDetail<string>>;
     if (ev.detail.role === 'confirm') {
       this.message = `Hello, ${ev.detail.data}!`;
     }

--- a/static/usage/modal/inline/basic/angular/app_module_ts.md
+++ b/static/usage/modal/inline/basic/angular/app_module_ts.md
@@ -1,0 +1,16 @@
+```ts
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+
+import { IonicModule } from '@ionic/angular';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  imports: [BrowserModule, IonicModule.forRoot({}), FormsModule],
+  declarations: [AppComponent],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```

--- a/static/usage/modal/inline/basic/demo.html
+++ b/static/usage/modal/inline/basic/demo.html
@@ -24,9 +24,9 @@
       <ion-modal trigger="open-modal">
         <ion-header>
           <ion-toolbar>
-            <ion-button slot="start" fill="clear" onclick="cancel()" color="medium">Cancel</ion-button>
+            <ion-button slot="start" fill="clear" onclick="cancel()">Cancel</ion-button>
             <ion-title>Welcome</ion-title>
-            <ion-button slot="end" fill="clear" onclick="confirm()">Confirm</ion-button>
+            <ion-button slot="end" fill="clear" onclick="confirm()" strong="true">Confirm</ion-button>
           </ion-toolbar>
         </ion-header>
         <ion-content class="ion-padding">

--- a/static/usage/modal/inline/basic/demo.html
+++ b/static/usage/modal/inline/basic/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Inline</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Inline Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button id="open-modal" expand="block">Open</ion-button>
+      <p id="message">This modal example uses triggers to automatically open a modal when the button is clicked.</p>
+      <ion-modal trigger="open-modal">
+        <ion-header>
+          <ion-toolbar>
+            <ion-button slot="start" fill="clear" onclick="cancel()" color="medium">Cancel</ion-button>
+            <ion-title>Welcome</ion-title>
+            <ion-button slot="end" fill="clear" onclick="confirm()">Confirm</ion-button>
+          </ion-toolbar>
+        </ion-header>
+        <ion-content class="ion-padding">
+          <ion-item>
+            <ion-label position="stacked">Enter your name</ion-label>
+            <ion-input type="text" placeholder="Your name"></ion-input>
+          </ion-item>
+        </ion-content>
+      </ion-modal>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const modal = document.querySelector('ion-modal');
+
+    function cancel() {
+      modal.dismiss(null, 'cancel');
+    }
+
+    function confirm() {
+      const input = document.querySelector('ion-input');
+      modal.dismiss(input.value, 'confirm');
+    }
+
+    modal.addEventListener('didDismiss', ev => {
+      if (ev.detail.role === 'confirm') {
+        const message = document.querySelector('#message');
+        message.textContent = `Hello ${ev.detail.data}!`;
+      }
+    });
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/inline/basic/demo.html
+++ b/static/usage/modal/inline/basic/demo.html
@@ -51,7 +51,7 @@
       modal.dismiss(input.value, 'confirm');
     }
 
-    modal.addEventListener('didDismiss', ev => {
+    modal.addEventListener('willDismiss', ev => {
       if (ev.detail.role === 'confirm') {
         const message = document.querySelector('#message');
         message.textContent = `Hello ${ev.detail.data}!`;

--- a/static/usage/modal/inline/basic/index.md
+++ b/static/usage/modal/inline/basic/index.md
@@ -1,0 +1,26 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_app_module_ts from './angular/app_module_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_app_component_ts from './angular/app_component_ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+        'src/app/app.module.ts': angular_app_module_ts,
+      },
+    },
+  }}
+  src="usage/modal/inline/basic/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/inline/basic/javascript.md
+++ b/static/usage/modal/inline/basic/javascript.md
@@ -11,9 +11,9 @@
     <ion-modal trigger="open-modal">
       <ion-header>
         <ion-toolbar>
-          <ion-button slot="start" fill="clear" onclick="cancel()" color="medium">Cancel</ion-button>
+          <ion-button slot="start" fill="clear" onclick="cancel()">Cancel</ion-button>
           <ion-title>Welcome</ion-title>
-          <ion-button slot="end" fill="clear" onclick="confirm()">Confirm</ion-button>
+          <ion-button slot="end" fill="clear" onclick="confirm()" strong="true">Confirm</ion-button>
         </ion-toolbar>
       </ion-header>
       <ion-content class="ion-padding">

--- a/static/usage/modal/inline/basic/javascript.md
+++ b/static/usage/modal/inline/basic/javascript.md
@@ -37,7 +37,7 @@
     modal.dismiss(input.value, 'confirm');
   }
 
-  modal.addEventListener('didDismiss', (ev) => {
+  modal.addEventListener('willDismiss', (ev) => {
     if (ev.detail.role === 'confirm') {
       const message = document.querySelector('#message');
       message.textContent = `Hello ${ev.detail.data}!`;

--- a/static/usage/modal/inline/basic/javascript.md
+++ b/static/usage/modal/inline/basic/javascript.md
@@ -1,0 +1,47 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open</ion-button>
+    <p id="message">This modal example uses triggers to automatically open a modal when the button is clicked.</p>
+    <ion-modal trigger="open-modal">
+      <ion-header>
+        <ion-toolbar>
+          <ion-button slot="start" fill="clear" onclick="cancel()" color="medium">Cancel</ion-button>
+          <ion-title>Welcome</ion-title>
+          <ion-button slot="end" fill="clear" onclick="confirm()">Confirm</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <ion-item>
+          <ion-label position="stacked">Enter your name</ion-label>
+          <ion-input type="text" placeholder="Your name"></ion-input>
+        </ion-item>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+<script>
+  var modal = document.querySelector('ion-modal');
+
+  function cancel() {
+    modal.dismiss(null, 'cancel');
+  }
+
+  function confirm() {
+    const input = document.querySelector('ion-input');
+    modal.dismiss(input.value, 'confirm');
+  }
+
+  modal.addEventListener('didDismiss', (ev) => {
+    if (ev.detail.role === 'confirm') {
+      const message = document.querySelector('#message');
+      message.textContent = `Hello ${ev.detail.data}!`;
+    }
+  });
+</script>
+```

--- a/static/usage/modal/inline/basic/react.md
+++ b/static/usage/modal/inline/basic/react.md
@@ -46,11 +46,11 @@ function Example() {
         <IonModal ref={modal} trigger="open-modal" onWillDismiss={(ev) => onWillDismiss(ev)}>
           <IonHeader>
             <IonToolbar>
-              <IonButton slot="start" fill="clear" color="medium" onClick={() => modal.current?.dismiss()}>
+              <IonButton slot="start" fill="clear" onClick={() => modal.current?.dismiss()}>
                 Cancel
               </IonButton>
               <IonTitle>Welcome</IonTitle>
-              <IonButton slot="end" fill="clear" onClick={() => confirm()}>
+              <IonButton slot="end" fill="clear" strong={true} onClick={() => confirm()}>
                 Confirm
               </IonButton>
             </IonToolbar>

--- a/static/usage/modal/inline/basic/react.md
+++ b/static/usage/modal/inline/basic/react.md
@@ -46,7 +46,7 @@ function Example() {
         <IonModal ref={modal} trigger="open-modal" onWillDismiss={(ev) => onWillDismiss(ev)}>
           <IonHeader>
             <IonToolbar>
-              <IonButton slot="start" fill="clear" color="medium" onClick={() => modal.dismiss()}>
+              <IonButton slot="start" fill="clear" color="medium" onClick={() => modal.current?.dismiss()}>
                 Cancel
               </IonButton>
               <IonTitle>Welcome</IonTitle>

--- a/static/usage/modal/inline/basic/react.md
+++ b/static/usage/modal/inline/basic/react.md
@@ -25,7 +25,7 @@ function Example() {
     modal.current?.dismiss(input.current?.value, 'confirm');
   }
 
-  function onDismiss(ev) {
+  function onWillDismiss(ev) {
     if (ev.detail.role === 'confirm') {
       setMessage(`Hello, ${ev.detail.data}!`);
     }
@@ -43,7 +43,7 @@ function Example() {
           Open
         </IonButton>
         <p>{message}</p>
-        <IonModal ref={modal} trigger="open-modal" onDidDismiss={(ev) => onDismiss(ev)}>
+        <IonModal ref={modal} trigger="open-modal" onWillDismiss={(ev) => onWillDismiss(ev)}>
           <IonHeader>
             <IonToolbar>
               <IonButton slot="start" fill="clear" color="medium" onClick={() => modal.dismiss()}>

--- a/static/usage/modal/inline/basic/react.md
+++ b/static/usage/modal/inline/basic/react.md
@@ -1,0 +1,71 @@
+```tsx
+import React, { useState, useRef } from 'react';
+import {
+  IonButton,
+  IonModal,
+  IonHeader,
+  IonContent,
+  IonToolbar,
+  IonTitle,
+  IonPage,
+  IonItem,
+  IonLabel,
+  IonInput,
+} from '@ionic/react';
+
+function Example() {
+  const modal = useRef(null);
+  const input = useRef(null);
+
+  const [message, setMessage] = useState(
+    'This modal example uses triggers to automatically open a modal when the button is clicked.'
+  );
+
+  function confirm() {
+    modal.current?.dismiss(input.current?.value, 'confirm');
+  }
+
+  function onDismiss(ev) {
+    if (ev.detail.role === 'confirm') {
+      setMessage(`Hello, ${ev.detail.data}!`);
+    }
+  }
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Inline Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonButton id="open-modal" expand="block">
+          Open
+        </IonButton>
+        <p>{message}</p>
+        <IonModal ref={modal} trigger="open-modal" onDidDismiss={(ev) => onDismiss(ev)}>
+          <IonHeader>
+            <IonToolbar>
+              <IonButton slot="start" fill="clear" color="medium" onClick={() => modal.dismiss()}>
+                Cancel
+              </IonButton>
+              <IonTitle>Welcome</IonTitle>
+              <IonButton slot="end" fill="clear" onClick={() => confirm()}>
+                Confirm
+              </IonButton>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent className="ion-padding">
+            <IonItem>
+              <IonLabel position="stacked">Enter your name</IonLabel>
+              <IonInput ref={input} type="text" placeholder="Your name" />
+            </IonItem>
+          </IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/inline/basic/vue.md
+++ b/static/usage/modal/inline/basic/vue.md
@@ -8,7 +8,7 @@
   <ion-content class="ion-padding">
     <ion-button id="open-modal" expand="block">Open</ion-button>
     <p>{{ message }}</p>
-    <ion-modal ref="modal" trigger="open-modal" @didDismiss="onDidDismiss">
+    <ion-modal ref="modal" trigger="open-modal" @willDismiss="onWillDismiss">
       <ion-header>
         <ion-toolbar>
           <ion-button slot="start" fill="clear" color="medium" @click="cancel()">Cancel</ion-button>
@@ -55,7 +55,7 @@
         const name = this.$refs.input.$el.value;
         this.$refs.modal.$el.dismiss(name, 'confirm');
       },
-      onDidDismiss(ev) {
+      onWillDismiss(ev) {
         if (ev.detail.role === 'confirm') {
           this.message = `Hello, ${ev.detail.data}!`;
         }

--- a/static/usage/modal/inline/basic/vue.md
+++ b/static/usage/modal/inline/basic/vue.md
@@ -1,0 +1,66 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open</ion-button>
+    <p>{{ message }}</p>
+    <ion-modal ref="modal" trigger="open-modal" @didDismiss="onDidDismiss">
+      <ion-header>
+        <ion-toolbar>
+          <ion-button slot="start" fill="clear" color="medium" @click="cancel()">Cancel</ion-button>
+          <ion-title>Welcome</ion-title>
+          <ion-button slot="end" fill="clear" @click="confirm()">Confirm</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <ion-item>
+          <ion-label position="stacked">Enter your name</ion-label>
+          <ion-input ref="input" type="text" placeholder="Your name"></ion-input>
+        </ion-item>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</template>
+
+<script>
+  import {
+    IonButton,
+    IonModal,
+    IonHeader,
+    IonContent,
+    IonToolbar,
+    IonTitle,
+    IonItem,
+    IonInput,
+    IonLabel,
+  } from '@ionic/vue';
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonModal, IonHeader, IonContent, IonToolbar, IonTitle, IonItem, IonInput, IonLabel },
+    data() {
+      return {
+        message: 'This modal example uses triggers to automatically open a modal when the button is clicked.',
+      };
+    },
+    methods: {
+      cancel() {
+        this.$refs.modal.$el.dismiss(null, 'cancel');
+      },
+      confirm() {
+        const name = this.$refs.input.$el.value;
+        this.$refs.modal.$el.dismiss(name, 'confirm');
+      },
+      onDidDismiss(ev) {
+        if (ev.detail.role === 'confirm') {
+          this.message = `Hello, ${ev.detail.data}!`;
+        }
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/modal/inline/basic/vue.md
+++ b/static/usage/modal/inline/basic/vue.md
@@ -11,9 +11,9 @@
     <ion-modal ref="modal" trigger="open-modal" @willDismiss="onWillDismiss">
       <ion-header>
         <ion-toolbar>
-          <ion-button slot="start" fill="clear" color="medium" @click="cancel()">Cancel</ion-button>
+          <ion-button slot="start" fill="clear" @click="cancel()">Cancel</ion-button>
           <ion-title>Welcome</ion-title>
-          <ion-button slot="end" fill="clear" @click="confirm()">Confirm</ion-button>
+          <ion-button slot="end" fill="clear" :strong="true" @click="confirm()">Confirm</ion-button>
         </ion-toolbar>
       </ion-header>
       <ion-content class="ion-padding">

--- a/static/usage/modal/inline/is-open/angular/app_component_html.md
+++ b/static/usage/modal/inline/is-open/angular/app_component_html.md
@@ -1,0 +1,27 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Inline Modal</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <ion-button expand="block" (click)="setOpen(true)">Open</ion-button>
+  <ion-modal [isOpen]="isModalOpen">
+    <ng-template>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+          <ion-button slot="end" fill="clear" (click)="setOpen(false)">Close</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni illum quidem recusandae ducimus quos
+          reprehenderit. Veniam, molestias quos, dolorum consequuntur nisi deserunt omnis id illo sit cum qui. Eaque,
+          dicta.
+        </p>
+      </ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>
+```

--- a/static/usage/modal/inline/is-open/angular/app_component_ts.md
+++ b/static/usage/modal/inline/is-open/angular/app_component_ts.md
@@ -1,0 +1,15 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  isModalOpen = false;
+
+  setOpen(isOpen: boolean) {
+    this.isModalOpen = isOpen;
+  }
+}
+```

--- a/static/usage/modal/inline/is-open/demo.html
+++ b/static/usage/modal/inline/is-open/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Inline</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Inline Modal</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button expand="block" onclick="modal.isOpen = true">Open</ion-button>
+      <ion-modal>
+        <ion-header>
+          <ion-toolbar>
+            <ion-title>Modal</ion-title>
+            <ion-button slot="end" fill="clear" onclick="modal.isOpen = false">Close</ion-button>
+          </ion-toolbar>
+        </ion-header>
+        <ion-content class="ion-padding">
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni illum quidem recusandae ducimus quos
+            reprehenderit. Veniam, molestias quos, dolorum consequuntur nisi deserunt omnis id illo sit cum qui. Eaque,
+            dicta.</p>
+        </ion-content>
+      </ion-modal>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const modal = document.querySelector('ion-modal');
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/inline/is-open/index.md
+++ b/static/usage/modal/inline/is-open/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_app_component_ts from './angular/app_component_ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+      },
+    },
+  }}
+  src="usage/modal/inline/is-open/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/inline/is-open/javascript.md
+++ b/static/usage/modal/inline/is-open/javascript.md
@@ -1,0 +1,31 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button expand="block" onclick="modal.isOpen = true">Open</ion-button>
+    <ion-modal>
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+          <ion-button slot="end" fill="clear" onclick="modal.isOpen = false">Close</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni illum quidem recusandae ducimus quos
+          reprehenderit. Veniam, molestias quos, dolorum consequuntur nisi deserunt omnis id illo sit cum qui. Eaque,
+          dicta.
+        </p>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+
+<script>
+  var modal = document.querySelector('ion-modal');
+</script>
+```

--- a/static/usage/modal/inline/is-open/react.md
+++ b/static/usage/modal/inline/is-open/react.md
@@ -1,0 +1,42 @@
+```tsx
+import React, { useState } from 'react';
+import { IonButton, IonModal, IonHeader, IonContent, IonToolbar, IonTitle, IonPage } from '@ionic/react';
+
+function Example() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Inline Modal</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonButton expand="block" onClick={() => setIsOpen(true)}>
+          Open
+        </IonButton>
+        <IonModal isOpen={isOpen}>
+          <IonHeader>
+            <IonToolbar>
+              <IonTitle>Modal</IonTitle>
+              <IonButton slot="end" fill="clear" onClick={() => setIsOpen(false)}>
+                Close
+              </IonButton>
+            </IonToolbar>
+          </IonHeader>
+          <IonContent className="ion-padding">
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni illum quidem recusandae ducimus quos
+              reprehenderit. Veniam, molestias quos, dolorum consequuntur nisi deserunt omnis id illo sit cum qui.
+              Eaque, dicta.
+            </p>
+          </IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/inline/is-open/vue.md
+++ b/static/usage/modal/inline/is-open/vue.md
@@ -1,0 +1,47 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Inline Modal</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button expand="block" @click="setOpen(true)">Open</ion-button>
+
+    <ion-modal :is-open="isOpen">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Modal</ion-title>
+          <ion-button slot="end" fill="clear" @click="setOpen(false)">Close</ion-button>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni illum quidem recusandae ducimus quos
+          reprehenderit. Veniam, molestias quos, dolorum consequuntur nisi deserunt omnis id illo sit cum qui. Eaque,
+          dicta.
+        </p>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</template>
+
+<script>
+  import { IonButton, IonModal, IonHeader, IonToolbar, IonContent, IonTitle } from '@ionic/vue';
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonModal, IonHeader, IonContent, IonToolbar, IonTitle },
+    data() {
+      return {
+        isOpen: false,
+      };
+    },
+    methods: {
+      setOpen(isOpen: boolean) {
+        this.isOpen = isOpen;
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/modal/inline/is-open/vue.md
+++ b/static/usage/modal/inline/is-open/vue.md
@@ -38,7 +38,7 @@
       };
     },
     methods: {
-      setOpen(isOpen: boolean) {
+      setOpen(isOpen) {
         this.isOpen = isOpen;
       },
     },


### PR DESCRIPTION
Re-approach to the inline modal component playground examples. 

Shows two examples:
1. Kitchen sink (presenting, dismissing with data & role)
2. `isOpen` (isolated example of using `isOpen` property)

This will still have the extra padding in the device header, compared to the legacy example. We will likely need to capture that as a separate work item.

This PR is in favor of: #2317 and #2313.