### PR TITLE
docs(modal): modal sheet playground

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -122,17 +122,15 @@ The `backdropBreakpoint` property can be used to customize the point at which th
  Note: The `swipeToClose` property has no effect when using a sheet modal as sheet modals must be swipeable in order to be usable.
 :::
 
-#### Using breakpoints
+import SheetExample from '@site/static/usage/modal/sheet/basic/index.md';
 
-TODO: Playground Example
+<SheetExample />
 
 #### Interacting with background content
 
-TODO: Playground Example
+import SheetBackgroundContentExample from '@site/static/usage/modal/sheet/background-content/index.md';
 
-#### Moving to a breakpoint
-
-TODO: Playground Example
+<SheetBackgroundContentExample />
 
 ## Interfaces
 

--- a/static/usage/modal/sheet/background-content/angular/app_component_css.md
+++ b/static/usage/modal/sheet/background-content/angular/app_component_css.md
@@ -1,0 +1,7 @@
+```css
+.counter__section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+```

--- a/static/usage/modal/sheet/background-content/angular/app_component_html.md
+++ b/static/usage/modal/sheet/background-content/angular/app_component_html.md
@@ -25,7 +25,7 @@
     >
       <ng-template>
         <ion-content>
-          <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
+          <ion-searchbar placeholder="Search" (click)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
           <ion-list>
             <ion-item>
               <ion-avatar slot="start">

--- a/static/usage/modal/sheet/background-content/angular/app_component_html.md
+++ b/static/usage/modal/sheet/background-content/angular/app_component_html.md
@@ -1,0 +1,70 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>App</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <p>You can interact with the +/- buttons until the sheet is fully expanded.</p>
+
+  <div class="counter__section">
+    <ion-button (click)="decrement()">-</ion-button>
+    <p>{{count }}</p>
+    <ion-button (click)="increment()">+</ion-button>
+  </div>
+
+  <ion-modal
+    #modal
+    trigger="open-modal"
+    [isOpen]="true"
+    [initialBreakpoint]="0.25"
+    [breakpoints]="[0.25, 0.5, 0.75]"
+    [backdropDismiss]="false"
+    [backdropBreakpoint]="0.5"
+  >
+    <ng-template>
+      <ion-content>
+        <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
+        <ion-list>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Connor Smith</h2>
+              <p>Sales Rep</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Daniel Smith</h2>
+              <p>Product Designer</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Greg Smith</h2>
+              <p>Director of Operations</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Zoey Smith</h2>
+              <p>CEO</p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+      </ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>
+```

--- a/static/usage/modal/sheet/background-content/angular/app_component_html.md
+++ b/static/usage/modal/sheet/background-content/angular/app_component_html.md
@@ -1,70 +1,72 @@
 ```html
-<ion-header>
-  <ion-toolbar>
-    <ion-title>App</ion-title>
-  </ion-toolbar>
-</ion-header>
-<ion-content class="ion-padding">
-  <p>You can interact with the +/- buttons until the sheet is fully expanded.</p>
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <p>You can interact with the +/- buttons until the sheet is fully expanded.</p>
 
-  <div class="counter__section">
-    <ion-button (click)="decrement()">-</ion-button>
-    <p>{{count }}</p>
-    <ion-button (click)="increment()">+</ion-button>
-  </div>
+    <div class="counter__section">
+      <ion-button (click)="decrement()">-</ion-button>
+      <p>{{count }}</p>
+      <ion-button (click)="increment()">+</ion-button>
+    </div>
 
-  <ion-modal
-    #modal
-    trigger="open-modal"
-    [isOpen]="true"
-    [initialBreakpoint]="0.25"
-    [breakpoints]="[0.25, 0.5, 0.75]"
-    [backdropDismiss]="false"
-    [backdropBreakpoint]="0.5"
-  >
-    <ng-template>
-      <ion-content>
-        <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
-        <ion-list>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Connor Smith</h2>
-              <p>Sales Rep</p>
-            </ion-label>
-          </ion-item>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Daniel Smith</h2>
-              <p>Product Designer</p>
-            </ion-label>
-          </ion-item>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Greg Smith</h2>
-              <p>Director of Operations</p>
-            </ion-label>
-          </ion-item>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Zoey Smith</h2>
-              <p>CEO</p>
-            </ion-label>
-          </ion-item>
-        </ion-list>
-      </ion-content>
-    </ng-template>
-  </ion-modal>
-</ion-content>
+    <ion-modal
+      #modal
+      trigger="open-modal"
+      [isOpen]="true"
+      [initialBreakpoint]="0.25"
+      [breakpoints]="[0.25, 0.5, 0.75]"
+      [backdropDismiss]="false"
+      [backdropBreakpoint]="0.5"
+    >
+      <ng-template>
+        <ion-content>
+          <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
+          <ion-list>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Connor Smith</h2>
+                <p>Sales Rep</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Daniel Smith</h2>
+                <p>Product Designer</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Greg Smith</h2>
+                <p>Director of Operations</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Zoey Smith</h2>
+                <p>CEO</p>
+              </ion-label>
+            </ion-item>
+          </ion-list>
+        </ion-content>
+      </ng-template>
+    </ion-modal>
+  </ion-content>
+</ion-app>
 ```

--- a/static/usage/modal/sheet/background-content/angular/app_component_ts.md
+++ b/static/usage/modal/sheet/background-content/angular/app_component_ts.md
@@ -1,0 +1,20 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css'],
+})
+export class AppComponent {
+  count = 0;
+
+  increment() {
+    this.count++;
+  }
+
+  decrement() {
+    this.count--;
+  }
+}
+```

--- a/static/usage/modal/sheet/background-content/demo.html
+++ b/static/usage/modal/sheet/background-content/demo.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Sheet</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    .counter__section {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>App</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+
+      <p>You can interact with the +/- buttons until the sheet is fully expanded.</p>
+
+      <div class="counter__section">
+        <ion-button id="decrement" onclick="decrement()">-</ion-button>
+        <p id="counter">0</p>
+        <ion-button id="increment" onclick="increment()">+</ion-button>
+      </div>
+
+      <ion-modal is-open="true" initial-breakpoint="0.25" backdrop-dismiss="false" backdrop-breakpoint="0.5">
+        <ion-content>
+          <ion-searchbar placeholder="Search"></ion-searchbar>
+          <ion-list>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=b" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Connor Smith</h2>
+                <p>Sales Rep</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=a" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Daniel Smith</h2>
+                <p>Product Designer</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=d" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Greg Smith</h2>
+                <p>Director of Operations</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=e" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Zoey Smith</h2>
+                <p>CEO</p>
+              </ion-label>
+            </ion-item>
+          </ion-list>
+        </ion-content>
+      </ion-modal>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const modal = document.querySelector('ion-modal');
+    const searchBar = document.querySelector('ion-searchbar');
+
+    modal.breakpoints = [0, 0.25, 0.5, 0.75];
+
+    searchBar.addEventListener('ionFocus', () => {
+      console.log('setting the current breakpoint');
+      modal.setCurrentBreakpoint(0.75);
+    });
+
+    function increment() {
+      const counter = document.querySelector('#counter');
+      counter.innerHTML = parseInt(counter.innerText) + 1;
+    }
+
+    function decrement() {
+      const counter = document.querySelector('#counter');
+      counter.innerHTML = parseInt(counter.innerText) - 1;
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/sheet/background-content/demo.html
+++ b/static/usage/modal/sheet/background-content/demo.html
@@ -88,7 +88,6 @@
     modal.breakpoints = [0, 0.25, 0.5, 0.75];
 
     searchBar.addEventListener('ionFocus', () => {
-      console.log('setting the current breakpoint');
       modal.setCurrentBreakpoint(0.75);
     });
 

--- a/static/usage/modal/sheet/background-content/demo.html
+++ b/static/usage/modal/sheet/background-content/demo.html
@@ -87,7 +87,7 @@
 
     modal.breakpoints = [0, 0.25, 0.5, 0.75];
 
-    searchBar.addEventListener('ionFocus', () => {
+    searchBar.addEventListener('click', () => {
       modal.setCurrentBreakpoint(0.75);
     });
 

--- a/static/usage/modal/sheet/background-content/index.md
+++ b/static/usage/modal/sheet/background-content/index.md
@@ -1,0 +1,26 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+import react from './react.md';
+
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_css from './angular/app_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+        'src/app/app.component.css': angular_app_component_css,
+      },
+    },
+  }}
+  src="usage/modal/sheet/background-content/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/sheet/background-content/javascript.md
+++ b/static/usage/modal/sheet/background-content/javascript.md
@@ -74,7 +74,7 @@
 
   modal.breakpoints = [0, 0.25, 0.5, 0.75];
 
-  searchBar.addEventListener('ionFocus', () => {
+  searchBar.addEventListener('click', () => {
     modal.setCurrentBreakpoint(0.75);
   });
 

--- a/static/usage/modal/sheet/background-content/javascript.md
+++ b/static/usage/modal/sheet/background-content/javascript.md
@@ -75,7 +75,6 @@
   modal.breakpoints = [0, 0.25, 0.5, 0.75];
 
   searchBar.addEventListener('ionFocus', () => {
-    console.log('setting the current breakpoint');
     modal.setCurrentBreakpoint(0.75);
   });
 

--- a/static/usage/modal/sheet/background-content/javascript.md
+++ b/static/usage/modal/sheet/background-content/javascript.md
@@ -1,0 +1,92 @@
+```html
+<style>
+  .counter__section {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+</style>
+
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <p>You can interact with the +/- buttons until the sheet is fully expanded.</p>
+
+    <div class="counter__section">
+      <ion-button id="decrement" onclick="decrement()">-</ion-button>
+      <p id="counter">0</p>
+      <ion-button id="increment" onclick="increment()">+</ion-button>
+    </div>
+
+    <ion-modal is-open="true" initial-breakpoint="0.25" backdrop-dismiss="false" backdrop-breakpoint="0.5">
+      <ion-content>
+        <ion-searchbar placeholder="Search"></ion-searchbar>
+        <ion-list>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=b" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Connor Smith</h2>
+              <p>Sales Rep</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=a" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Daniel Smith</h2>
+              <p>Product Designer</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=d" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Greg Smith</h2>
+              <p>Director of Operations</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=e" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Zoey Smith</h2>
+              <p>CEO</p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+
+<script>
+  var modal = document.querySelector('ion-modal');
+  var searchBar = document.querySelector('ion-searchbar');
+
+  modal.breakpoints = [0, 0.25, 0.5, 0.75];
+
+  searchBar.addEventListener('ionFocus', () => {
+    console.log('setting the current breakpoint');
+    modal.setCurrentBreakpoint(0.75);
+  });
+
+  function increment() {
+    const counter = document.querySelector('#counter');
+    counter.innerHTML = parseInt(counter.innerText) + 1;
+  }
+
+  function decrement() {
+    const counter = document.querySelector('#counter');
+    counter.innerHTML = parseInt(counter.innerText) - 1;
+  }
+</script>
+```

--- a/static/usage/modal/sheet/background-content/react.md
+++ b/static/usage/modal/sheet/background-content/react.md
@@ -50,10 +50,7 @@ function Example() {
           backdropBreakpoint={0.5}
         >
           <IonContent className="ion-padding">
-            <IonSearchbar
-              onIonFocus={() => modal.current?.setCurrentBreakpoint(0.75)}
-              placeholder="Search"
-            ></IonSearchbar>
+            <IonSearchbar onClick={() => modal.current?.setCurrentBreakpoint(0.75)} placeholder="Search"></IonSearchbar>
             <IonList>
               <IonItem>
                 <IonAvatar slot="start">

--- a/static/usage/modal/sheet/background-content/react.md
+++ b/static/usage/modal/sheet/background-content/react.md
@@ -1,0 +1,103 @@
+```tsx
+import React, { useRef, useState } from 'react';
+import {
+  IonButton,
+  IonModal,
+  IonHeader,
+  IonContent,
+  IonToolbar,
+  IonTitle,
+  IonPage,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonAvatar,
+  IonImg,
+  IonSearchbar,
+} from '@ionic/react';
+
+function Example() {
+  const modal = useRef(null);
+  const [count, setCount] = useState(0);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>App</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <p>You can interact with the +/- buttons until the sheet is fully expanded.</p>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <IonButton onClick={() => setCount(count - 1)}>-</IonButton>
+          <p>{count}</p>
+          <IonButton onClick={() => setCount(count + 1)}>+</IonButton>
+        </div>
+        <IonModal
+          ref={modal}
+          trigger="open-modal"
+          isOpen={true}
+          initialBreakpoint={0.25}
+          breakpoints={[0.25, 0.5, 0.75]}
+          backdropDismiss={false}
+          backdropBreakpoint={0.5}
+        >
+          <IonContent className="ion-padding">
+            <IonSearchbar
+              onIonFocus={() => modal.current?.setCurrentBreakpoint(0.75)}
+              placeholder="Search"
+            ></IonSearchbar>
+            <IonList>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=b" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Connor Smith</h2>
+                  <p>Sales Rep</p>
+                </IonLabel>
+              </IonItem>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=a" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Daniel Smith</h2>
+                  <p>Product Designer</p>
+                </IonLabel>
+              </IonItem>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=d" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Greg Smith</h2>
+                  <p>Director of Operations</p>
+                </IonLabel>
+              </IonItem>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=e" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Zoey Smith</h2>
+                  <p>CEO</p>
+                </IonLabel>
+              </IonItem>
+            </IonList>
+          </IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/sheet/background-content/vue.md
+++ b/static/usage/modal/sheet/background-content/vue.md
@@ -32,7 +32,7 @@
       :backdrop-breakpoint="0.5"
     >
       <ion-content class="ion-padding">
-        <ion-searchbar @ionFocus="$refs.modal.$el.setCurrentBreakpoint(0.75)" placeholder="Search"></ion-searchbar>
+        <ion-searchbar @click="$refs.modal.$el.setCurrentBreakpoint(0.75)" placeholder="Search"></ion-searchbar>
         <ion-list>
           <ion-item>
             <ion-avatar slot="start">

--- a/static/usage/modal/sheet/background-content/vue.md
+++ b/static/usage/modal/sheet/background-content/vue.md
@@ -1,0 +1,126 @@
+```html
+<style>
+  .counter__section {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+</style>
+
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <p>You can interact with the +/- buttons until the sheet is fully expanded.</p>
+
+    <div class="counter__section">
+      <ion-button id="decrement" @click="decrement()">-</ion-button>
+      <p>{{count}}</p>
+      <ion-button id="increment" @click="increment()">+</ion-button>
+    </div>
+
+    <ion-modal
+      ref="modal"
+      trigger="open-modal"
+      :is-open="true"
+      :initial-breakpoint="0.25"
+      :breakpoints="[0.25, 0.5, 0.75]"
+      :backdrop-dismiss="false"
+      :backdrop-breakpoint="0.5"
+    >
+      <ion-content class="ion-padding">
+        <ion-searchbar @ionFocus="$refs.modal.$el.setCurrentBreakpoint(0.75)" placeholder="Search"></ion-searchbar>
+        <ion-list>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Connor Smith</h2>
+              <p>Sales Rep</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Daniel Smith</h2>
+              <p>Product Designer</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Greg Smith</h2>
+              <p>Director of Operations</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Zoey Smith</h2>
+              <p>CEO</p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</template>
+
+<script>
+  import {
+    IonButton,
+    IonModal,
+    IonHeader,
+    IonContent,
+    IonToolbar,
+    IonTitle,
+    IonItem,
+    IonList,
+    IonAvatar,
+    IonImg,
+    IonLabel,
+    IonSearchbar,
+  } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton,
+      IonModal,
+      IonHeader,
+      IonContent,
+      IonToolbar,
+      IonTitle,
+      IonItem,
+      IonList,
+      IonAvatar,
+      IonImg,
+      IonLabel,
+      IonSearchbar,
+    },
+    data() {
+      return {
+        count: 0,
+      };
+    },
+    methods: {
+      increment() {
+        this.count++;
+      },
+      decrement() {
+        this.count--;
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/modal/sheet/basic/angular.md
+++ b/static/usage/modal/sheet/basic/angular.md
@@ -1,56 +1,58 @@
 ```html
-<ion-header>
-  <ion-toolbar>
-    <ion-title>App</ion-title>
-  </ion-toolbar>
-</ion-header>
-<ion-content class="ion-padding">
-  <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
 
-  <ion-modal #modal trigger="open-modal" [initialBreakpoint]="0.25" [breakpoints]="[0, 0.25, 0.5, 0.75]">
-    <ng-template>
-      <ion-content>
-        <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
-        <ion-list>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Connor Smith</h2>
-              <p>Sales Rep</p>
-            </ion-label>
-          </ion-item>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Daniel Smith</h2>
-              <p>Product Designer</p>
-            </ion-label>
-          </ion-item>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Greg Smith</h2>
-              <p>Director of Operations</p>
-            </ion-label>
-          </ion-item>
-          <ion-item>
-            <ion-avatar slot="start">
-              <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
-            </ion-avatar>
-            <ion-label>
-              <h2>Zoey Smith</h2>
-              <p>CEO</p>
-            </ion-label>
-          </ion-item>
-        </ion-list>
-      </ion-content>
-    </ng-template>
-  </ion-modal>
-</ion-content>
+    <ion-modal #modal trigger="open-modal" [initialBreakpoint]="0.25" [breakpoints]="[0, 0.25, 0.5, 0.75]">
+      <ng-template>
+        <ion-content>
+          <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
+          <ion-list>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Connor Smith</h2>
+                <p>Sales Rep</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Daniel Smith</h2>
+                <p>Product Designer</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Greg Smith</h2>
+                <p>Director of Operations</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
+              </ion-avatar>
+              <ion-label>
+                <h2>Zoey Smith</h2>
+                <p>CEO</p>
+              </ion-label>
+            </ion-item>
+          </ion-list>
+        </ion-content>
+      </ng-template>
+    </ion-modal>
+  </ion-content>
+</ion-app>
 ```

--- a/static/usage/modal/sheet/basic/angular.md
+++ b/static/usage/modal/sheet/basic/angular.md
@@ -1,0 +1,56 @@
+```html
+<ion-header>
+  <ion-toolbar>
+    <ion-title>App</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+  <ion-modal #modal trigger="open-modal" [initialBreakpoint]="0.25" [breakpoints]="[0, 0.25, 0.5, 0.75]">
+    <ng-template>
+      <ion-content>
+        <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
+        <ion-list>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Connor Smith</h2>
+              <p>Sales Rep</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Daniel Smith</h2>
+              <p>Product Designer</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Greg Smith</h2>
+              <p>Director of Operations</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Zoey Smith</h2>
+              <p>CEO</p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+      </ion-content>
+    </ng-template>
+  </ion-modal>
+</ion-content>
+```

--- a/static/usage/modal/sheet/basic/angular.md
+++ b/static/usage/modal/sheet/basic/angular.md
@@ -11,7 +11,7 @@
     <ion-modal #modal trigger="open-modal" [initialBreakpoint]="0.25" [breakpoints]="[0, 0.25, 0.5, 0.75]">
       <ng-template>
         <ion-content>
-          <ion-searchbar placeholder="Search" (ionFocus)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
+          <ion-searchbar placeholder="Search" (click)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
           <ion-list>
             <ion-item>
               <ion-avatar slot="start">

--- a/static/usage/modal/sheet/basic/demo.html
+++ b/static/usage/modal/sheet/basic/demo.html
@@ -74,7 +74,6 @@
     modal.breakpoints = [0, 0.25, 0.5, 0.75];
 
     searchBar.addEventListener('ionFocus', () => {
-      console.log('setting the current breakpoint');
       modal.setCurrentBreakpoint(0.75);
     });
   </script>

--- a/static/usage/modal/sheet/basic/demo.html
+++ b/static/usage/modal/sheet/basic/demo.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Sheet</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>App</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+      <ion-modal trigger="open-modal" initial-breakpoint="0.25">
+        <ion-content>
+          <ion-searchbar placeholder="Search"></ion-searchbar>
+          <ion-list>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=b" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Connor Smith</h2>
+                <p>Sales Rep</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=a" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Daniel Smith</h2>
+                <p>Product Designer</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=d" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Greg Smith</h2>
+                <p>Director of Operations</p>
+              </ion-label>
+            </ion-item>
+            <ion-item>
+              <ion-avatar slot="start">
+                <ion-img src="https://i.pravatar.cc/300?u=e" />
+              </ion-avatar>
+              <ion-label>
+                <h2>Zoey Smith</h2>
+                <p>CEO</p>
+              </ion-label>
+            </ion-item>
+          </ion-list>
+        </ion-content>
+      </ion-modal>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const modal = document.querySelector('ion-modal');
+    const searchBar = document.querySelector('ion-searchbar');
+
+    modal.breakpoints = [0, 0.25, 0.5, 0.75];
+
+    searchBar.addEventListener('ionFocus', () => {
+      console.log('setting the current breakpoint');
+      modal.setCurrentBreakpoint(0.75);
+    });
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/sheet/basic/demo.html
+++ b/static/usage/modal/sheet/basic/demo.html
@@ -73,7 +73,7 @@
 
     modal.breakpoints = [0, 0.25, 0.5, 0.75];
 
-    searchBar.addEventListener('ionFocus', () => {
+    searchBar.addEventListener('click', () => {
       modal.setCurrentBreakpoint(0.75);
     });
   </script>

--- a/static/usage/modal/sheet/basic/index.md
+++ b/static/usage/modal/sheet/basic/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+import react from './react.md';
+import angular from './angular.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/modal/sheet/basic/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/sheet/basic/javascript.md
+++ b/static/usage/modal/sheet/basic/javascript.md
@@ -1,0 +1,67 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+    <ion-modal trigger="open-modal" initial-breakpoint="0.25">
+      <ion-content>
+        <ion-searchbar placeholder="Search"></ion-searchbar>
+        <ion-list>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=b" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Connor Smith</h2>
+              <p>Sales Rep</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=a" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Daniel Smith</h2>
+              <p>Product Designer</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=d" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Greg Smith</h2>
+              <p>Director of Operations</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=e" />
+            </ion-avatar>
+            <ion-label>
+              <h2>Zoey Smith</h2>
+              <p>CEO</p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+
+<script>
+  var modal = document.querySelector('ion-modal');
+  var searchBar = document.querySelector('ion-searchbar');
+
+  modal.breakpoints = [0, 0.25, 0.5, 0.75];
+
+  searchBar.addEventListener('ionFocus', () => {
+    modal.setCurrentBreakpoint(0.75);
+  });
+</script>
+```

--- a/static/usage/modal/sheet/basic/javascript.md
+++ b/static/usage/modal/sheet/basic/javascript.md
@@ -60,7 +60,7 @@
 
   modal.breakpoints = [0, 0.25, 0.5, 0.75];
 
-  searchBar.addEventListener('ionFocus', () => {
+  searchBar.addEventListener('click', () => {
     modal.setCurrentBreakpoint(0.75);
   });
 </script>

--- a/static/usage/modal/sheet/basic/react.md
+++ b/static/usage/modal/sheet/basic/react.md
@@ -32,10 +32,7 @@ function Example() {
         </IonButton>
         <IonModal ref={modal} trigger="open-modal" initialBreakpoint={0.25} breakpoints={[0, 0.25, 0.5, 0.75]}>
           <IonContent className="ion-padding">
-            <IonSearchbar
-              onIonFocus={() => modal.current?.setCurrentBreakpoint(0.75)}
-              placeholder="Search"
-            ></IonSearchbar>
+            <IonSearchbar onClick={() => modal.current?.setCurrentBreakpoint(0.75)} placeholder="Search"></IonSearchbar>
             <IonList>
               <IonItem>
                 <IonAvatar slot="start">

--- a/static/usage/modal/sheet/basic/react.md
+++ b/static/usage/modal/sheet/basic/react.md
@@ -1,0 +1,85 @@
+```tsx
+import React, { useRef } from 'react';
+import {
+  IonButton,
+  IonModal,
+  IonHeader,
+  IonContent,
+  IonToolbar,
+  IonTitle,
+  IonPage,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonAvatar,
+  IonImg,
+  IonSearchbar,
+} from '@ionic/react';
+
+function Example() {
+  const modal = useRef(null);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>App</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonButton id="open-modal" expand="block">
+          Open Sheet Modal
+        </IonButton>
+        <IonModal ref={modal} trigger="open-modal" initialBreakpoint={0.25} breakpoints={[0, 0.25, 0.5, 0.75]}>
+          <IonContent className="ion-padding">
+            <IonSearchbar
+              onIonFocus={() => modal.current?.setCurrentBreakpoint(0.75)}
+              placeholder="Search"
+            ></IonSearchbar>
+            <IonList>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=b" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Connor Smith</h2>
+                  <p>Sales Rep</p>
+                </IonLabel>
+              </IonItem>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=a" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Daniel Smith</h2>
+                  <p>Product Designer</p>
+                </IonLabel>
+              </IonItem>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=d" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Greg Smith</h2>
+                  <p>Director of Operations</p>
+                </IonLabel>
+              </IonItem>
+              <IonItem>
+                <IonAvatar slot="start">
+                  <IonImg src="https://i.pravatar.cc/300?u=e" />
+                </IonAvatar>
+                <IonLabel>
+                  <h2>Zoey Smith</h2>
+                  <p>CEO</p>
+                </IonLabel>
+              </IonItem>
+            </IonList>
+          </IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/sheet/basic/vue.md
+++ b/static/usage/modal/sheet/basic/vue.md
@@ -1,0 +1,91 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+    <ion-modal ref="modal" trigger="open-modal" :initial-breakpoint="0.25" :breakpoints="[0, 0.25, 0.5, 0.75]">
+      <ion-content class="ion-padding">
+        <ion-searchbar @ionFocus="$refs.modal.$el.setCurrentBreakpoint(0.75)" placeholder="Search"></ion-searchbar>
+        <ion-list>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=b"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Connor Smith</h2>
+              <p>Sales Rep</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=a"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Daniel Smith</h2>
+              <p>Product Designer</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=d"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Greg Smith</h2>
+              <p>Director of Operations</p>
+            </ion-label>
+          </ion-item>
+          <ion-item>
+            <ion-avatar slot="start">
+              <ion-img src="https://i.pravatar.cc/300?u=e"></ion-img>
+            </ion-avatar>
+            <ion-label>
+              <h2>Zoey Smith</h2>
+              <p>CEO</p>
+            </ion-label>
+          </ion-item>
+        </ion-list>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</template>
+
+<script>
+  import {
+    IonButton,
+    IonModal,
+    IonHeader,
+    IonContent,
+    IonToolbar,
+    IonTitle,
+    IonItem,
+    IonList,
+    IonAvatar,
+    IonImg,
+    IonLabel,
+    IonSearchbar,
+  } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton,
+      IonModal,
+      IonHeader,
+      IonContent,
+      IonToolbar,
+      IonTitle,
+      IonItem,
+      IonList,
+      IonAvatar,
+      IonImg,
+      IonLabel,
+      IonSearchbar,
+    },
+  });
+</script>
+```

--- a/static/usage/modal/sheet/basic/vue.md
+++ b/static/usage/modal/sheet/basic/vue.md
@@ -10,7 +10,7 @@
 
     <ion-modal ref="modal" trigger="open-modal" :initial-breakpoint="0.25" :breakpoints="[0, 0.25, 0.5, 0.75]">
       <ion-content class="ion-padding">
-        <ion-searchbar @ionFocus="$refs.modal.$el.setCurrentBreakpoint(0.75)" placeholder="Search"></ion-searchbar>
+        <ion-searchbar @click="$refs.modal.$el.setCurrentBreakpoint(0.75)" placeholder="Search"></ion-searchbar>
         <ion-list>
           <ion-item>
             <ion-avatar slot="start">


### PR DESCRIPTION
Introduces the sheet modal examples to the component playground.

Combined the basic and move to breakpoint sections, as the examples felt redundant. 

In the basic example, if you click the backdrop to dismiss the background you will notice that the searchbar will no longer move to the correct breakpoint. This has been resolved and you can use this dev build: `6.1.5-dev.11651770915.1670c308` if that is a blocker for you.