### PR TITLE
fix(playground): vanilla JS stackblitz loads core styles

### DIFF
--- a/static/code/stackblitz/html/index.ts
+++ b/static/code/stackblitz/html/index.ts
@@ -2,6 +2,21 @@ import { defineCustomElements } from '@ionic/core/loader';
 
 import { pickerController } from '@ionic/core';
 
+/* Core CSS required for Ionic components to work properly */
+import '@ionic/core/css/core.css';
+
+/* Basic CSS for apps built with Ionic */
+import '@ionic/core/css/normalize.css';
+import '@ionic/core/css/structure.css';
+import '@ionic/core/css/typography.css';
+
+/* Optional CSS utils that can be commented out */
+import '@ionic/core/css/padding.css';
+import '@ionic/core/css/float-elements.css';
+import '@ionic/core/css/text-alignment.css';
+import '@ionic/core/css/text-transformation.css';
+import '@ionic/core/css/flex-utils.css';
+
 defineCustomElements();
 
 (window as any).pickerController = pickerController;


### PR DESCRIPTION
The Vanilla JS StackBlitz examples did not load the core CSS stylesheets. This resulted in certain layouts being wrong and fonts defaulting to serif fonts.

To test: https://ionic-docs-git-fw-1382-ionic1.vercel.app/docs/api/datetime#basic-usage

Make sure "JavaScript" is selected and open the StackBlitz. The font should be sans-serif.