### PR TITLE
docs(react): update router quick start for react router 5

### DIFF
--- a/docs/react/quickstart.md
+++ b/docs/react/quickstart.md
@@ -235,19 +235,21 @@ import { add } from ‘ionicons/icons’;
 
 On our main `IonFab`, we're setting its positioning with the vertical and horizontal attributes. We're also setting the render location to "fixed" with the slot attribute. This will tell `IonFab` to render outside of the scrollable content in `IonContent`.
 
-Now let's wire up a click handler to this. What we want to do is when we click the button, we'll navigate to a new page (which we'll create in a moment). To do this, we'll need to get access to React Router's navigation API. Thankfully since this is rendered in a Router/Route context, we have access to React Routers APIs via Props passed to our Home component.
+Now let's wire up a click handler to this. What we want to do is when we click the button, we'll navigate to a new page (which we'll create in a moment). To do this, we'll need to get access to React Router's `useHistory` hook API. Thankfully the `useHistory` hook makes this easy since it can be imported from the react-router package. 
 
 ```tsx
 import { add } from 'ionicons/icons';
+import { useHistory } from "react-router";
 ...
-const Home: React.FC<RouteComponentProps> = (props) => {
+const Home: React.FC<RouteComponentProps> = () => {
+const history = useHistory();
   return (
     <IonPage>
       <IonHeader>...</IonHeader>
       <IonContent>
         <IonList>...</IonList>
         <IonFab vertical="bottom" horizontal="end" slot="fixed">
-          <IonFabButton onClick={() => props.history.push('/new')}>
+          <IonFabButton onClick={() => history.push('/new')}>
             <IonIcon icon={add} />
           </IonFabButton>
         </IonFab>

--- a/docs/react/quickstart.md
+++ b/docs/react/quickstart.md
@@ -239,10 +239,10 @@ Now let's wire up a click handler to this. What we want to do is when we click t
 
 ```tsx
 import { add } from 'ionicons/icons';
-import { useHistory } from "react-router";
+import { useHistory } from 'react-router';
 ...
 const Home: React.FC<RouteComponentProps> = () => {
-const history = useHistory();
+  const history = useHistory();
   return (
     <IonPage>
       <IonHeader>...</IonHeader>


### PR DESCRIPTION
react router 5 which is now used by the CLI.  Props.history has been removed from this version