### PR TITLE
feat(playground): add ability to expand code block by default

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -92,7 +92,7 @@ export default function Playground({
   src,
   size = 'small',
   devicePreview,
-  defaultCodeExpanded = false,
+  expandCodeByDefault = false,
 }: {
   code: { [key in UsageTarget]?: MdxContent | UsageTargetOptions };
   title?: string;
@@ -100,7 +100,7 @@ export default function Playground({
   size: string;
   description?: string;
   devicePreview?: boolean;
-  defaultCodeExpanded: boolean
+  expandCodeByDefault: boolean
 }) {
   if (!code || Object.keys(code).length === 0) {
     console.warn('No code usage examples provided for this Playground example.');
@@ -120,7 +120,7 @@ export default function Playground({
   const frameSize = FRAME_SIZES[size] || size;
   const [usageTarget, setUsageTarget] = useState(UsageTarget.JavaScript);
   const [mode, setMode] = useState(Mode.iOS);
-  const [codeExpanded, setCodeExpanded] = useState(defaultCodeExpanded);
+  const [codeExpanded, setCodeExpanded] = useState(expandCodeByDefault);
   const [codeSnippets, setCodeSnippets] = useState({});
 
   /**

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -92,6 +92,7 @@ export default function Playground({
   src,
   size = 'small',
   devicePreview,
+  defaultCodeExpanded = false,
 }: {
   code: { [key in UsageTarget]?: MdxContent | UsageTargetOptions };
   title?: string;
@@ -99,6 +100,7 @@ export default function Playground({
   size: string;
   description?: string;
   devicePreview?: boolean;
+  defaultCodeExpanded: boolean
 }) {
   if (!code || Object.keys(code).length === 0) {
     console.warn('No code usage examples provided for this Playground example.');
@@ -118,7 +120,7 @@ export default function Playground({
   const frameSize = FRAME_SIZES[size] || size;
   const [usageTarget, setUsageTarget] = useState(UsageTarget.JavaScript);
   const [mode, setMode] = useState(Mode.iOS);
-  const [codeExpanded, setCodeExpanded] = useState(false);
+  const [codeExpanded, setCodeExpanded] = useState(defaultCodeExpanded);
   const [codeSnippets, setCodeSnippets] = useState({});
 
   /**

--- a/static/usage/button/basic/index.md
+++ b/static/usage/button/basic/index.md
@@ -18,5 +18,5 @@ import angular from './angular.md';
     },
   }}
   src="usage/button/basic/demo.html"
-  defaultCodeExpanded={true}
+  expandCodeByDefault={true}
 />

--- a/static/usage/button/basic/index.md
+++ b/static/usage/button/basic/index.md
@@ -18,4 +18,5 @@ import angular from './angular.md';
     },
   }}
   src="usage/button/basic/demo.html"
+  defaultCodeExpanded={true}
 />


### PR DESCRIPTION
This PR adds the `expandCodeByDefault` prop to the playground. The prop is also set on the button example at URL `/docs/playground/button` for testing purposes.