### PR TITLE
docs(popover): add nested playground

### DIFF
--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -106,8 +106,12 @@ import ControllerExample from '@site/static/usage/popover/presenting/controller/
 Popovers are presented at the root of your application so they overlay your entire app. This behavior applies to both inline popovers and popovers presented from a controller. As a result, custom popover styles can not be scoped to a particular component as they will not apply to the popover. Instead, styles must be applied globally. For most developers, placing the custom styles in `global.css` is sufficient.
 
 :::note
- If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file. Read [Style Placement](#style-placement) in the Angular section below for more information.
+ If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file.
 :::
+
+import Styling from '@site/static/usage/popover/customization/styling/index.md';
+
+<Styling />
 
 
 ## Positioning
@@ -124,13 +128,25 @@ Regardless of what you choose for your reference point, you can position a popov
 
 The `alignment` property allows you to line up an edge of your popover with a corresponding edge on your trigger element. The exact edge that is used depends on the value of the `side` property. 
 
+### Side and Alignment Demo
+
+import Positioning from '@site/static/usage/popover/customization/positioning/index.md';
+
+<Positioning />
+
 ### Offsets
 
 If you need finer grained control over the positioning of your popover you can use the `--offset-x` and `--offset-y` CSS Variables. For example, `--offset-x: 10px` will move your popover content to the right by `10px`.
 
 ## Sizing
 
-When making dropdown menus, you may want to have the width of the popover match the width of the trigger element. Doing this without knowing the trigger width ahead of time is tricky. You can set the `size` property to `'cover'` and Ionic Framework will ensure that the width of the popover matches the width of your trigger element. If you are using the `popoverController`, you must provide an event via the `event` option and Ionic Framework will use `event.target` as the reference element.
+When making dropdown menus, you may want to have the width of the popover match the width of the trigger element. Doing this without knowing the trigger width ahead of time is tricky. You can set the `size` property to `'cover'` and Ionic Framework will ensure that the width of the popover matches the width of your trigger element.
+
+If you are using the `popoverController`, you must provide an event via the `event` option and Ionic Framework will use `event.target` as the reference element. See the [controller demo](#controller-popovers) for an example of this pattern.
+
+import Sizing from '@site/static/usage/popover/customization/sizing/index.md';
+
+<Sizing />
 
 ## Nested Popovers
 

--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -142,6 +142,10 @@ You can use the `dismissOnSelect` property to automatically close the popover wh
  Nested popovers cannot be created when using the `popoverController` because the popover is automatically added to the root of your application when the `create` method is called.
 :::
 
+import NestedPopover from '@site/static/usage/popover/nested/index.md';
+
+<NestedPopover />
+
 
 ## Interfaces
 

--- a/static/usage/popover/customization/positioning/angular/angular_css.md
+++ b/static/usage/popover/customization/positioning/angular/angular_css.md
@@ -1,0 +1,12 @@
+```css
+ion-popover {
+  --width: 80px;
+}
+
+.container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  padding: 80px;
+}
+```

--- a/static/usage/popover/customization/positioning/angular/angular_html.md
+++ b/static/usage/popover/customization/positioning/angular/angular_html.md
@@ -1,0 +1,31 @@
+```html
+<div class="container">
+  <ion-button id="top-center">Side=Top, Alignment=Center</ion-button>
+  <ion-popover trigger="top-center" side="top" alignment="center">
+    <ng-template>
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ng-template>
+  </ion-popover>
+
+  <ion-button id="bottom-start">Side=Bottom, Alignment=Start</ion-button>
+  <ion-popover trigger="bottom-start" side="bottom" alignment="start">
+    <ng-template>
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ng-template>
+  </ion-popover>
+
+  <ion-button id="left-start">Side=Left, Alignment=Start</ion-button>
+  <ion-popover trigger="left-start" side="left" alignment="start">
+    <ng-template>  
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ng-template>
+  </ion-popover>
+
+  <ion-button id="right-end">Side=Right, Alignment=End</ion-button>
+  <ion-popover trigger="right-end" side="right" alignment="end">
+    <ng-template>
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ng-template>
+  </ion-popover>
+</div>
+```

--- a/static/usage/popover/customization/positioning/angular/angular_ts.md
+++ b/static/usage/popover/customization/positioning/angular/angular_ts.md
@@ -1,0 +1,11 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css']
+})
+export class AppComponent { }
+
+```

--- a/static/usage/popover/customization/positioning/demo.html
+++ b/static/usage/popover/customization/positioning/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popover</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      flex-direction: column;
+    }
+
+    ion-popover {
+      --width: 80px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button id="top-center">Side=Top, Alignment=Center</ion-button>
+        <ion-popover trigger="top-center" side="top" alignment="center">
+          <ion-content class="ion-padding">Hello World!</ion-content>
+        </ion-popover>
+
+        <ion-button id="bottom-start">Side=Bottom, Alignment=Start</ion-button>
+        <ion-popover trigger="bottom-start" side="bottom" alignment="start">
+          <ion-content class="ion-padding">Hello World!</ion-content>
+        </ion-popover>
+
+        <ion-button id="left-start">Side=Left, Alignment=Start</ion-button>
+        <ion-popover trigger="left-start" side="left" alignment="start">
+          <ion-content class="ion-padding">Hello World!</ion-content>
+        </ion-popover>
+
+        <ion-button id="right-end">Side=Right, Alignment=End</ion-button>
+        <ion-popover trigger="right-end" side="right" alignment="end">
+          <ion-content class="ion-padding">Hello World!</ion-content>
+        </ion-popover>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/popover/customization/positioning/index.md
+++ b/static/usage/popover/customization/positioning/index.md
@@ -1,0 +1,33 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+
+import reactTS from './react/react_ts.md';
+import reactCSS from './react/react_css.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularCSS from './angular/angular_css.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  size="400px"
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTS,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.css': angularCSS,
+        'src/app/app.component.ts': angularTS
+      }
+    }
+  }}
+  src="usage/popover/customization/positioning/demo.html"
+/>

--- a/static/usage/popover/customization/positioning/javascript.md
+++ b/static/usage/popover/customization/positioning/javascript.md
@@ -1,0 +1,36 @@
+```html
+<div class="container">
+  <ion-button id="top-center">Side=Top, Alignment=Center</ion-button>
+  <ion-popover trigger="top-center" side="top" alignment="center">
+    <ion-content class="ion-padding">Hello World!</ion-content>
+  </ion-popover>
+
+  <ion-button id="bottom-start">Side=Bottom, Alignment=Start</ion-button>
+  <ion-popover trigger="bottom-start" side="bottom" alignment="start">
+    <ion-content class="ion-padding">Hello World!</ion-content>
+  </ion-popover>
+
+  <ion-button id="left-start">Side=Left, Alignment=Start</ion-button>
+  <ion-popover trigger="left-start" side="left" alignment="start">
+    <ion-content class="ion-padding">Hello World!</ion-content>
+  </ion-popover>
+
+  <ion-button id="right-end">Side=Right, Alignment=End</ion-button>
+  <ion-popover trigger="right-end" side="right" alignment="end">
+    <ion-content class="ion-padding">Hello World!</ion-content>
+  </ion-popover>
+</div>
+
+<style>
+  ion-popover {
+    --width: 80px;
+  }
+
+  .container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    padding: 80px;
+  }
+</style>
+```

--- a/static/usage/popover/customization/positioning/react/react_css.md
+++ b/static/usage/popover/customization/positioning/react/react_css.md
@@ -1,0 +1,12 @@
+```css
+ion-popover {
+  --width: 80px;
+}
+
+.container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  padding: 80px;
+}
+```

--- a/static/usage/popover/customization/positioning/react/react_ts.md
+++ b/static/usage/popover/customization/positioning/react/react_ts.md
@@ -1,0 +1,33 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, IonPopover } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <div className="container">
+      <IonButton id="top-center">Side=Top, Alignment=Center</IonButton>
+      <IonPopover trigger="top-center" side="top" alignment="center">
+        <IonContent class="ion-padding">Hello World!</IonContent>
+      </IonPopover>
+
+      <IonButton id="bottom-start">Side=Bottom, Alignment=Start</IonButton>
+      <IonPopover trigger="bottom-start" side="bottom" alignment="start">
+        <IonContent class="ion-padding">Hello World!</IonContent>
+      </IonPopover>
+
+      <IonButton id="left-start">Side=Left, Alignment=Start</IonButton>
+      <IonPopover trigger="left-start" side="left" alignment="start">
+        <IonContent class="ion-padding">Hello World!</IonContent>
+      </IonPopover>
+
+      <IonButton id="right-end">Side=Right, Alignment=End</IonButton>
+      <IonPopover trigger="right-end" side="right" alignment="end">
+        <IonContent class="ion-padding">Hello World!</IonContent>
+      </IonPopover>
+    </div>
+  );
+}
+export default Example;
+```

--- a/static/usage/popover/customization/positioning/vue.md
+++ b/static/usage/popover/customization/positioning/vue.md
@@ -1,0 +1,47 @@
+```html
+<template>
+  <div class="container">
+    <ion-button id="top-center">Side=Top, Alignment=Center</ion-button>
+    <ion-popover trigger="top-center" side="top" alignment="center">
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ion-popover>
+
+    <ion-button id="bottom-start">Side=Bottom, Alignment=Start</ion-button>
+    <ion-popover trigger="bottom-start" side="bottom" alignment="start">
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ion-popover>
+
+    <ion-button id="left-start">Side=Left, Alignment=Start</ion-button>
+    <ion-popover trigger="left-start" side="left" alignment="start">
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ion-popover>
+
+    <ion-button id="right-end">Side=Right, Alignment=End</ion-button>
+    <ion-popover trigger="right-end" side="right" alignment="end">
+      <ion-content class="ion-padding">Hello World!</ion-content>
+    </ion-popover>
+  </div>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonContent, IonPopover } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonContent, IonPopover },
+  });
+</script>
+
+<style>
+  ion-popover {
+    --width: 80px;
+  }
+
+  .container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    padding: 80px;
+  }
+</style>
+```

--- a/static/usage/popover/customization/sizing/angular.md
+++ b/static/usage/popover/customization/sizing/angular.md
@@ -1,0 +1,15 @@
+```html
+<ion-button id="auto-trigger">Size=Auto</ion-button>
+<ion-popover trigger="auto-trigger" size="auto">
+  <ng-template>
+    <ion-content class="ion-padding">Hello!</ion-content>
+  </ng-template>
+</ion-popover>
+
+<ion-button id="cover-trigger">Size=Cover</ion-button>
+<ion-popover trigger="cover-trigger" size="cover">
+  <ng-template>
+    <ion-content class="ion-padding">Hello!</ion-content>
+  </ng-template>
+</ion-popover>
+```

--- a/static/usage/popover/customization/sizing/demo.html
+++ b/static/usage/popover/customization/sizing/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popover</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button id="auto-trigger">Size=Auto</ion-button>
+        <ion-popover trigger="auto-trigger" size="auto">
+          <ion-content class="ion-padding">Hello!</ion-content>
+        </ion-popover>
+
+        <ion-button id="cover-trigger">Size=Cover</ion-button>
+        <ion-popover trigger="cover-trigger" size="cover">
+          <ion-content class="ion-padding">Hello!</ion-content>
+        </ion-popover>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/popover/customization/sizing/index.md
+++ b/static/usage/popover/customization/sizing/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  size="300px"
+  code={{ javascript, react, vue, angular }}
+  src="usage/popover/customization/sizing/demo.html"
+/>

--- a/static/usage/popover/customization/sizing/javascript.md
+++ b/static/usage/popover/customization/sizing/javascript.md
@@ -1,0 +1,11 @@
+```html
+<ion-button id="auto-trigger">Size=Auto</ion-button>
+<ion-popover trigger="auto-trigger" size="auto">
+  <ion-content class="ion-padding">Hello!</ion-content>
+</ion-popover>
+
+<ion-button id="cover-trigger">Size=Cover</ion-button>
+<ion-popover trigger="cover-trigger" size="cover">
+  <ion-content class="ion-padding">Hello!</ion-content>
+</ion-popover>
+```

--- a/static/usage/popover/customization/sizing/react.md
+++ b/static/usage/popover/customization/sizing/react.md
@@ -1,0 +1,20 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, IonPopover } from '@ionic/react';
+function Example() {
+  return (
+    <IonContent>
+      <IonButton id="auto-trigger">Size=Auto</IonButton>
+      <IonPopover trigger="auto-trigger" size="auto">
+        <IonContent class="ion-padding">Hello!</IonContent>
+      </IonPopover>
+
+      <IonButton id="cover-trigger">Size=Cover</IonButton>
+      <IonPopover trigger="cover-trigger" size="cover">
+        <IonContent class="ion-padding">Hello!</IonContent>
+      </IonPopover>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/popover/customization/sizing/vue.md
+++ b/static/usage/popover/customization/sizing/vue.md
@@ -1,0 +1,24 @@
+```html
+<template>
+  <ion-content>
+    <ion-button id="auto-trigger">Size=Auto</ion-button>
+    <ion-popover trigger="auto-trigger" size="auto">
+      <ion-content class="ion-padding">Hello!</ion-content>
+    </ion-popover>
+
+    <ion-button id="cover-trigger">Size=Cover</ion-button>
+    <ion-popover trigger="cover-trigger" size="cover">
+      <ion-content class="ion-padding">Hello!</ion-content>
+    </ion-popover>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonContent, IonPopover } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonContent, IonPopover },
+  });
+</script>
+```

--- a/static/usage/popover/customization/styling/angular/angular_css.md
+++ b/static/usage/popover/customization/styling/angular/angular_css.md
@@ -1,0 +1,30 @@
+```css
+/* Core CSS required for Ionic components to work properly */
+@import '~@ionic/angular/css/core.css';
+/* Basic CSS for apps built with Ionic */
+@import '~@ionic/angular/css/normalize.css';
+@import '~@ionic/angular/css/structure.css';
+@import '~@ionic/angular/css/typography.css';
+/* Optional CSS utils that can be commented out */
+@import '~@ionic/angular/css/padding.css';
+@import '~@ionic/angular/css/float-elements.css';
+@import '~@ionic/angular/css/text-alignment.css';
+@import '~@ionic/angular/css/text-transformation.css';
+@import '~@ionic/angular/css/flex-utils.css';
+
+ion-popover {
+  --background: rgba(40, 173, 218, 0.6);
+  --backdrop-opacity: 0.6;
+  --box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.6);
+  --color: white;
+  --width: 300px;
+}
+
+ion-popover ion-content {
+  --background: rgba(40, 173, 218, 0.6);
+}
+
+ion-popover::part(backdrop) {
+  background-color: rgb(6, 14, 106);
+}
+```

--- a/static/usage/popover/customization/styling/angular/angular_html.md
+++ b/static/usage/popover/customization/styling/angular/angular_html.md
@@ -1,0 +1,8 @@
+```html
+<ion-button id="trigger-button">Click Me</ion-button>
+<ion-popover trigger="trigger-button">
+  <ng-template>
+    <ion-content class="ion-padding">Hello Styled World!</ion-content>
+  </ng-template>
+</ion-popover>
+```

--- a/static/usage/popover/customization/styling/demo.html
+++ b/static/usage/popover/customization/styling/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popover</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    ion-popover {
+      --background: rgba(40, 173, 218, 0.6);
+      --backdrop-opacity: 0.6;
+      --box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.6);
+      --color: white;
+      --width: 300px;
+    }
+
+    ion-popover ion-content {
+      --background: rgba(40, 173, 218, 0.6);
+    }
+
+    ion-popover::part(backdrop) {
+      background-color: rgb(6, 14, 106);
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button id="trigger-button">Click Me</ion-button>
+        <ion-popover trigger="trigger-button">
+          <ion-content class="ion-padding">Hello Styled World!</ion-content>
+        </ion-popover>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/popover/customization/styling/index.md
+++ b/static/usage/popover/customization/styling/index.md
@@ -1,0 +1,31 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+
+import reactTS from './react/react_ts.md';
+import reactCSS from './react/react_css.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularCSS from './angular/angular_css.md';
+
+<Playground
+  size="300px"
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTS,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/styles.css': angularCSS
+      }
+    }
+  }}
+  src="usage/popover/customization/styling/demo.html"
+/>

--- a/static/usage/popover/customization/styling/javascript.md
+++ b/static/usage/popover/customization/styling/javascript.md
@@ -1,0 +1,24 @@
+```html
+<ion-button id="trigger-button">Click Me</ion-button>
+<ion-popover trigger="trigger-button">
+  <ion-content class="ion-padding">Hello Styled World!</ion-content>
+</ion-popover>
+
+<style>
+  ion-popover {
+    --background: rgba(40, 173, 218, 0.6);
+    --backdrop-opacity: 0.6;
+    --box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.6);
+    --color: white;
+    --width: 300px;
+  }
+
+  ion-popover ion-content {
+    --background: rgba(40, 173, 218, 0.6);
+  }
+
+  ion-popover::part(backdrop) {
+    background-color: rgb(6, 14, 106);
+  }
+</style>
+```

--- a/static/usage/popover/customization/styling/react/react_css.md
+++ b/static/usage/popover/customization/styling/react/react_css.md
@@ -1,0 +1,17 @@
+```css
+ion-popover {
+  --background: rgba(40, 173, 218, 0.6);
+  --backdrop-opacity: 0.6;
+  --box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.6);
+  --color: white;
+  --width: 300px;
+}
+
+ion-popover ion-content {
+  --background: rgba(40, 173, 218, 0.6);
+}
+
+ion-popover::part(backdrop) {
+  background-color: rgb(6, 14, 106);
+}
+```

--- a/static/usage/popover/customization/styling/react/react_ts.md
+++ b/static/usage/popover/customization/styling/react/react_ts.md
@@ -1,0 +1,18 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, IonPopover } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonContent>
+      <IonButton id="trigger-button">Click Me</IonButton>
+      <IonPopover trigger="trigger-button">
+        <IonContent className="ion-padding">Hello Styled World!</IonContent>
+      </IonPopover>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/popover/customization/styling/vue.md
+++ b/static/usage/popover/customization/styling/vue.md
@@ -1,0 +1,37 @@
+```html
+<template>
+  <ion-content>
+    <ion-button id="trigger-button">Click Me</ion-button>
+    <ion-popover trigger="trigger-button">
+      <ion-content>Hello Styled World!</ion-content>
+    </ion-popover>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonContent, IonPopover } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonContent, IonPopover },
+  });
+</script>
+
+<style>
+  ion-popover {
+    --background: rgba(40, 173, 218, 0.6);
+    --backdrop-opacity: 0.6;
+    --box-shadow: 0 5px 10px 0 rgba(0, 0, 0, 0.6);
+    --color: white;
+    --width: 300px;
+  }
+
+  ion-popover ion-content {
+    --background: rgba(40, 173, 218, 0.6);
+  }
+
+  ion-popover::part(backdrop) {
+    background-color: rgb(6, 14, 106);
+  }
+</style>
+```

--- a/static/usage/popover/nested/angular.md
+++ b/static/usage/popover/nested/angular.md
@@ -1,0 +1,24 @@
+```html
+<ion-button id="popover-button">Open Menu</ion-button>
+<ion-popover trigger="popover-button" [dismissOnSelect]="true">
+  <ng-template>
+    <ion-content>
+      <ion-list>
+        <ion-item [button]="true" [detail]="false">Option 1</ion-item>
+        <ion-item [button]="true" [detail]="false">Option 2</ion-item>
+        <ion-item [button]="true" id="nested-trigger">More options...</ion-item>
+
+        <ion-popover trigger="nested-trigger" [dismissOnSelect]="true" side="end">
+          <ng-template>
+            <ion-content>
+              <ion-list>
+                <ion-item [button]="true" [detail]="false">Nested option</ion-item>
+              </ion-list>
+            </ion-content>
+          </ng-template>
+        </ion-popover>
+      </ion-list>
+    </ion-content>
+  </ng-template>
+</ion-popover>
+```

--- a/static/usage/popover/nested/demo.html
+++ b/static/usage/popover/nested/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popover</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button id="popover-button">Open Menu</ion-button>
+        <ion-popover trigger="popover-button" dismiss-on-select="true">
+          <ion-content>
+            <ion-list>
+              <ion-item button="true" detail="false">Option 1</ion-item>
+              <ion-item button="true" detail="false">Option 2</ion-item>
+              <ion-item button="true" id="nested-trigger">More options...</ion-item>
+
+              <ion-popover trigger="nested-trigger" dismiss-on-select="true" side="end">
+                <ion-content>
+                  <ion-list>
+                    <ion-item button="true" detail="false">Nested option</ion-item>
+                  </ion-list>
+                </ion-content>
+              </ion-popover>
+            </ion-list>
+          </ion-content>
+        </ion-popover>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/popover/nested/index.md
+++ b/static/usage/popover/nested/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  size="medium"
+  code={{ javascript, react, vue, angular }}
+  src="usage/popover/nested/demo.html"
+/>

--- a/static/usage/popover/nested/javascript.md
+++ b/static/usage/popover/nested/javascript.md
@@ -1,0 +1,20 @@
+```html
+<ion-button id="popover-button">Open Menu</ion-button>
+<ion-popover trigger="popover-button" dismiss-on-select="true">
+  <ion-content>
+    <ion-list>
+      <ion-item button="true" detail="false">Option 1</ion-item>
+      <ion-item button="true" detail="false">Option 2</ion-item>
+      <ion-item button="true" id="nested-trigger">More options...</ion-item>
+
+      <ion-popover trigger="nested-trigger" dismiss-on-select="true" side="end">
+        <ion-content>
+          <ion-list>
+            <ion-item button="true" detail="false">Nested option</ion-item>
+          </ion-list>
+        </ion-content>
+      </ion-popover>
+    </ion-list>
+  </ion-content>
+</ion-popover>
+```

--- a/static/usage/popover/nested/react.md
+++ b/static/usage/popover/nested/react.md
@@ -3,7 +3,7 @@ import React from 'react';
 import { IonButton, IonContent, IonItem, IonList, IonPopover } from '@ionic/react';
 function Example() {
   return (
-    <div>
+    <IonContent>
       <IonButton id="popover-button">Open Menu</IonButton>
       <IonPopover trigger="popover-button" dismissOnSelect={true}>
         <IonContent>
@@ -22,7 +22,7 @@ function Example() {
           </IonList>
         </IonContent>
       </IonPopover>
-    </div>
+    </IonContent>
   );
 }
 export default Example;

--- a/static/usage/popover/nested/react.md
+++ b/static/usage/popover/nested/react.md
@@ -1,0 +1,29 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, IonItem, IonList, IonPopover } from '@ionic/react';
+function Example() {
+  return (
+    <div>
+      <IonButton id="popover-button">Open Menu</IonButton>
+      <IonPopover trigger="popover-button" dismissOnSelect={true}>
+        <IonContent>
+          <IonList>
+            <IonItem button={true} detail={false}>Option 1</IonItem>
+            <IonItem button={true} detail={false}>Option 2</IonItem>
+            <IonItem button={true} id="nested-trigger">More options...</IonItem>
+
+            <IonPopover trigger="nested-trigger" dismissOnSelect={true} side="end">
+              <IonContent>
+                <IonList>
+                  <IonItem button={true} detail={false}>Nested option</IonItem>
+                </IonList>
+              </IonContent>
+            </IonPopover>
+          </IonList>
+        </IonContent>
+      </IonPopover>
+    </div>
+  );
+}
+export default Example;
+```

--- a/static/usage/popover/nested/vue.md
+++ b/static/usage/popover/nested/vue.md
@@ -1,0 +1,33 @@
+```html
+<template>
+  <div>
+    <ion-button id="popover-button">Open Menu</ion-button>
+    <ion-popover trigger="popover-button" :dismiss-on-select="true">
+      <ion-content>
+        <ion-list>
+          <ion-item :button="true" :detail="false">Option 1</ion-item>
+          <ion-item :button="true" :detail="false">Option 2</ion-item>
+          <ion-item :button="true" id="nested-trigger">More options...</ion-item>
+
+          <ion-popover trigger="nested-trigger" :dismiss-on-select="true" side="end">
+            <ion-content>
+              <ion-list>
+                <ion-item :button="true" :detail="false">Nested option</ion-item>
+              </ion-list>
+            </ion-content>
+          </ion-popover>
+        </ion-list>
+      </ion-content>
+    </ion-popover>
+  </div>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonContent, IonItem, IonList, IonPopover } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonContent, IonItem, IonList, IonPopover },
+  });
+</script>
+```

--- a/static/usage/popover/nested/vue.md
+++ b/static/usage/popover/nested/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <div>
+  <ion-content>
     <ion-button id="popover-button">Open Menu</ion-button>
     <ion-popover trigger="popover-button" :dismiss-on-select="true">
       <ion-content>
@@ -19,7 +19,7 @@
         </ion-list>
       </ion-content>
     </ion-popover>
-  </div>
+  </ion-content>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
Adds the Nested Popovers playground. `dismissOnSelect` was folded in here rather than having its own separate playground, since separating the two felt redundant.