### PR TITLE
fix(playground): fall back to first tab if selectedValue isn't in tabs

### DIFF
--- a/static/usage/button/basic/index.md
+++ b/static/usage/button/basic/index.md
@@ -16,7 +16,13 @@ import angular from './angular.md';
         'src/example-five.html': javascript,
       },
     },
-    react,
+    react: {
+      files: {
+        'src/react-example.html': react,
+        'src/react-example-two.html': react,
+        'src/react-example-three.html': react,
+      }
+    },
     vue,
     angular,
   }}


### PR DESCRIPTION
Currently in the playground, if you switch between two framework tabs (for example, Javascript and React) that both have multiple files in their code snippets, the active tab for the code files is not updated. This means that if the previously selected file name does not appear in the newly selected framework (very common), the new framework will not have any code tabs selected.

![no selected tab](https://i.gyazo.com/9a1342ea49cc2194a9c0f0a240409781.png)

This happens because React detects that the only thing changed about the tabs is their children (the `<TabItem>s`), but the `PlaygroundTabs` component isn't designed to account for reactive children, so `selectedValue` doesn't update in response to it.

However, making `selectedValue` respond to dynamic children would require calling `setSelectedValue` during the render cycle. For example, this was my initial strategy:
```tsx
useEffect(() => {
  setSelectedValue(defaultValue);
}, [defaultValue]);
// then set defaultValue to first file name in Playground's renderCodeSnippets function
```
The problem with this is that it triggers a new render, which leads to visual flicker where the new default tab doesn't appear until a frame or two later. The same thing happens with similar strategies such as watching for updates to `values` or `children`.

This PR's current strategy, which falls back to the first tab via a manual check, ensures that the fallback happens in the same render cycle.