### PR TITLE
docs(accordion): add performance section

### DIFF
--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -108,7 +108,17 @@ When used inside an `ion-accordion-group`, `ion-accordion` has full keyboard sup
 | `Home`             | When focus is on an accordion header, moves focus to the first accordion header. |
 | `End`              | When focus is on an accordion header, moves focus to the last accordion header. |
 
+## Performance
 
+### Animations
+
+The accordion animation works by knowing the height of the `content` slot when the animation starts. It also expects that this height will remain consistent throughout the animation. As a result, developers should avoid performing any operation that may change the height of the content during the animation.
+
+For example, using [ion-img](../img) may cause layout shifts as it lazily loads images. This means that as the animation plays, `ion-img` will load the image data, and the dimensions of  `ion-img` will change to account for the loaded image data. Developers have a couple options for avoiding this:
+
+1. Use an `img` element without any lazy loading. `ion-img` always uses lazy loading, but `img` does not use lazy loading by default. This is the simplest option and works well if you have small images that do not significantly benefit from lazy loading.
+
+2. Set a minimum width and height on `ion-img`. If you need to use lazy loading and know the dimensions of the images ahead of time (such as if you are loading icons of the same size), you can set the `ion-img` to have a minimum width or height using CSS. This means gives developers the benefit of lazy loading while avoiding layout shifts. This works when using an `img` element with `loading="lazy"` too!
 
 ## Usage
 


### PR DESCRIPTION
Users found an instance where ion-img's lazy loading can interfere with the accordion animation. Added some docs to clarify how to correctly use lazy loaded content in an accordion:

https://github.com/ionic-team/ionic-framework/issues/25364