### PR TITLE
feat(range): component playground set-up

### DIFF
--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -1,8 +1,6 @@
 ---
 title: "ion-range"
 hide_table_of_contents: true
-demoUrl: "/docs/demos/api/range/index.html"
-demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/range/index.html"
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -38,6 +36,8 @@ The Range slider lets users select from a range of values by moving
 the slider knob. It can accept dual knobs, but by default one knob
 controls the value of the range.
 
+TODO: Playground Example
+
 ## Range Labels
 
 Labels can be placed on either side of the range by adding the
@@ -45,9 +45,41 @@ Labels can be placed on either side of the range by adding the
 be an `ion-label`, it can be added to any element to place it to the
 left or right of the range.
 
-## Custom Pin Formatters
+TODO: Playground Example
 
-When using a pin, the default behavior is to round the value that gets displayed using `Math.round()`. This behavior can be customized by passing in a formatter function to the `pinFormatter` property. See the [Usage](#usage) section for an example.
+## Dual Knobs
+
+TODO: Playground Example
+
+## Pins
+
+TODO: Playground Example
+
+## Ticks
+
+TODO: Playground Example
+
+## Snapping
+
+TODO: Playground Example
+
+## Event Handling
+
+### Using `ionChange`
+
+TODO: Playground Example
+
+### Using `ionKnobMoveStart` and `ionKnobMoveEnd`
+
+TODO: Playground Example
+
+## Styling
+
+TODO: Playground Example
+
+### Theming
+
+TODO: Playground Example
 
 ## Interfaces
 
@@ -94,322 +126,6 @@ interface RangeCustomEvent extends CustomEvent {
 type RangeValue = number | { lower: number, upper: number };
 ```
 
-
-
-## Usage
-
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
-
-<TabItem value="angular">
-
-```html
-<ion-list>
-  <ion-item>
-    <ion-range color="danger" [pin]="true"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="-200" max="200" color="secondary">
-      <ion-label slot="start">-200</ion-label>
-      <ion-label slot="end">200</ion-label>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="20" max="80" step="2">
-      <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-      <ion-icon slot="end" name="sunny"></ion-icon>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" ticks="false" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range dualKnobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
-  </ion-item>
-  
-  <ion-item>
-    <ion-range min="0" max="100" [pinFormatter]="customFormatter" [pin]="true"></ion-range>
-  </ion-item>
-</ion-list>
-```
-
-```typescript
-import { Component } from '@angular/core';
-
-@Component({…})
-export class MyComponent {
-  constructor() {}
-  
-  public customFormatter(value: number) {
-    return `${value}%`
-  }
-}
-```
-
-</TabItem>
-
-
-<TabItem value="javascript">
-
-```html
-<ion-list>
-  <ion-item>
-    <ion-range color="danger" pin="true"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="-200" max="200" color="secondary">
-      <ion-label slot="start">-200</ion-label>
-      <ion-label slot="end">200</ion-label>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="20" max="80" step="2">
-      <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-      <ion-icon slot="end" name="sunny"></ion-icon>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" ticks="false" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range dual-knobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
-  </ion-item>
-  
-  <ion-item>
-    <ion-range min="0" max="100" pin="true" id="custom-range"></ion-range>
-  </ion-item>
-</ion-list>
-
-<script>
-  const customRange = document.querySelector('#custom-range');
-  customRange.pinFormatter = (value) => `${value}%`; 
-</script>
-```
-
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React, { useState } from 'react';
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonList, IonItem, IonRange, IonLabel, IonIcon, IonItemDivider } from '@ionic/react';
-import { sunny } from 'ionicons/icons';
-import { RangeValue } from '@ionic/core';
-
-export const RangeExamples: React.FC = () => {
-
-  const [value, setValue] = useState(0);
-  const [rangeValue, setRangeValue] = useState<{
-    lower: number;
-    upper: number;
-  }>({ lower: 0, upper: 0 });
-  
-  const customFormatter = (value: number) => `${value}%`;
-
-  return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>IonRange Examples</IonTitle>
-        </IonToolbar>
-      </IonHeader>
-      <IonContent>
-        <IonList>
-          <IonItemDivider>Default</IonItemDivider>
-          <IonItem>
-            <IonRange pin={true} value={value} onIonChange={e => setValue(e.detail.value as number)} />
-          </IonItem>
-          <IonItem>
-            <IonLabel>Value: {value}</IonLabel>
-          </IonItem>
-
-          <IonItemDivider>Min & Max</IonItemDivider>
-          <IonItem>
-            <IonRange min={-200} max={200} color="secondary">
-              <IonLabel slot="start">-200</IonLabel>
-              <IonLabel slot="end">200</IonLabel>
-            </IonRange>
-          </IonItem>
-
-          <IonItemDivider>Icons</IonItemDivider>
-          <IonItem>
-            <IonRange min={20} max={80} step={2}>
-              <IonIcon size="small" slot="start" icon={sunny} />
-              <IonIcon slot="end" icon={sunny} />
-            </IonRange>
-          </IonItem>
-
-          <IonItemDivider>With Snaps & Ticks</IonItemDivider>
-          <IonItem>
-            <IonRange min={1000} max={2000} step={100} snaps={true} color="secondary" />
-          </IonItem>
-
-          <IonItemDivider>With Snaps & No Ticks</IonItemDivider>
-          <IonItem>
-            <IonRange min={1000} max={2000} step={100} snaps={true} ticks={false} color="secondary" />
-          </IonItem>
-
-          <IonItemDivider>Dual Knobs</IonItemDivider>
-          <IonItem>
-            <IonRange dualKnobs={true} min={0} max={60} step={3} snaps={true} onIonChange={e => setRangeValue(e.detail.value as any)} />
-          </IonItem>
-          <IonItem>
-            <IonLabel>Value: lower: {rangeValue.lower} upper: {rangeValue.upper}</IonLabel>
-          </IonItem>
-          
-          <IonItem>
-            <IonRange min={0} max={100} pinFormatter={customFormatter} pin={true}></IonRange>
-          </IonItem>
-        </IonList>
-      </IonContent>
-    </IonPage>
-  );
-};
-```
-
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'range-example',
-  styleUrl: 'range-example.css'
-})
-export class RangeExample {
-  private customFormatter = (value: number) => `${value}%`;
-  
-  render() {
-    return [
-      <ion-list>
-        <ion-item>
-          <ion-range color="danger" pin={true}></ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={-200} max={200} color="secondary">
-            <ion-label slot="start">-200</ion-label>
-            <ion-label slot="end">200</ion-label>
-          </ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={20} max={80} step={2}>
-            <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-            <ion-icon slot="end" name="sunny"></ion-icon>
-          </ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={1000} max={2000} step={100} snaps={true} color="secondary"></ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={1000} max={2000} step={100} snaps={true} ticks={false} color="secondary"></ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range dualKnobs={true} min={21} max={72} step={3} snaps={true}></ion-range>
-        </ion-item>
-        
-        <ion-item>
-          <ion-range min="0" max="100" pinFormatter={this.customFormatter} pin={true}></ion-range>
-        </ion-item>
-      </ion-list>
-    ];
-  }
-}
-```
-
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <ion-list>
-    <ion-item>
-      <ion-range color="danger" :pin="true"></ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="-200" max="200" color="secondary">
-        <ion-label slot="start">-200</ion-label>
-        <ion-label slot="end">200</ion-label>
-      </ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="20" max="80" step="2">
-        <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-        <ion-icon slot="end" name="sunny"></ion-icon>
-      </ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="1000" max="2000" step="100" snaps="true" color="secondary"></ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="1000" max="2000" step="100" snaps="true" ticks="false" color="secondary"></ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range ref="rangeDualKnobs" dual-knobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
-    </ion-item>
-    
-    <ion-item>
-      <ion-range min="0" max="100" :pin-formatter="customFormatter" :pin="true"></ion-range>
-    </ion-item>
-  </ion-list>
-</template>
-
-<script lang="ts">
-import { IonItem, IonLabel, IonList, IonRange } from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: {  IonItem, IonLabel, IonList, IonRange },
-  mounted() {
-    // Sets initial value for dual-knob ion-range
-    this.$refs.rangeDualKnobs.value = { lower: 24, upper: 42 };
-  },
-  setup() {
-    const customFormatter = (value: number) => `${value}%`;
-    
-    return { customFormatter };
-  }
-});
-</script>
-```
-
-
-</TabItem>
-
-</Tabs>
 
 <Props />
 <Events />


### PR DESCRIPTION
Sets up the playground example sections for `ion-range`. 