### PR TITLE
docs(breadcrumbs): add basic and icons playgrounds

### DIFF
--- a/docs/api/breadcrumbs.md
+++ b/docs/api/breadcrumbs.md
@@ -31,6 +31,26 @@ import APITOCInline from '@components/page/api/APITOCInline';
 
 Breadcrumbs are navigation items that are used to indicate where a user is on an app or site. They should be used for large sites and apps with hierarchically arranged pages. Breadcrumbs can be collapsed based on the maximum number that can show, and the collapsed indicator can be clicked on to present a popover with more information or expand the collapsed breadcrumbs.
 
+## Basic Usage
+
+import Basic from '@site/static/usage/breadcrumbs/basic/index.md';
+
+<Basic />
+
+## Using Icons
+
+### Icons on Items
+
+import IconsOnItems from '@site/static/usage/breadcrumbs/icons/icons-on-items/index.md';
+
+<IconsOnItems />
+
+### Custom Separators
+
+import CustomSeparators from '@site/static/usage/breadcrumbs/icons/custom-separators/index.md';
+
+<CustomSeparators />
+
 
 <Props />
 <Events />

--- a/docs/api/breadcrumbs.md
+++ b/docs/api/breadcrumbs.md
@@ -51,6 +51,54 @@ import CustomSeparators from '@site/static/usage/breadcrumbs/icons/custom-separa
 
 <CustomSeparators />
 
+## Collapsing Items
+
+### Max Items
+
+If there are more items than the value of `maxItems`, the breadcrumbs will be collapsed. By default, only the first and last items will be shown.
+
+import MaxItems from '@site/static/usage/breadcrumbs/collapsing-items/max-items/index.md';
+
+<MaxItems />
+
+### Items Before or After Collapse
+
+Once the items are collapsed, the number of items to show can be controlled by the `itemsBeforeCollapse` and `itemsAfterCollapse` properties.
+
+import ItemsBeforeAfter from '@site/static/usage/breadcrumbs/collapsing-items/items-before-after/index.md';
+
+<ItemsBeforeAfter />
+
+### Collapsed Indicator Click -- Expand Breadcrumbs
+
+Clicking the collapsed indicator will fire the `ionCollapsedClick` event. This can be used to, for example, expand the breadcrumbs.
+
+import ExpandOnClick from '@site/static/usage/breadcrumbs/collapsing-items/expand-on-click/index.md';
+
+<ExpandOnClick />
+
+### Collapsed Indicator Click -- Present Popover
+
+The `ionCollapsedClick` event can also be used to present an overlay (in this case, an `ion-popover`) showing the hidden breadcrumbs.
+
+import PopoverOnClick from '@site/static/usage/breadcrumbs/collapsing-items/popover-on-click/index.md';
+
+<PopoverOnClick />
+
+## Styling
+
+## Color Property
+
+import ColorProp from '@site/static/usage/breadcrumbs/styling/color/index.md';
+
+<ColorProp />
+
+## CSS Properties
+
+import CSSProps from '@site/static/usage/breadcrumbs/styling/css-props/index.md';
+
+<CSSProps />
+
 
 <Props />
 <Events />

--- a/static/usage/breadcrumbs/basic/angular.md
+++ b/static/usage/breadcrumbs/basic/angular.md
@@ -1,6 +1,6 @@
 ```html
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
   <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
   <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
   <ion-breadcrumb href="#film">Film</ion-breadcrumb>

--- a/static/usage/breadcrumbs/basic/angular.md
+++ b/static/usage/breadcrumbs/basic/angular.md
@@ -1,0 +1,8 @@
+```html
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/basic/demo.html
+++ b/static/usage/breadcrumbs/basic/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumbs</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-breadcrumbs>
+          <ion-breadcrumb href="#">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/basic/demo.html
+++ b/static/usage/breadcrumbs/basic/demo.html
@@ -16,7 +16,7 @@
     <ion-content>
       <div class="container">
         <ion-breadcrumbs>
-          <ion-breadcrumb href="#">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
           <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
           <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
           <ion-breadcrumb href="#film">Film</ion-breadcrumb>

--- a/static/usage/breadcrumbs/basic/index.md
+++ b/static/usage/breadcrumbs/basic/index.md
@@ -1,0 +1,11 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{ javascript, react, vue, angular }}
+  src="usage/breadcrumbs/basic/demo.html"
+/>

--- a/static/usage/breadcrumbs/basic/javascript.md
+++ b/static/usage/breadcrumbs/basic/javascript.md
@@ -1,6 +1,6 @@
 ```html
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
   <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
   <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
   <ion-breadcrumb href="#film">Film</ion-breadcrumb>

--- a/static/usage/breadcrumbs/basic/javascript.md
+++ b/static/usage/breadcrumbs/basic/javascript.md
@@ -1,0 +1,8 @@
+```html
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/basic/react.md
+++ b/static/usage/breadcrumbs/basic/react.md
@@ -1,0 +1,15 @@
+```tsx
+import React from 'react';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/react';
+function Example() {
+  return (
+    <IonBreadcrumbs>
+      <IonBreadcrumb href="#">Home</IonBreadcrumb>
+      <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+      <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+      <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+    </IonBreadcrumbs>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/basic/react.md
+++ b/static/usage/breadcrumbs/basic/react.md
@@ -4,7 +4,7 @@ import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/react';
 function Example() {
   return (
     <IonBreadcrumbs>
-      <IonBreadcrumb href="#">Home</IonBreadcrumb>
+      <IonBreadcrumb href="#home">Home</IonBreadcrumb>
       <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
       <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
       <IonBreadcrumb href="#film">Film</IonBreadcrumb>

--- a/static/usage/breadcrumbs/basic/vue.md
+++ b/static/usage/breadcrumbs/basic/vue.md
@@ -1,0 +1,19 @@
+```html
+<template>
+  <ion-breadcrumbs>
+    <ion-breadcrumb href="#">Home</ion-breadcrumb>
+    <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+    <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+    <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  </ion-breadcrumbs>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs },
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/basic/vue.md
+++ b/static/usage/breadcrumbs/basic/vue.md
@@ -1,7 +1,7 @@
 ```html
 <template>
   <ion-breadcrumbs>
-    <ion-breadcrumb href="#">Home</ion-breadcrumb>
+    <ion-breadcrumb href="#home">Home</ion-breadcrumb>
     <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
     <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
     <ion-breadcrumb href="#film">Film</ion-breadcrumb>

--- a/static/usage/breadcrumbs/collapsing-items/expand-on-click/angular/angular_html.md
+++ b/static/usage/breadcrumbs/collapsing-items/expand-on-click/angular/angular_html.md
@@ -1,0 +1,10 @@
+```html
+<ion-breadcrumbs [maxItems]="maxBreadcrumbs" (ionCollapsedClick)="expandBreadcrumbs()">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/collapsing-items/expand-on-click/angular/angular_ts.md
+++ b/static/usage/breadcrumbs/collapsing-items/expand-on-click/angular/angular_ts.md
@@ -1,0 +1,15 @@
+```ts
+import { Component, ViewChild } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  maxBreadcrumbs = 4;
+
+  expandBreadcrumbs() {
+    this.maxBreadcrumbs = undefined;
+  }
+}
+```

--- a/static/usage/breadcrumbs/collapsing-items/expand-on-click/demo.html
+++ b/static/usage/breadcrumbs/collapsing-items/expand-on-click/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popover</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-breadcrumbs max-items="4">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+          <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const breadcrumbs = document.querySelector('ion-breadcrumbs');
+
+    breadcrumbs.addEventListener('ionCollapsedClick', () => {
+      breadcrumbs.maxItems = undefined;
+    });
+  </script>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/collapsing-items/expand-on-click/index.md
+++ b/static/usage/breadcrumbs/collapsing-items/expand-on-click/index.md
@@ -1,0 +1,23 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.ts': angularTS,
+      }
+    }
+  }}
+  src="usage/breadcrumbs/collapsing-items/expand-on-click/demo.html"
+/>

--- a/static/usage/breadcrumbs/collapsing-items/expand-on-click/javascript.md
+++ b/static/usage/breadcrumbs/collapsing-items/expand-on-click/javascript.md
@@ -1,0 +1,18 @@
+```html
+<ion-breadcrumbs max-items="4">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<script>
+  const breadcrumbs = document.querySelector('ion-breadcrumbs');
+
+  breadcrumbs.addEventListener('ionCollapsedClick', () => {
+    breadcrumbs.maxItems = undefined;
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/collapsing-items/expand-on-click/react.md
+++ b/static/usage/breadcrumbs/collapsing-items/expand-on-click/react.md
@@ -1,0 +1,20 @@
+```tsx
+import React, { useState } from 'react';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/react';
+
+function Example() {
+  const [maxBreadcrumbs, setMaxBreadcrumbs] = useState<number | undefined>(4);
+
+  return (
+    <IonBreadcrumbs maxItems={maxBreadcrumbs} onIonCollapsedClick={() => setMaxBreadcrumbs(undefined)}>
+      <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+      <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+      <IonBreadcrumb href="#photography">Photography</IonBreadcrumb>
+      <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+      <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+      <IonBreadcrumb href="#35mm">35 mm</IonBreadcrumb>
+    </IonBreadcrumbs>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/collapsing-items/expand-on-click/vue.md
+++ b/static/usage/breadcrumbs/collapsing-items/expand-on-click/vue.md
@@ -1,0 +1,31 @@
+```html
+<template>
+  <ion-breadcrumbs :max-items="maxBreadcrumbs" @ionCollapsedClick="expandBreadcrumbs()">
+    <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+    <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+    <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+    <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+    <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+    <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+  </ion-breadcrumbs>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs },
+    data() {
+      return {
+        maxBreadcrumbs: 4
+      }
+    },
+    methods: {
+      expandBreadcrumbs() {
+        this.maxBreadcrumbs = undefined;
+      }
+    }
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/collapsing-items/items-before-after/angular.md
+++ b/static/usage/breadcrumbs/collapsing-items/items-before-after/angular.md
@@ -1,0 +1,41 @@
+```html
+<div>Before Collapse = 2</div>
+<ion-breadcrumbs [maxItems]="4" [itemsBeforeCollapse]="2">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<div class="ion-margin-top">Before Collapse = 0</div>
+<ion-breadcrumbs [maxItems]="4" [itemsBeforeCollapse]="0">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<div class="ion-margin-top">After Collapse = 2</div>
+<ion-breadcrumbs [maxItems]="4" [itemsAfterCollapse]="2">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<div class="ion-margin-top">Before Collapse = 2, After Collapse = 2</div>
+<ion-breadcrumbs [maxItems]="4" [itemsBeforeCollapse]="2" [itemsAfterCollapse]="2">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/collapsing-items/items-before-after/demo.html
+++ b/static/usage/breadcrumbs/collapsing-items/items-before-after/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumbs</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      flex-direction: column;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div>Before Collapse = 2</div>
+        <ion-breadcrumbs max-items="4" items-before-collapse="2">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+          <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+        </ion-breadcrumbs>
+
+        <div class="ion-margin-top">Before Collapse = 0</div>
+        <ion-breadcrumbs max-items="4" items-before-collapse="0">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+          <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+        </ion-breadcrumbs>
+
+        <div class="ion-margin-top">After Collapse = 2</div>
+        <ion-breadcrumbs max-items="4" items-after-collapse="2">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+          <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+        </ion-breadcrumbs>
+
+        <div class="ion-margin-top">Before Collapse = 2, After Collapse = 2</div>
+        <ion-breadcrumbs max-items="4" items-before-collapse="2" items-after-collapse="2">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+          <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/collapsing-items/items-before-after/index.md
+++ b/static/usage/breadcrumbs/collapsing-items/items-before-after/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  size="300px"
+  code={{ javascript, react, vue, angular }}
+  src="usage/breadcrumbs/collapsing-items/items-before-after/demo.html"
+/>

--- a/static/usage/breadcrumbs/collapsing-items/items-before-after/javascript.md
+++ b/static/usage/breadcrumbs/collapsing-items/items-before-after/javascript.md
@@ -1,0 +1,41 @@
+```html
+<div>Before Collapse = 2</div>
+<ion-breadcrumbs max-items="4" items-before-collapse="2">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<div class="ion-margin-top">Before Collapse = 0</div>
+<ion-breadcrumbs max-items="4" items-before-collapse="0">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<div class="ion-margin-top">After Collapse = 2</div>
+<ion-breadcrumbs max-items="4" items-after-collapse="2">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<div class="ion-margin-top">Before Collapse = 2, After Collapse = 2</div>
+<ion-breadcrumbs max-items="4" items-before-collapse="2" items-after-collapse="2">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/collapsing-items/items-before-after/react.md
+++ b/static/usage/breadcrumbs/collapsing-items/items-before-after/react.md
@@ -1,0 +1,50 @@
+```tsx
+import React from 'react';
+import { IonBreadcrumb, IonBreadcrumbs, IonContent } from '@ionic/react';
+function Example() {
+  return (
+    <IonContent>
+      <div>Before Collapse = 2</div>
+      <IonBreadcrumbs maxItems={4} itemsBeforeCollapse={2}>
+        <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+        <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+        <IonBreadcrumb href="#photography">Photography</IonBreadcrumb>
+        <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+        <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+        <IonBreadcrumb href="#35mm">35 mm</IonBreadcrumb>
+      </IonBreadcrumbs>
+
+      <div className="ion-margin-top">Before Collapse = 0</div>
+      <IonBreadcrumbs maxItems={4} itemsBeforeCollapse={0}>
+        <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+        <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+        <IonBreadcrumb href="#photography">Photography</IonBreadcrumb>
+        <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+        <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+        <IonBreadcrumb href="#35mm">35 mm</IonBreadcrumb>
+      </IonBreadcrumbs>
+
+      <div className="ion-margin-top">After Collapse = 2</div>
+      <IonBreadcrumbs maxItems={4} itemsAfterCollapse={2}>
+        <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+        <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+        <IonBreadcrumb href="#photography">Photography</IonBreadcrumb>
+        <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+        <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+        <IonBreadcrumb href="#35mm">35 mm</IonBreadcrumb>
+      </IonBreadcrumbs>
+
+      <div className="ion-margin-top">Before Collapse = 2, After Collapse = 2</div>
+      <IonBreadcrumbs maxItems={4} itemsBeforeCollapse={2} itemsAfterCollapse={2}>
+        <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+        <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+        <IonBreadcrumb href="#photography">Photography</IonBreadcrumb>
+        <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+        <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+        <IonBreadcrumb href="#35mm">35 mm</IonBreadcrumb>
+      </IonBreadcrumbs>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/collapsing-items/items-before-after/vue.md
+++ b/static/usage/breadcrumbs/collapsing-items/items-before-after/vue.md
@@ -1,0 +1,54 @@
+```html
+<template>
+  <ion-content>
+    <div>Before Collapse = 2</div>
+    <ion-breadcrumbs :max-items="4" :items-before-collapse="2">
+      <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+      <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+      <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+      <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+      <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+      <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+    </ion-breadcrumbs>
+
+    <div class="ion-margin-top">Before Collapse = 0</div>
+    <ion-breadcrumbs :max-items="4" :items-before-collapse="0">
+      <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+      <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+      <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+      <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+      <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+      <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+    </ion-breadcrumbs>
+
+    <div class="ion-margin-top">After Collapse = 2</div>
+    <ion-breadcrumbs :max-items="4" :items-after-collapse="2">
+      <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+      <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+      <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+      <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+      <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+      <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+    </ion-breadcrumbs>
+
+    <div class="ion-margin-top">Before Collapse = 2, After Collapse = 2</div>
+    <ion-breadcrumbs :max-items="4" :items-before-collapse="2" :items-after-collapse="2">
+      <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+      <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+      <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+      <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+      <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+      <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+    </ion-breadcrumbs>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs, IonContent } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs, IonContent },
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/collapsing-items/max-items/angular.md
+++ b/static/usage/breadcrumbs/collapsing-items/max-items/angular.md
@@ -1,0 +1,10 @@
+```html
+<ion-breadcrumbs [maxItems]="4">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/collapsing-items/max-items/demo.html
+++ b/static/usage/breadcrumbs/collapsing-items/max-items/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumbs</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-breadcrumbs max-items="4">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+          <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/collapsing-items/max-items/index.md
+++ b/static/usage/breadcrumbs/collapsing-items/max-items/index.md
@@ -1,0 +1,11 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{ javascript, react, vue, angular }}
+  src="usage/breadcrumbs/collapsing-items/max-items/demo.html"
+/>

--- a/static/usage/breadcrumbs/collapsing-items/max-items/javascript.md
+++ b/static/usage/breadcrumbs/collapsing-items/max-items/javascript.md
@@ -1,0 +1,10 @@
+```html
+<ion-breadcrumbs max-items="4">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/collapsing-items/max-items/react.md
+++ b/static/usage/breadcrumbs/collapsing-items/max-items/react.md
@@ -1,0 +1,17 @@
+```tsx
+import React from 'react';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/react';
+function Example() {
+  return (
+    <IonBreadcrumbs maxItems={4}>
+      <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+      <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+      <IonBreadcrumb href="#photography">Photography</IonBreadcrumb>
+      <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+      <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+      <IonBreadcrumb href="#35mm">35 mm</IonBreadcrumb>
+    </IonBreadcrumbs>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/collapsing-items/max-items/vue.md
+++ b/static/usage/breadcrumbs/collapsing-items/max-items/vue.md
@@ -1,0 +1,21 @@
+```html
+<template>
+  <ion-breadcrumbs :max-items="4">
+    <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+    <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+    <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+    <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+    <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+    <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+  </ion-breadcrumbs>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs },
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/collapsing-items/popover-on-click/angular/angular_html.md
+++ b/static/usage/breadcrumbs/collapsing-items/popover-on-click/angular/angular_html.md
@@ -1,0 +1,25 @@
+```html
+<ion-breadcrumbs [maxItems]="4" (ionCollapsedClick)="presentPopover($event)">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+<ion-popover #popover [isOpen]="isOpen" (didDismiss)="isOpen = false">
+  <ng-template>
+    <ion-content>
+      <ion-list>
+        <ion-item
+          *ngFor="let breadcrumb of collapsedBreadcrumbs; last as isLast"
+          [href]="breadcrumb.href"
+          [lines]="isLast ? 'none' : null"
+        >
+          <ion-label>{{ breadcrumb.textContent }}</ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ng-template>
+</ion-popover>
+```

--- a/static/usage/breadcrumbs/collapsing-items/popover-on-click/angular/angular_ts.md
+++ b/static/usage/breadcrumbs/collapsing-items/popover-on-click/angular/angular_ts.md
@@ -1,0 +1,20 @@
+```ts
+import { Component, ViewChild } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  @ViewChild('popover') popover;
+
+  isOpen = false;
+  collapsedBreadcrumbs: HTMLIonBreadcrumbElement[] = [];
+
+  async presentPopover(e: Event) {
+    this.collapsedBreadcrumbs = (e as CustomEvent).detail.collapsedBreadcrumbs;
+    this.popover.event = e;
+    this.isOpen = true;
+  }
+}
+```

--- a/static/usage/breadcrumbs/collapsing-items/popover-on-click/demo.html
+++ b/static/usage/breadcrumbs/collapsing-items/popover-on-click/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Popover</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-breadcrumbs max-items="4">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+          <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+        </ion-breadcrumbs>
+        <ion-popover>
+          <ion-content>
+            <ion-list></ion-list>
+          </ion-content>
+        </ion-popover>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const breadcrumbs = document.querySelector('ion-breadcrumbs');
+    const popover = document.querySelector('ion-popover');
+    const popoverList = document.querySelector('ion-popover ion-list');
+
+    breadcrumbs.addEventListener('ionCollapsedClick', e => {
+      let listHTML = ``;
+      e.detail.collapsedBreadcrumbs.forEach((breadcrumb, i) => {
+        listHTML += `
+          <ion-item
+            ${i === e.detail.collapsedBreadcrumbs.length - 1 ? `lines="none"` : ""}
+            href="${breadcrumb.href}"
+          >
+            <ion-label>${breadcrumb.textContent}</ion-label>
+          </ion-item>
+        `;
+      });
+
+      popoverList.innerHTML = listHTML;
+      popover.event = e;
+      popover.isOpen = true;
+    });
+
+    popover.addEventListener('didDismiss', () => popover.isOpen = false);
+  </script>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/collapsing-items/popover-on-click/index.md
+++ b/static/usage/breadcrumbs/collapsing-items/popover-on-click/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  size="500px"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.ts': angularTS,
+      }
+    }
+  }}
+  src="usage/breadcrumbs/collapsing-items/popover-on-click/demo.html"
+/>

--- a/static/usage/breadcrumbs/collapsing-items/popover-on-click/javascript.md
+++ b/static/usage/breadcrumbs/collapsing-items/popover-on-click/javascript.md
@@ -1,0 +1,41 @@
+```html
+<ion-breadcrumbs max-items="4">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+</ion-breadcrumbs>
+<ion-popover>
+  <ion-content>
+    <ion-list></ion-list>
+  </ion-content>
+</ion-popover>
+
+<script>
+  const breadcrumbs = document.querySelector('ion-breadcrumbs');
+  const popover = document.querySelector('ion-popover');
+  const popoverList = document.querySelector('ion-popover ion-list');
+
+  breadcrumbs.addEventListener('ionCollapsedClick', e => {
+    let listHTML = ``;
+    e.detail.collapsedBreadcrumbs.forEach((breadcrumb, i) => {
+      listHTML += `
+        <ion-item
+          ${i === e.detail.collapsedBreadcrumbs.length - 1 ? `lines="none"` : ""}
+          href="${breadcrumb.href}"
+        >
+          <ion-label>${breadcrumb.textContent}</ion-label>
+        </ion-item>
+      `;
+    });
+
+    popoverList.innerHTML = listHTML;
+    popover.event = e;
+    popover.isOpen = true;
+  });
+
+  popover.addEventListener('didDismiss', () => popover.isOpen = false);
+</script>
+```

--- a/static/usage/breadcrumbs/collapsing-items/popover-on-click/react.md
+++ b/static/usage/breadcrumbs/collapsing-items/popover-on-click/react.md
@@ -1,0 +1,44 @@
+```tsx
+import React, { useRef, useState } from 'react';
+import { IonBreadcrumb, IonBreadcrumbs, IonContent, IonItem, IonLabel, IonList, IonPopover } from '@ionic/react';
+
+function Example() {
+  const popover = useRef<HTMLIonPopoverElement>(null);
+  const [collapsedBreadcrumbs, setCollapsedBreadcrumbs] = useState<HTMLIonBreadcrumbElement[]>([]);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+
+  const openPopover = (e: Event) => {
+    setCollapsedBreadcrumbs((e as CustomEvent).detail.collapsedBreadcrumbs);
+    popover.current!.event = e;
+    setPopoverOpen(true);
+  };
+
+  return (
+    <>
+      <IonBreadcrumbs maxItems={4} onIonCollapsedClick={openPopover}>
+        <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+        <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+        <IonBreadcrumb href="#photography">Photography</IonBreadcrumb>
+        <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+        <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+        <IonBreadcrumb href="#35mm">35 mm</IonBreadcrumb>
+      </IonBreadcrumbs>
+      <IonPopover ref={popover} isOpen={popoverOpen} onDidDismiss={() => setPopoverOpen(false)}>
+        <IonContent>
+          <IonList>
+            {collapsedBreadcrumbs.map((breadcrumb, i) => (
+              <IonItem
+                href={breadcrumb.href}
+                lines={i === collapsedBreadcrumbs.length - 1 ? "none" : undefined}
+              >
+                <IonLabel>{breadcrumb.textContent}</IonLabel>
+              </IonItem>
+            ))}
+          </IonList>
+        </IonContent>
+      </IonPopover>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/collapsing-items/popover-on-click/vue.md
+++ b/static/usage/breadcrumbs/collapsing-items/popover-on-click/vue.md
@@ -1,0 +1,48 @@
+```html
+<template>
+  <ion-breadcrumbs :max-items="4" @ionCollapsedClick="presentPopover($event)">
+    <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+    <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+    <ion-breadcrumb href="#photography">Photography</ion-breadcrumb>
+    <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+    <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+    <ion-breadcrumb href="#35mm">35 mm</ion-breadcrumb>
+  </ion-breadcrumbs>
+  <ion-popover :is-open="popoverOpen" :event="event" @didDismiss="popoverOpen = false">
+    <ion-content>
+      <ion-list>
+        <ion-item
+          v-for="(breadcrumb, i) in collapsedBreadcrumbs"
+          :href="breadcrumb.href"
+          :lines="i === collapsedBreadcrumbs.length - 1 ? 'none' : undefined"
+        >
+          <ion-label>{{ breadcrumb.textContent }}</ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-popover>
+</template>
+
+<script lang="ts">
+import { IonBreadcrumb, IonBreadcrumbs, IonContent, IonItem, IonLabel, IonList, IonPopover } from '@ionic/vue';
+import Popover from './Popover.vue';
+
+export default {
+  components: { IonBreadcrumb, IonBreadcrumbs, IonContent, IonItem, IonLabel, IonList, IonPopover },
+  data() {
+    return {
+      popoverOpen: false,
+      collapsedBreadcrumbs: [],
+      event: null
+    }
+  },
+  methods: {
+    presentPopover(e: Event) {
+      this.collapsedBreadcrumbs = (e as CustomEvent).detail.collapsedBreadcrumbs;
+      this.event = e;
+      this.popoverOpen = true;
+    }
+  },
+}
+</script>
+```

--- a/static/usage/breadcrumbs/icons/custom-separators/angular.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/angular.md
@@ -1,0 +1,20 @@
+```html
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">
+    Home
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">
+    Electronics
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">
+    Cameras
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#film">
+    Film
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/icons/custom-separators/angular.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/angular.md
@@ -1,6 +1,6 @@
 ```html
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">
+  <ion-breadcrumb href="#home">
     Home
     <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
   </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/custom-separators/demo.html
+++ b/static/usage/breadcrumbs/icons/custom-separators/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumbs</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-breadcrumbs>
+          <ion-breadcrumb href="#">
+            Home
+            <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">
+            Electronics
+            <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">
+            Cameras
+            <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#film">
+            Film
+            <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+          </ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/icons/custom-separators/demo.html
+++ b/static/usage/breadcrumbs/icons/custom-separators/demo.html
@@ -16,7 +16,7 @@
     <ion-content>
       <div class="container">
         <ion-breadcrumbs>
-          <ion-breadcrumb href="#">
+          <ion-breadcrumb href="#home">
             Home
             <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
           </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/custom-separators/index.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/index.md
@@ -1,0 +1,11 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{ javascript, react, vue, angular }}
+  src="usage/breadcrumbs/icons/custom-separators/demo.html"
+/>

--- a/static/usage/breadcrumbs/icons/custom-separators/javascript.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/javascript.md
@@ -1,0 +1,20 @@
+```html
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">
+    Home
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">
+    Electronics
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">
+    Cameras
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#film">
+    Film
+    <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
+  </ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/icons/custom-separators/javascript.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/javascript.md
@@ -1,6 +1,6 @@
 ```html
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">
+  <ion-breadcrumb href="#home">
     Home
     <ion-icon slot="separator" name="arrow-forward-circle"></ion-icon>
   </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/custom-separators/react.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/react.md
@@ -1,0 +1,29 @@
+```tsx
+import React from 'react';
+import { IonBreadcrumb, IonBreadcrumbs, IonIcon } from '@ionic/react';
+import { arrowForwardCircle } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <IonBreadcrumbs>
+      <IonBreadcrumb href="#">
+        Home
+        <IonIcon slot="separator" icon={arrowForwardCircle}></IonIcon>
+      </IonBreadcrumb>
+      <IonBreadcrumb href="#electronics">
+        Electronics
+        <IonIcon slot="separator" icon={arrowForwardCircle}></IonIcon>
+      </IonBreadcrumb>
+      <IonBreadcrumb href="#cameras">
+        Cameras
+        <IonIcon slot="separator" icon={arrowForwardCircle}></IonIcon>
+      </IonBreadcrumb>
+      <IonBreadcrumb href="#film">
+        Film
+        <IonIcon slot="separator" icon={arrowForwardCircle}></IonIcon>
+      </IonBreadcrumb>
+    </IonBreadcrumbs>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/icons/custom-separators/react.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/react.md
@@ -6,7 +6,7 @@ import { arrowForwardCircle } from 'ionicons/icons';
 function Example() {
   return (
     <IonBreadcrumbs>
-      <IonBreadcrumb href="#">
+      <IonBreadcrumb href="#home">
         Home
         <IonIcon slot="separator" icon={arrowForwardCircle}></IonIcon>
       </IonBreadcrumb>

--- a/static/usage/breadcrumbs/icons/custom-separators/vue.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/vue.md
@@ -1,7 +1,7 @@
 ```html
 <template>
   <ion-breadcrumbs>
-    <ion-breadcrumb href="#">
+    <ion-breadcrumb href="#home">
       Home
       <ion-icon slot="separator" :icon="arrowForwardCircle"></ion-icon>
     </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/custom-separators/vue.md
+++ b/static/usage/breadcrumbs/icons/custom-separators/vue.md
@@ -1,0 +1,35 @@
+```html
+<template>
+  <ion-breadcrumbs>
+    <ion-breadcrumb href="#">
+      Home
+      <ion-icon slot="separator" :icon="arrowForwardCircle"></ion-icon>
+    </ion-breadcrumb>
+    <ion-breadcrumb href="#electronics">
+      Electronics
+      <ion-icon slot="separator" :icon="arrowForwardCircle"></ion-icon>
+    </ion-breadcrumb>
+    <ion-breadcrumb href="#cameras">
+      Cameras
+      <ion-icon slot="separator" :icon="arrowForwardCircle"></ion-icon>
+    </ion-breadcrumb>
+    <ion-breadcrumb href="#film">
+      Film
+      <ion-icon slot="separator" :icon="arrowForwardCircle"></ion-icon>
+    </ion-breadcrumb>
+  </ion-breadcrumbs>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs, IonIcon } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+  import { arrowForwardCircle } from 'ionicons/icons';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs, IonIcon },
+    setup() {
+      return { arrowForwardCircle };
+    }
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/icons/icons-on-items/angular.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/angular.md
@@ -1,0 +1,41 @@
+```html
+<ion-label>Icons at Start</ion-label>
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">
+    <ion-icon slot="start" name="home"></ion-icon>
+    Home
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">
+    <ion-icon slot="start" name="flash"></ion-icon>
+    Electronics
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">
+    <ion-icon slot="start" name="camera"></ion-icon>
+    Cameras
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#film">
+    <ion-icon slot="start" name="film"></ion-icon>
+    Film
+  </ion-breadcrumb>
+</ion-breadcrumbs>
+
+<ion-label class="ion-margin-top">Icons at End</ion-label>
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">
+    Home
+    <ion-icon slot="end" name="home"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">
+    Electronics
+    <ion-icon slot="end" name="flash"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">
+    Cameras
+    <ion-icon slot="end" name="camera"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#film">
+    Film
+    <ion-icon slot="end" name="film"></ion-icon>
+  </ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/icons/icons-on-items/angular.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/angular.md
@@ -1,7 +1,7 @@
 ```html
 <ion-label>Icons at Start</ion-label>
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">
+  <ion-breadcrumb href="#home">
     <ion-icon slot="start" name="home"></ion-icon>
     Home
   </ion-breadcrumb>
@@ -21,7 +21,7 @@
 
 <ion-label class="ion-margin-top">Icons at End</ion-label>
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">
+  <ion-breadcrumb href="#home">
     Home
     <ion-icon slot="end" name="home"></ion-icon>
   </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/icons-on-items/demo.html
+++ b/static/usage/breadcrumbs/icons/icons-on-items/demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumbs</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      flex-direction: column;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-label>Icons at Start</ion-label>
+        <ion-breadcrumbs>
+          <ion-breadcrumb href="#">
+            <ion-icon slot="start" name="home"></ion-icon>
+            Home
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">
+            <ion-icon slot="start" name="flash"></ion-icon>
+            Electronics
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">
+            <ion-icon slot="start" name="camera"></ion-icon>
+            Cameras
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#film">
+            <ion-icon slot="start" name="film"></ion-icon>
+            Film
+          </ion-breadcrumb>
+        </ion-breadcrumbs>
+
+        <ion-label class="ion-margin-top">Icons at End</ion-label>
+        <ion-breadcrumbs>
+          <ion-breadcrumb href="#">
+            Home
+            <ion-icon slot="end" name="home"></ion-icon>
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">
+            Electronics
+            <ion-icon slot="end" name="flash"></ion-icon>
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">
+            Cameras
+            <ion-icon slot="end" name="camera"></ion-icon>
+          </ion-breadcrumb>
+          <ion-breadcrumb href="#film">
+            Film
+            <ion-icon slot="end" name="film"></ion-icon>
+          </ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/icons/icons-on-items/demo.html
+++ b/static/usage/breadcrumbs/icons/icons-on-items/demo.html
@@ -23,7 +23,7 @@
       <div class="container">
         <ion-label>Icons at Start</ion-label>
         <ion-breadcrumbs>
-          <ion-breadcrumb href="#">
+          <ion-breadcrumb href="#home">
             <ion-icon slot="start" name="home"></ion-icon>
             Home
           </ion-breadcrumb>
@@ -43,7 +43,7 @@
 
         <ion-label class="ion-margin-top">Icons at End</ion-label>
         <ion-breadcrumbs>
-          <ion-breadcrumb href="#">
+          <ion-breadcrumb href="#home">
             Home
             <ion-icon slot="end" name="home"></ion-icon>
           </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/icons-on-items/index.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  size="300px"
+  code={{ javascript, react, vue, angular }}
+  src="usage/breadcrumbs/icons/icons-on-items/demo.html"
+/>

--- a/static/usage/breadcrumbs/icons/icons-on-items/javascript.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/javascript.md
@@ -1,0 +1,41 @@
+```html
+<ion-label>Icons at Start</ion-label>
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">
+    <ion-icon slot="start" name="home"></ion-icon>
+    Home
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">
+    <ion-icon slot="start" name="flash"></ion-icon>
+    Electronics
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">
+    <ion-icon slot="start" name="camera"></ion-icon>
+    Cameras
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#film">
+    <ion-icon slot="start" name="film"></ion-icon>
+    Film
+  </ion-breadcrumb>
+</ion-breadcrumbs>
+
+<ion-label class="ion-margin-top">Icons at End</ion-label>
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#">
+    Home
+    <ion-icon slot="end" name="home"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">
+    Electronics
+    <ion-icon slot="end" name="flash"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">
+    Cameras
+    <ion-icon slot="end" name="camera"></ion-icon>
+  </ion-breadcrumb>
+  <ion-breadcrumb href="#film">
+    Film
+    <ion-icon slot="end" name="film"></ion-icon>
+  </ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/icons/icons-on-items/javascript.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-label>Icons at Start</ion-label>
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">
+  <ion-breadcrumb href="#home">
     <ion-icon slot="start" name="home"></ion-icon>
     Home
   </ion-breadcrumb>
@@ -21,7 +21,7 @@
 
 <ion-label class="ion-margin-top">Icons at End</ion-label>
 <ion-breadcrumbs>
-  <ion-breadcrumb href="#">
+  <ion-breadcrumb href="#home">
     Home
     <ion-icon slot="end" name="home"></ion-icon>
   </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/icons-on-items/react.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/react.md
@@ -8,7 +8,7 @@ function Example() {
     <IonContent>
       <IonLabel>Icons at Start</IonLabel>
       <IonBreadcrumbs>
-        <IonBreadcrumb href="#">
+        <IonBreadcrumb href="#home">
           <IonIcon slot="start" icon={home}></IonIcon>
           Home
         </IonBreadcrumb>
@@ -28,7 +28,7 @@ function Example() {
 
       <IonLabel class="ion-margin-top">Icons at End</IonLabel>
       <IonBreadcrumbs>
-        <IonBreadcrumb href="#">
+        <IonBreadcrumb href="#home">
           Home
           <IonIcon slot="end" icon={home}></IonIcon>
         </IonBreadcrumb>

--- a/static/usage/breadcrumbs/icons/icons-on-items/react.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/react.md
@@ -1,0 +1,52 @@
+```tsx
+import React from 'react';
+import { IonBreadcrumb, IonBreadcrumbs, IonContent, IonIcon, IonLabel } from '@ionic/react';
+import { camera, film, flash, home } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <IonContent>
+      <IonLabel>Icons at Start</IonLabel>
+      <IonBreadcrumbs>
+        <IonBreadcrumb href="#">
+          <IonIcon slot="start" icon={home}></IonIcon>
+          Home
+        </IonBreadcrumb>
+        <IonBreadcrumb href="#electronics">
+          <IonIcon slot="start" icon={flash}></IonIcon>
+          Electronics
+        </IonBreadcrumb>
+        <IonBreadcrumb href="#cameras">
+          <IonIcon slot="start" icon={camera}></IonIcon>
+          Cameras
+        </IonBreadcrumb>
+        <IonBreadcrumb href="#film">
+          <IonIcon slot="start" icon={film}></IonIcon>
+          Film
+        </IonBreadcrumb>
+      </IonBreadcrumbs>
+
+      <IonLabel class="ion-margin-top">Icons at End</IonLabel>
+      <IonBreadcrumbs>
+        <IonBreadcrumb href="#">
+          Home
+          <IonIcon slot="end" icon={home}></IonIcon>
+        </IonBreadcrumb>
+        <IonBreadcrumb href="#electronics">
+          Electronics
+          <IonIcon slot="end" icon={flash}></IonIcon>
+        </IonBreadcrumb>
+        <IonBreadcrumb href="#cameras">
+          Cameras
+          <IonIcon slot="end" icon={camera}></IonIcon>
+        </IonBreadcrumb>
+        <IonBreadcrumb href="#film">
+          Film
+          <IonIcon slot="end" icon={film}></IonIcon>
+        </IonBreadcrumb>
+      </IonBreadcrumbs>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/icons/icons-on-items/vue.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/vue.md
@@ -3,7 +3,7 @@
   <ion-content>
     <ion-label>Icons at Start</ion-label>
     <ion-breadcrumbs>
-      <ion-breadcrumb href="#">
+      <ion-breadcrumb href="#home">
         <ion-icon slot="start" :icon="home"></ion-icon>
         Home
       </ion-breadcrumb>
@@ -23,7 +23,7 @@
 
     <ion-label class="ion-margin-top">Icons at End</ion-label>
     <ion-breadcrumbs>
-      <ion-breadcrumb href="#">
+      <ion-breadcrumb href="#home">
         Home
         <ion-icon slot="end" :icon="home"></ion-icon>
       </ion-breadcrumb>

--- a/static/usage/breadcrumbs/icons/icons-on-items/vue.md
+++ b/static/usage/breadcrumbs/icons/icons-on-items/vue.md
@@ -1,0 +1,58 @@
+```html
+<template>
+  <ion-content>
+    <ion-label>Icons at Start</ion-label>
+    <ion-breadcrumbs>
+      <ion-breadcrumb href="#">
+        <ion-icon slot="start" :icon="home"></ion-icon>
+        Home
+      </ion-breadcrumb>
+      <ion-breadcrumb href="#electronics">
+        <ion-icon slot="start" :icon="flash"></ion-icon>
+        Electronics
+      </ion-breadcrumb>
+      <ion-breadcrumb href="#cameras">
+        <ion-icon slot="start" :icon="camera"></ion-icon>
+        Cameras
+      </ion-breadcrumb>
+      <ion-breadcrumb href="#film">
+        <ion-icon slot="start" :icon="film"></ion-icon>
+        Film
+      </ion-breadcrumb>
+    </ion-breadcrumbs>
+
+    <ion-label class="ion-margin-top">Icons at End</ion-label>
+    <ion-breadcrumbs>
+      <ion-breadcrumb href="#">
+        Home
+        <ion-icon slot="end" :icon="home"></ion-icon>
+      </ion-breadcrumb>
+      <ion-breadcrumb href="#electronics">
+        Electronics
+        <ion-icon slot="end" :icon="flash"></ion-icon>
+      </ion-breadcrumb>
+      <ion-breadcrumb href="#cameras">
+        Cameras
+        <ion-icon slot="end" :icon="camera"></ion-icon>
+      </ion-breadcrumb>
+      <ion-breadcrumb href="#film">
+        Film
+        <ion-icon slot="end" :icon="film"></ion-icon>
+      </ion-breadcrumb>
+    </ion-breadcrumbs>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs, IonContent, IonIcon, IonLabel } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+  import { camera, film, flash, home } from 'ionicons/icons';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs, IonContent, IonIcon, IonLabel },
+    setup() {
+      return { camera, film, flash, home };
+    }
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/styling/color/angular.md
+++ b/static/usage/breadcrumbs/styling/color/angular.md
@@ -1,0 +1,8 @@
+```html
+<ion-breadcrumbs color="primary">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/styling/color/demo.html
+++ b/static/usage/breadcrumbs/styling/color/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumbs</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-breadcrumbs color="primary">
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/styling/color/index.md
+++ b/static/usage/breadcrumbs/styling/color/index.md
@@ -1,0 +1,11 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{ javascript, react, vue, angular }}
+  src="usage/breadcrumbs/styling/color/demo.html"
+/>

--- a/static/usage/breadcrumbs/styling/color/javascript.md
+++ b/static/usage/breadcrumbs/styling/color/javascript.md
@@ -1,0 +1,8 @@
+```html
+<ion-breadcrumbs color="primary">
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/styling/color/react.md
+++ b/static/usage/breadcrumbs/styling/color/react.md
@@ -1,0 +1,15 @@
+```tsx
+import React from 'react';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/react';
+function Example() {
+  return (
+    <IonBreadcrumbs color="primary">
+      <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+      <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+      <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+      <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+    </IonBreadcrumbs>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/styling/color/vue.md
+++ b/static/usage/breadcrumbs/styling/color/vue.md
@@ -1,0 +1,19 @@
+```html
+<template>
+  <ion-breadcrumbs>
+    <ion-breadcrumb color="primary" href="#home">Home</ion-breadcrumb>
+    <ion-breadcrumb color="primary" href="#electronics">Electronics</ion-breadcrumb>
+    <ion-breadcrumb color="primary" href="#cameras">Cameras</ion-breadcrumb>
+    <ion-breadcrumb color="primary" href="#film">Film</ion-breadcrumb>
+  </ion-breadcrumbs>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs },
+  });
+</script>
+```

--- a/static/usage/breadcrumbs/styling/css-props/angular/angular_css.md
+++ b/static/usage/breadcrumbs/styling/css-props/angular/angular_css.md
@@ -1,0 +1,7 @@
+```css
+ion-breadcrumb {
+  --color: rgb(81, 155, 198);
+  --color-active: rgb(150, 112, 220);
+  --color-hover: rgb(103, 61, 180);
+}
+```

--- a/static/usage/breadcrumbs/styling/css-props/angular/angular_html.md
+++ b/static/usage/breadcrumbs/styling/css-props/angular/angular_html.md
@@ -1,0 +1,8 @@
+```html
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+</ion-breadcrumbs>
+```

--- a/static/usage/breadcrumbs/styling/css-props/demo.html
+++ b/static/usage/breadcrumbs/styling/css-props/demo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Breadcrumbs</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    ion-breadcrumb {
+      --color: rgb(81, 155, 198);
+      --color-active: rgb(150, 112, 220);
+      --color-hover: rgb(103, 61, 180);
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-breadcrumbs>
+          <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+          <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+          <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+          <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+        </ion-breadcrumbs>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/breadcrumbs/styling/css-props/index.md
+++ b/static/usage/breadcrumbs/styling/css-props/index.md
@@ -1,0 +1,30 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+
+import reactTS from './react/react_ts.md';
+import reactCSS from './react/react_css.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularCSS from './angular/angular_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.css': reactCSS,
+        'src/main.tsx': reactTS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.css': angularCSS,
+        'src/app/app.component.html': angularHTML
+      }
+    }
+  }}
+  src="usage/breadcrumbs/styling/css-props/demo.html"
+/>

--- a/static/usage/breadcrumbs/styling/css-props/javascript.md
+++ b/static/usage/breadcrumbs/styling/css-props/javascript.md
@@ -1,0 +1,16 @@
+```html
+<ion-breadcrumbs>
+  <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+  <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+  <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+  <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+</ion-breadcrumbs>
+
+<style>
+  ion-breadcrumb {
+    --color: rgb(81, 155, 198);
+    --color-active: rgb(150, 112, 220);
+    --color-hover: rgb(103, 61, 180);
+  }
+</style>
+```

--- a/static/usage/breadcrumbs/styling/css-props/react/react_css.md
+++ b/static/usage/breadcrumbs/styling/css-props/react/react_css.md
@@ -1,0 +1,7 @@
+```css
+ion-breadcrumb {
+  --color: rgb(81, 155, 198);
+  --color-active: rgb(150, 112, 220);
+  --color-hover: rgb(103, 61, 180);
+}
+```

--- a/static/usage/breadcrumbs/styling/css-props/react/react_ts.md
+++ b/static/usage/breadcrumbs/styling/css-props/react/react_ts.md
@@ -1,0 +1,18 @@
+```tsx
+import React from 'react';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonBreadcrumbs>
+      <IonBreadcrumb href="#home">Home</IonBreadcrumb>
+      <IonBreadcrumb href="#electronics">Electronics</IonBreadcrumb>
+      <IonBreadcrumb href="#cameras">Cameras</IonBreadcrumb>
+      <IonBreadcrumb href="#film">Film</IonBreadcrumb>
+    </IonBreadcrumbs>
+  );
+}
+export default Example;
+```

--- a/static/usage/breadcrumbs/styling/css-props/vue.md
+++ b/static/usage/breadcrumbs/styling/css-props/vue.md
@@ -1,0 +1,27 @@
+```html
+<template>
+  <ion-breadcrumbs>
+    <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+    <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+    <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+    <ion-breadcrumb href="#film">Film</ion-breadcrumb>
+  </ion-breadcrumbs>
+</template>
+
+<script lang="ts">
+  import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonBreadcrumb, IonBreadcrumbs },
+  });
+</script>
+
+<style>
+  ion-breadcrumb {
+    --color: rgb(81, 155, 198);
+    --color-active: rgb(150, 112, 220);
+    --color-hover: rgb(103, 61, 180);
+  }
+</style>
+```


### PR DESCRIPTION
Adds the following playgrounds:
- Basic Usage
- Icons on Items
- Custom Separators