### PR TITLE
docs(index): license typo 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -155,6 +155,6 @@ There are millions of Ionic developers in over 200 countries worldwide. Here are
 
 ## License
 
-The Ionic UI Toolkit is a free and open source project, released under the permissable <a href="https://opensource.org/licenses/MIT" target="_blank">MIT license</a>. This means it can be used in personal or commercial projects for free. MIT is the same license used by such popular projects as jQuery and Ruby on Rails.
+The Ionic UI Toolkit is a free and open source project, released under the permissible <a href="https://opensource.org/licenses/MIT" target="_blank">MIT license</a>. This means it can be used in personal or commercial projects for free. MIT is the same license used by such popular projects as jQuery and Ruby on Rails.
 
 This documentation content (found in the <a href="https://github.com/ionic-team/ionic-docs" target="_blank">ionic-docs</a> repo) is licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">Apache 2 license</a>.


### PR DESCRIPTION
url: https://ionicframework.com/docs/#license