### PR TITLE
docs(range): pins playground

### DIFF
--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -58,6 +58,8 @@ TODO: Playground Example
 
 The `pin` attribute will display the value of the Range above the knob when dragged. This allows users to select a specific value within the Range.
 
+With the `pinFormatter` function, developers can customize the formatting of the range value to the user.
+
 import Pins from '@site/static/usage/range/pins/index.md';
 
 <Pins />

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -56,7 +56,11 @@ TODO: Playground Example
 
 ## Pins
 
-TODO: Playground Example
+The `pin` attribute will display the value of the Range above the knob when dragged. This allows users to select a specific value within the Range.
+
+import Pins from '@site/static/usage/range/pins/index.md';
+
+<Pins />
 
 ## Ticks
 

--- a/static/usage/range/pins/angular.md
+++ b/static/usage/range/pins/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-range [pin]="true"></ion-range>
+```

--- a/static/usage/range/pins/angular.md
+++ b/static/usage/range/pins/angular.md
@@ -1,3 +1,0 @@
-```html
-<ion-range [pin]="true"></ion-range>
-```

--- a/static/usage/range/pins/angular/app_component_html.md
+++ b/static/usage/range/pins/angular/app_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-range [pin]="true" [pinFormatter]="pinFormatter"></ion-range>
+```

--- a/static/usage/range/pins/angular/app_component_html.md
+++ b/static/usage/range/pins/angular/app_component_html.md
@@ -1,3 +1,5 @@
 ```html
-<ion-range [pin]="true" [pinFormatter]="pinFormatter"></ion-range>
+<ion-content>
+  <ion-range [pin]="true" [pinFormatter]="pinFormatter"></ion-range>
+</ion-content>
 ```

--- a/static/usage/range/pins/angular/app_component_ts.md
+++ b/static/usage/range/pins/angular/app_component_ts.md
@@ -1,0 +1,14 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css'],
+})
+export class AppComponent {
+  pinFormatter(value: number) {
+    return `${value}%`;
+  }
+}
+```

--- a/static/usage/range/pins/demo.html
+++ b/static/usage/range/pins/demo.html
@@ -24,6 +24,12 @@
       </div>
     </ion-content>
   </ion-app>
+  <script>
+    const range = document.querySelector('ion-range');
+    range.pinFormatter = (value) => {
+      return `${value}%`;
+    };
+  </script>
 </body>
 
 </html>

--- a/static/usage/range/pins/demo.html
+++ b/static/usage/range/pins/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range pin="true"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/range/pins/index.md
+++ b/static/usage/range/pins/index.md
@@ -3,6 +3,21 @@ import Playground from '@site/src/components/global/Playground';
 import javascript from './javascript.md';
 import react from './react.md';
 import vue from './vue.md';
-import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/range/pins/demo.html" />
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.ts': angular_app_component_ts,
+        'src/app/app.component.html': angular_app_component_html,
+      },
+    },
+  }}
+  src="usage/range/pins/demo.html"
+/>

--- a/static/usage/range/pins/index.md
+++ b/static/usage/range/pins/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/range/pins/demo.html" />

--- a/static/usage/range/pins/index.md
+++ b/static/usage/range/pins/index.md
@@ -14,8 +14,8 @@ import angular_app_component_html from './angular/app_component_html.md';
     vue,
     angular: {
       files: {
-        'src/app/app.component.ts': angular_app_component_ts,
         'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
       },
     },
   }}

--- a/static/usage/range/pins/javascript.md
+++ b/static/usage/range/pins/javascript.md
@@ -1,7 +1,9 @@
 ```html
-<ion-content>
-  <ion-range pin="true"></ion-range>
-</ion-content>
+<ion-app>
+  <ion-content>
+    <ion-range pin="true"></ion-range>
+  </ion-content>
+</ion-app>
 
 <script>
   const range = document.querySelector('ion-range');

--- a/static/usage/range/pins/javascript.md
+++ b/static/usage/range/pins/javascript.md
@@ -1,3 +1,10 @@
 ```html
 <ion-range pin="true"></ion-range>
+
+<script>
+  const range = document.querySelector('ion-range');
+  range.pinFormatter = (value) => {
+    return `${value}%`;
+  };
+</script>
 ```

--- a/static/usage/range/pins/javascript.md
+++ b/static/usage/range/pins/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-range pin="true"></ion-range>
+```

--- a/static/usage/range/pins/javascript.md
+++ b/static/usage/range/pins/javascript.md
@@ -1,5 +1,7 @@
 ```html
-<ion-range pin="true"></ion-range>
+<ion-content>
+  <ion-range pin="true"></ion-range>
+</ion-content>
 
 <script>
   const range = document.querySelector('ion-range');

--- a/static/usage/range/pins/react.md
+++ b/static/usage/range/pins/react.md
@@ -1,8 +1,12 @@
 ```tsx
 import React from 'react';
-import { IonRange } from '@ionic/react';
+import { IonContent, IonRange } from '@ionic/react';
 function Example() {
-  return <IonRange pin={true} pinFormatter={(value: number) => `${value}%`}></IonRange>;
+  return (
+    <IonContent>
+      <IonRange pin={true} pinFormatter={(value: number) => `${value}%`}></IonRange>
+    </IonContent>
+  );
 }
 export default Example;
 ```

--- a/static/usage/range/pins/react.md
+++ b/static/usage/range/pins/react.md
@@ -2,7 +2,7 @@
 import React from 'react';
 import { IonRange } from '@ionic/react';
 function Example() {
-  return <IonRange pin={true}></IonRange>;
+  return <IonRange pin={true} pinFormatter={(value: number) => `${value}%`}></IonRange>;
 }
 export default Example;
 ```

--- a/static/usage/range/pins/react.md
+++ b/static/usage/range/pins/react.md
@@ -1,0 +1,8 @@
+```tsx
+import React from 'react';
+import { IonRange } from '@ionic/react';
+function Example() {
+  return <IonRange pin={true}></IonRange>;
+}
+export default Example;
+```

--- a/static/usage/range/pins/vue.md
+++ b/static/usage/range/pins/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-range :pin="true"></ion-range>
+</template>
+
+<script lang="ts">
+  import { IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRange },
+  });
+</script>
+```

--- a/static/usage/range/pins/vue.md
+++ b/static/usage/range/pins/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range :pin="true"></ion-range>
+  <ion-range :pin="true" :pinFormatter="pinFormatter"></ion-range>
 </template>
 
 <script lang="ts">
@@ -9,6 +9,11 @@
 
   export default defineComponent({
     components: { IonRange },
+    setup() {
+      return {
+        pinFormatter: (value: number) => `${value}%`,
+      };
+    },
   });
 </script>
 ```

--- a/static/usage/range/pins/vue.md
+++ b/static/usage/range/pins/vue.md
@@ -1,14 +1,16 @@
 ```html
 <template>
-  <ion-range :pin="true" :pinFormatter="pinFormatter"></ion-range>
+  <ion-content>
+    <ion-range :pin="true" :pin-formatter="pinFormatter"></ion-range>
+  </ion-content>
 </template>
 
 <script lang="ts">
-  import { IonRange } from '@ionic/vue';
+  import { IonContent, IonRange } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonRange },
+    components: { IonContent, IonRange },
     setup() {
       return {
         pinFormatter: (value: number) => `${value}%`,


### PR DESCRIPTION
Introduces the component playground for displaying a pin with `ion-range`. 

Quick link: https://ionic-docs-git-range-playground-pins-ionic1.vercel.app/docs/api/range#pins