### PR TITLE
docs(range): dual knobs

### DIFF
--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -52,7 +52,19 @@ TODO: Playground Example
 
 ## Dual Knobs
 
-TODO: Playground Example
+Dual knobs introduce two knob controls that users can use to select a value at a lower and upper bounds. When selected, the Range will emit an `ionChange` event with a value object, containing the upper and lower values selected.
+
+```js
+// Example value event detail
+{
+  lower: 20,
+  upper: 80
+}
+```
+
+import DualKnobs from '@site/static/usage/range/dual-knobs/index.md';
+
+<DualKnobs />
 
 ## Pins
 

--- a/static/usage/range/dual-knobs/angular.md
+++ b/static/usage/range/dual-knobs/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-range [dualKnobs]="true" [value]="{ lower: 20, upper: 80 }"></ion-range>
+```

--- a/static/usage/range/dual-knobs/demo.html
+++ b/static/usage/range/dual-knobs/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range dual-knobs="true"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+  <script>
+    const range = document.querySelector('ion-range');
+    range.value = {
+      lower: 20,
+      upper: 80
+    };
+  </script>
+</body>
+
+</html>

--- a/static/usage/range/dual-knobs/index.md
+++ b/static/usage/range/dual-knobs/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/range/dual-knobs/demo.html" />

--- a/static/usage/range/dual-knobs/javascript.md
+++ b/static/usage/range/dual-knobs/javascript.md
@@ -1,0 +1,11 @@
+```html
+<ion-range dual-knobs="true"></ion-range>
+
+<script>
+  const range = document.querySelector('ion-range');
+  range.value = {
+    lower: 20,
+    upper: 80,
+  };
+</script>
+```

--- a/static/usage/range/dual-knobs/react.md
+++ b/static/usage/range/dual-knobs/react.md
@@ -1,0 +1,16 @@
+```tsx
+import React from 'react';
+import { IonRange } from '@ionic/react';
+function Example() {
+  return (
+    <IonRange
+      dualKnobs={true}
+      value={{
+        lower: 20,
+        upper: 80,
+      }}
+    ></IonRange>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/dual-knobs/vue.md
+++ b/static/usage/range/dual-knobs/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-range :dual-knobs="true" :value="{ lower: 20, upper: 80 }"></ion-range>
+</template>
+
+<script lang="ts">
+  import { IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRange },
+  });
+</script>
+```


### PR DESCRIPTION
Introduces the playground example for using dual knobs with `ion-range`. 