### PR TITLE
docs(range): snapping and ticks playground

### DIFF
--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -58,13 +58,15 @@ TODO: Playground Example
 
 TODO: Playground Example
 
-## Ticks
+## Snapping & Ticks
 
-TODO: Playground Example
+Ticks show indications for each available value on the Range. In order to use ticks, developers must set both `snaps` and the `ticks` property to `true`. 
 
-## Snapping
+With snapping enabled, the Range knob will snap to the nearest available value as the knob is dragged and released. 
 
-TODO: Playground Example
+import SnappingTicks from '@site/static/usage/range/snapping-ticks/index.md';
+
+<SnappingTicks />
 
 ## Event Handling
 

--- a/static/usage/range/snapping-ticks/angular.md
+++ b/static/usage/range/snapping-ticks/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-range [ticks]="true" [snaps]="true" [min]="0" [max]="10"></ion-range>
+```

--- a/static/usage/range/snapping-ticks/demo.html
+++ b/static/usage/range/snapping-ticks/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range ticks="true" snaps="true" min="0" max="10"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/range/snapping-ticks/index.md
+++ b/static/usage/range/snapping-ticks/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/range/snapping-ticks/demo.html" />

--- a/static/usage/range/snapping-ticks/javascript.md
+++ b/static/usage/range/snapping-ticks/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-range ticks="true" snaps="true" min="0" max="10"></ion-range>
+```

--- a/static/usage/range/snapping-ticks/react.md
+++ b/static/usage/range/snapping-ticks/react.md
@@ -1,0 +1,8 @@
+```tsx
+import React from 'react';
+import { IonRange } from '@ionic/react';
+function Example() {
+  return <IonRange ticks={true} snaps={true} min={0} max={10}></IonRange>;
+}
+export default Example;
+```

--- a/static/usage/range/snapping-ticks/vue.md
+++ b/static/usage/range/snapping-ticks/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-range :ticks="true" :snaps="true" :min="0" :max="10"></ion-range>
+</template>
+
+<script lang="ts">
+  import { IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRange },
+  });
+</script>
+```


### PR DESCRIPTION
Introduces the snapping and ticks playground example for the Range component. 

Initially these were separately planned playground examples, but since `ticks` is dependent on `snaps` being `true`, I have combined them. 