### PR TITLE
docs(support): add angular 14 support

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -44,7 +44,7 @@ The Ionic team generally recommends the latest releases of third party packages 
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v6     |           v12           |          v13.x          |    4.0+    |
+|    v6     |           v12           |          v14.x          |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |
 |    v4     |          v8.2           |          v11.x          |    3.5+    |
 |    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -50,7 +50,7 @@ The Ionic team generally recommends the latest releases of third party packages 
 |    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |
 
 :::note
-^ Angular 14.x support was added in Ionic v6.1.9
+^ Angular 14.x support was added in Ionic v6.1.9.
 :::
 
 #### Ionic React

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -49,7 +49,7 @@ The Ionic team generally recommends the latest releases of third party packages 
 |    v4     |          v8.2           |          v11.x          |    3.5+    |
 |    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |
 
-:::
+:::note
 ^ Angular 14.x support was added in Ionic v6.1.9
 :::
 

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -49,9 +49,7 @@ The Ionic team generally recommends the latest releases of third party packages 
 |    v4     |          v8.2           |          v11.x          |    3.5+    |
 |    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |
 
-:::note
-^ Angular 14.x support was added in Ionic v6.1.9.
-:::
+> ^ Angular 14.x support was added in Ionic v6.1.9.
 
 #### Ionic React
 

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -44,10 +44,12 @@ The Ionic team generally recommends the latest releases of third party packages 
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v6     |           v12           |          v14.x          |    4.0+    |
+|    v6     |           v12           |          v14.x*          |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |
 |    v4     |          v8.2           |          v11.x          |    3.5+    |
 |    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |
+
+> * Angular 14.x support was added starting in Ionic v6.1.9.
 
 #### Ionic React
 

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -44,12 +44,14 @@ The Ionic team generally recommends the latest releases of third party packages 
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v6     |           v12           |          v14.x*          |    4.0+    |
+|    v6     |           v12           |          v14.x^         |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |
 |    v4     |          v8.2           |          v11.x          |    3.5+    |
 |    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |
 
-> * Angular 14.x support was added starting in Ionic v6.1.9.
+:::
+^ Angular 14.x support was added in Ionic v6.1.9
+:::
 
 #### Ionic React
 


### PR DESCRIPTION
This PR updates the support table for Angular to include Angular 14 as the maximum angular version