### PR TITLE
fix(playground): avoid white pixels at corners of device preview

### DIFF
--- a/src/components/global/Playground/device-preview.js
+++ b/src/components/global/Playground/device-preview.js
@@ -34,8 +34,6 @@ class DevicePreview extends HTMLElement {
      width: var(--device-width);
      height: var(--device-height);
 
-     overflow: hidden;
-
      position: relative;
 
      z-index: 1;


### PR DESCRIPTION
Currently, when viewing the device preview frame in Chromium browsers, there are white pixels at the corners of the content. This can be most easily seen in the card modal playground:
![card modal](https://i.gyazo.com/175a1358e552cd59fea953ae2bcceb01.png)

This happens due to a browser rendering issue around combining `border-radius` with `overflow: hidden`. Tweaking the `border-radius` values does not fix the issue.

This PR fixes things by removing an extra `overflow: hidden`. It isn't needed anyway since the inner content also has `overflow: hidden` and a border radius of its own.

An alternative fix would be to add `background-color: black` to the `figure`, but this leads to the frame being solid black while the iframe loads, which doesn't look great.