### PR TITLE
docs(accordion): add customization playgrounds

### DIFF
--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -91,9 +91,13 @@ The `content` slot is used as the part of the accordion that is revealed or hidd
 
 ### Expansion Styles
 
-There are two built in expansion styles: `compact` and `inset`. This expansion style is set via the `expand` property on `ion-accordion-group`. When `expand="inset"`, the accordion group is given a border radius. On `md` mode, the entire accordion will shift down when it is opened.
+There are two built in expansion styles: `compact` and `inset`. This expansion style is set via the `expand` property on `ion-accordion-group`.
 
-TODO Playground
+When `expand="inset"`, the accordion group is given a border radius. On `md` mode, the entire accordion will shift down when it is opened.
+
+import ExpansionStyles from '@site/static/usage/accordion/customization/expansion-styles/index.md';
+
+<ExpansionStyles />
 
 ### Advanced Expansion Styles
 

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -95,6 +95,10 @@ There are two built in expansion styles: `compact` and `inset`. This expansion s
 
 TODO Playground
 
+### Advanced Expansion Styles
+
+TODO Playground
+
 ### Icons
 
 When using an `ion-item` in the `header` slot, we automatically add an `ion-icon`. The type of icon used can be controlled by the `toggleIcon` property, and the slot it is added to can be controlled with the `toggleIconSlot` property.

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -101,7 +101,27 @@ import ExpansionStyles from '@site/static/usage/accordion/customization/expansio
 
 ### Advanced Expansion Styles
 
-TODO Playground
+You can customize the expansion behavior by styling based on the accordion's state. There are four state classes applied to `ion-accordion`. Styling using these classes can allow you to create advanced state transitions:
+
+| Class Name | Description |
+| ---------- | ----------- |
+| `.accordion-expanding` | Applied when the accordion is actively expanding |
+| `.accordion-expanded` | Applied when the accordion is fully expanded |
+| `.accordion-collapsing` | Applied when the accordion is actively collapsing |
+| `.accordion-collapsed` | Applied when the accordion is fully collapsed |
+
+If you need to target specific pieces of the accordion, we recommend targeting the element directly. For example, if you want to customize the ion-item in your header slot when the accordion is expanded, you can use the following selector:
+
+```css
+ion-accordion.accordion-expanding ion-item[slot="header"],
+ion-accordion.accordion-expanded ion-item[slot="header"] {
+  --color: red;
+}
+```
+
+import AdvancedExpansionStyles from '@site/static/usage/accordion/customization/advanced-expansion-styles/index.md';
+
+<AdvancedExpansionStyles />
 
 ### Icons
 

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -131,7 +131,9 @@ If you would like to manage the icon yourself or use an icon that is not an `ion
 
 Regardless of which option you choose, the icon will automatically be rotated when you expand or collapse the accordion.
 
-TODO Playground
+import Icons from '@site/static/usage/accordion/customization/icons/index.md';
+
+<Icons />
 
 ### Theming
 

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -137,7 +137,11 @@ import Icons from '@site/static/usage/accordion/customization/icons/index.md';
 
 ### Theming
 
-TODO Playground
+Since `ion-accordion` acts as a shell around the header and content elements, you can easily theme the accordion however you would like. You can theme the header by targeting the slotted `ion-item`. Since you are using `ion-item`, you also have access to all of the [ion-item CSS Variables](./item#css-custom-properties) and [ion-item Shadow Parts](./item#css-shadow-parts). Theming the content is also easily achieved by targeting the element that is in the `content` slot.
+
+import Theming from '@site/static/usage/accordion/customization/theming/index.md';
+
+<Theming />
 
 ## Accessibility
 

--- a/static/usage/accordion/customization/advanced-expansion-styles/angular/angular-css.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/angular/angular-css.md
@@ -1,0 +1,24 @@
+```css
+ion-accordion {
+  margin: 0 auto;
+}
+
+ion-accordion.accordion-expanding,
+ion-accordion.accordion-expanded {
+  width: calc(100% - 32px);
+
+  margin: 16px auto;
+}
+
+ion-accordion.accordion-collapsing ion-item[slot="header"],
+ion-accordion.accordion-collapsed ion-item[slot="header"] {
+  --background: var(--ion-color-light);
+  --color: var(--ion-color-light-contrast);
+}
+
+ion-accordion.accordion-expanding ion-item[slot="header"],
+ion-accordion.accordion-expanded ion-item[slot="header"] {
+  --background: var(--ion-color-primary);
+  --color: var(--ion-color-primary-contrast);
+}
+```

--- a/static/usage/accordion/customization/advanced-expansion-styles/angular/angular-html.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/angular/angular-html.md
@@ -1,0 +1,28 @@
+```html
+<ion-accordion-group>
+  <ion-accordion value="first">
+    <ion-item slot="header">
+      <ion-label>First Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      First Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="second">
+    <ion-item slot="header">
+      <ion-label>Second Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Second Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="third">
+    <ion-item slot="header">
+      <ion-label>Third Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Third Content
+    </div>
+  </ion-accordion>
+</ion-accordion-group>
+```

--- a/static/usage/accordion/customization/advanced-expansion-styles/angular/angular-ts.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/angular/angular-ts.md
@@ -1,0 +1,11 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css']
+})
+export class AppComponent { }
+
+```

--- a/static/usage/accordion/customization/advanced-expansion-styles/demo.html
+++ b/static/usage/accordion/customization/advanced-expansion-styles/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+    <style>
+      ion-accordion {
+        margin: 0 auto;
+      }
+
+      ion-accordion.accordion-expanding,
+      ion-accordion.accordion-expanded {
+        width: calc(100% - 32px);
+
+        margin: 16px auto;
+      }
+
+      ion-accordion.accordion-collapsing ion-item[slot="header"],
+      ion-accordion.accordion-collapsed ion-item[slot="header"] {
+        --background: var(--ion-color-light);
+        --color: var(--ion-color-light-contrast);
+      }
+
+      ion-accordion.accordion-expanding ion-item[slot="header"],
+      ion-accordion.accordion-expanded ion-item[slot="header"] {
+        --background: var(--ion-color-primary);
+        --color: var(--ion-color-primary-contrast);
+      }
+
+      .container {
+        width: 300px;
+        margin: 0 auto;
+      }
+
+      ion-accordion-group {
+        width: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-accordion-group>
+            <ion-accordion value="first">
+              <ion-item slot="header">
+                <ion-label>First Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                First Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="second">
+              <ion-item slot="header">
+                <ion-label>Second Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Second Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="third">
+              <ion-item slot="header">
+                <ion-label>Third Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Third Content
+              </div>
+            </ion-accordion>
+          </ion-accordion-group>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/accordion/customization/advanced-expansion-styles/index.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/index.md
@@ -16,8 +16,8 @@ import angularTS from './angular/angular-ts.md';
     javascript,
     react: {
       files: {
-        'main.tsx': reactTS,
-        'main.css': reactCSS
+        'src/main.tsx': reactTS,
+        'src/main.css': reactCSS
       }
     },
     vue,

--- a/static/usage/accordion/customization/advanced-expansion-styles/index.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/index.md
@@ -1,0 +1,34 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTS from './react/react-ts.md';
+import reactCSS from './react/react-css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/angular-html.md';
+import angularCSS from './angular/angular-css.md';
+import angularTS from './angular/angular-ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'main.tsx': reactTS,
+        'main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.css': angularCSS,
+        'src/app/app.component.ts': angularTS
+      }
+    },
+  }}
+  size="250px"
+  src="usage/accordion/customization/advanced-expansion-styles/demo.html"
+/>

--- a/static/usage/accordion/customization/advanced-expansion-styles/javascript.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/javascript.md
@@ -1,0 +1,53 @@
+```html
+<ion-accordion-group>
+  <ion-accordion value="first">
+    <ion-item slot="header">
+      <ion-label>First Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      First Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="second">
+    <ion-item slot="header">
+      <ion-label>Second Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Second Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="third">
+    <ion-item slot="header">
+      <ion-label>Third Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Third Content
+    </div>
+  </ion-accordion>
+</ion-accordion-group>
+
+<style>
+  ion-accordion {
+    margin: 0 auto;
+  }
+
+  ion-accordion.accordion-expanding,
+  ion-accordion.accordion-expanded {
+    width: calc(100% - 32px);
+
+    margin: 16px auto;
+  }
+
+  ion-accordion.accordion-collapsing ion-item[slot="header"],
+  ion-accordion.accordion-collapsed ion-item[slot="header"] {
+    --background: var(--ion-color-light);
+    --color: var(--ion-color-light-contrast);
+  }
+
+  ion-accordion.accordion-expanding ion-item[slot="header"],
+  ion-accordion.accordion-expanded ion-item[slot="header"] {
+    --background: var(--ion-color-primary);
+    --color: var(--ion-color-primary-contrast);
+  }
+</style>
+```

--- a/static/usage/accordion/customization/advanced-expansion-styles/react/react-css.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/react/react-css.md
@@ -1,0 +1,24 @@
+```css
+ion-accordion {
+  margin: 0 auto;
+}
+
+ion-accordion.accordion-expanding,
+ion-accordion.accordion-expanded {
+  width: calc(100% - 32px);
+
+  margin: 16px auto;
+}
+
+ion-accordion.accordion-collapsing ion-item[slot="header"],
+ion-accordion.accordion-collapsed ion-item[slot="header"] {
+  --background: var(--ion-color-light);
+  --color: var(--ion-color-light-contrast);
+}
+
+ion-accordion.accordion-expanding ion-item[slot="header"],
+ion-accordion.accordion-expanded ion-item[slot="header"] {
+  --background: var(--ion-color-primary);
+  --color: var(--ion-color-primary-contrast);
+}
+```

--- a/static/usage/accordion/customization/advanced-expansion-styles/react/react-ts.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/react/react-ts.md
@@ -1,0 +1,43 @@
+```tsx
+import React from 'react';
+import { 
+  IonAccordion, 
+  IonAccordionGroup,
+  IonItem, 
+  IonLabel
+} from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonAccordionGroup expand="inset">
+      <IonAccordion value="first">
+        <IonItem slot="header" color="light">
+          <IonLabel>First Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          First Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="second">
+        <IonItem slot="header" color="light">
+          <IonLabel>Second Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Second Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="third">
+        <IonItem slot="header" color="light">
+          <IonLabel>Third Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Third Content
+        </div>
+      </IonAccordion>
+    </IonAccordionGroup>
+  );
+}
+export default Example;
+```

--- a/static/usage/accordion/customization/advanced-expansion-styles/vue.md
+++ b/static/usage/accordion/customization/advanced-expansion-styles/vue.md
@@ -1,0 +1,74 @@
+```html
+<template>
+  <ion-accordion-group>
+    <ion-accordion value="first">
+      <ion-item slot="header">
+        <ion-label>First Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        First Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="second">
+      <ion-item slot="header">
+        <ion-label>Second Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Second Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="third">
+      <ion-item slot="header">
+        <ion-label>Third Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Third Content
+      </div>
+    </ion-accordion>
+  </ion-accordion-group>
+</template>
+
+<script lang="ts">
+  import {
+    IonAccordion, 
+    IonAccordionGroup,
+    IonItem, 
+    IonLabel
+  } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonAccordion, 
+      IonAccordionGroup,
+      IonItem, 
+      IonLabel
+    },
+  });
+</script>
+
+<style scoped>
+  ion-accordion {
+    margin: 0 auto;
+  }
+
+  ion-accordion.accordion-expanding,
+  ion-accordion.accordion-expanded {
+    width: calc(100% - 32px);
+  
+    margin: 16px auto;
+  }
+  
+  ion-accordion.accordion-collapsing ion-item[slot="header"],
+  ion-accordion.accordion-collapsed ion-item[slot="header"] {
+    --background: var(--ion-color-light);
+    --color: var(--ion-color-light-contrast);
+  }
+  
+  ion-accordion.accordion-expanding ion-item[slot="header"],
+  ion-accordion.accordion-expanded ion-item[slot="header"] {
+    --background: var(--ion-color-primary);
+    --color: var(--ion-color-primary-contrast);
+  }
+</style>
+```

--- a/static/usage/accordion/customization/expansion-styles/angular.md
+++ b/static/usage/accordion/customization/expansion-styles/angular.md
@@ -1,0 +1,28 @@
+```html
+<ion-accordion-group expand="inset">
+  <ion-accordion value="first">
+    <ion-item slot="header" color="light">
+      <ion-label>First Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      First Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="second">
+    <ion-item slot="header" color="light">
+      <ion-label>Second Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Second Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="third">
+    <ion-item slot="header" color="light">
+      <ion-label>Third Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Third Content
+    </div>
+  </ion-accordion>
+</ion-accordion-group>
+```

--- a/static/usage/accordion/customization/expansion-styles/demo.html
+++ b/static/usage/accordion/customization/expansion-styles/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  </head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-accordion-group expand="inset">
+            <ion-accordion value="first">
+              <ion-item slot="header" color="light">
+                <ion-label>First Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                First Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="second">
+              <ion-item slot="header" color="light">
+                <ion-label>Second Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Second Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="third">
+              <ion-item slot="header" color="light">
+                <ion-label>Third Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Third Content
+              </div>
+            </ion-accordion>
+          </ion-accordion-group>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/accordion/customization/expansion-styles/index.md
+++ b/static/usage/accordion/customization/expansion-styles/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  size="250px"
+  src="usage/accordion/customization/expansion-styles/demo.html"
+/>

--- a/static/usage/accordion/customization/expansion-styles/javascript.md
+++ b/static/usage/accordion/customization/expansion-styles/javascript.md
@@ -1,0 +1,28 @@
+```html
+<ion-accordion-group expand="inset">
+  <ion-accordion value="first">
+    <ion-item slot="header" color="light">
+      <ion-label>First Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      First Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="second">
+    <ion-item slot="header" color="light">
+      <ion-label>Second Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Second Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="third">
+    <ion-item slot="header" color="light">
+      <ion-label>Third Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Third Content
+    </div>
+  </ion-accordion>
+</ion-accordion-group>
+```

--- a/static/usage/accordion/customization/expansion-styles/react.md
+++ b/static/usage/accordion/customization/expansion-styles/react.md
@@ -1,0 +1,40 @@
+```tsx
+import React from 'react';
+import { 
+  IonAccordion, 
+  IonAccordionGroup,
+  IonItem, 
+  IonLabel
+} from '@ionic/react';
+function Example() {
+  return (
+    <IonAccordionGroup expand="inset">
+      <IonAccordion value="first">
+        <IonItem slot="header" color="light">
+          <IonLabel>First Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          First Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="second">
+        <IonItem slot="header" color="light">
+          <IonLabel>Second Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Second Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="third">
+        <IonItem slot="header" color="light">
+          <IonLabel>Third Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Third Content
+        </div>
+      </IonAccordion>
+    </IonAccordionGroup>
+  );
+}
+export default Example;
+```

--- a/static/usage/accordion/customization/expansion-styles/vue.md
+++ b/static/usage/accordion/customization/expansion-styles/vue.md
@@ -1,0 +1,49 @@
+```html
+<template>
+  <ion-accordion-group expand="inset">
+    <ion-accordion value="first">
+      <ion-item slot="header" color="light">
+        <ion-label>First Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        First Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="second">
+      <ion-item slot="header" color="light">
+        <ion-label>Second Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Second Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="third">
+      <ion-item slot="header" color="light">
+        <ion-label>Third Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Third Content
+      </div>
+    </ion-accordion>
+  </ion-accordion-group>
+</template>
+
+<script lang="ts">
+  import {
+    IonAccordion, 
+    IonAccordionGroup,
+    IonItem, 
+    IonLabel
+  } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonAccordion, 
+      IonAccordionGroup,
+      IonItem, 
+      IonLabel
+    },
+  });
+</script>
+```

--- a/static/usage/accordion/customization/icons/angular.md
+++ b/static/usage/accordion/customization/icons/angular.md
@@ -1,0 +1,30 @@
+```html
+<ion-content>
+  <ion-accordion-group>
+    <ion-accordion value="first" toggleIcon="caret-down-circle" toggleIconSlot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>First Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        First Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="second" toggleIcon="caret-down-circle" toggleIconSlot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>Second Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Second Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="third" toggleIcon="caret-down-circle" toggleIconSlot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>Third Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Third Content
+      </div>
+    </ion-accordion>
+  </ion-accordion-group>
+</ion-content>
+```

--- a/static/usage/accordion/customization/icons/demo.html
+++ b/static/usage/accordion/customization/icons/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  </head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-accordion-group>
+            <ion-accordion value="first" toggle-icon="caret-down-circle" toggle-icon-slot="start">
+              <ion-item slot="header" color="light">
+                <ion-label>First Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                First Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="second" toggle-icon="caret-down-circle" toggle-icon-slot="start">
+              <ion-item slot="header" color="light">
+                <ion-label>Second Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Second Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="third" toggle-icon="caret-down-circle" toggle-icon-slot="start">
+              <ion-item slot="header" color="light">
+                <ion-label>Third Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Third Content
+              </div>
+            </ion-accordion>
+          </ion-accordion-group>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/accordion/customization/icons/index.md
+++ b/static/usage/accordion/customization/icons/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  size="250px"
+  src="usage/accordion/customization/icons/demo.html"
+/>

--- a/static/usage/accordion/customization/icons/javascript.md
+++ b/static/usage/accordion/customization/icons/javascript.md
@@ -1,0 +1,28 @@
+```html
+<ion-accordion-group>
+  <ion-accordion value="first" toggle-icon="caret-down-circle" toggle-icon-slot="start">
+    <ion-item slot="header" color="light">
+      <ion-label>First Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      First Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="second" toggle-icon="caret-down-circle" toggle-icon-slot="start">
+    <ion-item slot="header" color="light">
+      <ion-label>Second Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Second Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="third" toggle-icon="caret-down-circle" toggle-icon-slot="start">
+    <ion-item slot="header" color="light">
+      <ion-label>Third Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Third Content
+    </div>
+  </ion-accordion>
+</ion-accordion-group>
+```

--- a/static/usage/accordion/customization/icons/react.md
+++ b/static/usage/accordion/customization/icons/react.md
@@ -1,0 +1,42 @@
+```tsx
+import React from 'react';
+import { 
+  IonAccordion, 
+  IonAccordionGroup,
+  IonItem, 
+  IonLabel
+} from '@ionic/react';
+import { caretDownCircle } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <IonAccordionGroup>
+      <IonAccordion value="first" toggleIcon={caretDownCircle} toggleIconSlot="start">
+        <IonItem slot="header" color="light">
+          <IonLabel>First Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          First Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="second" toggleIcon={caretDownCircle} toggleIconSlot="start">
+        <IonItem slot="header" color="light">
+          <IonLabel>Second Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Second Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="third" toggleIcon={caretDownCircle} toggleIconSlot="start">
+        <IonItem slot="header" color="light">
+          <IonLabel>Third Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Third Content
+        </div>
+      </IonAccordion>
+    </IonAccordionGroup>
+  );
+}
+export default Example;
+```

--- a/static/usage/accordion/customization/icons/vue.md
+++ b/static/usage/accordion/customization/icons/vue.md
@@ -1,0 +1,53 @@
+```html
+<template>
+  <ion-accordion-group>
+    <ion-accordion value="first" :toggle-icon="caretDownCircle" toggle-icon-slot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>First Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        First Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="second" :toggle-icon="caretDownCircle" toggle-icon-slot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>Second Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Second Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="third" :toggle-icon="caretDownCircle" toggle-icon-slot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>Third Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Third Content
+      </div>
+    </ion-accordion>
+  </ion-accordion-group>
+</template>
+
+<script lang="ts">
+  import {
+    IonAccordion, 
+    IonAccordionGroup,
+    IonItem, 
+    IonLabel
+  } from '@ionic/vue';
+  import { caretDownCircle } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonAccordion, 
+      IonAccordionGroup,
+      IonItem, 
+      IonLabel
+    },
+    setup() {
+      return { caretDownCircle }
+    }
+  });
+</script>
+```

--- a/static/usage/accordion/customization/theming/angular.md
+++ b/static/usage/accordion/customization/theming/angular.md
@@ -1,0 +1,30 @@
+```html
+<ion-content>
+  <ion-accordion-group>
+    <ion-accordion value="first" toggleIcon="caret-down-circle" toggleIconSlot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>First Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        First Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="second" toggleIcon="caret-down-circle" toggleIconSlot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>Second Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Second Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="third" toggleIcon="caret-down-circle" toggleIconSlot="start">
+      <ion-item slot="header" color="light">
+        <ion-label>Third Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Third Content
+      </div>
+    </ion-accordion>
+  </ion-accordion-group>
+</ion-content>
+```

--- a/static/usage/accordion/customization/theming/angular/angular-css.md
+++ b/static/usage/accordion/customization/theming/angular/angular-css.md
@@ -1,0 +1,23 @@
+```css
+:root {
+  --ion-color-rose: #fecdd3;
+  --ion-color-rose-rgb: 254,205,211;
+  --ion-color-rose-contrast: #000000;
+  --ion-color-rose-contrast-rgb: 0,0,0;
+  --ion-color-rose-shade: #e0b4ba;
+  --ion-color-rose-tint: #fed2d7;
+}
+
+.ion-color-rose {
+  --ion-color-base: var(--ion-color-rose);
+  --ion-color-base-rgb: var(--ion-color-rose-rgb);
+  --ion-color-contrast: var(--ion-color-rose-contrast);
+  --ion-color-contrast-rgb: var(--ion-color-rose-contrast-rgb);
+  --ion-color-shade: var(--ion-color-rose-shade);
+  --ion-color-tint: var(--ion-color-rose-tint);
+}
+
+div[slot="content"] {
+  background: rgba(var(--ion-color-rose-rgb), 0.25)
+}
+```

--- a/static/usage/accordion/customization/theming/angular/angular-css.md
+++ b/static/usage/accordion/customization/theming/angular/angular-css.md
@@ -1,4 +1,19 @@
 ```css
+/* Core CSS required for Ionic components to work properly */
+@import '~@ionic/angular/css/core.css';
+
+/* Basic CSS for apps built with Ionic */
+@import '~@ionic/angular/css/normalize.css';
+@import '~@ionic/angular/css/structure.css';
+@import '~@ionic/angular/css/typography.css';
+
+/* Optional CSS utils that can be commented out */
+@import '~@ionic/angular/css/padding.css';
+@import '~@ionic/angular/css/float-elements.css';
+@import '~@ionic/angular/css/text-alignment.css';
+@import '~@ionic/angular/css/text-transformation.css';
+@import '~@ionic/angular/css/flex-utils.css';
+
 :root {
   --ion-color-rose: #fecdd3;
   --ion-color-rose-rgb: 254,205,211;

--- a/static/usage/accordion/customization/theming/angular/angular-html.md
+++ b/static/usage/accordion/customization/theming/angular/angular-html.md
@@ -1,0 +1,28 @@
+```html
+<ion-accordion-group expand="inset">
+  <ion-accordion value="first">
+    <ion-item slot="header" color="rose">
+      <ion-label>First Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      First Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="second">
+    <ion-item slot="header" color="rose">
+      <ion-label>Second Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Second Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="third">
+    <ion-item slot="header" color="rose">
+      <ion-label>Third Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Third Content
+    </div>
+  </ion-accordion>
+</ion-accordion-group>
+```

--- a/static/usage/accordion/customization/theming/demo.html
+++ b/static/usage/accordion/customization/theming/demo.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+    <style>
+      :root {
+        --ion-color-rose: #fecdd3;
+        --ion-color-rose-rgb: 254,205,211;
+        --ion-color-rose-contrast: #000000;
+        --ion-color-rose-contrast-rgb: 0,0,0;
+        --ion-color-rose-shade: #e0b4ba;
+        --ion-color-rose-tint: #fed2d7;
+      }
+
+      .ion-color-rose {
+        --ion-color-base: var(--ion-color-rose);
+        --ion-color-base-rgb: var(--ion-color-rose-rgb);
+        --ion-color-contrast: var(--ion-color-rose-contrast);
+        --ion-color-contrast-rgb: var(--ion-color-rose-contrast-rgb);
+        --ion-color-shade: var(--ion-color-rose-shade);
+        --ion-color-tint: var(--ion-color-rose-tint);
+      }
+
+      div[slot="content"] {
+        background: rgba(var(--ion-color-rose-rgb), 0.25)
+      }
+    </style>
+  </head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-accordion-group expand="inset">
+            <ion-accordion value="first">
+              <ion-item slot="header" color="rose">
+                <ion-label>First Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                First Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="second">
+              <ion-item slot="header" color="rose">
+                <ion-label>Second Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Second Content
+              </div>
+            </ion-accordion>
+            <ion-accordion value="third">
+              <ion-item slot="header" color="rose">
+                <ion-label>Third Accordion</ion-label>
+              </ion-item>
+              <div class="ion-padding" slot="content">
+                Third Content
+              </div>
+            </ion-accordion>
+          </ion-accordion-group>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/accordion/customization/theming/index.md
+++ b/static/usage/accordion/customization/theming/index.md
@@ -1,0 +1,32 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTS from './react/react-ts.md';
+import reactCSS from './react/react-css.md';
+
+import vue from './vue.md';
+
+import angularCSS from './angular/angular-css.md';
+import angularHTML from './angular/angular-html.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'main.js': reactTS,
+        'main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/styles.css': angularCSS
+      }
+    }
+  }}
+  size="250px"
+  src="usage/accordion/customization/theming/demo.html"
+/>

--- a/static/usage/accordion/customization/theming/index.md
+++ b/static/usage/accordion/customization/theming/index.md
@@ -15,8 +15,8 @@ import angularHTML from './angular/angular-html.md';
     javascript,
     react: {
       files: {
-        'main.js': reactTS,
-        'main.css': reactCSS
+        'src/main.tsx': reactTS,
+        'src/main.css': reactCSS
       }
     },
     vue,

--- a/static/usage/accordion/customization/theming/javascript.md
+++ b/static/usage/accordion/customization/theming/javascript.md
@@ -1,0 +1,52 @@
+```html
+<ion-accordion-group expand="inset">
+  <ion-accordion value="first">
+    <ion-item slot="header" color="rose">
+      <ion-label>First Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      First Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="second">
+    <ion-item slot="header" color="rose">
+      <ion-label>Second Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Second Content
+    </div>
+  </ion-accordion>
+  <ion-accordion value="third">
+    <ion-item slot="header" color="rose">
+      <ion-label>Third Accordion</ion-label>
+    </ion-item>
+    <div class="ion-padding" slot="content">
+      Third Content
+    </div>
+  </ion-accordion>
+</ion-accordion-group>
+
+<style>
+  :root {
+    --ion-color-rose: #fecdd3;
+    --ion-color-rose-rgb: 254,205,211;
+    --ion-color-rose-contrast: #000000;
+    --ion-color-rose-contrast-rgb: 0,0,0;
+    --ion-color-rose-shade: #e0b4ba;
+    --ion-color-rose-tint: #fed2d7;
+  }
+  
+  .ion-color-rose {
+    --ion-color-base: var(--ion-color-rose);
+    --ion-color-base-rgb: var(--ion-color-rose-rgb);
+    --ion-color-contrast: var(--ion-color-rose-contrast);
+    --ion-color-contrast-rgb: var(--ion-color-rose-contrast-rgb);
+    --ion-color-shade: var(--ion-color-rose-shade);
+    --ion-color-tint: var(--ion-color-rose-tint);
+  }
+  
+  div[slot="content"] {
+    background: rgba(var(--ion-color-rose-rgb), 0.25)
+  }
+</style>
+```

--- a/static/usage/accordion/customization/theming/react/react-css.md
+++ b/static/usage/accordion/customization/theming/react/react-css.md
@@ -1,0 +1,23 @@
+```css
+:root {
+  --ion-color-rose: #fecdd3;
+  --ion-color-rose-rgb: 254,205,211;
+  --ion-color-rose-contrast: #000000;
+  --ion-color-rose-contrast-rgb: 0,0,0;
+  --ion-color-rose-shade: #e0b4ba;
+  --ion-color-rose-tint: #fed2d7;
+}
+
+.ion-color-rose {
+  --ion-color-base: var(--ion-color-rose);
+  --ion-color-base-rgb: var(--ion-color-rose-rgb);
+  --ion-color-contrast: var(--ion-color-rose-contrast);
+  --ion-color-contrast-rgb: var(--ion-color-rose-contrast-rgb);
+  --ion-color-shade: var(--ion-color-rose-shade);
+  --ion-color-tint: var(--ion-color-rose-tint);
+}
+
+div[slot="content"] {
+  background: rgba(var(--ion-color-rose-rgb), 0.25)
+}
+```

--- a/static/usage/accordion/customization/theming/react/react-ts.md
+++ b/static/usage/accordion/customization/theming/react/react-ts.md
@@ -1,0 +1,43 @@
+```tsx
+import React from 'react';
+import { 
+  IonAccordion, 
+  IonAccordionGroup,
+  IonItem, 
+  IonLabel
+} from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonAccordionGroup expand="inset">
+      <IonAccordion value="first">
+        <IonItem slot="header" color="rose">
+          <IonLabel>First Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          First Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="second">
+        <IonItem slot="header" color="rose">
+          <IonLabel>Second Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Second Content
+        </div>
+      </IonAccordion>
+      <IonAccordion value="third">
+        <IonItem slot="header" color="rose">
+          <IonLabel>Third Accordion</IonLabel>
+        </IonItem>
+        <div className="ion-padding" slot="content">
+          Third Content
+        </div>
+      </IonAccordion>
+    </IonAccordionGroup>
+  );
+}
+export default Example;
+```

--- a/static/usage/accordion/customization/theming/vue.md
+++ b/static/usage/accordion/customization/theming/vue.md
@@ -1,0 +1,77 @@
+```html
+<template>
+  <ion-accordion-group expand="inset">
+    <ion-accordion value="first">
+      <ion-item slot="header" color="rose">
+        <ion-label>First Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        First Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="second">
+      <ion-item slot="header" color="rose">
+        <ion-label>Second Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Second Content
+      </div>
+    </ion-accordion>
+    <ion-accordion value="third">
+      <ion-item slot="header" color="rose">
+        <ion-label>Third Accordion</ion-label>
+      </ion-item>
+      <div class="ion-padding" slot="content">
+        Third Content
+      </div>
+    </ion-accordion>
+  </ion-accordion-group>
+</template>
+
+<script lang="ts">
+  import {
+    IonAccordion, 
+    IonAccordionGroup,
+    IonItem, 
+    IonLabel
+  } from '@ionic/vue';
+  import { caretDownCircle } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonAccordion, 
+      IonAccordionGroup,
+      IonItem, 
+      IonLabel
+    },
+    setup() {
+      return { caretDownCircle }
+    }
+  });
+</script>
+
+<style>
+  :root {
+    --ion-color-rose: #fecdd3;
+    --ion-color-rose-rgb: 254,205,211;
+    --ion-color-rose-contrast: #000000;
+    --ion-color-rose-contrast-rgb: 0,0,0;
+    --ion-color-rose-shade: #e0b4ba;
+    --ion-color-rose-tint: #fed2d7;
+  }
+  
+  .ion-color-rose {
+    --ion-color-base: var(--ion-color-rose);
+    --ion-color-base-rgb: var(--ion-color-rose-rgb);
+    --ion-color-contrast: var(--ion-color-rose-contrast);
+    --ion-color-contrast-rgb: var(--ion-color-rose-contrast-rgb);
+    --ion-color-shade: var(--ion-color-rose-shade);
+    --ion-color-tint: var(--ion-color-rose-tint);
+  }
+  
+  div[slot="content"] {
+    background: rgba(var(--ion-color-rose-rgb), 0.25)
+  }
+</style>
+```


### PR DESCRIPTION
https://ionic-docs-git-1310-customization-ionic1.vercel.app/docs/api/accordion#customization

A few notes:

1. The stackblitz "Advanced Expansion Styles" apps will not have the active accordion header turn blue. This is due to FW-1666.
2. The theming example for Angular won't look quite right. This is due to FW-1677.