### PR TITLE
docs(range): component playground

### DIFF
--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -1,8 +1,6 @@
 ---
 title: "ion-range"
 hide_table_of_contents: true
-demoUrl: "/docs/demos/api/range/index.html"
-demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/range/index.html"
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -38,6 +36,8 @@ The Range slider lets users select from a range of values by moving
 the slider knob. It can accept dual knobs, but by default one knob
 controls the value of the range.
 
+TODO: Playground Example
+
 ## Range Labels
 
 Labels can be placed on either side of the range by adding the
@@ -45,9 +45,41 @@ Labels can be placed on either side of the range by adding the
 be an `ion-label`, it can be added to any element to place it to the
 left or right of the range.
 
-## Custom Pin Formatters
+TODO: Playground Example
 
-When using a pin, the default behavior is to round the value that gets displayed using `Math.round()`. This behavior can be customized by passing in a formatter function to the `pinFormatter` property. See the [Usage](#usage) section for an example.
+## Dual Knobs
+
+TODO: Playground Example
+
+## Pins
+
+TODO: Playground Example
+
+## Ticks
+
+TODO: Playground Example
+
+## Snapping
+
+TODO: Playground Example
+
+## Event Handling
+
+### Using `ionChange`
+
+TODO: Playground Example
+
+### Using `ionKnobMoveStart` and `ionKnobMoveEnd`
+
+TODO: Playground Example
+
+## Styling
+
+TODO: Playground Example
+
+### Theming
+
+TODO: Playground Example
 
 ## Interfaces
 
@@ -94,322 +126,6 @@ interface RangeCustomEvent extends CustomEvent {
 type RangeValue = number | { lower: number, upper: number };
 ```
 
-
-
-## Usage
-
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
-
-<TabItem value="angular">
-
-```html
-<ion-list>
-  <ion-item>
-    <ion-range color="danger" [pin]="true"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="-200" max="200" color="secondary">
-      <ion-label slot="start">-200</ion-label>
-      <ion-label slot="end">200</ion-label>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="20" max="80" step="2">
-      <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-      <ion-icon slot="end" name="sunny"></ion-icon>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" ticks="false" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range dualKnobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
-  </ion-item>
-  
-  <ion-item>
-    <ion-range min="0" max="100" [pinFormatter]="customFormatter" [pin]="true"></ion-range>
-  </ion-item>
-</ion-list>
-```
-
-```typescript
-import { Component } from '@angular/core';
-
-@Component({…})
-export class MyComponent {
-  constructor() {}
-  
-  public customFormatter(value: number) {
-    return `${value}%`
-  }
-}
-```
-
-</TabItem>
-
-
-<TabItem value="javascript">
-
-```html
-<ion-list>
-  <ion-item>
-    <ion-range color="danger" pin="true"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="-200" max="200" color="secondary">
-      <ion-label slot="start">-200</ion-label>
-      <ion-label slot="end">200</ion-label>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="20" max="80" step="2">
-      <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-      <ion-icon slot="end" name="sunny"></ion-icon>
-    </ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range min="1000" max="2000" step="100" snaps="true" ticks="false" color="secondary"></ion-range>
-  </ion-item>
-
-  <ion-item>
-    <ion-range dual-knobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
-  </ion-item>
-  
-  <ion-item>
-    <ion-range min="0" max="100" pin="true" id="custom-range"></ion-range>
-  </ion-item>
-</ion-list>
-
-<script>
-  const customRange = document.querySelector('#custom-range');
-  customRange.pinFormatter = (value) => `${value}%`; 
-</script>
-```
-
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React, { useState } from 'react';
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonList, IonItem, IonRange, IonLabel, IonIcon, IonItemDivider } from '@ionic/react';
-import { sunny } from 'ionicons/icons';
-import { RangeValue } from '@ionic/core';
-
-export const RangeExamples: React.FC = () => {
-
-  const [value, setValue] = useState(0);
-  const [rangeValue, setRangeValue] = useState<{
-    lower: number;
-    upper: number;
-  }>({ lower: 0, upper: 0 });
-  
-  const customFormatter = (value: number) => `${value}%`;
-
-  return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>IonRange Examples</IonTitle>
-        </IonToolbar>
-      </IonHeader>
-      <IonContent>
-        <IonList>
-          <IonItemDivider>Default</IonItemDivider>
-          <IonItem>
-            <IonRange pin={true} value={value} onIonChange={e => setValue(e.detail.value as number)} />
-          </IonItem>
-          <IonItem>
-            <IonLabel>Value: {value}</IonLabel>
-          </IonItem>
-
-          <IonItemDivider>Min & Max</IonItemDivider>
-          <IonItem>
-            <IonRange min={-200} max={200} color="secondary">
-              <IonLabel slot="start">-200</IonLabel>
-              <IonLabel slot="end">200</IonLabel>
-            </IonRange>
-          </IonItem>
-
-          <IonItemDivider>Icons</IonItemDivider>
-          <IonItem>
-            <IonRange min={20} max={80} step={2}>
-              <IonIcon size="small" slot="start" icon={sunny} />
-              <IonIcon slot="end" icon={sunny} />
-            </IonRange>
-          </IonItem>
-
-          <IonItemDivider>With Snaps & Ticks</IonItemDivider>
-          <IonItem>
-            <IonRange min={1000} max={2000} step={100} snaps={true} color="secondary" />
-          </IonItem>
-
-          <IonItemDivider>With Snaps & No Ticks</IonItemDivider>
-          <IonItem>
-            <IonRange min={1000} max={2000} step={100} snaps={true} ticks={false} color="secondary" />
-          </IonItem>
-
-          <IonItemDivider>Dual Knobs</IonItemDivider>
-          <IonItem>
-            <IonRange dualKnobs={true} min={0} max={60} step={3} snaps={true} onIonChange={e => setRangeValue(e.detail.value as any)} />
-          </IonItem>
-          <IonItem>
-            <IonLabel>Value: lower: {rangeValue.lower} upper: {rangeValue.upper}</IonLabel>
-          </IonItem>
-          
-          <IonItem>
-            <IonRange min={0} max={100} pinFormatter={customFormatter} pin={true}></IonRange>
-          </IonItem>
-        </IonList>
-      </IonContent>
-    </IonPage>
-  );
-};
-```
-
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'range-example',
-  styleUrl: 'range-example.css'
-})
-export class RangeExample {
-  private customFormatter = (value: number) => `${value}%`;
-  
-  render() {
-    return [
-      <ion-list>
-        <ion-item>
-          <ion-range color="danger" pin={true}></ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={-200} max={200} color="secondary">
-            <ion-label slot="start">-200</ion-label>
-            <ion-label slot="end">200</ion-label>
-          </ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={20} max={80} step={2}>
-            <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-            <ion-icon slot="end" name="sunny"></ion-icon>
-          </ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={1000} max={2000} step={100} snaps={true} color="secondary"></ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range min={1000} max={2000} step={100} snaps={true} ticks={false} color="secondary"></ion-range>
-        </ion-item>
-
-        <ion-item>
-          <ion-range dualKnobs={true} min={21} max={72} step={3} snaps={true}></ion-range>
-        </ion-item>
-        
-        <ion-item>
-          <ion-range min="0" max="100" pinFormatter={this.customFormatter} pin={true}></ion-range>
-        </ion-item>
-      </ion-list>
-    ];
-  }
-}
-```
-
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <ion-list>
-    <ion-item>
-      <ion-range color="danger" :pin="true"></ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="-200" max="200" color="secondary">
-        <ion-label slot="start">-200</ion-label>
-        <ion-label slot="end">200</ion-label>
-      </ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="20" max="80" step="2">
-        <ion-icon size="small" slot="start" name="sunny"></ion-icon>
-        <ion-icon slot="end" name="sunny"></ion-icon>
-      </ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="1000" max="2000" step="100" snaps="true" color="secondary"></ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range min="1000" max="2000" step="100" snaps="true" ticks="false" color="secondary"></ion-range>
-    </ion-item>
-
-    <ion-item>
-      <ion-range ref="rangeDualKnobs" dual-knobs="true" min="21" max="72" step="3" snaps="true"></ion-range>
-    </ion-item>
-    
-    <ion-item>
-      <ion-range min="0" max="100" :pin-formatter="customFormatter" :pin="true"></ion-range>
-    </ion-item>
-  </ion-list>
-</template>
-
-<script lang="ts">
-import { IonItem, IonLabel, IonList, IonRange } from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: {  IonItem, IonLabel, IonList, IonRange },
-  mounted() {
-    // Sets initial value for dual-knob ion-range
-    this.$refs.rangeDualKnobs.value = { lower: 24, upper: 42 };
-  },
-  setup() {
-    const customFormatter = (value: number) => `${value}%`;
-    
-    return { customFormatter };
-  }
-});
-</script>
-```
-
-
-</TabItem>
-
-</Tabs>
 
 <Props />
 <Events />

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -87,11 +87,21 @@ TODO: Playground Example
 
 ## Styling
 
-TODO: Playground Example
+### Styling with CSS Variables
 
-### Theming
+Range includes [CSS Variables](#css-custom-properties) to quickly theme and customize the appearance of the Range component to match your application's design.
 
-TODO: Playground Example
+import CssVariablesPlayground from '@site/static/usage/range/css-variables/index.md';
+
+<CssVariablesPlayground />
+
+### Styling with CSS Shadow Parts
+
+Range includes [CSS Shadow Parts](#css-shadow-parts) to allow complete customization of specific element nodes within the Range component. CSS Shadow Parts offer the most customization capabilities and are the recommended approach when requiring advance styling with the Range component.
+
+import CssShadowPartsPlayground from '@site/static/usage/range/css-shadow-parts/index.md';
+
+<CssShadowPartsPlayground />
 
 ## Interfaces
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -41,12 +41,11 @@ import Basic from '@site/static/usage/range/basic/index.md';
 
 ## Range Labels
 
-Labels can be placed on either side of the range by adding the
-`slot="start"` or `slot="end"` to the element. The element doesn't have to
-be an `ion-label`, it can be added to any element to place it to the
-left or right of the range.
+Labels and custom UI elements can be slotted on either side of the range by adding `slot="start"` or `slot="end"` to the element. The element can be any element, such as an `ion-label`, `ion-icon` or a `div`. If the directionality of the document is set to left to right, the contents slotted to the `start` position will display to the left of the range, where as contents slotted to the `end` position will display to the right of the range. In right to left (rtl) directionality, the contents slotted to the `start` position will display to the right of the range, where as contents slotted to the `end` position` will display to the left of the range.
 
-TODO: Playground Example
+import SlotsPlayground from '@site/static/usage/range/slots/index.md';
+
+<SlotsPlayground />
 
 ## Dual Knobs
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -58,13 +58,15 @@ TODO: Playground Example
 
 TODO: Playground Example
 
-## Ticks
+## Snapping & Ticks
 
-TODO: Playground Example
+Ticks show indications for each available value on the Range. In order to use ticks, developers must set both `snaps` and the `ticks` property to `true`. 
 
-## Snapping
+With snapping enabled, the Range knob will snap to the nearest available value as the knob is dragged and released. 
 
-TODO: Playground Example
+import SnappingTicks from '@site/static/usage/range/snapping-ticks/index.md';
+
+<SnappingTicks />
 
 ## Event Handling
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -79,11 +79,19 @@ import SnappingTicks from '@site/static/usage/range/snapping-ticks/index.md';
 
 ### Using `ionChange`
 
-TODO: Playground Example
+The `ionChange` event emits as the Range knob value changes. 
+
+import IonChangeEvent from '@site/static/usage/range/ion-change-event/index.md';
+
+<IonChangeEvent />
 
 ### Using `ionKnobMoveStart` and `ionKnobMoveEnd`
 
-TODO: Playground Example
+The `ionKnobMoveStart` event emits when the Range knob begins dragging, whether through mouse drag, touch gesture or keyboard interaction. Inversely, `ionKnobMoveEnd` emits when the Range knob is released. Both events emit with the `RangeValue` type and work in combination with the `dualKnobs` property.
+
+import IonKnobMoveEvent from '@site/static/usage/range/ion-knob-move-event/index.md';
+
+<IonKnobMoveEvent />
 
 ## Styling
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -56,7 +56,13 @@ TODO: Playground Example
 
 ## Pins
 
-TODO: Playground Example
+The `pin` attribute will display the value of the Range above the knob when dragged. This allows users to select a specific value within the Range.
+
+With the `pinFormatter` function, developers can customize the formatting of the range value to the user.
+
+import Pins from '@site/static/usage/range/pins/index.md';
+
+<Pins />
 
 ## Snapping & Ticks
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -31,10 +31,13 @@ import APITOCInline from '@components/page/api/APITOCInline';
 />
 
 
+The Range slider lets users select from a range of values by moving the slider knob. By default one knob controls the value of the range. This behavior can be customized using [dual knobs](#dual-knobs).
 
-The Range slider lets users select from a range of values by moving
-the slider knob. It can accept dual knobs, but by default one knob
-controls the value of the range.
+By default the Range slider has a minimum value of `0` and a maximum value of `100`. This can be configured with the `min` and `max` properties.
+
+import Basic from '@site/static/usage/range/basic/index.md';
+
+<Basic />
 
 TODO: Playground Example
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -39,8 +39,6 @@ import Basic from '@site/static/usage/range/basic/index.md';
 
 <Basic />
 
-TODO: Playground Example
-
 ## Range Labels
 
 Labels can be placed on either side of the range by adding the

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -50,7 +50,11 @@ TODO: Playground Example
 
 ## Dual Knobs
 
-TODO: Playground Example
+Dual knobs introduce two knob controls that users can use to select a value at a lower and upper bounds. When selected, the Range will emit an `ionChange` event with a [RangeValue](#rangevalue), containing the upper and lower values selected.
+
+import DualKnobs from '@site/static/usage/range/dual-knobs/index.md';
+
+<DualKnobs />
 
 ## Pins
 

--- a/static/usage/range/basic/angular.md
+++ b/static/usage/range/basic/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-range></ion-range>
+```

--- a/static/usage/range/basic/angular.md
+++ b/static/usage/range/basic/angular.md
@@ -1,3 +1,5 @@
 ```html
-<ion-range></ion-range>
+<ion-content>
+  <ion-range></ion-range>
+</ion-content>
 ```

--- a/static/usage/range/basic/demo.html
+++ b/static/usage/range/basic/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/range/basic/index.md
+++ b/static/usage/range/basic/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/range/basic/demo.html" />

--- a/static/usage/range/basic/javascript.md
+++ b/static/usage/range/basic/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-range></ion-range>
+```

--- a/static/usage/range/basic/javascript.md
+++ b/static/usage/range/basic/javascript.md
@@ -1,3 +1,7 @@
 ```html
-<ion-range></ion-range>
+<ion-app>
+  <ion-content>
+    <ion-range></ion-range>
+  </ion-content>
+</ion-app>
 ```

--- a/static/usage/range/basic/react.md
+++ b/static/usage/range/basic/react.md
@@ -1,0 +1,8 @@
+```tsx
+import React from 'react';
+import { IonRange } from '@ionic/react';
+function Example() {
+  return <IonRange></IonRange>;
+}
+export default Example;
+```

--- a/static/usage/range/basic/react.md
+++ b/static/usage/range/basic/react.md
@@ -1,8 +1,12 @@
 ```tsx
 import React from 'react';
-import { IonRange } from '@ionic/react';
+import { IonContent, IonRange } from '@ionic/react';
 function Example() {
-  return <IonRange></IonRange>;
+  return (
+    <IonContent>
+      <IonRange></IonRange>
+    </IonContent>
+  );
 }
 export default Example;
 ```

--- a/static/usage/range/basic/vue.md
+++ b/static/usage/range/basic/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-range></ion-range>
+</template>
+
+<script lang="ts">
+  import { IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRange },
+  });
+</script>
+```

--- a/static/usage/range/basic/vue.md
+++ b/static/usage/range/basic/vue.md
@@ -1,14 +1,16 @@
 ```html
 <template>
-  <ion-range></ion-range>
+  <ion-content>
+    <ion-range></ion-range>
+  </ion-content>
 </template>
 
 <script lang="ts">
-  import { IonRange } from '@ionic/vue';
+  import { IonContent, IonRange } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonRange },
+    components: { IonContent, IonRange },
   });
 </script>
 ```

--- a/static/usage/range/css-shadow-parts/angular/app_component_css.md
+++ b/static/usage/range/css-shadow-parts/angular/app_component_css.md
@@ -1,0 +1,43 @@
+```css
+ion-range::part(tick) {
+  background: #a2d2ff;
+}
+
+ion-range::part(tick-active) {
+  background: #bde0fe;
+}
+
+ion-range::part(pin) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  background: #ffafcc;
+  color: #fff;
+
+  border-radius: 50%;
+  transform: scale(1.01);
+
+  top: -20px;
+
+  min-width: 28px;
+  height: 28px;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+ion-range::part(pin)::before {
+  content: none;
+}
+
+ion-range::part(knob) {
+  background: #ffc8dd;
+}
+
+ion-range::part(bar) {
+  background: #a2d2ff;
+}
+
+ion-range::par(bar-active) {
+  background: #bde0fe;
+}
+```

--- a/static/usage/range/css-shadow-parts/angular/app_component_html.md
+++ b/static/usage/range/css-shadow-parts/angular/app_component_html.md
@@ -1,0 +1,5 @@
+```html
+<ion-content class="ion-padding">
+  <ion-range [min]="0" [max]="10" [value]="5" [pin]="true" [ticks]="true" [snaps]="true"></ion-range>
+</ion-content>
+```

--- a/static/usage/range/css-shadow-parts/demo.html
+++ b/static/usage/range/css-shadow-parts/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+
+    ion-range::part(tick) {
+      background: #a2d2ff;
+    }
+
+    ion-range::part(tick-active) {
+      background: #bde0fe;
+    }
+
+    ion-range::part(pin) {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      background: #ffafcc;
+      color: #fff;
+
+      border-radius: 50%;
+      transform: scale(1.01);
+
+      top: -20px;
+
+      min-width: 28px;
+      height: 28px;
+      transition: transform 120ms ease, background 120ms ease;
+    }
+
+    ion-range::part(pin)::before {
+      content: none;
+    }
+
+    ion-range::part(knob) {
+      background: #ffc8dd;
+    }
+
+    ion-range::part(bar) {
+      background: #a2d2ff;
+    }
+
+    ion-range::par(bar-active) {
+      background: #bde0fe;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range min="0" max="10" value="5" pin="true" ticks="true" snaps="true"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/range/css-shadow-parts/index.md
+++ b/static/usage/range/css-shadow-parts/index.md
@@ -1,0 +1,31 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_app_component_css from './angular/app_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.css': react_main_css,
+        'src/main.tsx': react_main_tsx,
+      },
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.css': angular_app_component_css,
+        'src/app/app.component.html': angular_app_component_html,
+      },
+    },
+  }}
+  src="usage/range/css-shadow-parts/demo.html"
+/>

--- a/static/usage/range/css-shadow-parts/javascript.md
+++ b/static/usage/range/css-shadow-parts/javascript.md
@@ -1,0 +1,51 @@
+```html
+<ion-app>
+  <ion-content class="ion-padding">
+    <ion-range min="0" max="10" value="5" pin="true" ticks="true" snaps="true"></ion-range>
+  </ion-content>
+</ion-app>
+
+<style>
+  ion-range::part(tick) {
+    background: #a2d2ff;
+  }
+
+  ion-range::part(tick-active) {
+    background: #bde0fe;
+  }
+
+  ion-range::part(pin) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    background: #ffafcc;
+    color: #fff;
+
+    border-radius: 50%;
+    transform: scale(1.01);
+
+    top: -20px;
+
+    min-width: 28px;
+    height: 28px;
+    transition: transform 120ms ease, background 120ms ease;
+  }
+
+  ion-range::part(pin)::before {
+    content: none;
+  }
+
+  ion-range::part(knob) {
+    background: #ffc8dd;
+  }
+
+  ion-range::part(bar) {
+    background: #a2d2ff;
+  }
+
+  ion-range::par(bar-active) {
+    background: #bde0fe;
+  }
+</style>
+```

--- a/static/usage/range/css-shadow-parts/react/main_css.md
+++ b/static/usage/range/css-shadow-parts/react/main_css.md
@@ -1,0 +1,43 @@
+```css
+ion-range::part(tick) {
+  background: #a2d2ff;
+}
+
+ion-range::part(tick-active) {
+  background: #bde0fe;
+}
+
+ion-range::part(pin) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  background: #ffafcc;
+  color: #fff;
+
+  border-radius: 50%;
+  transform: scale(1.01);
+
+  top: -20px;
+
+  min-width: 28px;
+  height: 28px;
+  transition: transform 120ms ease, background 120ms ease;
+}
+
+ion-range::part(pin)::before {
+  content: none;
+}
+
+ion-range::part(knob) {
+  background: #ffc8dd;
+}
+
+ion-range::part(bar) {
+  background: #a2d2ff;
+}
+
+ion-range::par(bar-active) {
+  background: #bde0fe;
+}
+```

--- a/static/usage/range/css-shadow-parts/react/main_tsx.md
+++ b/static/usage/range/css-shadow-parts/react/main_tsx.md
@@ -1,0 +1,16 @@
+```tsx
+import React from 'react';
+import { IonContent, IonRange } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonContent className="ion-padding">
+      <IonRange min={0} max={10} value={5} pin={true} ticks={true} snaps={true}></IonRange>
+    </IonContent>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/range/css-shadow-parts/vue.md
+++ b/static/usage/range/css-shadow-parts/vue.md
@@ -1,0 +1,60 @@
+```html
+<style>
+  ion-range::part(tick) {
+    background: #a2d2ff;
+  }
+
+  ion-range::part(tick-active) {
+    background: #bde0fe;
+  }
+
+  ion-range::part(pin) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    background: #ffafcc;
+    color: #fff;
+
+    border-radius: 50%;
+    transform: scale(1.01);
+
+    top: -20px;
+
+    min-width: 28px;
+    height: 28px;
+    transition: transform 120ms ease, background 120ms ease;
+  }
+
+  ion-range::part(pin)::before {
+    content: none;
+  }
+
+  ion-range::part(knob) {
+    background: #ffc8dd;
+  }
+
+  ion-range::part(bar) {
+    background: #a2d2ff;
+  }
+
+  ion-range::par(bar-active) {
+    background: #bde0fe;
+  }
+</style>
+
+<template>
+  <ion-content class="ion-padding">
+    <ion-range :min="0" :max="10" :value="5" :pin="true" :ticks="true" :snaps="true"></ion-range>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonRange },
+  });
+</script>
+```

--- a/static/usage/range/css-variables/angular/app_component_css.md
+++ b/static/usage/range/css-variables/angular/app_component_css.md
@@ -1,0 +1,12 @@
+```css
+ion-range {
+  --bar-background: #a2d2ff;
+  --bar-background-active: #bde0fe;
+  --bar-height: 8px;
+  --bar-border-radius: 8px;
+  --knob-background: #ffc8dd;
+  --knob-size: 40px;
+  --pin-background: #ffafcc;
+  --pin-color: #fff;
+}
+```

--- a/static/usage/range/css-variables/angular/app_component_html.md
+++ b/static/usage/range/css-variables/angular/app_component_html.md
@@ -1,0 +1,5 @@
+```html
+<ion-content class="ion-padding">
+  <ion-range [value]="50" [pin]="true"></ion-range>
+</ion-content>
+```

--- a/static/usage/range/css-variables/demo.html
+++ b/static/usage/range/css-variables/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      --bar-background: #a2d2ff;
+      --bar-background-active: #bde0fe;
+      --bar-height: 8px;
+      --bar-border-radius: 8px;
+      --knob-background: #ffc8dd;
+      --knob-size: 40px;
+      --pin-background: #ffafcc;
+      --pin-color: #fff;
+
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range value="50" pin="true"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/range/css-variables/index.md
+++ b/static/usage/range/css-variables/index.md
@@ -1,0 +1,31 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_app_component_css from './angular/app_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.css': react_main_css,
+        'src/main.tsx': react_main_tsx,
+      },
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.css': angular_app_component_css,
+        'src/app/app.component.html': angular_app_component_html,
+      },
+    },
+  }}
+  src="usage/range/css-variables/demo.html"
+/>

--- a/static/usage/range/css-variables/javascript.md
+++ b/static/usage/range/css-variables/javascript.md
@@ -1,0 +1,20 @@
+```html
+<ion-app>
+  <ion-content class="ion-padding">
+    <ion-range value="50" pin="true"></ion-range>
+  </ion-content>
+</ion-app>
+
+<style>
+  ion-range {
+    --bar-background: #a2d2ff;
+    --bar-background-active: #bde0fe;
+    --bar-height: 8px;
+    --bar-border-radius: 8px;
+    --knob-background: #ffc8dd;
+    --knob-size: 40px;
+    --pin-background: #ffafcc;
+    --pin-color: #fff;
+  }
+</style>
+```

--- a/static/usage/range/css-variables/react/main_css.md
+++ b/static/usage/range/css-variables/react/main_css.md
@@ -1,0 +1,12 @@
+```css
+ion-range {
+  --bar-background: #a2d2ff;
+  --bar-background-active: #bde0fe;
+  --bar-height: 8px;
+  --bar-border-radius: 8px;
+  --knob-background: #ffc8dd;
+  --knob-size: 40px;
+  --pin-background: #ffafcc;
+  --pin-color: #fff;
+}
+```

--- a/static/usage/range/css-variables/react/main_tsx.md
+++ b/static/usage/range/css-variables/react/main_tsx.md
@@ -1,0 +1,15 @@
+```tsx
+import React from 'react';
+import { IonContent, IonRange } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonContent className="ion-padding">
+      <IonRange value={50} pin={true}></IonRange>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/css-variables/vue.md
+++ b/static/usage/range/css-variables/vue.md
@@ -1,0 +1,29 @@
+```html
+<style>
+  ion-range {
+    --bar-background: #a2d2ff;
+    --bar-background-active: #bde0fe;
+    --bar-height: 8px;
+    --bar-border-radius: 8px;
+    --knob-background: #ffc8dd;
+    --knob-size: 40px;
+    --pin-background: #ffafcc;
+    --pin-color: #fff;
+  }
+</style>
+
+<template>
+  <ion-content class="ion-padding">
+    <ion-range :value="50" :pin="true"></ion-range>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonRange },
+  });
+</script>
+```

--- a/static/usage/range/dual-knobs/angular.md
+++ b/static/usage/range/dual-knobs/angular.md
@@ -1,0 +1,5 @@
+```html
+<ion-content>
+  <ion-range [dualKnobs]="true" [value]="{ lower: 20, upper: 80 }"></ion-range>
+</ion-content>
+```

--- a/static/usage/range/dual-knobs/demo.html
+++ b/static/usage/range/dual-knobs/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range dual-knobs="true"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+  <script>
+    const range = document.querySelector('ion-range');
+    range.value = {
+      lower: 20,
+      upper: 80
+    };
+  </script>
+</body>
+
+</html>

--- a/static/usage/range/dual-knobs/index.md
+++ b/static/usage/range/dual-knobs/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/range/dual-knobs/demo.html" />

--- a/static/usage/range/dual-knobs/javascript.md
+++ b/static/usage/range/dual-knobs/javascript.md
@@ -1,0 +1,15 @@
+```html
+<ion-app>
+  <ion-content>
+    <ion-range dual-knobs="true"></ion-range>
+  </ion-content>
+</ion-app>
+
+<script>
+  const range = document.querySelector('ion-range');
+  range.value = {
+    lower: 20,
+    upper: 80,
+  };
+</script>
+```

--- a/static/usage/range/dual-knobs/react.md
+++ b/static/usage/range/dual-knobs/react.md
@@ -1,0 +1,18 @@
+```tsx
+import React from 'react';
+import { IonContent, IonRange } from '@ionic/react';
+function Example() {
+  return (
+    <IonContent>
+      <IonRange
+        dualKnobs={true}
+        value={{
+          lower: 20,
+          upper: 80,
+        }}
+      ></IonRange>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/dual-knobs/vue.md
+++ b/static/usage/range/dual-knobs/vue.md
@@ -1,0 +1,16 @@
+```html
+<template>
+  <ion-content>
+    <ion-range :dual-knobs="true" :value="{ lower: 20, upper: 80 }"></ion-range>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonRange },
+  });
+</script>
+```

--- a/static/usage/range/ion-change-event/angular/app_component_html.md
+++ b/static/usage/range/ion-change-event/angular/app_component_html.md
@@ -1,0 +1,6 @@
+```html
+<ion-content>
+  <ion-range (ionChange)="onIonChange($event)"></ion-range>
+  <ion-label>ionChange emitted value: {{ lastEmittedValue }}</ion-label>
+</ion-content>
+```

--- a/static/usage/range/ion-change-event/angular/app_component_ts.md
+++ b/static/usage/range/ion-change-event/angular/app_component_ts.md
@@ -1,0 +1,19 @@
+```ts
+import { Component } from '@angular/core';
+
+import { RangeCustomEvent } from '@ionic/angular';
+import { RangeValue } from '@ionic/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css'],
+})
+export class AppComponent {
+  lastEmittedValue: RangeValue;
+
+  onIonChange(ev: Event) {
+    this.lastEmittedValue = (ev as RangeCustomEvent).detail.value;
+  }
+}
+```

--- a/static/usage/range/ion-change-event/demo.html
+++ b/static/usage/range/ion-change-event/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    .demo {
+      max-width: 320px;
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div class="demo">
+          <ion-range></ion-range>
+          <ion-label>ionChange emitted value: <span id="lastValue"></span></ion-label>
+        </div>
+    </ion-content>
+  </ion-app>
+  <script>
+    const range = document.querySelector('ion-range');
+    const lastValue = document.querySelector('#lastValue');
+
+    range.addEventListener('ionChange', ({ detail }) => {
+      lastValue.innerHTML = detail.value;
+    });
+  </script>
+</body>
+
+</html>

--- a/static/usage/range/ion-change-event/index.md
+++ b/static/usage/range/ion-change-event/index.md
@@ -1,0 +1,23 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_app_component_ts from './angular/app_component_ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+      },
+    },
+  }}
+  src="usage/range/ion-change-event/demo.html"
+/>

--- a/static/usage/range/ion-change-event/javascript.md
+++ b/static/usage/range/ion-change-event/javascript.md
@@ -1,0 +1,17 @@
+```html
+<ion-app>
+  <ion-content>
+    <ion-range></ion-range>
+    <ion-label>ionChange emitted value: <span id="lastValue"></span></ion-label>
+  </ion-content>
+</ion-app>
+
+<script>
+  const range = document.querySelector('ion-range');
+  const lastEmittedValue = document.querySelector('#lastValue');
+
+  range.addEventListener('ionChange', ({ detail }) => {
+    lastEmittedValue.innerHTML = detail.value;
+  });
+</script>
+```

--- a/static/usage/range/ion-change-event/react.md
+++ b/static/usage/range/ion-change-event/react.md
@@ -1,0 +1,15 @@
+```tsx
+import React, { useState } from 'react';
+import { IonContent, IonLabel, IonRange } from '@ionic/react';
+import { RangeValue } from '@ionic/core';
+function Example() {
+  const [lastEmittedValue, setLastEmittedValue] = useState<RangeValue>();
+  return (
+    <IonContent>
+      <IonRange onIonChange={({ detail }) => setLastEmittedValue(detail.value)}></IonRange>
+      <IonLabel>ionChange emitted value: {lastEmittedValue as number}</IonLabel>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/ion-change-event/vue.md
+++ b/static/usage/range/ion-change-event/vue.md
@@ -1,0 +1,27 @@
+```html
+<template>
+  <ion-content>
+    <ion-range @ionChange="onIonChange"></ion-range>
+    <ion-label>ionChange emitted value: {{lastEmittedValue}}</ion-label>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonLabel, IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonLabel, IonRange },
+    data() {
+      return {
+        lastEmittedValue: '',
+      };
+    },
+    methods: {
+      onIonChange({ detail }) {
+        this.lastEmittedValue = detail.value;
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/range/ion-knob-move-event/angular/app_component_html.md
+++ b/static/usage/range/ion-knob-move-event/angular/app_component_html.md
@@ -1,0 +1,11 @@
+```html
+<ion-content>
+  <ion-range (ionKnobMoveStart)="onIonKnobMoveStart($event)" (ionKnobMoveEnd)="onIonKnobMoveEnd($event)"></ion-range>
+  <div>
+    <ion-label>ionKnobMoveStart: {{ moveStart }}</ion-label>
+  </div>
+  <div>
+    <ion-label>ionKnobMoveEnd: {{ moveEnd }}</ion-label>
+  </div>
+</ion-content>
+```

--- a/static/usage/range/ion-knob-move-event/angular/app_component_ts.md
+++ b/static/usage/range/ion-knob-move-event/angular/app_component_ts.md
@@ -1,0 +1,24 @@
+```ts
+import { Component } from '@angular/core';
+
+import { RangeCustomEvent } from '@ionic/angular';
+import { RangeValue } from '@ionic/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css'],
+})
+export class AppComponent {
+  moveStart: RangeValue;
+  moveEnd: RangeValue;
+
+  onIonKnobMoveStart(ev: Event) {
+    this.moveStart = (ev as RangeCustomEvent).detail.value;
+  }
+
+  onIonKnobMoveEnd(ev: Event) {
+    this.moveEnd = (ev as RangeCustomEvent).detail.value;
+  }
+}
+```

--- a/static/usage/range/ion-knob-move-event/demo.html
+++ b/static/usage/range/ion-knob-move-event/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    .demo {
+      max-width: 320px;
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div class="demo">
+          <ion-range></ion-range>
+          <div>
+            <ion-label>ionKnobMoveStart: <span id="moveStart"></span></ion-label>
+          </div>
+          <div>
+            <ion-label>ionKnobMoveEnd: <span id="moveEnd"></span></ion-label>
+          </div>
+        </div>
+    </ion-content>
+  </ion-app>
+  <script>
+    const range = document.querySelector('ion-range');
+    const moveStart = document.querySelector('#moveStart');
+    const moveEnd = document.querySelector('#moveEnd');
+
+    range.addEventListener('ionKnobMoveStart', ({ detail }) => {
+      moveStart.innerHTML = detail.value;
+    });
+
+    range.addEventListener('ionKnobMoveEnd', ({ detail }) => {
+      moveEnd.innerHTML = detail.value;
+    });
+  </script>
+</body>
+
+</html>

--- a/static/usage/range/ion-knob-move-event/index.md
+++ b/static/usage/range/ion-knob-move-event/index.md
@@ -1,0 +1,23 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_app_component_html from './angular/app_component_html.md';
+import angular_app_component_ts from './angular/app_component_ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+      },
+    },
+  }}
+  src="usage/range/ion-knob-move-event/demo.html"
+/>

--- a/static/usage/range/ion-knob-move-event/javascript.md
+++ b/static/usage/range/ion-knob-move-event/javascript.md
@@ -1,0 +1,27 @@
+```html
+<ion-app>
+  <ion-content>
+    <ion-range></ion-range>
+    <div>
+      <ion-label>ionKnobMoveStart: <span id="moveStart"></span></ion-label>
+    </div>
+    <div>
+      <ion-label>ionKnobMoveEnd: <span id="moveEnd"></span></ion-label>
+    </div>
+  </ion-content>
+</ion-app>
+
+<script>
+  const range = document.querySelector('ion-range');
+  const moveStart = document.querySelector('#moveStart');
+  const moveEnd = document.querySelector('#moveEnd');
+
+  range.addEventListener('ionKnobMoveStart', ({ detail }) => {
+    moveStart.innerHTML = detail.value;
+  });
+
+  range.addEventListener('ionKnobMoveEnd', ({ detail }) => {
+    moveEnd.innerHTML = detail.value;
+  });
+</script>
+```

--- a/static/usage/range/ion-knob-move-event/react.md
+++ b/static/usage/range/ion-knob-move-event/react.md
@@ -1,0 +1,24 @@
+```tsx
+import React, { useState } from 'react';
+import { IonContent, IonLabel, IonRange } from '@ionic/react';
+import { RangeValue } from '@ionic/core';
+function Example() {
+  const [moveStartValue, setMoveStartValue] = useState<RangeValue>();
+  const [moveEndValue, setMoveEndValue] = useState<RangeValue>();
+  return (
+    <IonContent>
+      <IonRange
+        onIonKnobMoveStart={({ detail }) => setMoveStartValue(detail.value)}
+        onIonKnobMoveEnd={({ detail }) => setMoveEndValue(detail.value)}
+      ></IonRange>
+      <div>
+        <IonLabel>ionKnobMoveStart: {moveStartValue as number}</IonLabel>
+      </div>
+      <div>
+        <IonLabel>ionKnobMoveEnd: {moveEndValue as number}</IonLabel>
+      </div>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/ion-knob-move-event/vue.md
+++ b/static/usage/range/ion-knob-move-event/vue.md
@@ -1,0 +1,36 @@
+```html
+<template>
+  <ion-content>
+    <ion-range @ionKnobMoveStart="onIonKnobMoveStart" @ionKnobMoveEnd="onIonKnobMoveEnd"></ion-range>
+    <div>
+      <ion-label>ionKnobMoveStart: {{moveStart}}</ion-label>
+    </div>
+    <div>
+      <ion-label>onIonKnobMoveEnd: {{moveEnd}}</ion-label>
+    </div>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonLabel, IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonLabel, IonRange },
+    data() {
+      return {
+        moveStart: '',
+        moveEnd: '',
+      };
+    },
+    methods: {
+      onIonKnobMoveStart({ detail }) {
+        this.moveStart = detail.value;
+      },
+      onIonKnobMoveEnd({ detail }) {
+        this.moveEnd = detail.value;
+      },
+    },
+  });
+</script>
+```

--- a/static/usage/range/pins/angular/app_component_html.md
+++ b/static/usage/range/pins/angular/app_component_html.md
@@ -1,0 +1,5 @@
+```html
+<ion-content>
+  <ion-range [pin]="true" [pinFormatter]="pinFormatter"></ion-range>
+</ion-content>
+```

--- a/static/usage/range/pins/angular/app_component_ts.md
+++ b/static/usage/range/pins/angular/app_component_ts.md
@@ -1,0 +1,14 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.css'],
+})
+export class AppComponent {
+  pinFormatter(value: number) {
+    return `${value}%`;
+  }
+}
+```

--- a/static/usage/range/pins/demo.html
+++ b/static/usage/range/pins/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range pin="true"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+  <script>
+    const range = document.querySelector('ion-range');
+    range.pinFormatter = (value) => {
+      return `${value}%`;
+    };
+  </script>
+</body>
+
+</html>

--- a/static/usage/range/pins/index.md
+++ b/static/usage/range/pins/index.md
@@ -1,0 +1,23 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_app_component_ts from './angular/app_component_ts.md';
+import angular_app_component_html from './angular/app_component_html.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angular_app_component_html,
+        'src/app/app.component.ts': angular_app_component_ts,
+      },
+    },
+  }}
+  src="usage/range/pins/demo.html"
+/>

--- a/static/usage/range/pins/javascript.md
+++ b/static/usage/range/pins/javascript.md
@@ -1,0 +1,14 @@
+```html
+<ion-app>
+  <ion-content>
+    <ion-range pin="true"></ion-range>
+  </ion-content>
+</ion-app>
+
+<script>
+  const range = document.querySelector('ion-range');
+  range.pinFormatter = (value) => {
+    return `${value}%`;
+  };
+</script>
+```

--- a/static/usage/range/pins/react.md
+++ b/static/usage/range/pins/react.md
@@ -1,0 +1,12 @@
+```tsx
+import React from 'react';
+import { IonContent, IonRange } from '@ionic/react';
+function Example() {
+  return (
+    <IonContent>
+      <IonRange pin={true} pinFormatter={(value: number) => `${value}%`}></IonRange>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/pins/vue.md
+++ b/static/usage/range/pins/vue.md
@@ -1,0 +1,21 @@
+```html
+<template>
+  <ion-content>
+    <ion-range :pin="true" :pin-formatter="pinFormatter"></ion-range>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonRange },
+    setup() {
+      return {
+        pinFormatter: (value: number) => `${value}%`,
+      };
+    },
+  });
+</script>
+```

--- a/static/usage/range/slots/angular.md
+++ b/static/usage/range/slots/angular.md
@@ -1,0 +1,6 @@
+```html
+<ion-range>
+  <ion-icon slot="start" name="snow-outline"></ion-icon>
+  <ion-icon slot="end" name="sunny-outline"></ion-icon>
+</ion-range>
+```

--- a/static/usage/range/slots/demo.html
+++ b/static/usage/range/slots/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range>
+          <ion-icon slot="start" name="snow-outline"></ion-icon>
+          <ion-icon slot="end" name="sunny-outline"></ion-icon>
+        </ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/range/slots/index.md
+++ b/static/usage/range/slots/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/range/slots/demo.html" />

--- a/static/usage/range/slots/javascript.md
+++ b/static/usage/range/slots/javascript.md
@@ -1,0 +1,6 @@
+```html
+<ion-range>
+  <ion-icon slot="start" name="snow-outline"></ion-icon>
+  <ion-icon slot="end" name="sunny-outline"></ion-icon>
+</ion-range>
+```

--- a/static/usage/range/slots/react.md
+++ b/static/usage/range/slots/react.md
@@ -1,0 +1,15 @@
+```tsx
+import React from 'react';
+import { IonRange, IonIcon } from '@ionic/react';
+import { snowOutline, sunnyOutline } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <IonRange>
+      <IonIcon slot="start" icon={snowOutline}></IonIcon>
+      <IonIcon slot="end" icon={sunnyOutline}></IonIcon>
+    </IonRange>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/slots/vue.md
+++ b/static/usage/range/slots/vue.md
@@ -1,0 +1,24 @@
+```html
+<template>
+  <ion-range>
+    <ion-icon slot="start" :icon="snowOutline"></ion-icon>
+    <ion-icon slot="end" :icon="sunnyOutline"></ion-icon>
+  </ion-range>
+</template>
+
+<script lang="ts">
+  import { IonRange, IonIcon } from '@ionic/vue';
+  import { snowOutline, sunnyOutline } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRange, IonIcon },
+    setup() {
+      return {
+        snowOutline,
+        sunnyOutline,
+      };
+    },
+  });
+</script>
+```

--- a/static/usage/range/snapping-ticks/angular.md
+++ b/static/usage/range/snapping-ticks/angular.md
@@ -1,0 +1,5 @@
+```html
+<ion-content>
+  <ion-range [ticks]="true" [snaps]="true" [min]="0" [max]="10"></ion-range>
+</ion-content>
+```

--- a/static/usage/range/snapping-ticks/demo.html
+++ b/static/usage/range/snapping-ticks/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    ion-range {
+      max-width: 320px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-range ticks="true" snaps="true" min="0" max="10"></ion-range>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/range/snapping-ticks/index.md
+++ b/static/usage/range/snapping-ticks/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/range/snapping-ticks/demo.html" />

--- a/static/usage/range/snapping-ticks/javascript.md
+++ b/static/usage/range/snapping-ticks/javascript.md
@@ -1,0 +1,7 @@
+```html
+<ion-app>
+  <ion-content>
+    <ion-range ticks="true" snaps="true" min="0" max="10"></ion-range>
+  </ion-content>
+</ion-app>
+```

--- a/static/usage/range/snapping-ticks/react.md
+++ b/static/usage/range/snapping-ticks/react.md
@@ -1,0 +1,12 @@
+```tsx
+import React from 'react';
+import { IonContent, IonRange } from '@ionic/react';
+function Example() {
+  return (
+    <IonContent>
+      <IonRange ticks={true} snaps={true} min={0} max={10}></IonRange>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/range/snapping-ticks/vue.md
+++ b/static/usage/range/snapping-ticks/vue.md
@@ -1,0 +1,16 @@
+```html
+<template>
+  <ion-content>
+    <ion-range :ticks="true" :snaps="true" :min="0" :max="10"></ion-range>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonRange },
+  });
+</script>
+```


### PR DESCRIPTION
The complete component playground examples for `ion-range`. All previously reviewed PRs. This is just the final stamp to make sure the docs page looks good with no boilerplate/placeholder text. 