### PR TITLE
chore: Remove dollar sign from single line shell scripts

### DIFF
--- a/docs/angular/pwa.md
+++ b/docs/angular/pwa.md
@@ -19,7 +19,7 @@ The `@angular/pwa` package will automatically add a service worker and an app ma
 To add this package to the app, run:
 
 ```shell
-$ ng add @angular/pwa
+ng add @angular/pwa
 ```
 
 Once this package has been added run `ionic build --prod` and the `www` directory will be ready to deploy as a PWA.
@@ -73,7 +73,7 @@ First, if not already available, [create the project](https://console.firebase.g
 Next, in a Terminal, install the Firebase CLI:
 
 ```shell
-$ npm install -g firebase-tools
+npm install -g firebase-tools
 ```
 
 :::note
@@ -140,13 +140,13 @@ For more information about the `firebase.json` properties, see the [Firebase doc
 Next, build an optimized version of the app by running:
 
 ```shell
-$ ionic build --prod
+ionic build --prod
 ```
 
 Last, deploy the app by running:
 
 ```shell
-$ firebase deploy
+firebase deploy
 ```
 
 After this completes, the app will be live.

--- a/docs/angular/your-first-app.md
+++ b/docs/angular/your-first-app.md
@@ -60,7 +60,7 @@ To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
 :::
 
 ```shell
-$ npm install -g @ionic/cli native-run cordova-res
+npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
@@ -74,7 +74,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic Angular app that uses the “Tabs” starter template and adds Capacitor for native functionality:
 
 ```shell
-$ ionic start photo-gallery tabs --type=angular --capacitor
+ionic start photo-gallery tabs --type=angular --capacitor
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -82,7 +82,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 Next we'll need to install the necessary Capacitor plugins to make the app's native functionality work:
@@ -98,7 +98,7 @@ Some Capacitor plugins, including the Camera API, provide the web-based function
 It's a separate dependency, so install it next:
 
 ```shell
-$ npm install @ionic/pwa-elements
+npm install @ionic/pwa-elements
 ```
 
 Next, import `@ionic/pwa-elements` by editing `src/main.ts`.
@@ -117,7 +117,7 @@ That’s it! Now for the fun part - let’s see the app in action.
 Run this command next:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 And voilà! Your Ionic app is now running in a web browser. Most of your app can be built and tested right in the browser, greatly increasing development and testing speed.

--- a/docs/angular/your-first-app/2-taking-photos.md
+++ b/docs/angular/your-first-app/2-taking-photos.md
@@ -17,8 +17,8 @@ Now for the fun part - adding the ability to take photos with the device’s cam
 
 All Capacitor logic (Camera usage and other native features) will be encapsulated in a service class. Create `PhotoService` using the `ionic generate` command:
 
-```bash
-$ ionic g service services/photo
+```shell
+ionic g service services/photo
 ```
 
 Open the new `services/photo.service.ts` file, and let’s add the logic that will power the camera functionality. First, import Capacitor dependencies and get references to the Camera, Filesystem, and Storage plugins:

--- a/docs/angular/your-first-app/6-deploying-mobile.md
+++ b/docs/angular/your-first-app/6-deploying-mobile.md
@@ -20,7 +20,7 @@ Capacitor is Ionic’s official app runtime that makes it easy to deploy web app
 If you’re still running `ionic serve` in the terminal, cancel it. Complete a fresh build of your Ionic project, fixing any errors that it reports:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Next, create both the iOS and Android projects:
@@ -35,13 +35,13 @@ Both android and ios folders at the root of the project are created. These are e
 Every time you perform a build (e.g. `ionic build`) that updates your web directory (default: `www`), you'll need to copy those changes into your native projects:
 
 ```shell
-$ ionic cap copy
+ionic cap copy
 ```
 
 Note: After making updates to the native portion of the code (such as adding a new plugin), use the `sync` command:
 
 ```shell
-$ ionic cap sync
+ionic cap sync
 ```
 
 ## iOS Deployment
@@ -55,7 +55,7 @@ Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac I
 First, run the Capacitor `open` command, which opens the native iOS project in Xcode:
 
 ```shell
-$ ionic cap open ios
+ionic cap open ios
 ```
 
 In order for some native plugins to work, user permissions must be configured. In our photo gallery app, this includes the Camera plugin: iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. The permission that drives this is labeled “Privacy - Camera Usage.” To set it, the `Info.plist` file must be modified ([more details here](https://capacitor.ionicframework.com/docs/ios/configuration)). To access it, click "Info," then expand "Custom iOS Target Properties."
@@ -87,7 +87,7 @@ Capacitor Android apps are configured and managed through Android Studio. Before
 First, run the Capacitor `open` command, which opens the native Android project in Android Studio:
 
 ```shell
-$ ionic cap open android
+ionic cap open android
 ```
 
 Similar to iOS, we must enable the correct permissions to use the Camera. Configure these in the `AndroidManifest.xml` file. Android Studio will likely open this file automatically, but in case it doesn't, locate it under `android/app/src/main/`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ The Ionic command-line interface ([CLI](/docs/reference/glossary#cli)) is the go
 The Ionic CLI can be installed globally with npm:
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 ## Help

--- a/docs/cli/livereload.md
+++ b/docs/cli/livereload.md
@@ -36,7 +36,7 @@ For Android devices, the Ionic CLI will automatically forward the dev server por
 The following all-in-one command will start a live-reload server on `localhost` and deploy the app to an Android device using Cordova:
 
 ```shell
-$ ionic cordova run android -l
+ionic cordova run android -l
 ```
 
 #### iOS
@@ -52,7 +52,7 @@ In some cases, the Ionic CLI won't know the address with which to configure the 
 The following all-in-one command will start a live-reload server on **all addresses** and deploy the app to an iOS device using Cordova:
 
 ```shell
-$ ionic cordova run ios -l --external
+ionic cordova run ios -l --external
 ```
 
 :::note

--- a/docs/cli/using-a-proxy.md
+++ b/docs/cli/using-a-proxy.md
@@ -5,7 +5,7 @@ Proxy support is built-in to the Ionic CLI. Proxy settings can be configured via
 To configure proxy settings via the config file, run the following with the URL of the proxy server:
 
 ```shell
-$ ionic config set -g proxy http://proxy.example.com:8888
+ionic config set -g proxy http://proxy.example.com:8888
 ```
 
 To configure proxy settings via an environment variable, use one of the following:
@@ -23,13 +23,13 @@ Each CLI that you use must be configured separately to proxy network requests.
 #### npm
 
 ```shell
-$ npm config set proxy http://proxy.company.com:8888
+npm config set proxy http://proxy.company.com:8888
 ```
 
 #### git
 
 ```shell
-$ git config --global http.proxy http://proxy.example.com:8888
+git config --global http.proxy http://proxy.example.com:8888
 ```
 
 ### SSL Configuration

--- a/docs/deployment/app-store.md
+++ b/docs/deployment/app-store.md
@@ -27,13 +27,13 @@ To enroll in the Apple Developer Program, follow the instructions [listed here](
 If the iOS platform is not already added, be sure to add it:
 
 ```shell
-$ ionic cordova platform add ios
+ionic cordova platform add ios
 ```
 
 With the platform added, run the build command with the `--prod` flag:
 
 ```shell
-$ ionic cordova build ios --prod
+ionic cordova build ios --prod
 ```
 
 This will generate the minified code for the web portion of an app and copy it over the iOS code base.

--- a/docs/deployment/desktop-app.md
+++ b/docs/deployment/desktop-app.md
@@ -40,7 +40,7 @@ There are two hard requirements for publishing an app on the Windows app store
 `electron-windows-store` can be installed via npm:
 
 ```shell
-$ npm install -g electron-windows-store
+npm install -g electron-windows-store
 ```
 
 ### Publishing

--- a/docs/deployment/play-store.mdx
+++ b/docs/deployment/play-store.mdx
@@ -39,7 +39,7 @@ npx cap open android
 To generate a release build for Android, run the following cli command:
 
 ```shell
-$ ionic cordova build android --prod --release
+ionic cordova build android --prod --release
 ```
 
 This will generate a release build based on the settings in the `config.xml` in the `platforms/android/app/build/outputs/apk` directory of an app.
@@ -100,7 +100,7 @@ First, the unsigned APK must be signed. If a signing key has already been genera
 Generate a private key using the keytool command that comes with the Android SDK:
 
 ```shell
-$ keytool -genkey -v -keystore my-release-key.keystore -alias alias_name -keyalg RSA -keysize 2048 -validity 10000
+keytool -genkey -v -keystore my-release-key.keystore -alias alias_name -keyalg RSA -keysize 2048 -validity 10000
 ```
 
 Once that command has been ran and its prompts have been answered a file called `my-release-key.keystore` will be created in the current directory.
@@ -112,7 +112,7 @@ Save this file and keep it somewhere safe. If it is lost the Google Play Store w
 To sign the unsigned APK, run the jarsigner tool which is also included in the Android SDK:
 
 ```shell
-$ jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore my-release-key.keystore HelloWorld-release-unsigned.apk alias_name
+jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore my-release-key.keystore HelloWorld-release-unsigned.apk alias_name
 ```
 
 Finally, the zip align tool must be ran to optimize the APK.
@@ -120,7 +120,7 @@ The `zipalign` tool can be found in `/path/to/Android/sdk/build-tools/VERSION/zi
 For example, on macOS with Android Studio installed, `zipalign` is in `~/Library/Android/sdk/build-tools/VERSION/zipalign`:
 
 ```shell
-$ zipalign -v 4 HelloWorld-release-unsigned.apk HelloWorld.apk
+zipalign -v 4 HelloWorld-release-unsigned.apk HelloWorld.apk
 ```
 
 This generates a final release binary called HelloWorld.apk that can be accepted into the Google Play Store.

--- a/docs/developer-resources/guides/first-app-v3/creating-photo-gallery-device-storage.md
+++ b/docs/developer-resources/guides/first-app-v3/creating-photo-gallery-device-storage.md
@@ -7,7 +7,7 @@ Last time, we successfully added the Camera plugin to the About page of our Tabs
 From a terminal window, navigate to your Ionic project and run:
 
 ```shell
-$ ionic g provider PhotoProvider
+ionic g provider PhotoProvider
 ```
 
 This creates a PhotoProvider class in a dedicated providers/photo folder:
@@ -114,13 +114,13 @@ Having a working photo gallery is pretty cool, but you’ll likely notice that w
 The Storage plugin works perfectly for our base64 image data. To begin, add the SQLite plugin for native:
 
 ```shell
-$ ionic cordova plugin add cordova-sqlite-storage
+ionic cordova plugin add cordova-sqlite-storage
 ```
 
 Next, add the JavaScript library for the web:
 
 ```shell
-$ npm install --save @ionic/storage
+npm install --save @ionic/storage
 ```
 
 Last, import the Storage module and add it to the imports list in `app.module.ts`:

--- a/docs/developer-resources/guides/first-app-v3/intro.md
+++ b/docs/developer-resources/guides/first-app-v3/intro.md
@@ -15,7 +15,7 @@ If you don’t have Node.js installed already, [download the LTS version](https:
 Run the following in the command line (you may need to prepend “sudo” on a Mac):
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 ## Create an App
@@ -23,7 +23,7 @@ $ npm install -g @ionic/cli
 Next, create an Ionic app using our “Tabs” app template:
 
 ```shell
-$ ionic start photo-gallery tabs
+ionic start photo-gallery tabs
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!

--- a/docs/developer-resources/guides/first-app-v3/ios-android-camera.md
+++ b/docs/developer-resources/guides/first-app-v3/ios-android-camera.md
@@ -14,7 +14,7 @@ The Ionic DevApp is a free app that makes it easy to run your Ionic app directly
 Afterwards, open a terminal and navigate to your Ionic project. Execute the following:
 
 ```shell
-$ ionic serve -c
+ionic serve -c
 ```
 
 In DevApp, you should now see the app appear. If it doesn't, or you have any issues throughout creating this app, [see here](https://ionicframework.com/docs/pro/devapp/).
@@ -42,7 +42,7 @@ Save the file and watch - a camera button appears! Tap on it and notice that it 
 In order to use the Camera, we need to bring in its JavaScript and native library dependencies. Back over in your Terminal window, run the following command, which adds the JavaScript library to the project, thus exposing the Camera API in TypeScript code:
 
 ```shell
-$ npm install --save @awesome-cordova-plugins/camera
+npm install --save @awesome-cordova-plugins/camera
 ```
 
 In `package.json`, you’ll notice a new JavaScript dependency has been added:
@@ -52,7 +52,7 @@ In `package.json`, you’ll notice a new JavaScript dependency has been added:
 Next, run this command to add the native iOS and Android code, effectively allowing the Camera to work on a mobile device:
 
 ```shell
-$ ionic cordova plugin add cordova-plugin-camera
+ionic cordova plugin add cordova-plugin-camera
 ```
 
 In `config.xml`, a new plugin entry is created:

--- a/docs/developer-resources/guides/first-app-v3/realtime-updates-ionic-deploy.md
+++ b/docs/developer-resources/guides/first-app-v3/realtime-updates-ionic-deploy.md
@@ -5,7 +5,7 @@ As you’ve seen so far, building web and mobile apps is quick and easy with the
 Setting it up is quick and easy. For reference, continue to refer to [the part 3 folder](https://github.com/ionic-team/photo-gallery-tutorial-ionic3/tree/master/part3) on GitHub. First, install the Appflow JavaScript library:
 
 ```shell
-$ npm install @ionic/pro@latest --save
+npm install @ionic/pro@latest --save
 ```
 
 Then, add the Appflow plugin. Here’s the command to install it:

--- a/docs/developer-resources/guides/first-app-v3/track-bugs-ionic-monitoring.md
+++ b/docs/developer-resources/guides/first-app-v3/track-bugs-ionic-monitoring.md
@@ -64,13 +64,13 @@ Last, we need to need to create a Source Map for your app. This file makes it ea
 Sync the current version of the app by running the following:
 
 ```shell
-$ ionic monitoring syncmaps
+ionic monitoring syncmaps
 ```
 
 With our intentional error in place, let’s try it out to see what happens. Run your app locally:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 Tap on the Gallery tab, then the camera button. A runtime error should occur. In a browser, head over to the [Appflow dashboard](https://dashboard.ionicframework.com), then Monitor -> Monitoring. After a few minutes, the error should appear:

--- a/docs/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
+++ b/docs/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
@@ -9,7 +9,7 @@ Last time, we successfully added the Camera plugin to the Tab2 page of our Tabs 
 From a terminal window, navigate to your Ionic project and run:
 
 ```shell
-$ ionic g service services/Photo
+ionic g service services/Photo
 ```
 
 This creates a PhotoService class in a dedicated "services" folder:
@@ -110,13 +110,13 @@ Having a working photo gallery is pretty cool, but you’ll likely notice that w
 The Storage plugin works perfectly for our base64 image data. To begin, add the SQLite plugin for native:
 
 ```shell
-$ ionic cordova plugin add cordova-sqlite-storage
+ionic cordova plugin add cordova-sqlite-storage
 ```
 
 Next, add the JavaScript library for the web:
 
 ```shell
-$ npm install --save @ionic/storage
+npm install --save @ionic/storage
 ```
 
 Last, import the Storage module and add it to the imports list in `app.module.ts`:

--- a/docs/developer-resources/guides/first-app-v4/intro.md
+++ b/docs/developer-resources/guides/first-app-v4/intro.md
@@ -24,7 +24,7 @@ Download/install these right away to ensure an optimal Ionic development experie
 Run the following in the command line:
 
 ```shell
-$ npm install -g @ionic/cli cordova
+npm install -g @ionic/cli cordova
 ```
 
 :::note
@@ -38,7 +38,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic Angular app using our “Tabs” app template:
 
 ```shell
-$ ionic start photo-gallery tabs
+ionic start photo-gallery tabs
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -46,7 +46,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 That’s it! Now for the fun part - let’s see the app in action.

--- a/docs/developer-resources/guides/first-app-v4/ios-android-camera.md
+++ b/docs/developer-resources/guides/first-app-v4/ios-android-camera.md
@@ -38,7 +38,7 @@ Save the file and watch - a camera button appears! Tap on it and notice that it 
 In order to use the Camera, we need to bring in its JavaScript and native library dependencies. Back over in your Terminal window, run the following command, which adds the JavaScript library to the project, thus exposing the Camera API in TypeScript code:
 
 ```shell
-$ npm install @awesome-cordova-plugins/camera
+npm install @awesome-cordova-plugins/camera
 ```
 
 In `package.json`, you’ll notice a new JavaScript dependency has been added, with a version number similar to the following:
@@ -48,7 +48,7 @@ In `package.json`, you’ll notice a new JavaScript dependency has been added, w
 Next, run this command to add the native iOS and Android code, effectively allowing the Camera to work on a mobile device. For more info on how this works, read up on [Cordova](https://cordova.apache.org/docs/en/latest/guide/overview/) and [Ionic Native](https://ionicframework.com/docs/native).
 
 ```shell
-$ ionic cordova plugin add cordova-plugin-camera
+ionic cordova plugin add cordova-plugin-camera
 ```
 
 The `config.xml` file is now updated with an entry similar to the following for the native camera code:

--- a/docs/developing/android.md
+++ b/docs/developing/android.md
@@ -93,7 +93,7 @@ Actual Android hardware can also be used for Ionic app development. But first, t
 Verify the connection works by connecting the device to the computer with a USB cable and using the following command:
 
 ```shell
-$ adb devices
+adb devices
 ```
 
 The device should be listed. See the full <a href="https://developer.android.com/studio/command-line/adb" target="_blank">`adb` documentation</a> for troubleshooting and detailed information.
@@ -166,7 +166,7 @@ Capacitor uses Android Studio to build and run apps to simulators and devices.
 To start a live-reload server run the following command.
 
 ```shell
-$ ionic capacitor run android -l --host=YOUR_IP_ADDRESS
+ionic capacitor run android -l --host=YOUR_IP_ADDRESS
 ```
 
 When running on a device make sure the device and your development machine are connected to the same network.
@@ -178,7 +178,7 @@ The Ionic CLI can build, copy, and deploy Ionic apps to Android simulators and d
 Run the following to start a long-running CLI process that boots up a live-reload server:
 
 ```shell
-$ ionic cordova run android -l
+ionic cordova run android -l
 ```
 
 Now, when changes are made to the app's source files, web assets are rebuilt and the changes are reflected on the simulator or device without having to deploy again.
@@ -210,5 +210,5 @@ If the **Logcat** window is hidden, you can enable it in **View** &raquo; **Tool
 You can also access **Logcat** with [ADB](https://developer.android.com/studio/command-line/adb).
 
 ```shell
-$ adb logcat
+adb logcat
 ```

--- a/docs/developing/ios.md
+++ b/docs/developing/ios.md
@@ -28,7 +28,7 @@ The Xcode approach is generally more stable, but the Ionic CLI approach offers [
 Once Xcode is installed, make sure the command-line tools are selected for use:
 
 ```shell
-$ xcode-select --install
+xcode-select --install
 ```
 
 ### Setting up a Development Team
@@ -143,7 +143,7 @@ Capacitor does not yet have a way to build native projects. It relies on Xcode t
 Run the following, then select a target simulator or device and click the play button in Xcode:
 
 ```shell
-$ ionic capacitor run ios -l --external
+ionic capacitor run ios -l --external
 ```
 
 ### Live-reload with Cordova
@@ -153,7 +153,7 @@ Cordova can build and deploy native projects programmatically.
 To boot up a live-reload server, build, and deploy the app, run the following:
 
 ```shell
-$ ionic cordova run ios -l --external
+ionic cordova run ios -l --external
 ```
 
 ## Debugging iOS Apps

--- a/docs/developing/tips.md
+++ b/docs/developing/tips.md
@@ -79,13 +79,13 @@ Since these global directories are no longer owned by `root`, packages can be in
 To update an [npm](https://www.npmjs.com/) dependency, run the following, where `<package-name>` is the package to update:
 
 ```shell
-$ npm install <package-name>@<version|latest> --save
+npm install <package-name>@<version|latest> --save
 ```
 
 For example, to update the `@ionic/angular` package to the release tagged `latest`, run:
 
 ```shell
-$ npm install @ionic/angular@latest --save
+npm install @ionic/angular@latest --save
 ```
 
 It is recommended that packages get updated through the CLI since npm will now read package versions from the `package-lock.json` first.
@@ -134,7 +134,7 @@ Before it can be used, [Xcode](https://developer.apple.com/xcode/download/), App
 The [Ionic CLI](../cli.md) can then be used to run the app in the current directory on the simulator:
 
 ```shell
-$ ionic cordova emulate ios -lc
+ionic cordova emulate ios -lc
 ```
 
 Passing in the `-lc` flag will enable livereload and log console output to a terminal.

--- a/docs/intro/cdn.md
+++ b/docs/intro/cdn.md
@@ -36,7 +36,7 @@ This does not install Angular or any other frameworks. This allows use of the Io
 When using Ionic Framework in an Angular project, install the latest `@ionic/angular` package from [npm](../reference/glossary.md#npm). This comes with all of the Ionic Framework components and Angular specific services and features.
 
 ```shell
-$ npm install @ionic/angular@latest --save
+npm install @ionic/angular@latest --save
 ```
 
 Each time there is a new Ionic Framework release, this [version](../reference/versioning.md) will need to be updated to get the latest features and fixes. The version can be [updated using npm](../developing/tips.md#updating-dependencies), as well.
@@ -44,7 +44,7 @@ Each time there is a new Ionic Framework release, this [version](../reference/ve
 For adding Ionic to an already existing Angular project, use the Angular CLI's `ng add` feature.
 
 ```shell
-$ ng add @ionic/angular
+ng add @ionic/angular
 ```
 
 This will add the necessary imports to the `@ionic/angular` package as well as add the styles needed.
@@ -85,7 +85,7 @@ import '@ionic/react/css/display.css';
 To add Ionic Framework to an existing Vue project, install the `@ionic/vue` and `@ionic/vue-router` packages.
 
 ```shell
-$ npm install @ionic/vue @ionic/vue-router
+npm install @ionic/vue @ionic/vue-router
 ```
 
 After that, you will need to install the `IonicVue` plugin in your Vue app.

--- a/docs/intro/cli.md
+++ b/docs/intro/cli.md
@@ -24,7 +24,7 @@ Before proceeding, make sure your computer has [Node.js](../reference/glossary.m
 Install the Ionic CLI with npm:
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 If there was a previous installation of the Ionic CLI, it will need to be uninstalled due to a change in package name.
@@ -45,7 +45,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Create an Ionic app using one of the pre-made app templates, or a blank one to start fresh. The three most common starters are the `blank` starter, `tabs` starter, and `sidemenu` starter. Get started with the `ionic start` command:
 
 ```shell
-$ ionic start
+ionic start
 ```
 
 ![start app thumbnails](/img/installation/start-app-thumbnails.png)

--- a/docs/intro/environment.md
+++ b/docs/intro/environment.md
@@ -59,7 +59,7 @@ Otherwise, follow the [official installation instructions](https://git-scm.com/b
 To verify the installation, open a new terminal window and run:
 
 ```shell
-$ git --version
+git --version
 ```
 
 ### Git GUI

--- a/docs/native-faq.md
+++ b/docs/native-faq.md
@@ -23,7 +23,7 @@ $ ionic cordova plugin add cordova-plugin-camera
 To ensure that the same version of a plugin is always installed via `npm install`, specify the version number:
 
 ```shell
-$ ionic cordova plugin add cordova-plugin-camera@4.3.2
+ionic cordova plugin add cordova-plugin-camera@4.3.2
 ```
 
 **4) Restore Cordova in an existing Ionic project**

--- a/docs/react/overview.md
+++ b/docs/react/overview.md
@@ -9,13 +9,13 @@ The first official version of Ionic React is v4.11.
 First, install the Ionic CLI:
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 then run:
 
 ```shell
-$ ionic start myAppName
+ionic start myAppName
 ```
 
 The CLI will guide you through the setup process by asking a couple of questions, including the framework to use (React, of course!) and the starter code template.

--- a/docs/react/pwa.md
+++ b/docs/react/pwa.md
@@ -59,7 +59,7 @@ First, if not already available, [create the project](https://console.firebase.g
 Next, in a Terminal, install the Firebase CLI:
 
 ```shell
-$ npm install -g firebase-tools
+npm install -g firebase-tools
 ```
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -113,13 +113,13 @@ For more information about the `firebase.json` properties, see the [Firebase doc
 Next, build an optimized version of the app by running:
 
 ```shell
-$ ionic build --prod
+ionic build --prod
 ```
 
 Last, deploy the app by running:
 
 ```shell
-$ firebase deploy
+firebase deploy
 ```
 
 After this completes, the app will be live.

--- a/docs/react/your-first-app.md
+++ b/docs/react/your-first-app.md
@@ -56,7 +56,7 @@ To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
 :::
 
 ```shell
-$ npm install -g @ionic/cli native-run cordova-res
+npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
@@ -70,7 +70,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic React app that uses the “Tabs” starter template and adds Capacitor for native functionality:
 
 ```shell
-$ ionic start photo-gallery tabs --type=react --capacitor
+ionic start photo-gallery tabs --type=react --capacitor
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -78,7 +78,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 Next we'll need to install the necessary Capacitor plugins to make the app's native functionality work:
@@ -94,7 +94,7 @@ Some Capacitor plugins, including the Camera API, provide the web-based function
 It's a separate dependency, so install it next:
 
 ```shell
-$ npm install @ionic/pwa-elements
+npm install @ionic/pwa-elements
 ```
 
 After installation, open up the project in your code editor of choice.
@@ -115,7 +115,7 @@ That’s it! Now for the fun part - let’s see the app in action.
 Run this command in your shell:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 And voilà! Your Ionic app is now running in a web browser. Most of your app can be built and tested right in the browser, greatly increasing development and testing speed.

--- a/docs/react/your-first-app/6-deploying-mobile.md
+++ b/docs/react/your-first-app/6-deploying-mobile.md
@@ -13,7 +13,7 @@ Capacitor is Ionic’s official app runtime that makes it easy to deploy web app
 If you’re still running `ionic serve` in the terminal, cancel it. Complete a fresh build of the Ionic project, fixing any errors that it reports:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Next, create both the iOS and Android projects:
@@ -28,13 +28,13 @@ Both android and ios folders at the root of the project are created. These are e
 Every time you perform a build (e.g. `ionic build`) that updates your web directory (default: `build`), you'll need to copy those changes into your native projects:
 
 ```shell
-$ ionic cap copy
+ionic cap copy
 ```
 
 Note: After making updates to the native portion of the code (such as adding a new plugin), use the `sync` command:
 
 ```shell
-$ ionic cap sync
+ionic cap sync
 ```
 
 ## iOS
@@ -48,7 +48,7 @@ Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac I
 First, run the Capacitor `open` command, which opens the native iOS project in Xcode:
 
 ```shell
-$ ionic cap open ios
+ionic cap open ios
 ```
 
 In order for some native plugins to work, user permissions must be configured. In our photo gallery app, this includes the Camera plugin: iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. The permission that drives this is labeled “Privacy - Camera Usage.” To set it, the `Info.plist` file must be modified ([more details here](https://capacitor.ionicframework.com/docs/ios/configuration)). To access it, click "Info," then expand "Custom iOS Target Properties."
@@ -80,7 +80,7 @@ Capacitor Android apps are configured and managed through Android Studio. Before
 First, run the Capacitor `open` command, which opens the native Android project in Android Studio:
 
 ```shell
-$ ionic cap open android
+ionic cap open android
 ```
 
 Similar to iOS, we must enable the correct permissions to use the Camera. Configure these in the `AndroidManifest.xml` file. Android Studio will likely open this file automatically, but in case it doesn't, locate it under `android/app/src/main/`.

--- a/docs/troubleshooting/native.md
+++ b/docs/troubleshooting/native.md
@@ -81,13 +81,13 @@ Error: more than one library with package name com.google.android.gms
 This error is caused by two separate plugins trying to use different versions of the `Google Play Services`. To fix this issue make sure you are running `cordova` version `7.1.0` or higher and `cordova-android` `6.3.0` or higher. To install latest `cordova` run:
 
 ```shell
-$ npm install cordova@latest
+npm install cordova@latest
 ```
 
 and to update `cordova-android` run:
 
 ```shell
-$ cordova platform update android
+cordova platform update android
 ```
 
 Plugins that depend on `Google Play Services` can now be updated to use the same version. For example, if `pluginA` uses version 11.0 and `pluginB` uses version 15.0 they can be updated to use the same version with the following snippet in the `config.xml` file:

--- a/docs/vue/pwa.md
+++ b/docs/vue/pwa.md
@@ -122,7 +122,7 @@ First, if not already available, [create the project](https://console.firebase.g
 Next, in a Terminal, install the Firebase CLI:
 
 ```shell
-$ npm install -g firebase-tools
+npm install -g firebase-tools
 ```
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -194,13 +194,13 @@ For more information about the `firebase.json` properties, see the [Firebase doc
 Next, build an optimized version of the app by running:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Last, deploy the app by running:
 
 ```shell
-$ firebase deploy
+firebase deploy
 ```
 
 After this completes, the app will be live.

--- a/docs/vue/your-first-app.md
+++ b/docs/vue/your-first-app.md
@@ -56,7 +56,7 @@ To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
 :::
 
 ```shell
-$ npm install -g @ionic/cli@latest native-run cordova-res
+npm install -g @ionic/cli@latest native-run cordova-res
 ```
 
 :::note
@@ -70,7 +70,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic Vue app that uses the "Tabs" starter template and adds Capacitor for native functionality:
 
 ```shell
-$ ionic start photo-gallery tabs --type vue --capacitor
+ionic start photo-gallery tabs --type vue --capacitor
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -78,7 +78,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 Next we'll need to install the necessary Capacitor plugins to make the app's native functionality work:
@@ -94,7 +94,7 @@ Some Capacitor plugins, including the Camera API, provide the web-based function
 It's a separate dependency, so install it next:
 
 ```shell
-$ npm install @ionic/pwa-elements
+npm install @ionic/pwa-elements
 ```
 
 After installation, open up the project in your code editor of choice.
@@ -116,7 +116,7 @@ That’s it! Now for the fun part - let’s see the app in action.
 Run this command in your shell:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 And voilà! Your Ionic app is now running in a web browser. Most of your app can be built and tested right in the browser, greatly increasing development and testing speed.

--- a/docs/vue/your-first-app/6-deploying-mobile.md
+++ b/docs/vue/your-first-app/6-deploying-mobile.md
@@ -24,7 +24,7 @@ Capacitor is Ionic’s official app runtime that makes it easy to deploy web app
 If you’re still running `ionic serve` in the terminal, cancel it. Complete a fresh build of the Ionic project, fixing any errors that it reports:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Next, create both the iOS and Android projects:
@@ -39,13 +39,13 @@ Both android and ios folders at the root of the project are created. These are e
 Every time you perform a build (e.g. `ionic build`) that updates your web directory (default: `build`), you'll need to copy those changes into your native projects:
 
 ```shell
-$ ionic cap copy
+ionic cap copy
 ```
 
 Note: After making updates to the native portion of the code (such as adding a new plugin), use the `sync` command:
 
 ```shell
-$ ionic cap sync
+ionic cap sync
 ```
 
 ## iOS
@@ -59,7 +59,7 @@ Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac I
 First, run the Capacitor `open` command, which opens the native iOS project in Xcode:
 
 ```shell
-$ ionic cap open ios
+ionic cap open ios
 ```
 
 In order for some native plugins to work, user permissions must be configured. In our photo gallery app, this includes the Camera plugin: iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. The permission that drives this is labeled "Privacy - Camera Usage." To set it, the `Info.plist` file must be modified ([more details here](https://capacitor.ionicframework.com/docs/ios/configuration)). To access it, click "Info," then expand "Custom iOS Target Properties."
@@ -91,7 +91,7 @@ Capacitor Android apps are configured and managed through Android Studio. Before
 First, run the Capacitor `open` command, which opens the native Android project in Android Studio:
 
 ```shell
-$ ionic cap open android
+ionic cap open android
 ```
 
 Similar to iOS, we must enable the correct permissions to use the Camera. Configure these in the `AndroidManifest.xml` file. Android Studio will likely open this file automatically, but in case it doesn't, locate it under `android/app/src/main/`.

--- a/versioned_docs/version-v5/angular/pwa.md
+++ b/versioned_docs/version-v5/angular/pwa.md
@@ -12,7 +12,7 @@ The `@angular/pwa` package will automatically add a service worker and an app ma
 To add this package to the app, run:
 
 ```shell
-$ ng add @angular/pwa
+ng add @angular/pwa
 ```
 
 Once this package has been added run `ionic build --prod` and the `www` directory will be ready to deploy as a PWA.
@@ -66,7 +66,7 @@ First, if not already available, [create the project](https://console.firebase.g
 Next, in a Terminal, install the Firebase CLI:
 
 ```shell
-$ npm install -g firebase-tools
+npm install -g firebase-tools
 ```
 
 :::note
@@ -133,13 +133,13 @@ For more information about the `firebase.json` properties, see the [Firebase doc
 Next, build an optimized version of the app by running:
 
 ```shell
-$ ionic build --prod
+ionic build --prod
 ```
 
 Last, deploy the app by running:
 
 ```shell
-$ firebase deploy
+firebase deploy
 ```
 
 After this completes, the app will be live.

--- a/versioned_docs/version-v5/angular/your-first-app.md
+++ b/versioned_docs/version-v5/angular/your-first-app.md
@@ -53,7 +53,7 @@ To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
 :::
 
 ```shell
-$ npm install -g @ionic/cli native-run cordova-res
+npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
@@ -67,7 +67,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic Angular app that uses the “Tabs” starter template and adds Capacitor for native functionality:
 
 ```shell
-$ ionic start photo-gallery tabs --type=angular --capacitor
+ionic start photo-gallery tabs --type=angular --capacitor
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -75,7 +75,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 Next we'll need to install the necessary Capacitor plugins to make the app's native functionality work:
@@ -91,7 +91,7 @@ Some Capacitor plugins, including the Camera API, provide the web-based function
 It's a separate dependency, so install it next:
 
 ```shell
-$ npm install @ionic/pwa-elements
+npm install @ionic/pwa-elements
 ```
 
 Next, import `@ionic/pwa-elements` by editing `src/main.ts`.
@@ -110,7 +110,7 @@ That’s it! Now for the fun part - let’s see the app in action.
 Run this command next:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 And voilà! Your Ionic app is now running in a web browser. Most of your app can be built and tested right in the browser, greatly increasing development and testing speed.

--- a/versioned_docs/version-v5/angular/your-first-app/2-taking-photos.md
+++ b/versioned_docs/version-v5/angular/your-first-app/2-taking-photos.md
@@ -10,8 +10,8 @@ Now for the fun part - adding the ability to take photos with the device’s cam
 
 All Capacitor logic (Camera usage and other native features) will be encapsulated in a service class. Create `PhotoService` using the `ionic generate` command:
 
-```bash
-$ ionic g service services/photo
+```shell
+ionic g service services/photo
 ```
 
 Open the new `services/photo.service.ts` file, and let’s add the logic that will power the camera functionality. First, import Capacitor dependencies and get references to the Camera, Filesystem, and Storage plugins:

--- a/versioned_docs/version-v5/angular/your-first-app/6-deploying-mobile.md
+++ b/versioned_docs/version-v5/angular/your-first-app/6-deploying-mobile.md
@@ -13,7 +13,7 @@ Capacitor is Ionic’s official app runtime that makes it easy to deploy web app
 If you’re still running `ionic serve` in the terminal, cancel it. Complete a fresh build of your Ionic project, fixing any errors that it reports:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Next, create both the iOS and Android projects:
@@ -28,13 +28,13 @@ Both android and ios folders at the root of the project are created. These are e
 Every time you perform a build (e.g. `ionic build`) that updates your web directory (default: `www`), you'll need to copy those changes into your native projects:
 
 ```shell
-$ ionic cap copy
+ionic cap copy
 ```
 
 Note: After making updates to the native portion of the code (such as adding a new plugin), use the `sync` command:
 
 ```shell
-$ ionic cap sync
+ionic cap sync
 ```
 
 ## iOS Deployment
@@ -48,7 +48,7 @@ Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac I
 First, run the Capacitor `open` command, which opens the native iOS project in Xcode:
 
 ```shell
-$ ionic cap open ios
+ionic cap open ios
 ```
 
 In order for some native plugins to work, user permissions must be configured. In our photo gallery app, this includes the Camera plugin: iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. The permission that drives this is labeled “Privacy - Camera Usage.” To set it, the `Info.plist` file must be modified ([more details here](https://capacitor.ionicframework.com/docs/ios/configuration)). To access it, click "Info," then expand "Custom iOS Target Properties."
@@ -80,7 +80,7 @@ Capacitor Android apps are configured and managed through Android Studio. Before
 First, run the Capacitor `open` command, which opens the native Android project in Android Studio:
 
 ```shell
-$ ionic cap open android
+ionic cap open android
 ```
 
 Similar to iOS, we must enable the correct permissions to use the Camera. Configure these in the `AndroidManifest.xml` file. Android Studio will likely open this file automatically, but in case it doesn't, locate it under `android/app/src/main/`.

--- a/versioned_docs/version-v5/cli.md
+++ b/versioned_docs/version-v5/cli.md
@@ -13,7 +13,7 @@ The Ionic command-line interface ([CLI](/docs/reference/glossary#cli)) is the go
 The Ionic CLI can be installed globally with npm:
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 ## Help

--- a/versioned_docs/version-v5/cli/commands/build.md
+++ b/versioned_docs/version-v5/cli/commands/build.md
@@ -9,7 +9,7 @@ sidebar_label: 'build'
 Build web assets and prepare your app for any platform targets
 
 ```shell
-$ ionic build [options]
+ionic build [options]
 ```
 
 `ionic build` will perform an Ionic build, which compiles web assets and prepares them for deployment.

--- a/versioned_docs/version-v5/cli/commands/capacitor-add.md
+++ b/versioned_docs/version-v5/cli/commands/capacitor-add.md
@@ -7,7 +7,7 @@ sidebar_label: 'capacitor add'
 Add a native platform to your Ionic project
 
 ```shell
-$ ionic capacitor add [options]
+ionic capacitor add [options]
 ```
 
 `ionic capacitor add` will do the following:

--- a/versioned_docs/version-v5/cli/commands/capacitor-build.md
+++ b/versioned_docs/version-v5/cli/commands/capacitor-build.md
@@ -7,7 +7,7 @@ sidebar_label: 'capacitor build'
 Build an Ionic project for a given platform
 
 ```shell
-$ ionic capacitor build [options]
+ionic capacitor build [options]
 ```
 
 `ionic capacitor build` will do the following:

--- a/versioned_docs/version-v5/cli/commands/capacitor-copy.md
+++ b/versioned_docs/version-v5/cli/commands/capacitor-copy.md
@@ -7,7 +7,7 @@ sidebar_label: 'capacitor copy'
 Copy web assets to native platforms
 
 ```shell
-$ ionic capacitor copy [options]
+ionic capacitor copy [options]
 ```
 
 `ionic capacitor copy` will do the following:

--- a/versioned_docs/version-v5/cli/commands/capacitor-open.md
+++ b/versioned_docs/version-v5/cli/commands/capacitor-open.md
@@ -7,7 +7,7 @@ sidebar_label: 'capacitor open'
 Open the IDE for a given native platform project
 
 ```shell
-$ ionic capacitor open [options]
+ionic capacitor open [options]
 ```
 
 `ionic capacitor open` will do the following:

--- a/versioned_docs/version-v5/cli/commands/capacitor-run.md
+++ b/versioned_docs/version-v5/cli/commands/capacitor-run.md
@@ -7,7 +7,7 @@ sidebar_label: 'capacitor run'
 Run an Ionic project on a connected device
 
 ```shell
-$ ionic capacitor run [options]
+ionic capacitor run [options]
 ```
 
 `ionic capacitor run` will do the following:

--- a/versioned_docs/version-v5/cli/commands/capacitor-sync.md
+++ b/versioned_docs/version-v5/cli/commands/capacitor-sync.md
@@ -7,7 +7,7 @@ sidebar_label: 'capacitor sync'
 Sync (copy + update) an Ionic project
 
 ```shell
-$ ionic capacitor sync [options]
+ionic capacitor sync [options]
 ```
 
 `ionic capacitor sync` will do the following:

--- a/versioned_docs/version-v5/cli/commands/capacitor-update.md
+++ b/versioned_docs/version-v5/cli/commands/capacitor-update.md
@@ -7,7 +7,7 @@ sidebar_label: 'capacitor update'
 Update Capacitor native platforms, install Capacitor/Cordova plugins
 
 ```shell
-$ ionic capacitor update [options]
+ionic capacitor update [options]
 ```
 
 `ionic capacitor update` will do the following:

--- a/versioned_docs/version-v5/cli/commands/completion.md
+++ b/versioned_docs/version-v5/cli/commands/completion.md
@@ -7,7 +7,7 @@ sidebar_label: 'completion'
 Enables tab-completion for Ionic CLI commands.
 
 ```shell
-$ ionic completion [options]
+ionic completion [options]
 ```
 
 This command is experimental and only works for Z shell (zsh) and non-Windows platforms.

--- a/versioned_docs/version-v5/cli/commands/config-get.md
+++ b/versioned_docs/version-v5/cli/commands/config-get.md
@@ -7,7 +7,7 @@ sidebar_label: 'config get'
 Print config values
 
 ```shell
-$ ionic config get [options]
+ionic config get [options]
 ```
 
 This command reads and prints configuration values from the project's **./ionic.config.json** file. It can also operate on the global CLI configuration (**~/.ionic/config.json**) using the `--global` option.

--- a/versioned_docs/version-v5/cli/commands/config-set.md
+++ b/versioned_docs/version-v5/cli/commands/config-set.md
@@ -7,7 +7,7 @@ sidebar_label: 'config set'
 Set config values
 
 ```shell
-$ ionic config set [options]
+ionic config set [options]
 ```
 
 This command writes configuration values to the project's **./ionic.config.json** file. It can also operate on the global CLI configuration (**~/.ionic/config.json**) using the `--global` option.

--- a/versioned_docs/version-v5/cli/commands/config-unset.md
+++ b/versioned_docs/version-v5/cli/commands/config-unset.md
@@ -7,7 +7,7 @@ sidebar_label: 'config unset'
 Delete config values
 
 ```shell
-$ ionic config unset [options]
+ionic config unset [options]
 ```
 
 This command deletes configuration values from the project's **./ionic.config.json** file. It can also operate on the global CLI configuration (**~/.ionic/config.json**) using the `--global` option.

--- a/versioned_docs/version-v5/cli/commands/cordova-build.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-build.md
@@ -7,7 +7,7 @@ sidebar_label: 'cordova build'
 Use Cordova to build for Android and iOS platform targets
 
 ```shell
-$ ionic cordova build [options]
+ionic cordova build [options]
 ```
 
 Like running `cordova build` directly, `ionic cordova build` also builds web assets from `ionic build` and provides friendly checks for Android and iOS platforms.

--- a/versioned_docs/version-v5/cli/commands/cordova-compile.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-compile.md
@@ -7,7 +7,7 @@ sidebar_label: 'cordova compile'
 Compile native platform code
 
 ```shell
-$ ionic cordova compile [options]
+ionic cordova compile [options]
 ```
 
 Like running `cordova compile` directly, but provides friendly checks.

--- a/versioned_docs/version-v5/cli/commands/cordova-emulate.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-emulate.md
@@ -9,7 +9,7 @@ sidebar_label: 'cordova emulate'
 Emulate an Ionic project on a simulator/emulator
 
 ```shell
-$ ionic cordova emulate [options]
+ionic cordova emulate [options]
 ```
 
 Build your app and deploy it to devices and emulators using this command. Optionally specify the `--livereload` option to use the dev server from `ionic serve` for livereload functionality.

--- a/versioned_docs/version-v5/cli/commands/cordova-platform.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-platform.md
@@ -9,7 +9,7 @@ sidebar_label: 'cordova platform'
 Manage Cordova platform targets
 
 ```shell
-$ ionic cordova platform [options]
+ionic cordova platform [options]
 ```
 
 Like running `cordova platform` directly, but adds default Ionic icons and splash screen resources (during `add`) and provides friendly checks.

--- a/versioned_docs/version-v5/cli/commands/cordova-plugin.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-plugin.md
@@ -7,7 +7,7 @@ sidebar_label: 'cordova plugin'
 Manage Cordova plugins
 
 ```shell
-$ ionic cordova plugin [options]
+ionic cordova plugin [options]
 ```
 
 Like running `cordova plugin` directly, but provides friendly checks.

--- a/versioned_docs/version-v5/cli/commands/cordova-prepare.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-prepare.md
@@ -7,7 +7,7 @@ sidebar_label: 'cordova prepare'
 Copies assets to Cordova platforms, preparing them for native builds
 
 ```shell
-$ ionic cordova prepare [options]
+ionic cordova prepare [options]
 ```
 
 `ionic cordova prepare` will do the following:

--- a/versioned_docs/version-v5/cli/commands/cordova-requirements.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-requirements.md
@@ -7,7 +7,7 @@ sidebar_label: 'cordova requirements'
 Checks and print out all the requirements for platforms
 
 ```shell
-$ ionic cordova requirements [options]
+ionic cordova requirements [options]
 ```
 
 Like running `cordova requirements` directly, but provides friendly checks.

--- a/versioned_docs/version-v5/cli/commands/cordova-resources.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-resources.md
@@ -9,7 +9,7 @@ sidebar_label: 'cordova resources'
 Automatically create icon and splash screen resources
 
 ```shell
-$ ionic cordova resources [options]
+ionic cordova resources [options]
 ```
 
 Generate perfectly sized icons and splash screens from PNG source images for your Cordova platforms with this command.

--- a/versioned_docs/version-v5/cli/commands/cordova-run.md
+++ b/versioned_docs/version-v5/cli/commands/cordova-run.md
@@ -9,7 +9,7 @@ sidebar_label: 'cordova run'
 Run an Ionic project on a connected device
 
 ```shell
-$ ionic cordova run [options]
+ionic cordova run [options]
 ```
 
 Build your app and deploy it to devices and emulators using this command. Optionally specify the `--livereload` option to use the dev server from `ionic serve` for livereload functionality.

--- a/versioned_docs/version-v5/cli/commands/deploy-add.md
+++ b/versioned_docs/version-v5/cli/commands/deploy-add.md
@@ -7,7 +7,7 @@ sidebar_label: 'deploy add'
 Adds Appflow Deploy to the project
 
 ```shell
-$ ionic deploy add [options]
+ionic deploy add [options]
 ```
 
 This command adds the Appflow Deploy plugin (`cordova-plugin-ionic`) for both Capacitor and Cordova projects.

--- a/versioned_docs/version-v5/cli/commands/deploy-build.md
+++ b/versioned_docs/version-v5/cli/commands/deploy-build.md
@@ -7,7 +7,7 @@ sidebar_label: 'deploy build'
 Create a deploy build on Appflow
 
 ```shell
-$ ionic deploy build [options]
+ionic deploy build [options]
 ```
 
 This command creates a deploy build on Appflow. While the build is running, it prints the remote build log to the terminal.

--- a/versioned_docs/version-v5/cli/commands/deploy-configure.md
+++ b/versioned_docs/version-v5/cli/commands/deploy-configure.md
@@ -7,7 +7,7 @@ sidebar_label: 'deploy configure'
 Overrides Appflow Deploy configuration
 
 ```shell
-$ ionic deploy configure [options]
+ionic deploy configure [options]
 ```
 
 This command overrides configuration for the Appflow Deploy plugin (`cordova-plugin-ionic`) in Capacitor projects.

--- a/versioned_docs/version-v5/cli/commands/deploy-manifest.md
+++ b/versioned_docs/version-v5/cli/commands/deploy-manifest.md
@@ -7,5 +7,5 @@ sidebar_label: 'deploy manifest'
 Generates a manifest file for the deploy service from a built app directory
 
 ```shell
-$ ionic deploy manifest [options]
+ionic deploy manifest [options]
 ```

--- a/versioned_docs/version-v5/cli/commands/docs.md
+++ b/versioned_docs/version-v5/cli/commands/docs.md
@@ -7,7 +7,7 @@ sidebar_label: 'docs'
 Open the Ionic documentation website
 
 ```shell
-$ ionic docs [options]
+ionic docs [options]
 ```
 
 ## Advanced Options

--- a/versioned_docs/version-v5/cli/commands/doctor-check.md
+++ b/versioned_docs/version-v5/cli/commands/doctor-check.md
@@ -7,7 +7,7 @@ sidebar_label: 'doctor check'
 Check the health of your Ionic project
 
 ```shell
-$ ionic doctor check [options]
+ionic doctor check [options]
 ```
 
 This command detects and prints common issues and suggested steps to fix them.

--- a/versioned_docs/version-v5/cli/commands/doctor-list.md
+++ b/versioned_docs/version-v5/cli/commands/doctor-list.md
@@ -7,7 +7,7 @@ sidebar_label: 'doctor list'
 List all issues and their identifiers
 
 ```shell
-$ ionic doctor list [options]
+ionic doctor list [options]
 ```
 
 Issues can have various tags:

--- a/versioned_docs/version-v5/cli/commands/doctor-treat.md
+++ b/versioned_docs/version-v5/cli/commands/doctor-treat.md
@@ -7,7 +7,7 @@ sidebar_label: 'doctor treat'
 Attempt to fix issues in your Ionic project
 
 ```shell
-$ ionic doctor treat [options]
+ionic doctor treat [options]
 ```
 
 This command detects and attempts to fix common issues. Before a fix is attempted, the steps are printed and a confirmation prompt is displayed.

--- a/versioned_docs/version-v5/cli/commands/enterprise-register.md
+++ b/versioned_docs/version-v5/cli/commands/enterprise-register.md
@@ -7,7 +7,7 @@ sidebar_label: 'enterprise register'
 Register your Product Key with this app
 
 ```shell
-$ ionic enterprise register [options]
+ionic enterprise register [options]
 ```
 
 ## Options

--- a/versioned_docs/version-v5/cli/commands/generate.md
+++ b/versioned_docs/version-v5/cli/commands/generate.md
@@ -7,7 +7,7 @@ sidebar_label: 'generate'
 Create Pages, Components, & Angular Features
 
 ```shell
-$ ionic generate [options]
+ionic generate [options]
 ```
 
 Automatically create framework features with Ionic Generate. This command uses the Angular CLI to generate features such as `pages`, `components`, `directives`, `services`, and more.

--- a/versioned_docs/version-v5/cli/commands/git-remote.md
+++ b/versioned_docs/version-v5/cli/commands/git-remote.md
@@ -7,7 +7,7 @@ sidebar_label: 'git remote'
 Adds/updates the Appflow git remote to your local Ionic app
 
 ```shell
-$ ionic git remote [options]
+ionic git remote [options]
 ```
 
 This command is used by `ionic link` when Appflow is used as the git host.

--- a/versioned_docs/version-v5/cli/commands/info.md
+++ b/versioned_docs/version-v5/cli/commands/info.md
@@ -7,7 +7,7 @@ sidebar_label: 'info'
 Print project, system, and environment information
 
 ```shell
-$ ionic info [options]
+ionic info [options]
 ```
 
 This command is an easy way to share information about your setup. If applicable, be sure to run `ionic info` within your project directory to display even more information.

--- a/versioned_docs/version-v5/cli/commands/init.md
+++ b/versioned_docs/version-v5/cli/commands/init.md
@@ -7,7 +7,7 @@ sidebar_label: 'init'
 Initialize existing projects with Ionic
 
 ```shell
-$ ionic init [options]
+ionic init [options]
 ```
 
 This command will initialize an Ionic app within the current directory. Usually, this means an `ionic.config.json` file is created. If used within a multi-app project, the app is initialized in the root `ionic.config.json`.

--- a/versioned_docs/version-v5/cli/commands/integrations-disable.md
+++ b/versioned_docs/version-v5/cli/commands/integrations-disable.md
@@ -7,7 +7,7 @@ sidebar_label: 'integrations disable'
 Disable an integration
 
 ```shell
-$ ionic integrations disable [options]
+ionic integrations disable [options]
 ```
 
 Integrations, such as Cordova, can be disabled with this command.

--- a/versioned_docs/version-v5/cli/commands/integrations-enable.md
+++ b/versioned_docs/version-v5/cli/commands/integrations-enable.md
@@ -7,7 +7,7 @@ sidebar_label: 'integrations enable'
 Add & enable integrations to your app
 
 ```shell
-$ ionic integrations enable [options]
+ionic integrations enable [options]
 ```
 
 Integrations, such as Cordova, can be enabled with this command. If the integration has never been added to the project, `ionic integrations enable` will download and add the integration.

--- a/versioned_docs/version-v5/cli/commands/integrations-list.md
+++ b/versioned_docs/version-v5/cli/commands/integrations-list.md
@@ -7,7 +7,7 @@ sidebar_label: 'integrations list'
 List available and active integrations in your app
 
 ```shell
-$ ionic integrations list [options]
+ionic integrations list [options]
 ```
 
 This command will print the status of integrations in Ionic projects. Integrations can be **enabled** (added and enabled), **disabled** (added but disabled), and **not added** (never added to the project).

--- a/versioned_docs/version-v5/cli/commands/link.md
+++ b/versioned_docs/version-v5/cli/commands/link.md
@@ -7,7 +7,7 @@ sidebar_label: 'link'
 Connect local apps to Ionic
 
 ```shell
-$ ionic link [options]
+ionic link [options]
 ```
 
 Link apps on Appflow to local Ionic projects with this command.

--- a/versioned_docs/version-v5/cli/commands/login.md
+++ b/versioned_docs/version-v5/cli/commands/login.md
@@ -7,7 +7,7 @@ sidebar_label: 'login'
 Log in to Ionic
 
 ```shell
-$ ionic login [options]
+ionic login [options]
 ```
 
 Authenticate with Ionic and retrieve a user token, which is stored in the CLI config. The most secure way to log in is running `ionic login` without arguments, which will open a browser where you can submit your credentials.

--- a/versioned_docs/version-v5/cli/commands/logout.md
+++ b/versioned_docs/version-v5/cli/commands/logout.md
@@ -7,7 +7,7 @@ sidebar_label: 'logout'
 Log out of Ionic
 
 ```shell
-$ ionic logout [options]
+ionic logout [options]
 ```
 
 Remove the Ionic user token from the CLI config.

--- a/versioned_docs/version-v5/cli/commands/package-build.md
+++ b/versioned_docs/version-v5/cli/commands/package-build.md
@@ -7,7 +7,7 @@ sidebar_label: 'package build'
 Create a package build on Appflow
 
 ```shell
-$ ionic package build [options]
+ionic package build [options]
 ```
 
 This command creates a package build on Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created app package file in the current directory.

--- a/versioned_docs/version-v5/cli/commands/package-deploy.md
+++ b/versioned_docs/version-v5/cli/commands/package-deploy.md
@@ -7,7 +7,7 @@ sidebar_label: 'package deploy'
 Deploys a binary to a destination, such as an app store using Appflow
 
 ```shell
-$ ionic package deploy [options]
+ionic package deploy [options]
 ```
 
 This command deploys a binary to a destination using Appflow. While running, the remote log is printed to the terminal.
@@ -18,7 +18,7 @@ Both can be retrieved from the [Dashboard](https://dashboard.ionicframework.com)
 ## Examples
 
 ```shell
-$ ionic package deploy 123456789 "My app store destination"
+ionic package deploy 123456789 "My app store destination"
 ```
 
 ## Inputs

--- a/versioned_docs/version-v5/cli/commands/repair.md
+++ b/versioned_docs/version-v5/cli/commands/repair.md
@@ -7,7 +7,7 @@ sidebar_label: 'repair'
 Remove and recreate dependencies and generated files
 
 ```shell
-$ ionic repair [options]
+ionic repair [options]
 ```
 
 This command may be useful when obscure errors or issues are encountered. It removes and recreates dependencies of your project.

--- a/versioned_docs/version-v5/cli/commands/serve.md
+++ b/versioned_docs/version-v5/cli/commands/serve.md
@@ -7,7 +7,7 @@ sidebar_label: 'serve'
 Start a local dev server for app dev/testing
 
 ```shell
-$ ionic serve [options]
+ionic serve [options]
 ```
 
 Easily spin up a development server which launches in your browser. It watches for changes in your source files and automatically reloads with the updated build.

--- a/versioned_docs/version-v5/cli/commands/signup.md
+++ b/versioned_docs/version-v5/cli/commands/signup.md
@@ -7,7 +7,7 @@ sidebar_label: 'signup'
 Create an Ionic account
 
 ```shell
-$ ionic signup [options]
+ionic signup [options]
 ```
 
 If you are having issues signing up, please get in touch with our [Support](https://ion.link/support-request).

--- a/versioned_docs/version-v5/cli/commands/ssh-add.md
+++ b/versioned_docs/version-v5/cli/commands/ssh-add.md
@@ -7,7 +7,7 @@ sidebar_label: 'ssh add'
 Add an SSH public key to Ionic
 
 ```shell
-$ ionic ssh add [options]
+ionic ssh add [options]
 ```
 
 ## Inputs

--- a/versioned_docs/version-v5/cli/commands/ssh-delete.md
+++ b/versioned_docs/version-v5/cli/commands/ssh-delete.md
@@ -7,7 +7,7 @@ sidebar_label: 'ssh delete'
 Delete an SSH public key from Ionic
 
 ```shell
-$ ionic ssh delete [options]
+ionic ssh delete [options]
 ```
 
 ## Inputs

--- a/versioned_docs/version-v5/cli/commands/ssh-generate.md
+++ b/versioned_docs/version-v5/cli/commands/ssh-generate.md
@@ -7,7 +7,7 @@ sidebar_label: 'ssh generate'
 Generates a private and public SSH key pair
 
 ```shell
-$ ionic ssh generate [options]
+ionic ssh generate [options]
 ```
 
 ## Inputs

--- a/versioned_docs/version-v5/cli/commands/ssh-list.md
+++ b/versioned_docs/version-v5/cli/commands/ssh-list.md
@@ -7,7 +7,7 @@ sidebar_label: 'ssh list'
 List your SSH public keys on Ionic
 
 ```shell
-$ ionic ssh list [options]
+ionic ssh list [options]
 ```
 
 ## Options

--- a/versioned_docs/version-v5/cli/commands/ssh-setup.md
+++ b/versioned_docs/version-v5/cli/commands/ssh-setup.md
@@ -7,7 +7,7 @@ sidebar_label: 'ssh setup'
 Setup your Ionic SSH keys automatically
 
 ```shell
-$ ionic ssh setup [options]
+ionic ssh setup [options]
 ```
 
 This command offers a setup wizard for Ionic SSH keys using a series of prompts. For more control, see the commands available for managing SSH keys with the `ionic ssh --help` command. For an entirely manual approach, see **Personal Settings** => **SSH Keys** in the [Dashboard](https://dashboard.ionicframework.com/settings/ssh-keys).

--- a/versioned_docs/version-v5/cli/commands/ssh-use.md
+++ b/versioned_docs/version-v5/cli/commands/ssh-use.md
@@ -7,7 +7,7 @@ sidebar_label: 'ssh use'
 Set your active Ionic SSH key
 
 ```shell
-$ ionic ssh use [options]
+ionic ssh use [options]
 ```
 
 This command modifies the SSH configuration file (**~/.ssh/config**) to set an active private key for the **git.ionicjs.com** host. Read more about SSH configuration by running the `man ssh_config` command or by visiting online man [pages](https://linux.die.net/man/5/ssh_config).

--- a/versioned_docs/version-v5/cli/commands/ssl-generate.md
+++ b/versioned_docs/version-v5/cli/commands/ssl-generate.md
@@ -7,7 +7,7 @@ sidebar_label: 'ssl generate'
 Generates an SSL key & certificate
 
 ```shell
-$ ionic ssl generate [options]
+ionic ssl generate [options]
 ```
 
 Uses OpenSSL to create a self-signed certificate for **localhost** (by default).

--- a/versioned_docs/version-v5/cli/commands/start.md
+++ b/versioned_docs/version-v5/cli/commands/start.md
@@ -9,7 +9,7 @@ sidebar_label: 'start'
 Create a new project
 
 ```shell
-$ ionic start [options]
+ionic start [options]
 ```
 
 This command creates a working Ionic app. It installs dependencies for you and sets up your project.

--- a/versioned_docs/version-v5/cli/livereload.md
+++ b/versioned_docs/version-v5/cli/livereload.md
@@ -36,7 +36,7 @@ For Android devices, the Ionic CLI will automatically forward the dev server por
 The following all-in-one command will start a live-reload server on `localhost` and deploy the app to an Android device using Cordova:
 
 ```shell
-$ ionic cordova run android -l
+ionic cordova run android -l
 ```
 
 #### iOS
@@ -52,7 +52,7 @@ In some cases, the Ionic CLI won't know the address with which to configure the 
 The following all-in-one command will start a live-reload server on **all addresses** and deploy the app to an iOS device using Cordova:
 
 ```shell
-$ ionic cordova run ios -l --external
+ionic cordova run ios -l --external
 ```
 
 :::note

--- a/versioned_docs/version-v5/cli/using-a-proxy.md
+++ b/versioned_docs/version-v5/cli/using-a-proxy.md
@@ -5,7 +5,7 @@ Proxy support is built-in to the Ionic CLI. Proxy settings can be configured via
 To configure proxy settings via the config file, run the following with the URL of the proxy server:
 
 ```shell
-$ ionic config set -g proxy http://proxy.example.com:8888
+ionic config set -g proxy http://proxy.example.com:8888
 ```
 
 To configure proxy settings via an environment variable, use one of the following:
@@ -23,13 +23,13 @@ Each CLI that you use must be configured separately to proxy network requests.
 #### npm
 
 ```shell
-$ npm config set proxy http://proxy.company.com:8888
+npm config set proxy http://proxy.company.com:8888
 ```
 
 #### git
 
 ```shell
-$ git config --global http.proxy http://proxy.example.com:8888
+git config --global http.proxy http://proxy.example.com:8888
 ```
 
 ### SSL Configuration

--- a/versioned_docs/version-v5/deployment/app-store.md
+++ b/versioned_docs/version-v5/deployment/app-store.md
@@ -20,13 +20,13 @@ To enroll in the Apple Developer Program, follow the instructions [listed here](
 If the iOS platform is not already added, be sure to add it:
 
 ```shell
-$ ionic cordova platform add ios
+ionic cordova platform add ios
 ```
 
 With the platform added, run the build command with the `--prod` flag:
 
 ```shell
-$ ionic cordova build ios --prod
+ionic cordova build ios --prod
 ```
 
 This will generate the minified code for the web portion of an app and copy it over the iOS code base.

--- a/versioned_docs/version-v5/deployment/desktop-app.md
+++ b/versioned_docs/version-v5/deployment/desktop-app.md
@@ -33,7 +33,7 @@ There are two hard requirements for publishing an app on the Windows app store
 `electron-windows-store` can be installed via npm:
 
 ```shell
-$ npm install -g electron-windows-store
+npm install -g electron-windows-store
 ```
 
 ### Publishing

--- a/versioned_docs/version-v5/deployment/play-store.md
+++ b/versioned_docs/version-v5/deployment/play-store.md
@@ -9,7 +9,7 @@ sidebar_label: Android Play Store
 To generate a release build for Android, run the following cli command:
 
 ```shell
-$ ionic cordova build android --prod --release
+ionic cordova build android --prod --release
 ```
 
 This will generate a release build based on the settings in the `config.xml` in the `platforms/android/app/build/outputs/apk` directory of an app.
@@ -21,7 +21,7 @@ First, the unsigned APK must be signed. If a signing key has already been genera
 Generate a private key using the keytool command that comes with the Android SDK:
 
 ```shell
-$ keytool -genkey -v -keystore my-release-key.keystore -alias alias_name -keyalg RSA -keysize 2048 -validity 10000
+keytool -genkey -v -keystore my-release-key.keystore -alias alias_name -keyalg RSA -keysize 2048 -validity 10000
 ```
 
 Once that command has been ran and its prompts have been answered a file called `my-release-key.keystore` will be created in the current directory.
@@ -33,7 +33,7 @@ Save this file and keep it somewhere safe. If it is lost the Google Play Store w
 To sign the unsigned APK, run the jarsigner tool which is also included in the Android SDK:
 
 ```shell
-$ jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore my-release-key.keystore HelloWorld-release-unsigned.apk alias_name
+jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore my-release-key.keystore HelloWorld-release-unsigned.apk alias_name
 ```
 
 Finally, the zip align tool must be ran to optimize the APK.
@@ -41,7 +41,7 @@ The `zipalign` tool can be found in `/path/to/Android/sdk/build-tools/VERSION/zi
 For example, on macOS with Android Studio installed, `zipalign` is in `~/Library/Android/sdk/build-tools/VERSION/zipalign`:
 
 ```shell
-$ zipalign -v 4 HelloWorld-release-unsigned.apk HelloWorld.apk
+zipalign -v 4 HelloWorld-release-unsigned.apk HelloWorld.apk
 ```
 
 This generates a final release binary called HelloWorld.apk that can be accepted into the Google Play Store.

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v3/creating-photo-gallery-device-storage.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v3/creating-photo-gallery-device-storage.md
@@ -7,7 +7,7 @@ Last time, we successfully added the Camera plugin to the About page of our Tabs
 From a terminal window, navigate to your Ionic project and run:
 
 ```shell
-$ ionic g provider PhotoProvider
+ionic g provider PhotoProvider
 ```
 
 This creates a PhotoProvider class in a dedicated providers/photo folder:
@@ -114,13 +114,13 @@ Having a working photo gallery is pretty cool, but you’ll likely notice that w
 The Storage plugin works perfectly for our base64 image data. To begin, add the SQLite plugin for native:
 
 ```shell
-$ ionic cordova plugin add cordova-sqlite-storage
+ionic cordova plugin add cordova-sqlite-storage
 ```
 
 Next, add the JavaScript library for the web:
 
 ```shell
-$ npm install --save @ionic/storage
+npm install --save @ionic/storage
 ```
 
 Last, import the Storage module and add it to the imports list in `app.module.ts`:

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v3/intro.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v3/intro.md
@@ -15,7 +15,7 @@ If you don’t have Node.js installed already, [download the LTS version](https:
 Run the following in the command line (you may need to prepend “sudo” on a Mac):
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 ## Create an App
@@ -23,7 +23,7 @@ $ npm install -g @ionic/cli
 Next, create an Ionic app using our “Tabs” app template:
 
 ```shell
-$ ionic start photo-gallery tabs
+ionic start photo-gallery tabs
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v3/ios-android-camera.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v3/ios-android-camera.md
@@ -14,7 +14,7 @@ The Ionic DevApp is a free app that makes it easy to run your Ionic app directly
 Afterwards, open a terminal and navigate to your Ionic project. Execute the following:
 
 ```shell
-$ ionic serve -c
+ionic serve -c
 ```
 
 In DevApp, you should now see the app appear. If it doesn't, or you have any issues throughout creating this app, [see here](https://ionicframework.com/docs/pro/devapp/).
@@ -42,7 +42,7 @@ Save the file and watch - a camera button appears! Tap on it and notice that it 
 In order to use the Camera, we need to bring in its JavaScript and native library dependencies. Back over in your Terminal window, run the following command, which adds the JavaScript library to the project, thus exposing the Camera API in TypeScript code:
 
 ```shell
-$ npm install --save @awesome-cordova-plugins/camera
+npm install --save @awesome-cordova-plugins/camera
 ```
 
 In `package.json`, you’ll notice a new JavaScript dependency has been added:
@@ -52,7 +52,7 @@ In `package.json`, you’ll notice a new JavaScript dependency has been added:
 Next, run this command to add the native iOS and Android code, effectively allowing the Camera to work on a mobile device:
 
 ```shell
-$ ionic cordova plugin add cordova-plugin-camera
+ionic cordova plugin add cordova-plugin-camera
 ```
 
 In `config.xml`, a new plugin entry is created:

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v3/realtime-updates-ionic-deploy.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v3/realtime-updates-ionic-deploy.md
@@ -5,7 +5,7 @@ As you’ve seen so far, building web and mobile apps is quick and easy with the
 Setting it up is quick and easy. For reference, continue to refer to [the part 3 folder](https://github.com/ionic-team/photo-gallery-tutorial-ionic3/tree/master/part3) on GitHub. First, install the Appflow JavaScript library:
 
 ```shell
-$ npm install @ionic/pro@latest --save
+npm install @ionic/pro@latest --save
 ```
 
 Then, add the Appflow plugin. Here’s the command to install it:

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v3/track-bugs-ionic-monitoring.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v3/track-bugs-ionic-monitoring.md
@@ -64,13 +64,13 @@ Last, we need to need to create a Source Map for your app. This file makes it ea
 Sync the current version of the app by running the following:
 
 ```shell
-$ ionic monitoring syncmaps
+ionic monitoring syncmaps
 ```
 
 With our intentional error in place, let’s try it out to see what happens. Run your app locally:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 Tap on the Gallery tab, then the camera button. A runtime error should occur. In a browser, head over to the [Appflow dashboard](https://dashboard.ionicframework.com), then Monitor -> Monitoring. After a few minutes, the error should appear:

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v4/creating-photo-gallery-device-storage.md
@@ -9,7 +9,7 @@ Last time, we successfully added the Camera plugin to the Tab2 page of our Tabs 
 From a terminal window, navigate to your Ionic project and run:
 
 ```shell
-$ ionic g service services/Photo
+ionic g service services/Photo
 ```
 
 This creates a PhotoService class in a dedicated "services" folder:
@@ -110,13 +110,13 @@ Having a working photo gallery is pretty cool, but you’ll likely notice that w
 The Storage plugin works perfectly for our base64 image data. To begin, add the SQLite plugin for native:
 
 ```shell
-$ ionic cordova plugin add cordova-sqlite-storage
+ionic cordova plugin add cordova-sqlite-storage
 ```
 
 Next, add the JavaScript library for the web:
 
 ```shell
-$ npm install --save @ionic/storage
+npm install --save @ionic/storage
 ```
 
 Last, import the Storage module and add it to the imports list in `app.module.ts`:

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v4/intro.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v4/intro.md
@@ -24,7 +24,7 @@ Download/install these right away to ensure an optimal Ionic development experie
 Run the following in the command line:
 
 ```shell
-$ npm install -g @ionic/cli cordova
+npm install -g @ionic/cli cordova
 ```
 
 :::note
@@ -38,7 +38,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic Angular app using our “Tabs” app template:
 
 ```shell
-$ ionic start photo-gallery tabs
+ionic start photo-gallery tabs
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -46,7 +46,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 That’s it! Now for the fun part - let’s see the app in action.

--- a/versioned_docs/version-v5/developer-resources/guides/first-app-v4/ios-android-camera.md
+++ b/versioned_docs/version-v5/developer-resources/guides/first-app-v4/ios-android-camera.md
@@ -38,7 +38,7 @@ Save the file and watch - a camera button appears! Tap on it and notice that it 
 In order to use the Camera, we need to bring in its JavaScript and native library dependencies. Back over in your Terminal window, run the following command, which adds the JavaScript library to the project, thus exposing the Camera API in TypeScript code:
 
 ```shell
-$ npm install @awesome-cordova-plugins/camera
+npm install @awesome-cordova-plugins/camera
 ```
 
 In `package.json`, you’ll notice a new JavaScript dependency has been added, with a version number similar to the following:
@@ -48,7 +48,7 @@ In `package.json`, you’ll notice a new JavaScript dependency has been added, w
 Next, run this command to add the native iOS and Android code, effectively allowing the Camera to work on a mobile device. For more info on how this works, read up on [Cordova](https://cordova.apache.org/docs/en/latest/guide/overview/) and [Ionic Native](https://ionicframework.com/docs/native).
 
 ```shell
-$ ionic cordova plugin add cordova-plugin-camera
+ionic cordova plugin add cordova-plugin-camera
 ```
 
 The `config.xml` file is now updated with an entry similar to the following for the native camera code:

--- a/versioned_docs/version-v5/developing/android.md
+++ b/versioned_docs/version-v5/developing/android.md
@@ -93,7 +93,7 @@ Actual Android hardware can also be used for Ionic app development. But first, t
 Verify the connection works by connecting the device to the computer with a USB cable and using the following command:
 
 ```shell
-$ adb devices
+adb devices
 ```
 
 The device should be listed. See the full <a href="https://developer.android.com/studio/command-line/adb" target="_blank">`adb` documentation</a> for troubleshooting and detailed information.
@@ -166,7 +166,7 @@ Capacitor uses Android Studio to build and run apps to simulators and devices.
 To start a live-reload server run the following command.
 
 ```shell
-$ ionic capacitor run android -l --host=YOUR_IP_ADDRESS
+ionic capacitor run android -l --host=YOUR_IP_ADDRESS
 ```
 
 When running on a device make sure the device and your development machine are connected to the same network.
@@ -178,7 +178,7 @@ The Ionic CLI can build, copy, and deploy Ionic apps to Android simulators and d
 Run the following to start a long-running CLI process that boots up a live-reload server:
 
 ```shell
-$ ionic cordova run android -l
+ionic cordova run android -l
 ```
 
 Now, when changes are made to the app's source files, web assets are rebuilt and the changes are reflected on the simulator or device without having to deploy again.
@@ -210,5 +210,5 @@ If the **Logcat** window is hidden, you can enable it in **View** &raquo; **Tool
 You can also access **Logcat** with [ADB](https://developer.android.com/studio/command-line/adb).
 
 ```shell
-$ adb logcat
+adb logcat
 ```

--- a/versioned_docs/version-v5/developing/ios.md
+++ b/versioned_docs/version-v5/developing/ios.md
@@ -21,7 +21,7 @@ The Xcode approach is generally more stable, but the Ionic CLI approach offers [
 Once Xcode is installed, make sure the command-line tools are selected for use:
 
 ```shell
-$ xcode-select --install
+xcode-select --install
 ```
 
 ### Setting up a Development Team
@@ -145,7 +145,7 @@ Capacitor does not yet have a way to build native projects. It relies on Xcode t
 Run the following, then select a target simulator or device and click the play button in Xcode:
 
 ```shell
-$ ionic capacitor run ios -l --external
+ionic capacitor run ios -l --external
 ```
 
 ### Live-reload with Cordova
@@ -155,7 +155,7 @@ Cordova can build and deploy native projects programmatically.
 To boot up a live-reload server, build, and deploy the app, run the following:
 
 ```shell
-$ ionic cordova run ios -l --external
+ionic cordova run ios -l --external
 ```
 
 ## Debugging iOS Apps

--- a/versioned_docs/version-v5/developing/tips.md
+++ b/versioned_docs/version-v5/developing/tips.md
@@ -69,13 +69,13 @@ Since these global directories are no longer owned by `root`, packages can be in
 To update an [npm](https://www.npmjs.com/) dependency, run the following, where `<package-name>` is the package to update:
 
 ```shell
-$ npm install <package-name>@<version|latest> --save
+npm install <package-name>@<version|latest> --save
 ```
 
 For example, to update the `@ionic/angular` package to the release tagged `latest`, run:
 
 ```shell
-$ npm install @ionic/angular@latest --save
+npm install @ionic/angular@latest --save
 ```
 
 It is recommended that packages get updated through the CLI since npm will now read package versions from the `package-lock.json` first.
@@ -124,7 +124,7 @@ Before it can be used, [Xcode](https://developer.apple.com/xcode/download/), App
 The [Ionic CLI](../cli.md) can then be used to run the app in the current directory on the simulator:
 
 ```shell
-$ ionic cordova emulate ios -lc
+ionic cordova emulate ios -lc
 ```
 
 Passing in the `-lc` flag will enable livereload and log console output to a terminal.

--- a/versioned_docs/version-v5/intro/cdn.md
+++ b/versioned_docs/version-v5/intro/cdn.md
@@ -29,7 +29,7 @@ This does not install Angular or any other frameworks. This allows use of the Io
 When using Ionic Framework in an Angular project, install the latest `@ionic/angular` package from [npm](../reference/glossary.md#npm). This comes with all of the Ionic Framework components and Angular specific services and features.
 
 ```shell
-$ npm install @ionic/angular@latest --save
+npm install @ionic/angular@latest --save
 ```
 
 Each time there is a new Ionic Framework release, this [version](../reference/versioning.md) will need to be updated to get the latest features and fixes. The version can be [updated using npm](../developing/tips.md#updating-dependencies), as well.
@@ -37,7 +37,7 @@ Each time there is a new Ionic Framework release, this [version](../reference/ve
 For adding Ionic to an already existing Angular project, use the Angular CLI's `ng add` feature.
 
 ```shell
-$ ng add @ionic/angular
+ng add @ionic/angular
 ```
 
 This will add the necessary imports to the `@ionic/angular` package as well as add the styles needed.
@@ -78,7 +78,7 @@ import '@ionic/react/css/display.css';
 To add Ionic Framework to an existing Vue project, install the `@ionic/vue` and `@ionic/vue-router` packages.
 
 ```shell
-$ npm install @ionic/vue @ionic/vue-router
+npm install @ionic/vue @ionic/vue-router
 ```
 
 After that, you will need to install the `IonicVue` plugin in your Vue app.

--- a/versioned_docs/version-v5/intro/cli.md
+++ b/versioned_docs/version-v5/intro/cli.md
@@ -17,7 +17,7 @@ Before proceeding, make sure your computer has [Node.js](../reference/glossary.m
 Install the Ionic CLI with npm:
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 If there was a previous installation of the Ionic CLI, it will need to be uninstalled due to a change in package name.
@@ -38,7 +38,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Create an Ionic app using one of the pre-made app templates, or a blank one to start fresh. The three most common starters are the `blank` starter, `tabs` starter, and `sidemenu` starter. Get started with the `ionic start` command:
 
 ```shell
-$ ionic start myApp tabs
+ionic start myApp tabs
 ```
 
 ![start app thumbnails](/img/installation/start-app-thumbnails.png)

--- a/versioned_docs/version-v5/intro/environment.md
+++ b/versioned_docs/version-v5/intro/environment.md
@@ -49,7 +49,7 @@ Otherwise, follow the [official installation instructions](https://git-scm.com/b
 To verify the installation, open a new terminal window and run:
 
 ```shell
-$ git --version
+git --version
 ```
 
 ### Git GUI

--- a/versioned_docs/version-v5/native-faq.md
+++ b/versioned_docs/version-v5/native-faq.md
@@ -23,7 +23,7 @@ $ ionic cordova plugin add cordova-plugin-camera
 To ensure that the same version of a plugin is always installed via `npm install`, specify the version number:
 
 ```shell
-$ ionic cordova plugin add cordova-plugin-camera@4.3.2
+ionic cordova plugin add cordova-plugin-camera@4.3.2
 ```
 
 **4) Restore Cordova in an existing Ionic project**

--- a/versioned_docs/version-v5/react/overview.md
+++ b/versioned_docs/version-v5/react/overview.md
@@ -9,13 +9,13 @@ The first official version of Ionic React is v4.11.
 First, install the Ionic CLI:
 
 ```shell
-$ npm install -g @ionic/cli
+npm install -g @ionic/cli
 ```
 
 then run:
 
 ```shell
-$ ionic start myAppName
+ionic start myAppName
 ```
 
 The CLI will guide you through the setup process by asking a couple of questions, including the framework to use (React, of course!) and the starter code template.

--- a/versioned_docs/version-v5/react/pwa.md
+++ b/versioned_docs/version-v5/react/pwa.md
@@ -53,7 +53,7 @@ First, if not already available, [create the project](https://console.firebase.g
 Next, in a Terminal, install the Firebase CLI:
 
 ```shell
-$ npm install -g firebase-tools
+npm install -g firebase-tools
 ```
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -107,13 +107,13 @@ For more information about the `firebase.json` properties, see the [Firebase doc
 Next, build an optimized version of the app by running:
 
 ```shell
-$ ionic build --prod
+ionic build --prod
 ```
 
 Last, deploy the app by running:
 
 ```shell
-$ firebase deploy
+firebase deploy
 ```
 
 After this completes, the app will be live.

--- a/versioned_docs/version-v5/react/your-first-app.md
+++ b/versioned_docs/version-v5/react/your-first-app.md
@@ -51,7 +51,7 @@ To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
 :::
 
 ```shell
-$ npm install -g @ionic/cli native-run cordova-res
+npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
@@ -65,7 +65,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic React app that uses the “Tabs” starter template and adds Capacitor for native functionality:
 
 ```shell
-$ ionic start photo-gallery tabs --type=react --capacitor
+ionic start photo-gallery tabs --type=react --capacitor
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -73,7 +73,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 Next we'll need to install the necessary Capacitor plugins to make the app's native functionality work:
@@ -89,7 +89,7 @@ Some Capacitor plugins, including the Camera API, provide the web-based function
 It's a separate dependency, so install it next:
 
 ```shell
-$ npm install @ionic/pwa-elements
+npm install @ionic/pwa-elements
 ```
 
 After installation, open up the project in your code editor of choice.
@@ -110,7 +110,7 @@ That’s it! Now for the fun part - let’s see the app in action.
 Run this command in your shell:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 And voilà! Your Ionic app is now running in a web browser. Most of your app can be built and tested right in the browser, greatly increasing development and testing speed.

--- a/versioned_docs/version-v5/react/your-first-app/6-deploying-mobile.md
+++ b/versioned_docs/version-v5/react/your-first-app/6-deploying-mobile.md
@@ -13,7 +13,7 @@ Capacitor is Ionic’s official app runtime that makes it easy to deploy web app
 If you’re still running `ionic serve` in the terminal, cancel it. Complete a fresh build of the Ionic project, fixing any errors that it reports:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Next, create both the iOS and Android projects:
@@ -28,13 +28,13 @@ Both android and ios folders at the root of the project are created. These are e
 Every time you perform a build (e.g. `ionic build`) that updates your web directory (default: `build`), you'll need to copy those changes into your native projects:
 
 ```shell
-$ ionic cap copy
+ionic cap copy
 ```
 
 Note: After making updates to the native portion of the code (such as adding a new plugin), use the `sync` command:
 
 ```shell
-$ ionic cap sync
+ionic cap sync
 ```
 
 ## iOS
@@ -48,7 +48,7 @@ Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac I
 First, run the Capacitor `open` command, which opens the native iOS project in Xcode:
 
 ```shell
-$ ionic cap open ios
+ionic cap open ios
 ```
 
 In order for some native plugins to work, user permissions must be configured. In our photo gallery app, this includes the Camera plugin: iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. The permission that drives this is labeled “Privacy - Camera Usage.” To set it, the `Info.plist` file must be modified ([more details here](https://capacitor.ionicframework.com/docs/ios/configuration)). To access it, click "Info," then expand "Custom iOS Target Properties."
@@ -80,7 +80,7 @@ Capacitor Android apps are configured and managed through Android Studio. Before
 First, run the Capacitor `open` command, which opens the native Android project in Android Studio:
 
 ```shell
-$ ionic cap open android
+ionic cap open android
 ```
 
 Similar to iOS, we must enable the correct permissions to use the Camera. Configure these in the `AndroidManifest.xml` file. Android Studio will likely open this file automatically, but in case it doesn't, locate it under `android/app/src/main/`.

--- a/versioned_docs/version-v5/troubleshooting/native.md
+++ b/versioned_docs/version-v5/troubleshooting/native.md
@@ -71,13 +71,13 @@ Error: more than one library with package name com.google.android.gms
 This error is caused by two separate plugins trying to use different versions of the `Google Play Services`. To fix this issue make sure you are running `cordova` version `7.1.0` or higher and `cordova-android` `6.3.0` or higher. To install latest `cordova` run:
 
 ```shell
-$ npm install cordova@latest
+npm install cordova@latest
 ```
 
 and to update `cordova-android` run:
 
 ```shell
-$ cordova platform update android
+cordova platform update android
 ```
 
 Plugins that depend on `Google Play Services` can now be updated to use the same version. For example, if `pluginA` uses version 11.0 and `pluginB` uses version 15.0 they can be updated to use the same version with the following snippet in the `config.xml` file:

--- a/versioned_docs/version-v5/vue/pwa.md
+++ b/versioned_docs/version-v5/vue/pwa.md
@@ -122,7 +122,7 @@ First, if not already available, [create the project](https://console.firebase.g
 Next, in a Terminal, install the Firebase CLI:
 
 ```shell
-$ npm install -g firebase-tools
+npm install -g firebase-tools
 ```
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -194,13 +194,13 @@ For more information about the `firebase.json` properties, see the [Firebase doc
 Next, build an optimized version of the app by running:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Last, deploy the app by running:
 
 ```shell
-$ firebase deploy
+firebase deploy
 ```
 
 After this completes, the app will be live.

--- a/versioned_docs/version-v5/vue/your-first-app.md
+++ b/versioned_docs/version-v5/vue/your-first-app.md
@@ -49,7 +49,7 @@ To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
 :::
 
 ```shell
-$ npm install -g @ionic/cli@latest native-run cordova-res
+npm install -g @ionic/cli@latest native-run cordova-res
 ```
 
 :::note
@@ -63,7 +63,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic Vue app that uses the "Tabs" starter template and adds Capacitor for native functionality:
 
 ```shell
-$ ionic start photo-gallery tabs --type vue --capacitor
+ionic start photo-gallery tabs --type vue --capacitor
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -71,7 +71,7 @@ This starter project comes complete with three pre-built pages and best practice
 Next, change into the app folder:
 
 ```shell
-$ cd photo-gallery
+cd photo-gallery
 ```
 
 Next we'll need to install the necessary Capacitor plugins to make the app's native functionality work:
@@ -87,7 +87,7 @@ Some Capacitor plugins, including the Camera API, provide the web-based function
 It's a separate dependency, so install it next:
 
 ```shell
-$ npm install @ionic/pwa-elements
+npm install @ionic/pwa-elements
 ```
 
 After installation, open up the project in your code editor of choice.
@@ -109,7 +109,7 @@ That’s it! Now for the fun part - let’s see the app in action.
 Run this command in your shell:
 
 ```shell
-$ ionic serve
+ionic serve
 ```
 
 And voilà! Your Ionic app is now running in a web browser. Most of your app can be built and tested right in the browser, greatly increasing development and testing speed.

--- a/versioned_docs/version-v5/vue/your-first-app/6-deploying-mobile.md
+++ b/versioned_docs/version-v5/vue/your-first-app/6-deploying-mobile.md
@@ -17,7 +17,7 @@ Capacitor is Ionic’s official app runtime that makes it easy to deploy web app
 If you’re still running `ionic serve` in the terminal, cancel it. Complete a fresh build of the Ionic project, fixing any errors that it reports:
 
 ```shell
-$ ionic build
+ionic build
 ```
 
 Next, create both the iOS and Android projects:
@@ -32,13 +32,13 @@ Both android and ios folders at the root of the project are created. These are e
 Every time you perform a build (e.g. `ionic build`) that updates your web directory (default: `build`), you'll need to copy those changes into your native projects:
 
 ```shell
-$ ionic cap copy
+ionic cap copy
 ```
 
 Note: After making updates to the native portion of the code (such as adding a new plugin), use the `sync` command:
 
 ```shell
-$ ionic cap sync
+ionic cap sync
 ```
 
 ## iOS
@@ -52,7 +52,7 @@ Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac I
 First, run the Capacitor `open` command, which opens the native iOS project in Xcode:
 
 ```shell
-$ ionic cap open ios
+ionic cap open ios
 ```
 
 In order for some native plugins to work, user permissions must be configured. In our photo gallery app, this includes the Camera plugin: iOS displays a modal dialog automatically after the first time that `Camera.getPhoto()` is called, prompting the user to allow the app to use the Camera. The permission that drives this is labeled "Privacy - Camera Usage." To set it, the `Info.plist` file must be modified ([more details here](https://capacitor.ionicframework.com/docs/ios/configuration)). To access it, click "Info," then expand "Custom iOS Target Properties."
@@ -84,7 +84,7 @@ Capacitor Android apps are configured and managed through Android Studio. Before
 First, run the Capacitor `open` command, which opens the native Android project in Android Studio:
 
 ```shell
-$ ionic cap open android
+ionic cap open android
 ```
 
 Similar to iOS, we must enable the correct permissions to use the Camera. Configure these in the `AndroidManifest.xml` file. Android Studio will likely open this file automatically, but in case it doesn't, locate it under `android/app/src/main/`.


### PR DESCRIPTION
shell/bash code tags have a button to copy the command, but the $ sign makes it useless 

I have removed the $ from single line shell/bash code tags so they can be used after copied 
Also changed the 2 bash tags to be shell for consistency.

closes https://github.com/ionic-team/ionic-docs/pull/2129
closes https://github.com/ionic-team/ionic-docs/pull/2128
closes https://github.com/ionic-team/ionic-docs/issues/2244