### PR TITLE
Update back button docs for Capacitor 3+

### DIFF
--- a/docs/developing/hardware-back-button.md
+++ b/docs/developing/hardware-back-button.md
@@ -248,8 +248,7 @@ In some scenarios, it may be desirable to quit the app when pressing the hardwar
 
 ```tsx
 import { BackButtonEvent } from '@ionic/core';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 
@@ -268,8 +267,7 @@ document.addEventListener('ionBackButton', (ev: BackButtonEvent) => {
 
 ```tsx
 import { IonRouterOutlet, Platform } from '@ionic/angular';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 
@@ -290,8 +288,7 @@ constructor(
 
 ```tsx
 import { useIonRouter } from '@ionic/react';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 
@@ -309,8 +306,7 @@ document.addEventListener('ionBackButton', (ev) => {
 
 ```tsx
 import { useBackButton, useIonRouter } from '@ionic/vue';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 

--- a/versioned_docs/version-v5/developing/hardware-back-button.md
+++ b/versioned_docs/version-v5/developing/hardware-back-button.md
@@ -238,8 +238,7 @@ In some scenarios, it may be desirable to quit the app when pressing the hardwar
 
 ```tsx
 import { BackButtonEvent } from '@ionic/core';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 
@@ -258,8 +257,7 @@ document.addEventListener('ionBackButton', (ev: BackButtonEvent) => {
 
 ```tsx
 import { IonRouterOutlet, Platform } from '@ionic/angular';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 
@@ -280,8 +278,7 @@ constructor(
 
 ```tsx
 import { useIonRouter } from '@ionic/react';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 
@@ -299,8 +296,7 @@ document.addEventListener('ionBackButton', (ev) => {
 
 ```tsx
 import { useBackButton, useIonRouter } from '@ionic/vue';
-import { Plugins } from '@capacitor/core';
-const { App } = Plugins;
+import { App } from '@capacitor/app';
 
 ...
 


### PR DESCRIPTION
In Capacitor 3+ the plugins are separate and App plugin is on it's own package instead of in @capacitor/core

closes https://github.com/ionic-team/ionic-docs/issues/2101