### PR TITLE
docs(datetime): make theming playground taller

### DIFF
--- a/static/usage/datetime/theming/index.md
+++ b/static/usage/datetime/theming/index.md
@@ -8,7 +8,7 @@ import angularHTML from './angular-html.md';
 import angularCSS from './angular-css.md';
 
 <Playground 
-  size="medium" 
+  size="450px" 
   code={{ 
     javascript, 
     react: {


### PR DESCRIPTION
Ben noted that the MD playground for the datetime theming section is too short, causing the shadow to get cut off:

![image](https://user-images.githubusercontent.com/2721089/174838826-68dd9692-6a5e-4380-ba1d-2efc882465b5.png)
