### PR TITLE
fix(playground): tabs now have dark theme

### DIFF
--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -25,6 +25,9 @@
    * @prop --playground-btn-icon-hover-background The background color of the button icon in the toolbar when hovered.
    * @prop --playground-separator-color The color of the separator/border in the toolbar.
    * @prop --playground-code-background The background color of the code block when expanded.
+   * @prop --playground-tabs-background: The background color of the tabs bar not including the active tab button.
+   * @prop --playground-tab-btn-color: The text color of the tab buttons.
+   * @prop --playground-tab-btn-border-color: The border color of the tab buttons.
    */
   --playground-btn-color: var(--c-indigo-90);
   --playground-btn-selected-color: var(--c-blue-90);

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -10,6 +10,10 @@
   --playground-separator-color: var(--c-carbon-70);
 
   --playground-code-background: rgb(22, 29, 37);
+
+  --playground-tabs-background: var(--c-carbon-90);
+  --playground-tab-btn-color: var(--c-carbon-20);
+  --playground-tab-btn-border-color: transparent;
 }
 
 .playground {
@@ -29,6 +33,10 @@
   --playground-btn-icon-color: var(--c-indigo-80);
   --playground-separator-color: var(--c-indigo-30);
   --playground-code-background: var(--c-indigo-10);
+
+  --playground-tabs-background: var(--c-indigo-20);
+  --playground-tab-btn-color: var(--c-carbon-100);
+  --playground-tab-btn-border-color: var(--c-indigo-30);
 
   overflow: hidden;
 
@@ -207,13 +215,13 @@
 
 /** Tabs **/
 .playground .tabs-container {
-  background: var(--c-indigo-10);
+  background: var(--playground-code-background);
   border-radius: 16px;
   overflow: hidden;
 }
 
 .playground .tabs {
-  background: var(--c-indigo-20);
+  background: var(--playground-tabs-background);
 
   --ifm-tabs-spacing: 0;
 }
@@ -223,7 +231,7 @@
 }
 
 .playground .tabs__item {
-  color: var(--c-carbon-100);
+  color: var(--playground-tab-btn-color);
   font-size: 12px;
   display: inline-flex;
   align-items: center;
@@ -242,18 +250,18 @@
 }
 
 .playground .tabs__item:not(.tabs__item--active) {
-  border-left: 1px solid var(--c-indigo-30);
-  border-bottom: 1px solid var(--c-indigo-30);
+  border-left: 1px solid var(--playground-tab-btn-border-color);
+  border-bottom: 1px solid var(--playground-tab-btn-border-color);
 }
 
 .playground .tabs__item--active {
   border-color: transparent;
-  background: var(--c-indigo-10);
+  background: var(--playground-code-background);
   font-weight: 400;
 }
 
 .playground .tabs__item--active:hover {
-  background: var(--c-indigo-10);
+  background: var(--playground-code-background);
 }
 
 /* Tooltip styling */

--- a/src/components/global/PlaygroundTabs/styles.module.css
+++ b/src/components/global/PlaygroundTabs/styles.module.css
@@ -1,3 +1,9 @@
+/* Dark theme overrides */
+[data-theme="dark"] .tabNav {
+  --tab-nav-btn-background: rgba(34, 45, 58, 0.5);
+  --tab-nav-btn-color: var(--c-carbon-20);
+}
+
 /**
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
@@ -7,6 +13,13 @@
 
 .tabNav {
   position: relative;
+
+  /**
+   * @prop --tab-nav-btn-background: The background color of the next/prev arrow buttons
+   * @prop --tab-nav-btn-color: The text color of the next/prev arrow buttons.
+   */
+  --tab-nav-btn-background: linear-gradient(90deg, rgba(233, 237, 243, 0.9), var(--c-indigo-30));
+  --tab-nav-btn-color: var(--c-carbon-100);
 }
 
 .tabList {
@@ -37,7 +50,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  background: linear-gradient(90deg, rgba(233, 237, 243, 0.9), var(--c-indigo-30));
+  background: var(--tab-nav-btn-background);
 }
 
 .tabNavItemLeft {
@@ -50,7 +63,7 @@
   background: transparent;
   border: 0;
   cursor: pointer;
-  color: var(--c-carbon-100);
+  color: var(--tab-nav-btn-color);
 }
 
 .tabs__nav-button--hidden {

--- a/src/components/global/PlaygroundTabs/styles.module.css
+++ b/src/components/global/PlaygroundTabs/styles.module.css
@@ -1,6 +1,6 @@
 /* Dark theme overrides */
 [data-theme="dark"] .tabNav {
-  --tab-nav-btn-background: rgba(34, 45, 58, 0.5);
+  --tab-nav-btn-background: rgb(34, 45, 58);
   --tab-nav-btn-color: var(--c-carbon-20);
 }
 


### PR DESCRIPTION
Light Mode (note: there should be no changes):

| `main` | branch |
| ------ | ----- |
| ![light-before](https://user-images.githubusercontent.com/2721089/174850671-d37eb993-b8ff-466d-9165-8fdf6ee056b6.png) | ![light-after](https://user-images.githubusercontent.com/2721089/174850699-74fae04b-554e-47b4-8877-607bef4bb18d.png) |

Dark Mode:

| `main` | branch |
| ----- | ----- |
| ![dark-before](https://user-images.githubusercontent.com/2721089/174850765-2026a61c-ef64-4bf1-aab4-cceec3cc73c6.png) | ![Screen Shot 2022-06-21 at 12 31 07 PM](https://user-images.githubusercontent.com/2721089/174851056-9e02b58c-fc70-4594-bb25-fa36fac7a6d3.png) |
 