### PR TITLE
docs(datetime): remove stray contents header

### DIFF
--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -46,8 +46,6 @@ import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
 Datetimes present a calendar interface and time wheel, making it easy for users to select dates and times. Datetimes are similar to the native `input` elements of `datetime-local`, however, Ionic Framework's Datetime component makes it easy to display the date and time in the preferred format, and manage the datetime values.
 
 ## Overview 


### PR DESCRIPTION
When removing the inline TOC, I forgot to remove the "Contents" header.