### PR TITLE
docs(alert): add presenting playground/examples

### DIFF
--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -25,6 +25,81 @@ import APITOCInline from '@components/page/api/APITOCInline';
 
 An Alert is a dialog that presents users with information or collects information from the user using inputs. An alert appears on top of the app's content, and must be manually dismissed by the user before they can resume interaction with the app. It can also optionally have a `header`, `subHeader` and `message`.
 
+## Presenting
+
+### Controller
+
+import Controller from '@site/static/usage/alert/presenting/controller/index.md';
+
+<Controller />
+
+### Inline
+
+When using Ionic with React or Vue, `ion-alert` can also be placed directly in the template through use of the `isOpen` property. Note that `isOpen` must be set to `false` manually when the alert is dismissed; it will not be updated automatically.
+
+<Tabs defaultValue="react" values={[{ value: 'react', label: 'React' }, { value: 'vue', label: 'Vue' }]}>
+<TabItem value="react">
+
+```tsx
+import React, { useState } from 'react';
+import { IonAlert, IonButton, IonContent } from '@ionic/react';
+
+function Example() {
+  const [showAlert, setShowAlert] = useState(false);
+
+  return (
+    <IonContent>
+      <IonButton onClick={() => setShowAlert(true)}>Click Me</IonButton>
+      <IonAlert
+        isOpen={showAlert}
+        onDidDismiss={() => setShowAlert(false)}
+        header="Alert"
+        subHeader="Important message"
+        message="This is an alert!"
+        buttons={['OK']}
+      />
+    </IonContent>
+  );
+}
+```
+
+</TabItem>
+<TabItem value="vue">
+
+```html
+<template>
+  <ion-content>
+    <ion-button @click="setOpen(true)">Show Alert</ion-button>
+    <ion-alert
+      :is-open="isOpenRef"
+      header="Alert"
+      sub-header="Important message"
+      message="This is an alert!"
+      :buttons="['OK']"
+      @didDismiss="setOpen(false)"
+    ></ion-alert>
+  </ion-content>
+</template>
+
+<script lang="ts">
+import { IonAlert, IonButton, IonContent } from '@ionic/vue';
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  components: { IonAlert, IonButton },
+  setup() {
+    const isOpenRef = ref(false);
+    const setOpen = (state: boolean) => isOpenRef.value = state;
+    
+    return { isOpenRef, setOpen }
+  }
+});
+</script>
+```
+
+</TabItem>
+</Tabs>
+
 ## Buttons
 
 In the array of `buttons`, each button includes properties for its `text`, and optionally a `handler`. If a handler returns `false` then the alert will not automatically be dismissed when the button is clicked. All buttons will show up in the order they have been added to the `buttons` array from left to right. Note: The right most button (the last one in the array) is the main button.

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -106,16 +106,32 @@ In the array of `buttons`, each button includes properties for its `text`, and o
 
 Optionally, a `role` property can be added to a button, such as `cancel`. If a `cancel` role is on one of the buttons, then if the alert is dismissed by tapping the backdrop, then it will fire the handler from the button with a cancel role.
 
+import Buttons from '@site/static/usage/alert/buttons/index.md';
+
+<Buttons />
+
 
 ## Inputs
 
 Alerts can also include several different inputs whose data can be passed back to the app. Inputs can be used as a simple way to prompt users for information. Radios, checkboxes and text inputs are all accepted, but they cannot be mixed. For example, an alert could have all radio button inputs, or all checkbox inputs, but the same alert cannot mix radio and checkbox inputs. Do note however, different types of "text" inputs can be mixed, such as `url`, `email`, `text`, `textarea` etc. If you require a complex form UI which doesn't fit within the guidelines of an alert then we recommend building the form within a modal instead.
 
+### Text Inputs Example
+
+import TextInputs from '@site/static/usage/alert/inputs/text-inputs/index.md';
+
+<TextInputs />
+
+### Radio Example
+
+import Radios from '@site/static/usage/alert/inputs/radios/index.md';
+
+<Radios />
+
 ## Customization
 
 Alert uses scoped encapsulation, which means it will automatically scope its CSS by appending each of the styles with an additional class at runtime. Overriding scoped selectors in CSS requires a [higher specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) selector.
 
-We recommend passing a custom class to `cssClass` in the `create` method and using that to add custom styles to the host and inner elements. This property can also accept multiple classes separated by spaces. View the [Usage](#usage) section for an example of how to pass a class using `cssClass`.
+We recommend passing a custom class to `cssClass` in the `create` method and using that to add custom styles to the host and inner elements. This property can also accept multiple classes separated by spaces.
 
 ```css
 /* DOES NOT WORK - not specific enough */
@@ -137,8 +153,12 @@ Any of the defined [CSS Custom Properties](#css-custom-properties) can be used t
 }
 ```
 
+import Customization from '@site/static/usage/alert/customization/index.md';
+
+<Customization />
+
 :::note
- If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file. Read [Style Placement](#style-placement) in the Angular section below for more information.
+ If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file.
 :::
 
 

--- a/static/usage/alert/buttons/angular/angular_html.md
+++ b/static/usage/alert/buttons/angular/angular_html.md
@@ -1,0 +1,5 @@
+```html
+<ion-button (click)="presentAlert()">Click Me</ion-button>
+<p>{{ handlerMessage }}</p>
+<p>{{ roleMessage }}</p>
+```

--- a/static/usage/alert/buttons/angular/angular_ts.md
+++ b/static/usage/alert/buttons/angular/angular_ts.md
@@ -1,0 +1,38 @@
+```ts
+import { Component } from '@angular/core';
+import { AlertController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  handlerMessage = '';
+  roleMessage = '';
+
+  constructor(private alertController: AlertController) {}
+
+  async presentAlert() {
+    const alert = await this.alertController.create({
+      header: 'Alert!',
+      buttons: [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+          handler: () => { this.handlerMessage = 'Alert canceled'; }
+        },
+        {
+          text: 'OK',
+          role: 'confirm',
+          handler: () => { this.handlerMessage = 'Alert confirmed'; }
+        }
+      ]
+    });
+
+    await alert.present();
+
+    const { role } = await alert.onDidDismiss();
+    this.roleMessage = `Dismissed with role: ${role}`;
+  }
+}
+```

--- a/static/usage/alert/buttons/demo.html
+++ b/static/usage/alert/buttons/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      flex-direction: column;
+    }
+
+    .container p {
+      margin-bottom: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button onclick="presentAlert()">Click Me</ion-button>
+        <p id="handlerResult"></p>
+        <p id="roleResult"></p>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const handlerOutput = document.querySelector('#handlerResult');
+    const roleOutput = document.querySelector('#roleResult');
+
+    async function presentAlert() {
+      const alert = document.createElement('ion-alert');
+      alert.header = 'Alert!';
+      alert.buttons = [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+          handler: () => { handlerOutput.innerText = 'Alert canceled'; }
+        },
+        {
+          text: 'OK',
+          role: 'confirm',
+          handler: () => { handlerOutput.innerText = 'Alert confirmed'; }
+        }
+      ];
+
+      document.body.appendChild(alert);
+      await alert.present();
+
+      const { role } = await alert.onDidDismiss();
+      roleOutput.innerText = `Dismissed with role: ${role}`;
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/alert/buttons/index.md
+++ b/static/usage/alert/buttons/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  size="300px"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.ts': angularTS
+      }
+    }
+  }}
+  src="usage/alert/buttons/demo.html"
+/>

--- a/static/usage/alert/buttons/javascript.md
+++ b/static/usage/alert/buttons/javascript.md
@@ -1,0 +1,33 @@
+```html
+<ion-button onclick="presentAlert()">Click Me</ion-button>
+<p id="handlerResult"></p>
+<p id="roleResult"></p>
+
+<script>
+  const handlerOutput = document.querySelector('#handlerResult');
+  const roleOutput = document.querySelector('#roleResult');
+
+  async function presentAlert() {
+    const alert = document.createElement('ion-alert');
+    alert.header = 'Alert!';
+    alert.buttons = [
+      {
+        text: 'Cancel',
+        role: 'cancel',
+        handler: () => { handlerOutput.innerText = 'Alert canceled'; }
+      },
+      {
+        text: 'OK',
+        role: 'confirm',
+        handler: () => { handlerOutput.innerText = 'Alert confirmed'; }
+      }
+    ];
+
+    document.body.appendChild(alert);
+    await alert.present();
+
+    const { role } = await alert.onDidDismiss();
+    roleOutput.innerText = `Dismissed with role: ${role}`;
+  }
+</script>
+```

--- a/static/usage/alert/buttons/react.md
+++ b/static/usage/alert/buttons/react.md
@@ -1,0 +1,34 @@
+```tsx
+import React, { useState } from 'react';
+import { IonButton, IonContent, useIonAlert } from '@ionic/react';
+
+function Example() {
+  const [presentAlert] = useIonAlert();
+  const [handlerMessage, setHandlerMessage] = useState('');
+  const [roleMessage, setRoleMessage] = useState('');
+
+  return (
+    <IonContent>
+      <IonButton onClick={() => presentAlert({
+        header: 'Alert!',
+        buttons: [
+          {
+            text: 'Cancel',
+            role: 'cancel',
+            handler: () => { setHandlerMessage('Alert canceled'); }
+          },
+          {
+            text: 'OK',
+            role: 'confirm',
+            handler: () => { setHandlerMessage('Alert confirmed'); }
+          }
+        ],
+        onDidDismiss: (e: CustomEvent) => setRoleMessage(`Dismissed with role: ${e.detail.role}`)
+      })}>Click Me</IonButton>
+      <p>{handlerMessage}</p>
+      <p>{roleMessage}</p>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/alert/buttons/vue.md
+++ b/static/usage/alert/buttons/vue.md
@@ -1,0 +1,47 @@
+```html
+<template>
+  <ion-content>
+    <ion-button @click="presentAlert">Click Me</ion-button>
+    <p>{{ handlerMessage }}</p>
+    <p>{{ roleMessage }}</p>
+  </ion-content>
+</template>
+
+<script lang="ts">
+import { IonButton, IonContent, alertController } from '@ionic/vue';
+
+export default {
+  components: { IonButton, IonContent },
+  data() {
+    return {
+      handlerMessage: '',
+      roleMessage: ''
+    };
+  },
+  methods: {
+    async presentAlert() {
+      const alert = await alertController.create({
+        header: 'Alert!',
+        buttons: [
+          {
+            text: 'Cancel',
+            role: 'cancel',
+            handler: () => { this.handlerMessage = 'Alert canceled'; }
+          },
+          {
+            text: 'OK',
+            role: 'confirm',
+            handler: () => { this.handlerMessage = 'Alert confirmed'; }
+          }
+        ]
+      });
+
+      await alert.present();
+
+      const { role } = await alert.onDidDismiss();
+      this.roleMessage = `Dismissed with role: ${role}`;
+    },
+  },
+}
+</script>
+```

--- a/static/usage/alert/customization/angular/angular_css.md
+++ b/static/usage/alert/customization/angular/angular_css.md
@@ -1,0 +1,46 @@
+```css
+/* Core CSS required for Ionic components to work properly */
+@import '~@ionic/angular/css/core.css';
+/* Basic CSS for apps built with Ionic */
+@import '~@ionic/angular/css/normalize.css';
+@import '~@ionic/angular/css/structure.css';
+@import '~@ionic/angular/css/typography.css';
+/* Optional CSS utils that can be commented out */
+@import '~@ionic/angular/css/padding.css';
+@import '~@ionic/angular/css/float-elements.css';
+@import '~@ionic/angular/css/text-alignment.css';
+@import '~@ionic/angular/css/text-transformation.css';
+@import '~@ionic/angular/css/flex-utils.css';
+
+ion-alert.custom-alert {
+  --backdrop-opacity: 0.7;
+}
+
+.custom-alert .alert-button-group {
+  padding: 8px;
+}
+
+button.alert-button.alert-button-confirm {
+  background-color: var(--ion-color-success);
+  color: var(--ion-color-success-contrast);
+}
+
+.md button.alert-button.alert-button-confirm {
+  border-radius: 4px;
+}
+
+.ios .custom-alert button.alert-button {
+  border: 0.55px solid rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.2)
+}
+
+.ios button.alert-button.alert-button-cancel {
+  border-right: 0;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+}
+
+.ios button.alert-button.alert-button-confirm {
+  border-bottom-right-radius: 13px;
+  border-top-right-radius: 13px;
+}
+```

--- a/static/usage/alert/customization/angular/angular_html.md
+++ b/static/usage/alert/customization/angular/angular_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-button (click)="presentAlert()">Click Me</ion-button>
+```

--- a/static/usage/alert/customization/angular/angular_ts.md
+++ b/static/usage/alert/customization/angular/angular_ts.md
@@ -1,0 +1,31 @@
+```ts
+import { Component } from '@angular/core';
+import { AlertController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  constructor(private alertController: AlertController) {}
+
+  async presentAlert() {
+    const alert = await this.alertController.create({
+      header: 'Are you sure?',
+      cssClass: 'custom-alert',
+      buttons: [
+        {
+          text: 'No',
+          cssClass: 'alert-button-cancel'
+        },
+        {
+          text: 'Yes',
+          cssClass: 'alert-button-confirm'
+        }
+      ]
+    });
+
+    await alert.present();
+  }
+}
+```

--- a/static/usage/alert/customization/demo.html
+++ b/static/usage/alert/customization/demo.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    ion-alert.custom-alert {
+      --backdrop-opacity: 0.7;
+    }
+
+    .custom-alert .alert-button-group {
+      padding: 8px;
+    }
+
+    button.alert-button.alert-button-confirm {
+      background-color: var(--ion-color-success);
+      color: var(--ion-color-success-contrast);
+    }
+
+    .md button.alert-button.alert-button-confirm {
+      border-radius: 4px;
+    }
+
+    .ios .custom-alert button.alert-button {
+      border: 0.55px solid rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.2)
+    }
+
+    .ios button.alert-button.alert-button-cancel {
+      border-right: 0;
+      border-bottom-left-radius: 13px;
+      border-top-left-radius: 13px;
+    }
+
+    .ios button.alert-button.alert-button-confirm {
+      border-bottom-right-radius: 13px;
+      border-top-right-radius: 13px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button onclick="presentAlert()">Click Me</ion-button>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    async function presentAlert() {
+      const alert = document.createElement('ion-alert');
+      alert.header = 'Are you sure?';
+      alert.cssClass = 'custom-alert';
+      alert.buttons = [
+        {
+          text: 'No',
+          cssClass: 'alert-button-cancel'
+        },
+        {
+          text: 'Yes',
+          cssClass: 'alert-button-confirm'
+        }
+      ];
+
+      document.body.appendChild(alert);
+      await alert.present();
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/alert/customization/index.md
+++ b/static/usage/alert/customization/index.md
@@ -1,0 +1,33 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+
+import reactTS from './react/react_ts.md';
+import reactCSS from './react/react_css.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularCSS from './angular/angular_css.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  size="300px"
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTS,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.ts': angularTS,
+        'src/styles.css': angularCSS
+      }
+    }
+  }}
+  src="usage/alert/customization/demo.html"
+/>

--- a/static/usage/alert/customization/javascript.md
+++ b/static/usage/alert/customization/javascript.md
@@ -1,0 +1,58 @@
+```html
+<ion-button onclick="presentAlert()">Click Me</ion-button>
+
+<script>
+  async function presentAlert() {
+    const alert = document.createElement('ion-alert');
+    alert.header = 'Are you sure?';
+    alert.cssClass = 'custom-alert';
+    alert.buttons = [
+      {
+        text: 'No',
+        cssClass: 'alert-button-cancel'
+      },
+      {
+        text: 'Yes',
+        cssClass: 'alert-button-confirm'
+      }
+    ];
+
+    document.body.appendChild(alert);
+    await alert.present();
+  }
+</script>
+
+<style>
+  ion-alert.custom-alert {
+    --backdrop-opacity: 0.7;
+  }
+
+  .custom-alert .alert-button-group {
+    padding: 8px;
+  }
+
+  button.alert-button.alert-button-confirm {
+    background-color: var(--ion-color-success);
+    color: var(--ion-color-success-contrast);
+  }
+
+  .md button.alert-button.alert-button-confirm {
+    border-radius: 4px;
+  }
+
+  .ios .custom-alert button.alert-button {
+    border: 0.55px solid rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.2)
+  }
+
+  .ios button.alert-button.alert-button-cancel {
+    border-right: 0;
+    border-bottom-left-radius: 13px;
+    border-top-left-radius: 13px;
+  }
+
+  .ios button.alert-button.alert-button-confirm {
+    border-bottom-right-radius: 13px;
+    border-top-right-radius: 13px;
+  }
+</style>
+```

--- a/static/usage/alert/customization/react/react_css.md
+++ b/static/usage/alert/customization/react/react_css.md
@@ -1,0 +1,33 @@
+```css
+ion-alert.custom-alert {
+  --backdrop-opacity: 0.7;
+}
+
+.custom-alert .alert-button-group {
+  padding: 8px;
+}
+
+button.alert-button.alert-button-confirm {
+  background-color: var(--ion-color-success);
+  color: var(--ion-color-success-contrast);
+}
+
+.md button.alert-button.alert-button-confirm {
+  border-radius: 4px;
+}
+
+.ios .custom-alert button.alert-button {
+  border: 0.55px solid rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.2)
+}
+
+.ios button.alert-button.alert-button-cancel {
+  border-right: 0;
+  border-bottom-left-radius: 13px;
+  border-top-left-radius: 13px;
+}
+
+.ios button.alert-button.alert-button-confirm {
+  border-bottom-right-radius: 13px;
+  border-top-right-radius: 13px;
+}
+```

--- a/static/usage/alert/customization/react/react_ts.md
+++ b/static/usage/alert/customization/react/react_ts.md
@@ -1,0 +1,30 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, useIonAlert } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  const [presentAlert] = useIonAlert();
+
+  return (
+    <IonContent>
+      <IonButton onClick={() => presentAlert({
+        header: 'Are you sure?',
+        cssClass: 'custom-alert',
+        buttons: [
+          {
+            text: 'No',
+            cssClass: 'alert-button-cancel'
+          },
+          {
+            text: 'Yes',
+            cssClass: 'alert-button-confirm'
+          }
+        ]
+      })}>Click Me</IonButton>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/alert/customization/vue.md
+++ b/static/usage/alert/customization/vue.md
@@ -1,0 +1,69 @@
+```html
+<template>
+  <ion-content>
+    <ion-button @click="presentAlert">Click Me</ion-button>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonContent, alertController } from '@ionic/vue';
+
+  export default {
+    components: { IonButton, IonContent },
+    methods: {
+      async presentAlert() {
+        const alert = await alertController.create({
+          header: 'Are you sure?',
+          cssClass: 'custom-alert',
+          buttons: [
+            {
+              text: 'No',
+              cssClass: 'alert-button-cancel'
+            },
+            {
+              text: 'Yes',
+              cssClass: 'alert-button-confirm'
+            }
+          ]
+        });
+
+        await alert.present();
+      },
+    },
+  }
+</script>
+
+<style>
+  ion-alert.custom-alert {
+    --backdrop-opacity: 0.7;
+  }
+
+  .custom-alert .alert-button-group {
+    padding: 8px;
+  }
+
+  button.alert-button.alert-button-confirm {
+    background-color: var(--ion-color-success);
+    color: var(--ion-color-success-contrast);
+  }
+
+  .md button.alert-button.alert-button-confirm {
+    border-radius: 4px;
+  }
+
+  .ios .custom-alert button.alert-button {
+    border: 0.55px solid rgba(var(--ion-text-color-rgb, 0, 0, 0), 0.2)
+  }
+
+  .ios button.alert-button.alert-button-cancel {
+    border-right: 0;
+    border-bottom-left-radius: 13px;
+    border-top-left-radius: 13px;
+  }
+
+  .ios button.alert-button.alert-button-confirm {
+    border-bottom-right-radius: 13px;
+    border-top-right-radius: 13px;
+  }
+</style>
+```

--- a/static/usage/alert/inputs/radios/angular/angular_html.md
+++ b/static/usage/alert/inputs/radios/angular/angular_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-button (click)="presentAlert()">Click Me</ion-button>
+```

--- a/static/usage/alert/inputs/radios/angular/angular_ts.md
+++ b/static/usage/alert/inputs/radios/angular/angular_ts.md
@@ -1,0 +1,38 @@
+```ts
+import { Component } from '@angular/core';
+import { AlertController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  constructor(private alertController: AlertController) {}
+
+  async presentAlert() {
+    const alert = await this.alertController.create({
+      header: 'Select your favorite color',
+      buttons: ['OK'],
+      inputs: [
+        {
+          label: 'Red',
+          type: 'radio',
+          value: 'red'
+        },
+        {
+          label: 'Blue',
+          type: 'radio',
+          value: 'blue'
+        },
+        {
+          label: 'Green',
+          type: 'radio',
+          value: 'green'
+        }
+      ]
+    });
+
+    await alert.present();
+  }
+}
+```

--- a/static/usage/alert/inputs/radios/demo.html
+++ b/static/usage/alert/inputs/radios/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button onclick="presentAlert()">Click Me</ion-button>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    async function presentAlert() {
+      const alert = document.createElement('ion-alert');
+      alert.header = 'Select your favorite color';
+      alert.buttons = ['OK'];
+      alert.inputs = [
+        {
+          label: 'Red',
+          type: 'radio',
+          value: 'red'
+        },
+        {
+          label: 'Blue',
+          type: 'radio',
+          value: 'blue'
+        },
+        {
+          label: 'Green',
+          type: 'radio',
+          value: 'green'
+        }
+      ];
+
+      document.body.appendChild(alert);
+      await alert.present();
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/alert/inputs/radios/index.md
+++ b/static/usage/alert/inputs/radios/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  size="medium"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.ts': angularTS
+      }
+    }
+  }}
+  src="usage/alert/inputs/radios/demo.html"
+/>

--- a/static/usage/alert/inputs/radios/javascript.md
+++ b/static/usage/alert/inputs/radios/javascript.md
@@ -1,0 +1,31 @@
+```html
+<ion-button onclick="presentAlert()">Click Me</ion-button>
+
+<script>
+  async function presentAlert() {
+    const alert = document.createElement('ion-alert');
+    alert.header = 'Select your favorite color';
+    alert.buttons = ['OK'];
+    alert.inputs = [
+      {
+        label: 'Red',
+        type: 'radio',
+        value: 'red'
+      },
+      {
+        label: 'Blue',
+        type: 'radio',
+        value: 'blue'
+      },
+      {
+        label: 'Green',
+        type: 'radio',
+        value: 'green'
+      }
+    ];
+
+    document.body.appendChild(alert);
+    await alert.present();
+  }
+</script>
+```

--- a/static/usage/alert/inputs/radios/react.md
+++ b/static/usage/alert/inputs/radios/react.md
@@ -1,0 +1,35 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, useIonAlert } from '@ionic/react';
+
+function Example() {
+  const [presentAlert] = useIonAlert();
+
+  return (
+    <IonContent>
+      <IonButton onClick={() => presentAlert({
+        header: 'Select your favorite color',
+        buttons: ['OK'],
+        inputs: [
+          {
+            label: 'Red',
+            type: 'radio',
+            value: 'red'
+          },
+          {
+            label: 'Blue',
+            type: 'radio',
+            value: 'blue'
+          },
+          {
+            label: 'Green',
+            type: 'radio',
+            value: 'green'
+          }
+        ]
+      })}>Click Me</IonButton>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/alert/inputs/radios/vue.md
+++ b/static/usage/alert/inputs/radios/vue.md
@@ -1,0 +1,42 @@
+```html
+<template>
+  <ion-content>
+    <ion-button @click="presentAlert">Click Me</ion-button>
+  </ion-content>
+</template>
+
+<script lang="ts">
+import { IonButton, IonContent, alertController } from '@ionic/vue';
+
+export default {
+  components: { IonButton, IonContent },
+  methods: {
+    async presentAlert() {
+      const alert = await alertController.create({
+        header: 'Select your favorite color',
+        buttons: ['OK'],
+        inputs: [
+          {
+            label: 'Red',
+            type: 'radio',
+            value: 'red'
+          },
+          {
+            label: 'Blue',
+            type: 'radio',
+            value: 'blue'
+          },
+          {
+            label: 'Green',
+            type: 'radio',
+            value: 'green'
+          }
+        ]
+      });
+
+      await alert.present();
+    },
+  },
+}
+</script>
+```

--- a/static/usage/alert/inputs/text-inputs/angular/angular_html.md
+++ b/static/usage/alert/inputs/text-inputs/angular/angular_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-button (click)="presentAlert()">Click Me</ion-button>
+```

--- a/static/usage/alert/inputs/text-inputs/angular/angular_ts.md
+++ b/static/usage/alert/inputs/text-inputs/angular/angular_ts.md
@@ -1,0 +1,42 @@
+```ts
+import { Component } from '@angular/core';
+import { AlertController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  constructor(private alertController: AlertController) {}
+
+  async presentAlert() {
+    const alert = await this.alertController.create({
+      header: 'Please enter your info',
+      buttons: ['OK'],
+      inputs: [
+        {
+          placeholder: 'Name'
+        },
+        {
+          placeholder: 'Nickname (max 8 characters)',
+          attributes: {
+            maxlength: 8
+          }
+        },
+        {
+          type: 'number',
+          placeholder: 'Age',
+          min: 1,
+          max: 100
+        },
+        {
+          type: 'textarea',
+          placeholder: 'A little about yourself'
+        }
+      ]
+    });
+
+    await alert.present();
+  }
+}
+```

--- a/static/usage/alert/inputs/text-inputs/demo.html
+++ b/static/usage/alert/inputs/text-inputs/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button onclick="presentAlert()">Click Me</ion-button>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    async function presentAlert() {
+      const alert = document.createElement('ion-alert');
+      alert.header = 'Please enter your info';
+      alert.buttons = ['OK'];
+      alert.inputs = [
+        {
+          placeholder: 'Name'
+        },
+        {
+          placeholder: 'Nickname (max 8 characters)',
+          attributes: {
+            maxlength: 8
+          }
+        },
+        {
+          type: 'number',
+          placeholder: 'Age',
+          min: 1,
+          max: 100
+        },
+        {
+          type: 'textarea',
+          placeholder: 'A little about yourself'
+        }
+      ];
+
+      document.body.appendChild(alert);
+      await alert.present();
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/alert/inputs/text-inputs/index.md
+++ b/static/usage/alert/inputs/text-inputs/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  size="450px"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.ts': angularTS
+      }
+    }
+  }}
+  src="usage/alert/inputs/text-inputs/demo.html"
+/>

--- a/static/usage/alert/inputs/text-inputs/javascript.md
+++ b/static/usage/alert/inputs/text-inputs/javascript.md
@@ -1,0 +1,35 @@
+```html
+<ion-button onclick="presentAlert()">Click Me</ion-button>
+
+<script>
+  async function presentAlert() {
+    const alert = document.createElement('ion-alert');
+    alert.header = 'Please enter your info';
+    alert.buttons = ['OK'];
+    alert.inputs = [
+      {
+        placeholder: 'Name'
+      },
+      {
+        placeholder: 'Nickname (max 8 characters)',
+        attributes: {
+          maxlength: 8
+        }
+      },
+      {
+        type: 'number',
+        placeholder: 'Age',
+        min: 1,
+        max: 100
+      },
+      {
+        type: 'textarea',
+        placeholder: 'A little about yourself'
+      }
+    ];
+
+    document.body.appendChild(alert);
+    await alert.present();
+  }
+</script>
+```

--- a/static/usage/alert/inputs/text-inputs/react.md
+++ b/static/usage/alert/inputs/text-inputs/react.md
@@ -1,0 +1,39 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, useIonAlert } from '@ionic/react';
+
+function Example() {
+  const [presentAlert] = useIonAlert();
+
+  return (
+    <IonContent>
+      <IonButton onClick={() => presentAlert({
+        header: 'Please enter your info',
+        buttons: ['OK'],
+        inputs: [
+          {
+            placeholder: 'Name'
+          },
+          {
+            placeholder: 'Nickname (max 8 characters)',
+            attributes: {
+              maxlength: 8
+            }
+          },
+          {
+            type: 'number',
+            placeholder: 'Age',
+            min: 1,
+            max: 100
+          },
+          {
+            type: 'textarea',
+            placeholder: 'A little about yourself'
+          }
+        ]
+      })}>Click Me</IonButton>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/alert/inputs/text-inputs/vue.md
+++ b/static/usage/alert/inputs/text-inputs/vue.md
@@ -1,0 +1,46 @@
+```html
+<template>
+  <ion-content>
+    <ion-button @click="presentAlert">Click Me</ion-button>
+  </ion-content>
+</template>
+
+<script lang="ts">
+import { IonButton, IonContent, alertController } from '@ionic/vue';
+
+export default {
+  components: { IonButton, IonContent },
+  methods: {
+    async presentAlert() {
+      const alert = await alertController.create({
+        header: 'Please enter your info',
+        buttons: ['OK'],
+        inputs: [
+          {
+            placeholder: 'Name'
+          },
+          {
+            placeholder: 'Nickname (max 8 characters)',
+            attributes: {
+              maxlength: 8
+            }
+          },
+          {
+            type: 'number',
+            placeholder: 'Age',
+            min: 1,
+            max: 100
+          },
+          {
+            type: 'textarea',
+            placeholder: 'A little about yourself'
+          }
+        ]
+      });
+
+      await alert.present();
+    },
+  },
+}
+</script>
+```

--- a/static/usage/alert/presenting/controller/angular/angular_html.md
+++ b/static/usage/alert/presenting/controller/angular/angular_html.md
@@ -1,4 +1,3 @@
 ```html
 <ion-button (click)="presentAlert()">Click Me</ion-button>
-<p>{{ roleMsg }}</p>
 ```

--- a/static/usage/alert/presenting/controller/angular/angular_html.md
+++ b/static/usage/alert/presenting/controller/angular/angular_html.md
@@ -1,0 +1,4 @@
+```html
+<ion-button (click)="presentAlert()">Click Me</ion-button>
+<p>{{ roleMsg }}</p>
+```

--- a/static/usage/alert/presenting/controller/angular/angular_ts.md
+++ b/static/usage/alert/presenting/controller/angular/angular_ts.md
@@ -1,5 +1,5 @@
 ```ts
-import { Component, ViewChild } from '@angular/core';
+import { Component } from '@angular/core';
 import { AlertController } from '@ionic/angular';
 
 @Component({

--- a/static/usage/alert/presenting/controller/angular/angular_ts.md
+++ b/static/usage/alert/presenting/controller/angular/angular_ts.md
@@ -1,0 +1,28 @@
+```ts
+import { Component, ViewChild } from '@angular/core';
+import { AlertController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+})
+export class AppComponent {
+  roleMsg = "";
+
+  constructor(public alertController: AlertController) {}
+
+  async presentAlert() {
+    const alert = await this.alertController.create({
+      header: 'Alert',
+      subHeader: 'Important message',
+      message: 'This is an alert!',
+      buttons: ['OK']
+    });
+
+    await alert.present();
+  
+    const { role } = await alert.onDidDismiss();
+    this.roleMsg = `Alert dismissed with role: ${role}`;
+  }
+}
+```

--- a/static/usage/alert/presenting/controller/angular/angular_ts.md
+++ b/static/usage/alert/presenting/controller/angular/angular_ts.md
@@ -7,7 +7,7 @@ import { AlertController } from '@ionic/angular';
   templateUrl: 'app.component.html',
 })
 export class AppComponent {
-  constructor(public alertController: AlertController) {}
+  constructor(private alertController: AlertController) {}
 
   async presentAlert() {
     const alert = await this.alertController.create({

--- a/static/usage/alert/presenting/controller/angular/angular_ts.md
+++ b/static/usage/alert/presenting/controller/angular/angular_ts.md
@@ -7,8 +7,6 @@ import { AlertController } from '@ionic/angular';
   templateUrl: 'app.component.html',
 })
 export class AppComponent {
-  roleMsg = "";
-
   constructor(public alertController: AlertController) {}
 
   async presentAlert() {
@@ -20,9 +18,6 @@ export class AppComponent {
     });
 
     await alert.present();
-  
-    const { role } = await alert.onDidDismiss();
-    this.roleMsg = `Alert dismissed with role: ${role}`;
   }
 }
 ```

--- a/static/usage/alert/presenting/controller/demo.html
+++ b/static/usage/alert/presenting/controller/demo.html
@@ -15,7 +15,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-button>Click Me</ion-button>
+        <ion-button onclick="presentAlert()">Click Me</ion-button>
       </div>
     </ion-content>
   </ion-app>
@@ -31,9 +31,6 @@
       document.body.appendChild(alert);
       await alert.present();
     }
-
-    const button = document.querySelector('ion-button');
-    button.addEventListener('click', presentAlert);
   </script>
 </body>
 

--- a/static/usage/alert/presenting/controller/demo.html
+++ b/static/usage/alert/presenting/controller/demo.html
@@ -9,12 +9,6 @@
   <script src="../../../common.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
-
-  <style>
-    .container {
-      flex-direction: column;
-    }
-  </style>
 </head>
 
 <body>
@@ -22,14 +16,11 @@
     <ion-content>
       <div class="container">
         <ion-button>Click Me</ion-button>
-        <p></p>
       </div>
     </ion-content>
   </ion-app>
 
   <script>
-    const output = document.querySelector('p');
-
     async function presentAlert() {
       const alert = document.createElement('ion-alert');
       alert.header = 'Alert';
@@ -39,9 +30,6 @@
 
       document.body.appendChild(alert);
       await alert.present();
-
-      const { role } = await alert.onDidDismiss();
-      output.innerText = `Alert dismissed with role: ${role}`;
     }
 
     const button = document.querySelector('ion-button');

--- a/static/usage/alert/presenting/controller/demo.html
+++ b/static/usage/alert/presenting/controller/demo.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      flex-direction: column;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button>Click Me</ion-button>
+        <p></p>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const output = document.querySelector('p');
+
+    async function presentAlert() {
+      const alert = document.createElement('ion-alert');
+      alert.header = 'Alert';
+      alert.subHeader = 'Important message';
+      alert.message = 'This is an alert!';
+      alert.buttons = ['OK'];
+
+      document.body.appendChild(alert);
+      await alert.present();
+
+      const { role } = await alert.onDidDismiss();
+      output.innerText = `Alert dismissed with role: ${role}`;
+    }
+
+    const button = document.querySelector('ion-button');
+    button.addEventListener('click', presentAlert);
+  </script>
+</body>
+
+</html>

--- a/static/usage/alert/presenting/controller/index.md
+++ b/static/usage/alert/presenting/controller/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angularHTML from './angular/angular_html.md';
+import angularTS from './angular/angular_ts.md';
+
+<Playground
+  size="300px"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.ts': angularTS
+      }
+    }
+  }}
+  src="usage/alert/presenting/controller/demo.html"
+/>

--- a/static/usage/alert/presenting/controller/javascript.md
+++ b/static/usage/alert/presenting/controller/javascript.md
@@ -1,0 +1,25 @@
+```html
+<ion-button>Click Me</ion-button>
+<p></p>
+
+<script>
+  const output = document.querySelector('p');
+
+  async function presentAlert() {
+    const alert = document.createElement('ion-alert');
+    alert.header = 'Alert';
+    alert.subHeader = 'Important message';
+    alert.message = 'This is an alert!';
+    alert.buttons = ['OK'];
+
+    document.body.appendChild(alert);
+    await alert.present();
+
+    const { role } = await alert.onDidDismiss();
+    output.innerText = `Alert dismissed with role: ${role}`;
+  }
+
+  const button = document.querySelector('ion-button');
+  button.addEventListener('click', presentAlert);
+</script>
+```

--- a/static/usage/alert/presenting/controller/javascript.md
+++ b/static/usage/alert/presenting/controller/javascript.md
@@ -1,10 +1,7 @@
 ```html
 <ion-button>Click Me</ion-button>
-<p></p>
 
 <script>
-  const output = document.querySelector('p');
-
   async function presentAlert() {
     const alert = document.createElement('ion-alert');
     alert.header = 'Alert';
@@ -14,9 +11,6 @@
 
     document.body.appendChild(alert);
     await alert.present();
-
-    const { role } = await alert.onDidDismiss();
-    output.innerText = `Alert dismissed with role: ${role}`;
   }
 
   const button = document.querySelector('ion-button');

--- a/static/usage/alert/presenting/controller/javascript.md
+++ b/static/usage/alert/presenting/controller/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-button>Click Me</ion-button>
+<ion-button onclick="presentAlert()">Click Me</ion-button>
 
 <script>
   async function presentAlert() {
@@ -12,8 +12,5 @@
     document.body.appendChild(alert);
     await alert.present();
   }
-
-  const button = document.querySelector('ion-button');
-  button.addEventListener('click', presentAlert);
 </script>
 ```

--- a/static/usage/alert/presenting/controller/react.md
+++ b/static/usage/alert/presenting/controller/react.md
@@ -1,0 +1,23 @@
+```tsx
+import React, { useState } from 'react';
+import { IonButton, IonContent, useIonAlert } from '@ionic/react';
+
+function Example() {
+  const [presentAlert] = useIonAlert();
+  const [roleMsg, setRoleMsg] = useState('');
+
+  return (
+    <IonContent>
+      <IonButton onClick={() => presentAlert({
+        header: 'Alert',
+        subHeader: 'Important message',
+        message: 'This is an alert!',
+        buttons: ['OK'],
+        onDidDismiss: (e: CustomEvent) => setRoleMsg(`Popover dismissed with role: ${e.detail.role}`)
+      })}>Click Me</IonButton>
+      <p>{roleMsg}</p>
+    </IonContent>
+  );
+}
+export default Example;
+```

--- a/static/usage/alert/presenting/controller/react.md
+++ b/static/usage/alert/presenting/controller/react.md
@@ -1,10 +1,9 @@
 ```tsx
-import React, { useState } from 'react';
+import React from 'react';
 import { IonButton, IonContent, useIonAlert } from '@ionic/react';
 
 function Example() {
   const [presentAlert] = useIonAlert();
-  const [roleMsg, setRoleMsg] = useState('');
 
   return (
     <IonContent>
@@ -13,9 +12,7 @@ function Example() {
         subHeader: 'Important message',
         message: 'This is an alert!',
         buttons: ['OK'],
-        onDidDismiss: (e: CustomEvent) => setRoleMsg(`Popover dismissed with role: ${e.detail.role}`)
       })}>Click Me</IonButton>
-      <p>{roleMsg}</p>
     </IonContent>
   );
 }

--- a/static/usage/alert/presenting/controller/vue.md
+++ b/static/usage/alert/presenting/controller/vue.md
@@ -2,7 +2,6 @@
 <template>
   <ion-content>
     <ion-button @click="presentAlert">Click Me</ion-button>
-    <p>{{ roleMsg }}</p>
   </ion-content>
 </template>
 
@@ -11,11 +10,6 @@ import { IonButton, IonContent, alertController } from '@ionic/vue';
 
 export default {
   components: { IonButton, IonContent },
-  data() {
-    return {
-      roleMsg: ''
-    };
-  },
   methods: {
     async presentAlert() {
       const alert = await alertController.create({
@@ -26,9 +20,6 @@ export default {
       });
 
       await alert.present();
-
-      const { role } = await alert.onDidDismiss();
-      this.roleMsg = `Alert dismissed with role: ${role}`;
     },
   },
 }

--- a/static/usage/alert/presenting/controller/vue.md
+++ b/static/usage/alert/presenting/controller/vue.md
@@ -1,0 +1,36 @@
+```html
+<template>
+  <ion-content>
+    <ion-button @click="presentAlert">Click Me</ion-button>
+    <p>{{ roleMsg }}</p>
+  </ion-content>
+</template>
+
+<script lang="ts">
+import { IonButton, IonContent, alertController } from '@ionic/vue';
+
+export default {
+  components: { IonButton, IonContent },
+  data() {
+    return {
+      roleMsg: ''
+    };
+  },
+  methods: {
+    async presentAlert() {
+      const alert = await alertController.create({
+        header: 'Alert',
+        subHeader: 'Important message',
+        message: 'This is an alert!',
+        buttons: ['OK']
+      });
+
+      await alert.present();
+
+      const { role } = await alert.onDidDismiss();
+      this.roleMsg = `Alert dismissed with role: ${role}`;
+    },
+  },
+}
+</script>
+```


### PR DESCRIPTION
Adds the controller playground, and usage examples for an inline alert. (Inline alerts aren't available in vanilla JS, so we can't show a demo for it.)