### PR TITLE
docs(playground): fix datetime and select react urls

### DIFF
--- a/static/usage/datetime/theming/index.md
+++ b/static/usage/datetime/theming/index.md
@@ -13,8 +13,8 @@ import angularCSS from './angular-css.md';
     javascript, 
     react: {
       files: {
-        'main.js': reactHTML,
-        'main.css': reactCSS
+        'src/main.tsx': reactHTML,
+        'src/main.css': reactCSS
       }
     }, 
     vue, 

--- a/static/usage/select/customization/styling-select/index.md
+++ b/static/usage/select/customization/styling-select/index.md
@@ -16,8 +16,8 @@ import angularTS from './angular/angular-ts.md';
     javascript,
     react: {
       files: {
-        'main.js': reactTS,
-        'main.css': reactCSS
+        'src/main.tsx': reactTS,
+        'src/main.css': reactCSS
       }
     },
     vue,


### PR DESCRIPTION
Datetime and select still had some pre-TypeScript URLs for React. Currently this causes the apps to fail to load on StackBlitz. I updated the config for these playgrounds with the correct URLs.