### PR TITLE
docs(react): remove extra IonPage from tabs sample

### DIFF
--- a/docs/react/navigation.md
+++ b/docs/react/navigation.md
@@ -424,7 +424,6 @@ import {
   IonContent,
   IonIcon,
   IonLabel,
-  IonPage,
   IonRouterOutlet,
   IonTabBar,
   IonTabButton,
@@ -437,41 +436,39 @@ import Tab2 from './pages/Tab2';
 import Tab3 from './pages/Tab3';
 
 const Tabs: React.FC = () => (
-  <IonPage>
-    <IonContent>
-      <IonTabs>
-        <IonRouterOutlet>
-          <Redirect exact path="/tabs" to="/tabs/tab1" />
-          <Route exact path="/tabs/tab1">
-            <Tab1 />
-          </Route>
-          <Route exact path="/tabs/tab2">
-            <Tab2 />
-          </Route>
-          <Route path="/tabs/tab3">
-            <Tab3 />
-          </Route>
-          <Route exact path="/tabs">
-            <Redirect to="/tabs/tab1" />
-          </Route>
-        </IonRouterOutlet>
-        <IonTabBar slot="bottom">
-          <IonTabButton tab="tab1" href="/tabs/tab1">
-            <IonIcon icon={triangle} />
-            <IonLabel>Tab 1</IonLabel>
-          </IonTabButton>
-          <IonTabButton tab="tab2" href="/tabs/tab2">
-            <IonIcon icon={ellipse} />
-            <IonLabel>Tab 2</IonLabel>
-          </IonTabButton>
-          <IonTabButton tab="tab3" href="/tabs/tab3">
-            <IonIcon icon={square} />
-            <IonLabel>Tab 3</IonLabel>
-          </IonTabButton>
-        </IonTabBar>
-      </IonTabs>
-    </IonContent>
-  </IonPage>
+  <IonContent>
+    <IonTabs>
+      <IonRouterOutlet>
+        <Redirect exact path="/tabs" to="/tabs/tab1" />
+        <Route exact path="/tabs/tab1">
+          <Tab1 />
+        </Route>
+        <Route exact path="/tabs/tab2">
+          <Tab2 />
+        </Route>
+        <Route path="/tabs/tab3">
+          <Tab3 />
+        </Route>
+        <Route exact path="/tabs">
+          <Redirect to="/tabs/tab1" />
+        </Route>
+      </IonRouterOutlet>
+      <IonTabBar slot="bottom">
+        <IonTabButton tab="tab1" href="/tabs/tab1">
+          <IonIcon icon={triangle} />
+          <IonLabel>Tab 1</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab="tab2" href="/tabs/tab2">
+          <IonIcon icon={ellipse} />
+          <IonLabel>Tab 2</IonLabel>
+        </IonTabButton>
+        <IonTabButton tab="tab3" href="/tabs/tab3">
+          <IonIcon icon={square} />
+          <IonLabel>Tab 3</IonLabel>
+        </IonTabButton>
+      </IonTabBar>
+    </IonTabs>
+  </IonContent>
 );
 
 export default Tabs;


### PR DESCRIPTION
IonTabs already renders `.ion-page`, so adding another one causes the view to be hidden: https://github.com/ionic-team/ionic-framework/issues/25562