### PR TITLE
docs(picker): remove refresh key

### DIFF
--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -69,7 +69,6 @@ interface PickerColumn {
   prefixWidth?: string;
   suffixWidth?: string;
   optionsWidth?: string;
-  refresh?: () => void;
 }
 ```
 


### PR DESCRIPTION
Removes refresh key from PickerColumn interface

See https://github.com/ionic-team/ionic-framework/issues/25631 for context.