### PR TITLE
fix(datetime): override dark mode in theming playground

### DIFF
--- a/static/usage/datetime/theming/demo.html
+++ b/static/usage/datetime/theming/demo.html
@@ -9,7 +9,9 @@
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
     <style>
-      :root {
+      :root,
+      .ios body.dark,
+      .md body.dark {
         --ion-color-rose: #831843;
         --ion-color-rose-rgb: 131,24,67;
         --ion-color-rose-contrast: #ffffff;


### PR DESCRIPTION
This bug only impacted the playground demo, not the StackBlitz examples. The default dark mode was overriding the custom styles I had set.