### PR TITLE
docs(playground): add loading screen

### DIFF
--- a/src/components/global/Playground/icons/IconDots.css
+++ b/src/components/global/Playground/icons/IconDots.css
@@ -1,0 +1,63 @@
+.icon__dots {
+  position: relative;
+
+  width: 50px;
+  height: 50px;
+}
+
+.icon__dots circle {
+  stroke-width: 0;
+  fill: currentColor;
+}
+
+.icon__dots svg {
+  position: absolute;
+
+  top: 0;
+  left: 0;
+
+  width: 100%;
+  height: 100%;
+
+  transform-origin: center;
+
+  animation: spinner-dots 1s linear infinite;
+}
+
+.icon__dots svg:nth-of-type(1) {
+  left: 14px;
+  animation-delay: 0ms;
+  animation-duration: 750ms;
+}
+
+.icon__dots svg:nth-of-type(2) {
+  left: 0px;
+  animation-delay: -110ms;
+  animation-duration: 750ms;
+}
+
+.icon__dots svg:nth-of-type(3) {
+  left: -14px;
+  animation-delay: -220ms;
+  animation-duration: 750ms;
+}
+
+@keyframes spinner-dots {
+  0% {
+    transform: scale(1, 1);
+
+    opacity: .9;
+  }
+
+  50% {
+    transform: scale(.4, .4);
+
+    opacity: .3;
+  }
+
+  100% {
+    transform: scale(1, 1);
+
+    opacity: .9;
+  }
+}

--- a/src/components/global/Playground/icons/IconDots.tsx
+++ b/src/components/global/Playground/icons/IconDots.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import './IconDots.css';
+
+export const IconDots = () => (
+  <div class="icon__dots">
+    <svg viewBox="0 0 64 64">
+      <circle transform="translate(32,32)" r="6"></circle>
+    </svg>
+    <svg viewBox="0 0 64 64">
+      <circle transform="translate(32,32)" r="6"></circle>
+    </svg>
+    <svg viewBox="0 0 64 64">
+      <circle transform="translate(32,32)" r="6"></circle>
+    </svg>
+  </div>
+);

--- a/src/components/global/Playground/icons/index.ts
+++ b/src/components/global/Playground/icons/index.ts
@@ -1,3 +1,4 @@
 export * from './IconHtml';
 export * from './IconTs';
 export * from './IconVue';
+export * from './IconDots';

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -123,6 +123,7 @@ export default function Playground({
   const [codeExpanded, setCodeExpanded] = useState(expandCodeByDefault);
   const [codeSnippets, setCodeSnippets] = useState({});
   const [renderIframes, setRenderIframes] = useState(false);
+  const [iframesLoaded, setIframesLoaded] = useState(false);
 
   /**
    * Rather than encode isDarkTheme into the frame source
@@ -138,6 +139,17 @@ export default function Playground({
       frameMD.current.contentWindow.postMessage(message);
     }
   }, [isDarkTheme]);
+
+  /**
+   * The source of the iframe takes a moment to
+   * load, so a loading screen is shown by default.
+   * Once the source of the iframe loads we can
+   * hide the loading screen and show the inner content.
+   */
+  useEffect(async () => {
+    await Promise.all([waitForFrame(frameiOS.current), waitForFrame(frameMD.current)]);
+    setIframesLoaded(true);
+  }, [renderIframes]);
 
   useEffect(() => {
     /**
@@ -304,6 +316,12 @@ export default function Playground({
     }
   }
 
+  function renderLoadingScreen() {
+    return (
+      <div class="playground__loading">Loading...</div>
+    )
+  }
+
   return (
     <div className="playground" ref={hostRef}>
       <div className="playground__container">
@@ -444,6 +462,7 @@ export default function Playground({
         </div>
         { renderIframes ? [
           <div className="playground__preview">
+            {!iframesLoaded && renderLoadingScreen()}
             {/*
               We render two iframes, one for each mode.
               When the set mode changes, we hide one frame and

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -11,7 +11,7 @@ import 'tippy.js/dist/tippy.css';
 import PlaygroundTabs from '../PlaygroundTabs';
 import TabItem from '@theme/TabItem';
 
-import { IconHtml, IconTs, IconVue } from './icons';
+import { IconHtml, IconTs, IconVue, IconDots } from './icons';
 
 const ControlButton = ({ isSelected, handleClick, title, label }) => {
   return (
@@ -318,7 +318,7 @@ export default function Playground({
 
   function renderLoadingScreen() {
     return (
-      <div class="playground__loading">Loading...</div>
+      <div class="playground__loading"><IconDots /></div>
     )
   }
 

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -62,6 +62,8 @@
   padding: 16px 0;
 
   overflow: auto;
+
+  position: relative;
 }
 
 .playground__control-toolbar {
@@ -277,4 +279,23 @@
 
 .tippy-box[data-theme="playground"] .tippy-content {
   padding: 6px 10px;
+}
+
+
+/* Loading Screen */
+.playground .playground__loading {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+
+  display: flex;
+
+  justify-content: center;
+  align-items: center;
+
+  font-size: 1.4rem;
+
+  background: var(--ifm-background-color);
 }


### PR DESCRIPTION
Component playgrounds are now lazily loaded as you scroll the page (as opposed to all up front on page load). As a result, there is a moment between when the iframes are initialized and the source page is rendered. This PR adds a simple loading screen to inform users that the content is being loaded. Without this loading screen, the playgrounds may be perceived as broken, especially when a playground is being loaded over a slow connection.

Discussed with Ben and we decided on showing 3 animated dots on the same line instead of loading text.

Demo: https://ionic-docs-git-fw-1430-ionic1.vercel.app/docs/api/datetime#basic-usage