### PR TITLE
fix(playground): remove code expand/collapse feature

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -27,13 +27,12 @@ const ControlButton = ({ isSelected, handleClick, title, label }) => {
   );
 };
 
-const CodeBlockButton = ({ language, usageTarget, setUsageTarget, setCodeExpanded }) => {
+const CodeBlockButton = ({ language, usageTarget, setUsageTarget }) => {
   const langValue = UsageTarget[language];
   return (
     <ControlButton
       isSelected={usageTarget === langValue}
       handleClick={() => {
-        setCodeExpanded(true);
         setUsageTarget(langValue);
       }}
       title={`Show ${language} code`}
@@ -92,7 +91,6 @@ export default function Playground({
   src,
   size = 'small',
   devicePreview,
-  expandCodeByDefault = false,
 }: {
   code: { [key in UsageTarget]?: MdxContent | UsageTargetOptions };
   title?: string;
@@ -100,7 +98,6 @@ export default function Playground({
   size: string;
   description?: string;
   devicePreview?: boolean;
-  expandCodeByDefault: boolean
 }) {
   if (!code || Object.keys(code).length === 0) {
     console.warn('No code usage examples provided for this Playground example.');
@@ -120,7 +117,6 @@ export default function Playground({
   const frameSize = FRAME_SIZES[size] || size;
   const [usageTarget, setUsageTarget] = useState(UsageTarget.JavaScript);
   const [mode, setMode] = useState(Mode.iOS);
-  const [codeExpanded, setCodeExpanded] = useState(expandCodeByDefault);
   const [codeSnippets, setCodeSnippets] = useState({});
   const [renderIframes, setRenderIframes] = useState(false);
 
@@ -315,7 +311,6 @@ export default function Playground({
                 language={lang}
                 usageTarget={usageTarget}
                 setUsageTarget={setUsageTarget}
-                setCodeExpanded={setCodeExpanded}
               />
             ))}
           </div>
@@ -324,30 +319,6 @@ export default function Playground({
             <ControlButton isSelected={isMD} handleClick={() => setMode(Mode.MD)} title="MD mode" label="MD" />
           </div>
           <div className="playground__control-group playground__control-group--end">
-            <Tippy
-              theme="playground"
-              arrow={false}
-              placement="bottom"
-              content={codeExpanded ? 'Hide source code' : 'Show full source'}
-            >
-              <button
-                className="playground__icon-button playground__icon-button--primary"
-                aria-label={codeExpanded ? 'Hide source code' : 'Show full source'}
-                onClick={() => setCodeExpanded(!codeExpanded)}
-              >
-                <svg
-                  width="16"
-                  height="10"
-                  aria-hidden="true"
-                  viewBox="0 0 16 10"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path d="M5 9L1 5L5 1" stroke="current" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M11 9L15 5L11 1" stroke="current" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </button>
-            </Tippy>
             <Tippy theme="playground" arrow={false} placement="bottom" content="Open in StackBlitz">
               <button className="playground__icon-button playground__icon-button--primary" onClick={openEditor}>
                 <svg
@@ -483,8 +454,7 @@ export default function Playground({
       </div>
       <div
         ref={codeRef}
-        className={'playground__code-block ' + (codeExpanded ? 'playground__code-block--expanded' : '')}
-        aria-expanded={codeExpanded ? 'true' : 'false'}
+        className='playground__code-block'
       >
         {renderCodeSnippets()}
       </div>

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -24,7 +24,7 @@
    * @prop --playground-btn-icon-color The text color of the button icon in the toolbar.
    * @prop --playground-btn-icon-hover-background The background color of the button icon in the toolbar when hovered.
    * @prop --playground-separator-color The color of the separator/border in the toolbar.
-   * @prop --playground-code-background The background color of the code block when expanded.
+   * @prop --playground-code-background The background color of the code block.
    * @prop --playground-tabs-background: The background color of the tabs bar not including the active tab button.
    * @prop --playground-tab-btn-color: The text color of the tab buttons.
    * @prop --playground-tab-btn-border-color: The border color of the tab buttons.
@@ -181,19 +181,8 @@
 
 /* The code block example that users can copy to clipboard */
 .playground__code-block {
-  /*
-   * Height is set to zero instead of display: none so that when copying the contents
-   * of the code block to use in Stackblitz, the individual line breaks are preserved.
-   * Otherwise when using display: none, the result of el.outerText will not include
-   * the individual "\n" line breaks and the code snippet will be one line.
-   */
-  height: 0px;
-  overflow: hidden;
-}
-
-.playground__code-block--expanded {
-  height: initial;
   margin-top: 16px;
+  overflow: hidden;
 }
 
 /* overwrite existing Docusaurus style */

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -182,7 +182,6 @@
 /* The code block example that users can copy to clipboard */
 .playground__code-block {
   margin-top: 16px;
-  overflow: hidden;
 }
 
 /* overwrite existing Docusaurus style */

--- a/static/usage/accordion/basic/index.md
+++ b/static/usage/accordion/basic/index.md
@@ -14,5 +14,4 @@ import angular from './angular.md';
   }}
   src="usage/accordion/basic/demo.html"
   size="210px"
-  expandCodeByDefault={true}
 />

--- a/static/usage/accordion/listen-changes/index.md
+++ b/static/usage/accordion/listen-changes/index.md
@@ -20,5 +20,4 @@ import angularTS from './angular-ts.md';
   }}
   size="320px"
   src="usage/accordion/listen-changes/demo.html"
-  expandCodeByDefault={true}
 />

--- a/static/usage/accordion/multiple/index.md
+++ b/static/usage/accordion/multiple/index.md
@@ -14,5 +14,4 @@ import angular from './angular.md';
   }}
   size="320px"
   src="usage/accordion/multiple/demo.html"
-  expandCodeByDefault={true}
 />


### PR DESCRIPTION
We've received feedback that the collapsing behavior is confusing; namely, all snippets should be expanded by default, and the JS framework tab should not appear selected if its code isn't expanded. To keep things simple, we decided to remove the expand/collapse feature entirely and wait for user feedback before iterating further.