### PR TITLE
docs(modal): handleBehavior playground example

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -135,6 +135,14 @@ import SheetBackgroundContentExample from '@site/static/usage/modal/sheet/backgr
 
 <SheetBackgroundContentExample />
 
+#### Handle Behavior
+
+Sheet modals can optionally render a handle indicator used for dragging the sheet between breakpoints. The `handleBehavior` property can be used to configure the behavior of when the handle is tapped or clicked by the user.
+
+import SheetHandleBehaviorExample from '@site/static/usage/modal/sheet/handle-behavior/index.md';
+
+<SheetHandleBehaviorExample />
+
 ## Styling
 
 Modals are presented at the root of your application so they overlay your entire app. This behavior applies to both inline modals and modals presented from a controller. As a result, custom modal styles can not be scoped to a particular component as they will not apply to the modal. Instead, styles must be applied globally. For most developers, placing the custom styles in `global.css` is sufficient.

--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -137,7 +137,7 @@ import SheetBackgroundContentExample from '@site/static/usage/modal/sheet/backgr
 
 #### Handle Behavior
 
-Sheet modals can optionally render a handle indicator used for dragging the sheet between breakpoints. The `handleBehavior` property can be used to configure the behavior of when the handle is tapped or clicked by the user.
+Sheet modals can optionally render a handle indicator used for dragging the sheet between breakpoints. The `handleBehavior` property can be used to configure the behavior of when the handle is activated by the user.
 
 import SheetHandleBehaviorExample from '@site/static/usage/modal/sheet/handle-behavior/index.md';
 

--- a/static/usage/modal/sheet/background-content/angular/app_component_html.md
+++ b/static/usage/modal/sheet/background-content/angular/app_component_html.md
@@ -24,7 +24,7 @@
       [backdropBreakpoint]="0.5"
     >
       <ng-template>
-        <ion-content>
+        <ion-content class="ion-padding">
           <ion-searchbar placeholder="Search" (click)="modal.setCurrentBreakpoint(0.75)"></ion-searchbar>
           <ion-list>
             <ion-item>

--- a/static/usage/modal/sheet/handle-behavior/angular.md
+++ b/static/usage/modal/sheet/handle-behavior/angular.md
@@ -1,0 +1,27 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+    <ion-modal
+      trigger="open-modal"
+      [initialBreakpoint]="0.25"
+      [breakpoints]="[0, 0.25, 0.5, 0.75]"
+      handleBehavior="cycle"
+    >
+      <ng-template>
+        <ion-content class="ion-padding">
+          <div class="ion-margin-top">
+            <ion-label>Click the handle above to advance to the next breakpoint.</ion-label>
+          </div>
+        </ion-content>
+      </ng-template>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+```

--- a/static/usage/modal/sheet/handle-behavior/demo.html
+++ b/static/usage/modal/sheet/handle-behavior/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Modal | Sheet</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>App</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+      <ion-modal trigger="open-modal" initial-breakpoint="0.25" handle-behavior="cycle">
+        <ion-content>
+          <div class="ion-margin-top">
+            <ion-label>Click the handle above to advance to the next breakpoint.</ion-label>
+          </div>
+        </ion-content>
+      </ion-modal>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const modal = document.querySelector('ion-modal');
+
+    modal.breakpoints = [0, 0.25, 0.5, 0.75];
+  </script>
+</body>
+
+</html>

--- a/static/usage/modal/sheet/handle-behavior/demo.html
+++ b/static/usage/modal/sheet/handle-behavior/demo.html
@@ -22,7 +22,7 @@
       <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
 
       <ion-modal trigger="open-modal" initial-breakpoint="0.25" handle-behavior="cycle">
-        <ion-content>
+        <ion-content class="ion-padding">
           <div class="ion-margin-top">
             <ion-label>Click the handle above to advance to the next breakpoint.</ion-label>
           </div>

--- a/static/usage/modal/sheet/handle-behavior/index.md
+++ b/static/usage/modal/sheet/handle-behavior/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+import react from './react.md';
+import angular from './angular.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/modal/sheet/basic/demo.html"
+  devicePreview
+/>

--- a/static/usage/modal/sheet/handle-behavior/index.md
+++ b/static/usage/modal/sheet/handle-behavior/index.md
@@ -12,6 +12,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/modal/sheet/basic/demo.html"
+  src="usage/modal/sheet/handle-behavior/demo.html"
   devicePreview
 />

--- a/static/usage/modal/sheet/handle-behavior/javascript.md
+++ b/static/usage/modal/sheet/handle-behavior/javascript.md
@@ -1,0 +1,26 @@
+```html
+<ion-app>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+    <ion-modal trigger="open-modal" initial-breakpoint="0.25" handle-behavior="cycle">
+      <ion-content>
+        <div class="ion-margin-top">
+          <ion-label>Click the handle above to advance to the next breakpoint.</ion-label>
+        </div>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</ion-app>
+
+<script>
+  var modal = document.querySelector('ion-modal');
+
+  modal.breakpoints = [0, 0.25, 0.5, 0.75];
+</script>
+```

--- a/static/usage/modal/sheet/handle-behavior/javascript.md
+++ b/static/usage/modal/sheet/handle-behavior/javascript.md
@@ -9,7 +9,7 @@
     <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
 
     <ion-modal trigger="open-modal" initial-breakpoint="0.25" handle-behavior="cycle">
-      <ion-content>
+      <ion-content class="ion-padding">
         <div class="ion-margin-top">
           <ion-label>Click the handle above to advance to the next breakpoint.</ion-label>
         </div>

--- a/static/usage/modal/sheet/handle-behavior/react.md
+++ b/static/usage/modal/sheet/handle-behavior/react.md
@@ -1,0 +1,35 @@
+```tsx
+import React from 'react';
+import { IonButton, IonModal, IonHeader, IonContent, IonToolbar, IonTitle, IonPage, IonLabel } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>App</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonButton id="open-modal" expand="block">
+          Open Sheet Modal
+        </IonButton>
+        <IonModal
+          trigger="open-modal"
+          initialBreakpoint={0.25}
+          breakpoints={[0, 0.25, 0.5, 0.75]}
+          handleBehavior="cycle"
+        >
+          <IonContent className="ion-padding">
+            <div className="ion-margin-top">
+              <IonLabel>Click the handle above to advance to the next breakpoint.</IonLabel>
+            </div>
+          </IonContent>
+        </IonModal>
+      </IonContent>
+    </IonPage>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/modal/sheet/handle-behavior/vue.md
+++ b/static/usage/modal/sheet/handle-behavior/vue.md
@@ -1,0 +1,42 @@
+```html
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>App</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content class="ion-padding">
+    <ion-button id="open-modal" expand="block">Open Sheet Modal</ion-button>
+
+    <ion-modal
+      trigger="open-modal"
+      :initial-breakpoint="0.25"
+      :breakpoints="[0, 0.25, 0.5, 0.75]"
+      handle-behavior="cycle"
+    >
+      <ion-content class="ion-padding">
+        <div class="ion-margin-top">
+          <ion-label>Click the handle above to advance to the next breakpoint.</ion-label>
+        </div>
+      </ion-content>
+    </ion-modal>
+  </ion-content>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonModal, IonHeader, IonContent, IonToolbar, IonTitle, IonLabel } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton,
+      IonModal,
+      IonHeader,
+      IonContent,
+      IonToolbar,
+      IonTitle,
+      IonLabel,
+    },
+  });
+</script>
+```


### PR DESCRIPTION
Introduces a new section for the `handleBehavior` option available with Modal. 

Quick link: https://ionic-docs-git-docs-modal-handle-behavior-ionic1.vercel.app/docs/api/modal#handle-behavior

Misc:
- Fixed missing class for Angular background content example.

Note: The demo and Stackblitz examples are not using the dev-build. I can temporarily update the version they use, if that would be helpful for reviewing. 

Dev-build for testing: `6.1.14-dev.11658252995.1c2781cc`