### PR TITLE
WIP: add some documentation on IonicSlides

### DIFF
--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -166,7 +166,7 @@ See <a href="https://swiperjs.com/angular#usage" target="_blank" rel="noopener n
 
 ## The IonicSlides Module
 
-With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly.
+With `ion-slides`, Ionic automatically customized dozens of Swiper properties, for example turning off zoom on doubleclick. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly.
 
 We can install the `IonicSlides` module by importing it from `@ionic/angular` and passing it in as the last item in the array provided in `SwiperCore.use`:
 


### PR DESCRIPTION
WIP: would be great to have  some documentation on IonicSlides actually do. Migrating from ion-slides I got the regression that pinch zoom on mobiles work, but doubleclick to zoom (desktop) stopped working. Puzzled because https://swiperjs.com/types/interfaces/types_modules_zoom.zoomoptions says toggle is default true - and then I came to think about IonicSlides.

Not sure this is the best place to put it though, but it would be convenient with a list of what settings IonicSlides overrides somewhere, and link to it.