### PR TITLE
docs(): fix 6.2 demos to use correct cdn version

### DIFF
--- a/static/usage/datetime/multiple/demo.html
+++ b/static/usage/datetime/multiple/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/datetime/presentation/wheel/demo.html
+++ b/static/usage/datetime/presentation/wheel/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/modal/performance/mount/demo.html
+++ b/static/usage/modal/performance/mount/demo.html
@@ -7,10 +7,10 @@
   <title>Modal | Controller</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/css/ionic.bundle.css" />
   <script type="module">
-    import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
+    import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/dist/ionic/index.esm.js';
     window.modalController = modalController;
   </script>
 </head>

--- a/static/usage/modal/sheet/handle-behavior/demo.html
+++ b/static/usage/modal/sheet/handle-behavior/demo.html
@@ -7,8 +7,8 @@
   <title>Modal | Sheet</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/css/ionic.bundle.css" />
 </head>
 
 <body>

--- a/static/usage/popover/performance/mount/demo.html
+++ b/static/usage/popover/performance/mount/demo.html
@@ -7,8 +7,8 @@
   <title>Popover</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.2.0/css/ionic.bundle.css" />
 </head>
 
 <body>


### PR DESCRIPTION
JSDelivr caches `latest` for about 7 days: https://github.com/jsdelivr/jsdelivr#caching. Until we can get access to purging the cache, we need to fix the CDN version.