### PR TITLE
docs(support): update v5 to extended support only

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -23,7 +23,7 @@ The current status of each Ionic Framework version is:
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
 | V6      | **Active**            | Dec 8, 2021  | TBD              | TBD               |
-| V5      | Maintenance           | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
+| V5      | Extended Support Only | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
 | V4      | Extended Support Only | Jan 23, 2019 | Aug 11, 2020     | Sept 30, 2022     |
 | V3      | End of Support        | Apr 5, 2017  | Oct 30, 2019     | Aug 11, 2020      |
 | V2      | End of Support        | Jan 25, 2017 | Apr 5, 2017      | Apr 5, 2017       |


### PR DESCRIPTION
Updates the support table to list Ionic 5 as Extended Support Only, since maintenance ended in June.