### PR TITLE
docs(release-notes): update version names

### DIFF
--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -236,6 +236,16 @@ var versions = [
     symbol: 'V',
     element: 'Vanadium',
   },
+  {
+    minor: '6.2',
+    symbol: 'Cr',
+    element: 'Chromium'
+  },
+  {
+    minor: '6.3',
+    symbol: 'Mn',
+    element: 'Manganese'
+  }
 ];
 
 var fallbackVersion = { minor: '9201', symbol: 'Uo', element: 'Unobtainium' };


### PR DESCRIPTION
Adds version names for Ionic 6.2 and Ionic 6.3