### PR TITLE
fix(playground): ensure dark mode loads on iframes at start

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -138,8 +138,8 @@ export default function Playground({
     }
   };
 
-  const handleFrameRef = (ref: HTMLIFrameElement, frameMode: 'iOS' | 'md') => {
-    if (frameMode === 'iOS') {
+  const handleFrameRef = (ref: HTMLIFrameElement, frameMode: 'ios' | 'md') => {
+    if (frameMode === 'ios') {
       frameiOS.current = ref;
     } else {
       frameMD.current = ref;
@@ -497,7 +497,7 @@ export default function Playground({
                   ? [
                       <div className={!isIOS ? 'frame-hidden' : 'frame-visible'}>
                         <device-preview mode="ios">
-                          <iframe height={frameSize} ref={ref => handleFrameRef(ref, 'iOS')} src={sourceiOS}></iframe>
+                          <iframe height={frameSize} ref={ref => handleFrameRef(ref, 'ios')} src={sourceiOS}></iframe>
                         </device-preview>
                       </div>,
                       <div className={!isMD ? 'frame-hidden' : 'frame-visible'}>
@@ -510,7 +510,7 @@ export default function Playground({
                       <iframe
                         height={frameSize}
                         className={!isIOS ? 'frame-hidden' : ''}
-                        ref={ref => handleFrameRef(ref, 'iOS')}
+                        ref={ref => handleFrameRef(ref, 'ios')}
                         src={sourceiOS}
                       ></iframe>,
                       <iframe


### PR DESCRIPTION
Currently, if the page is set to dark mode on initial load, the playground iframes will still display in light mode. They only update when the mode is toggled on and off after the fact.

While the `useEffect` callback _does_ run on initial page load, the iframe refs haven't yet loaded, so the first run of the callback does nothing. The fix is to make use of a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) instead, which allows additional side effects to run only after both refs are ready.

This PR also fixes the two async `useEffect` callbacks (both the one that handles the dark mode message, and the one below it that clears the iframe loading dots), as that pattern is not allowed. Further reading: https://devtrium.com/posts/async-functions-useeffect