### PR TITLE
docs(skeleton-text): add theming example

### DIFF
--- a/docs/api/skeleton-text.md
+++ b/docs/api/skeleton-text.md
@@ -35,7 +35,9 @@ import Basic from '@site/static/usage/skeleton-text/basic/index.md';
 
 ### Theming
 
-TODO Playground
+import Theming from '@site/static/usage/skeleton-text/theming/index.md';
+
+<Theming />
 
 ## Properties
 <Props />

--- a/docs/api/skeleton-text.md
+++ b/docs/api/skeleton-text.md
@@ -33,10 +33,6 @@ import Basic from '@site/static/usage/skeleton-text/basic/index.md';
 
 ## Customization
 
-### Animations
-
-TODO Playground
-
 ### Theming
 
 TODO Playground

--- a/static/usage/skeleton-text/basic/angular/angular-html.md
+++ b/static/usage/skeleton-text/basic/angular/angular-html.md
@@ -19,7 +19,7 @@
   </ion-list-header>
   <ion-item>
     <ion-thumbnail slot="start">
-      <ion-skeleton-text></ion-skeleton-text>
+      <ion-skeleton-text [animated]="true"></ion-skeleton-text>
     </ion-thumbnail>
     <ion-label>
       <h3>

--- a/static/usage/skeleton-text/basic/demo.html
+++ b/static/usage/skeleton-text/basic/demo.html
@@ -45,21 +45,21 @@
       const setSkeletonText = () => {
         list.innerHTML = `
           <ion-list-header>
-            <ion-skeleton-text animated style="width: 80px"></ion-skeleton-text>
+            <ion-skeleton-text animated="true" style="width: 80px"></ion-skeleton-text>
           </ion-list-header>
           <ion-item>
             <ion-thumbnail slot="start">
-              <ion-skeleton-text></ion-skeleton-text>
+              <ion-skeleton-text animated="true"></ion-skeleton-text>
             </ion-thumbnail>
             <ion-label>
               <h3>
-                <ion-skeleton-text animated style="width: 80%;"></ion-skeleton-text>
+                <ion-skeleton-text animated="true" style="width: 80%;"></ion-skeleton-text>
               </h3>
               <p>
-                <ion-skeleton-text animated style="width: 60%;"></ion-skeleton-text>
+                <ion-skeleton-text animated="true" style="width: 60%;"></ion-skeleton-text>
               </p>
               <p>
-                <ion-skeleton-text animated style="width: 30%;"></ion-skeleton-text>
+                <ion-skeleton-text animated="true" style="width: 30%;"></ion-skeleton-text>
               </p>
             </ion-label>
           </ion-item>

--- a/static/usage/skeleton-text/basic/javascript.md
+++ b/static/usage/skeleton-text/basic/javascript.md
@@ -18,21 +18,21 @@
   function setSkeletonText() {
     list.innerHTML = `
       <ion-list-header>
-        <ion-skeleton-text animated style="width: 80px"></ion-skeleton-text>
+        <ion-skeleton-text animated="true" style="width: 80px"></ion-skeleton-text>
       </ion-list-header>
       <ion-item>
         <ion-thumbnail slot="start">
-          <ion-skeleton-text></ion-skeleton-text>
+          <ion-skeleton-text animated="true"></ion-skeleton-text>
         </ion-thumbnail>
         <ion-label>
           <h3>
-            <ion-skeleton-text animated style="width: 80%;"></ion-skeleton-text>
+            <ion-skeleton-text animated="true" style="width: 80%;"></ion-skeleton-text>
           </h3>
           <p>
-            <ion-skeleton-text animated style="width: 60%;"></ion-skeleton-text>
+            <ion-skeleton-text animated="true" style="width: 60%;"></ion-skeleton-text>
           </p>
           <p>
-            <ion-skeleton-text animated style="width: 30%;"></ion-skeleton-text>
+            <ion-skeleton-text animated="true" style="width: 30%;"></ion-skeleton-text>
           </p>
         </ion-label>
       </ion-item>

--- a/static/usage/skeleton-text/basic/react.md
+++ b/static/usage/skeleton-text/basic/react.md
@@ -37,7 +37,7 @@ function Example() {
           </IonListHeader>
           <IonItem>
             <IonThumbnail slot="start">
-              <IonSkeletonText></IonSkeletonText>
+              <IonSkeletonText animated={true}></IonSkeletonText>
             </IonThumbnail>
             <IonLabel>
               <h3>

--- a/static/usage/skeleton-text/basic/vue.md
+++ b/static/usage/skeleton-text/basic/vue.md
@@ -20,7 +20,7 @@
     </ion-list-header>
     <ion-item>
       <ion-thumbnail slot="start">
-        <ion-skeleton-text></ion-skeleton-text>
+        <ion-skeleton-text :animated="true"></ion-skeleton-text>
       </ion-thumbnail>
       <ion-label>
         <h3>

--- a/static/usage/skeleton-text/theming/angular/angular-css.md
+++ b/static/usage/skeleton-text/theming/angular/angular-css.md
@@ -1,0 +1,7 @@
+```css
+ion-skeleton-text {
+  --border-radius: 9999px;
+  --background: rgba(188, 0, 255, 0.065);
+  --background-rgb: 188, 0, 255;
+}
+```

--- a/static/usage/skeleton-text/theming/angular/angular-html.md
+++ b/static/usage/skeleton-text/theming/angular/angular-html.md
@@ -1,0 +1,23 @@
+```html
+<ion-list>
+  <ion-list-header>
+    <ion-skeleton-text [animated]="true" style="width: 80px"></ion-skeleton-text>
+  </ion-list-header>
+  <ion-item>
+    <ion-thumbnail slot="start">
+      <ion-skeleton-text></ion-skeleton-text>
+    </ion-thumbnail>
+    <ion-label>
+      <h3>
+        <ion-skeleton-text [animated]="true" style="width: 80%;"></ion-skeleton-text>
+      </h3>
+      <p>
+        <ion-skeleton-text [animated]="true" style="width: 60%;"></ion-skeleton-text>
+      </p>
+      <p>
+        <ion-skeleton-text [animated]="true" style="width: 30%;"></ion-skeleton-text>
+      </p>
+    </ion-label>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/skeleton-text/theming/angular/angular-html.md
+++ b/static/usage/skeleton-text/theming/angular/angular-html.md
@@ -5,7 +5,7 @@
   </ion-list-header>
   <ion-item>
     <ion-thumbnail slot="start">
-      <ion-skeleton-text></ion-skeleton-text>
+      <ion-skeleton-text [animated]="true"></ion-skeleton-text>
     </ion-thumbnail>
     <ion-label>
       <h3>

--- a/static/usage/skeleton-text/theming/demo.html
+++ b/static/usage/skeleton-text/theming/demo.html
@@ -31,21 +31,21 @@
         <div class="container">
           <ion-list>
             <ion-list-header>
-              <ion-skeleton-text animated style="width: 80px"></ion-skeleton-text>
+              <ion-skeleton-text animated="true" style="width: 80px"></ion-skeleton-text>
             </ion-list-header>
             <ion-item>
               <ion-thumbnail slot="start">
-                <ion-skeleton-text></ion-skeleton-text>
+                <ion-skeleton-text animated="true"></ion-skeleton-text>
               </ion-thumbnail>
               <ion-label>
                 <h3>
-                  <ion-skeleton-text animated style="width: 80%;"></ion-skeleton-text>
+                  <ion-skeleton-text animated="true" style="width: 80%;"></ion-skeleton-text>
                 </h3>
                 <p>
-                  <ion-skeleton-text animated style="width: 60%;"></ion-skeleton-text>
+                  <ion-skeleton-text animated="true" style="width: 60%;"></ion-skeleton-text>
                 </p>
                 <p>
-                  <ion-skeleton-text animated style="width: 30%;"></ion-skeleton-text>
+                  <ion-skeleton-text animated="true" style="width: 30%;"></ion-skeleton-text>
                 </p>
               </ion-label>
               </ion-item>

--- a/static/usage/skeleton-text/theming/demo.html
+++ b/static/usage/skeleton-text/theming/demo.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accordion</title>
+    <link rel="stylesheet" href="../../common.css" />
+    <script src="../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+    <style>
+      ion-list {
+        width: 300px;
+      }
+
+      .container {
+        flex-direction: column;
+      }
+
+      ion-skeleton-text {
+        --border-radius: 9999px;
+        --background: rgba(188, 0, 255, 0.065);
+        --background-rgb: 188, 0, 255;
+      }
+    </style>
+  </head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-list-header>
+              <ion-skeleton-text animated style="width: 80px"></ion-skeleton-text>
+            </ion-list-header>
+            <ion-item>
+              <ion-thumbnail slot="start">
+                <ion-skeleton-text></ion-skeleton-text>
+              </ion-thumbnail>
+              <ion-label>
+                <h3>
+                  <ion-skeleton-text animated style="width: 80%;"></ion-skeleton-text>
+                </h3>
+                <p>
+                  <ion-skeleton-text animated style="width: 60%;"></ion-skeleton-text>
+                </p>
+                <p>
+                  <ion-skeleton-text animated style="width: 30%;"></ion-skeleton-text>
+                </p>
+              </ion-label>
+              </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/skeleton-text/theming/index.md
+++ b/static/usage/skeleton-text/theming/index.md
@@ -1,0 +1,32 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTSX from './react/react-tsx.md';
+import reactCSS from './react/react-css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/angular-html.md';
+import angularCSS from './angular/angular-css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTSX,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/app.component.html': angularHTML,
+        'src/app/app.component.css': angularCSS
+      }
+    },
+  }}
+  src="usage/skeleton-text/theming/demo.html"
+  size="250px"
+/>

--- a/static/usage/skeleton-text/theming/javascript.md
+++ b/static/usage/skeleton-text/theming/javascript.md
@@ -1,0 +1,31 @@
+```html
+<style>
+  ion-skeleton-text {
+    --border-radius: 9999px;
+    --background: rgba(188, 0, 255, 0.065);
+    --background-rgb: 188, 0, 255;
+  }
+</style>
+
+<ion-list>
+  <ion-list-header>
+    <ion-skeleton-text animated style="width: 80px"></ion-skeleton-text>
+  </ion-list-header>
+  <ion-item>
+    <ion-thumbnail slot="start">
+      <ion-skeleton-text></ion-skeleton-text>
+    </ion-thumbnail>
+    <ion-label>
+      <h3>
+        <ion-skeleton-text animated style="width: 80%;"></ion-skeleton-text>
+      </h3>
+      <p>
+        <ion-skeleton-text animated style="width: 60%;"></ion-skeleton-text>
+      </p>
+      <p>
+        <ion-skeleton-text animated style="width: 30%;"></ion-skeleton-text>
+      </p>
+    </ion-label>
+    </ion-item>
+</ion-list>
+```

--- a/static/usage/skeleton-text/theming/javascript.md
+++ b/static/usage/skeleton-text/theming/javascript.md
@@ -9,21 +9,21 @@
 
 <ion-list>
   <ion-list-header>
-    <ion-skeleton-text animated style="width: 80px"></ion-skeleton-text>
+    <ion-skeleton-text animated="true" style="width: 80px"></ion-skeleton-text>
   </ion-list-header>
   <ion-item>
     <ion-thumbnail slot="start">
-      <ion-skeleton-text></ion-skeleton-text>
+      <ion-skeleton-text animated="true"></ion-skeleton-text>
     </ion-thumbnail>
     <ion-label>
       <h3>
-        <ion-skeleton-text animated style="width: 80%;"></ion-skeleton-text>
+        <ion-skeleton-text animated="true" style="width: 80%;"></ion-skeleton-text>
       </h3>
       <p>
-        <ion-skeleton-text animated style="width: 60%;"></ion-skeleton-text>
+        <ion-skeleton-text animated="true" style="width: 60%;"></ion-skeleton-text>
       </p>
       <p>
-        <ion-skeleton-text animated style="width: 30%;"></ion-skeleton-text>
+        <ion-skeleton-text animated="true" style="width: 30%;"></ion-skeleton-text>
       </p>
     </ion-label>
     </ion-item>

--- a/static/usage/skeleton-text/theming/react/react-css.md
+++ b/static/usage/skeleton-text/theming/react/react-css.md
@@ -1,0 +1,7 @@
+```css
+ion-skeleton-text {
+  --border-radius: 9999px;
+  --background: rgba(188, 0, 255, 0.065);
+  --background-rgb: 188, 0, 255;
+}
+```

--- a/static/usage/skeleton-text/theming/react/react-tsx.md
+++ b/static/usage/skeleton-text/theming/react/react-tsx.md
@@ -19,7 +19,7 @@ function Example() {
       </IonListHeader>
       <IonItem>
         <IonThumbnail slot="start">
-          <IonSkeletonText></IonSkeletonText>
+          <IonSkeletonText animated={true}></IonSkeletonText>
         </IonThumbnail>
         <IonLabel>
           <h3>

--- a/static/usage/skeleton-text/theming/react/react-tsx.md
+++ b/static/usage/skeleton-text/theming/react/react-tsx.md
@@ -1,0 +1,40 @@
+```tsx
+import React from 'react';
+import { 
+  IonItem,
+  IonLabel,
+  IonList,
+  IonListHeader,
+  IonSkeletonText,
+  IonThumbnail,
+} from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonList>
+      <IonListHeader>
+        <IonSkeletonText animated={true} style={{ 'width': '80px' }}></IonSkeletonText>
+      </IonListHeader>
+      <IonItem>
+        <IonThumbnail slot="start">
+          <IonSkeletonText></IonSkeletonText>
+        </IonThumbnail>
+        <IonLabel>
+          <h3>
+            <IonSkeletonText animated={true} style={{ 'width': '80%' }}></IonSkeletonText>
+          </h3>
+          <p>
+            <IonSkeletonText animated={true} style={{ 'width': '60%' }}></IonSkeletonText>
+          </p>
+          <p>
+            <IonSkeletonText animated={true} style={{ 'width': '30%' }}></IonSkeletonText>
+          </p>
+        </IonLabel>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/skeleton-text/theming/vue.md
+++ b/static/usage/skeleton-text/theming/vue.md
@@ -6,7 +6,7 @@
     </ion-list-header>
     <ion-item>
       <ion-thumbnail slot="start">
-        <ion-skeleton-text></ion-skeleton-text>
+        <ion-skeleton-text :animated="true"></ion-skeleton-text>
       </ion-thumbnail>
       <ion-label>
         <h3>

--- a/static/usage/skeleton-text/theming/vue.md
+++ b/static/usage/skeleton-text/theming/vue.md
@@ -32,7 +32,7 @@
     IonSkeletonText,
     IonThumbnail,
   } from '@ionic/vue';
-  import { defineComponent, ref } from 'vue';
+  import { defineComponent } from 'vue';
 
   export default defineComponent({
     components: {

--- a/static/usage/skeleton-text/theming/vue.md
+++ b/static/usage/skeleton-text/theming/vue.md
@@ -1,0 +1,56 @@
+```html
+<template>  
+  <ion-list>
+    <ion-list-header>
+      <ion-skeleton-text :animated="true" style="width: 80px"></ion-skeleton-text>
+    </ion-list-header>
+    <ion-item>
+      <ion-thumbnail slot="start">
+        <ion-skeleton-text></ion-skeleton-text>
+      </ion-thumbnail>
+      <ion-label>
+        <h3>
+          <ion-skeleton-text :animated="true" style="width: 80%;"></ion-skeleton-text>
+        </h3>
+        <p>
+          <ion-skeleton-text :animated="true" style="width: 60%;"></ion-skeleton-text>
+        </p>
+        <p>
+          <ion-skeleton-text :animated="true" style="width: 30%;"></ion-skeleton-text>
+        </p>
+      </ion-label>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import {
+    IonItem,
+    IonLabel,
+    IonList,
+    IonListHeader,
+    IonSkeletonText,
+    IonThumbnail,
+  } from '@ionic/vue';
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonItem,
+      IonLabel,
+      IonList,
+      IonListHeader,
+      IonSkeletonText,
+      IonThumbnail,
+    }
+  });
+</script>
+
+<style scoped>
+  ion-skeleton-text {
+    --border-radius: 9999px;
+    --background: rgba(188, 0, 255, 0.065);
+    --background-rgb: 188, 0, 255;
+  }
+</style>
+```


### PR DESCRIPTION
- Adds a theming example to customize the colors
- Removes "Animation" section
- Fixes some syntax issues I found re: best practices

Preview link: https://ionic-docs-git-1266-theming-ionic1.vercel.app/docs/api/skeleton-text