### PR TITLE
refactor(): remove unused TOC imports

### DIFF
--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/accordion/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/alert/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="scoped" />
 

--- a/docs/api/breadcrumbs.md
+++ b/docs/api/breadcrumbs.md
@@ -14,7 +14,6 @@ import Slots from '@site/static/auto-generated/breadcrumbs/slots.md';
 
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/chip.md
+++ b/docs/api/chip.md
@@ -14,7 +14,6 @@ import Slots from '@site/static/auto-generated/chip/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/datetime-button.md
+++ b/docs/api/datetime-button.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/datetime-button/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -44,7 +44,6 @@ import Theming from '@site/static/usage/datetime/theming/index.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/loading.md
+++ b/docs/api/loading.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/loading/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="scoped" />
 

--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/picker/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="scoped" />
 

--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/popover/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/range/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/select/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 

--- a/docs/api/skeleton-text.md
+++ b/docs/api/skeleton-text.md
@@ -17,7 +17,6 @@ import Slots from '@site/static/auto-generated/skeleton-text/slots.md';
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
-import APITOCInline from '@components/page/api/APITOCInline';
 
 <EncapsulationPill type="shadow" />
 


### PR DESCRIPTION
Most components that we've added playgrounds to (and thus have had their TOCs moved to the sidebar) still had the import for the inline TOC component sitting around, now unused. This PR just removes the import from applicable components.