### PR TITLE
docs(support): update JS framework and browser support

### DIFF
--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -18,6 +18,7 @@ In pursuit of [adaptive styling](../core-concepts/fundamentals.md#adaptive-styli
 
 | Framework |        Android         |  iOS  |
 | :-------: | :--------------------: | :---: |
+| Ionic v7  | 5.1+ with Chromium 79+ | 14.0+ |
 | Ionic v6  | 5.0+ with Chromium 60+ | 13.0+ |
 | Ionic v5  |          5.0+          | 11.0+ |
 | Ionic v4  |          4.4+          | 10.0+ |
@@ -28,27 +29,21 @@ Check the [latest Android stats](https://developer.android.com/about/dashboards/
 
 ### A Note on Android Support
 
-Starting with Android 5.0, the webview was moved to a separate application that can be updated independently of Android. This means that most Android 5.0+ devices are going to be running a modern version of Chromium. However, there are a still a subset of Android devices whose manufacturer has locked the webview version and does not allow the webview to update. These webviews are typically stuck at the version that was available when the device initially shipped.
-
-As a result, Ionic Framework v6 only supports Android devices and emulators running Android 5.0+ with a webview of Chromium 60 or newer. For context, this is the version that Stencil can support with no polyfills: https://stenciljs.com/docs/browser-support
+Starting with Android 5.0, the webview was moved to a separate application that can be updated independently of Android. This means that most Android 5.0+ devices are going to be running a modern version of Chromium. However, there are a still a subset of Android devices that are unable to have their webview updated. These webviews are typically stuck at the version that was available when the device initially shipped.
 
 To figure out what version of the webview a device is running, log `window.navigator.userAgent` to the console when inspecting the application using Chrome Dev Tools.
-
-### A Note on Angular 13+ Support
-
-Angular's support policy for iOS is the two most recent major versions. At the time of release that is iOS 14 and 15. To support iOS 13, change the project `target` specified in `compilerOptions` in the tsconfig.json to `es5`. Without this change an error of `Unexpected token '.' in promiseReactionJob` will occur on app startup in iOS 13.
 
 ## Desktop Browsers
 
 Because Ionic is based on web technologies, it works just as well on desktop browsers as it does on mobile devices. For more information on desktop layouts, see [Cross Platform](../core-concepts/cross-platform.md#desktop).
 
-|   Browser   | Ionic v6 | Ionic v5 | Ionic v4 |
-| :---------: | :------: | :------: | :------: |
-| **Chrome**  |   60+    |    ✔     |    ✔     |
-| **Safari**  |   13+    |    ✔     |    ✔     |
-|  **Edge**   |   79+    |   79+    |    ✔     |
-| **Firefox** |   63+    |    ✔     |    ✔     |
-|  **IE 11**  |  **X**   |  **X**   |  **X**   |
+|   Browser   | Ionic v7 | Ionic v6 | Ionic v5 | Ionic v4 |
+| :---------: | :------: | :------: | :------: | :------: |
+| **Chrome**  | 79+      | 60+      | ✔        | ✔        |
+| **Safari**  | 14+      | 13+      | ✔        | ✔        |
+|  **Edge**   | 79+      | 79+      | 79+      | ✔        |
+| **Firefox** | 63+      | 63+      | ✔        | ✔        |
+|  **IE 11**  | **X**    | **X**    | **X**    | **X**    |
 
 :::note
 Check the docs for [Ionic Animations](../utilities/animations.md#browser-support) and [Ionic Gestures](../utilities/gestures.md#browser-support) for specific browser support related to those utilities.

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -22,7 +22,8 @@ The current status of each Ionic Framework version is:
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
-| V6      | **Active**            | Dec 8, 2021  | TBD              | TBD               |
+| V7      | **Active**            | TBD          | TBD              | TBD               |
+| V6      | Maintenance           | Dec 8, 2021  | TBD              | TBD               |
 | V5      | Extended Support Only | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
 | V4      | Extended Support Only | Jan 23, 2019 | Aug 11, 2020     | Sept 30, 2022     |
 | V3      | End of Support        | Apr 5, 2017  | Oct 30, 2019     | Aug 11, 2020      |
@@ -42,10 +43,11 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v6     |           v12           |          v14.x^         |    4.0+    |
-|    v5     |          v8.2           |          v12.x          |    3.5+    |
-|    v4     |          v8.2           |          v11.x          |    3.5+    |
-|    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |
+| v7        | v13                     | v14.x                   | 4.4+       |   
+| v6        | v12                     | v14.x^                  | 4.0+       |
+| v5        | v8.2                    | v12.x                   | 3.5+       |
+| v4        | v8.2                    | v11.x                   | 3.5+       |
+| v3        | v5.2.11                 | v5.2.11                 | 2.6.2      |
 
 > ^ Angular 14.x support was added in Ionic v6.1.9.
 
@@ -53,16 +55,18 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Required React Version | TypeScript |
 | :-------: | :--------------------: | :--------: |
-|    v6     |          v17+          |    3.7+    |
-|    v5     |         v16.8+         |    3.7+    |
-|    v4     |         v16.8+         |    3.7+    |
+| v7        | v17+                   | 3.7+       |
+| v6        | v17+                   | 3.7+       |
+| v5        | v16.8+                 | 3.7+       |
+| v4        | v16.8+                 | 3.7+       |
 
 #### Ionic Vue
 
 | Framework | Required Vue Version | TypeScript |
 | :-------: | :------------------: | :--------: |
-|    v6     |       v3.0.6+        |    3.9+    |
-|    v5     |        v3.0+         |    3.9+    |
+| v7        | v3.0.6+              | 3.9+       |
+| v6        | v3.0.6+              | 3.9+       |
+| v5        | v3.0+                | 3.9+       |
 
 ### Native Bridges
 

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -55,6 +55,8 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 Angular's support policy for iOS is the two most recent major versions. This means that changes to your Angular project may be necessary to use Ionic Angular v4-v6 on iOS 13. To support iOS 13, change the project `target` specified in `compilerOptions` in the tsconfig.json to `es5`. Without this change an error of `Unexpected token '.' in promiseReactionJob` will occur on app startup in iOS 13.
 
+Note that later versions of Ionic do not support iOS 13; see [mobile support table here](./browser-support#mobile-browsers).
+
 #### Ionic React
 
 | Framework | Required React Version | TypeScript |

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -51,6 +51,10 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 > ^ Angular 14.x support was added in Ionic v6.1.9.
 
+**Angular 13+ Support On Older Versions of iOS**
+
+Angular's support policy for iOS is the two most recent major versions. This means that changes to your Angular project may be necessary to use Ionic Angular v4-v6 on iOS 13. To support iOS 13, change the project `target` specified in `compilerOptions` in the tsconfig.json to `es5`. Without this change an error of `Unexpected token '.' in promiseReactionJob` will occur on app startup in iOS 13.
+
 #### Ionic React
 
 | Framework | Required React Version | TypeScript |


### PR DESCRIPTION
Updates the following info for Ionic 7:

- Desktop browser support
- Mobile platform support
- JS Framework support for Angular, React, and Vue
- Updated the Angular 13 note to remove Ionic version-specific language. As a result, I moved it to the Platform support page.

JS Framework Support Policy: https://ionic-docs-git-fw-2005-ionic1.vercel.app/docs/reference/support
Browser Support: https://ionic-docs-git-fw-2005-ionic1.vercel.app/docs/reference/browser-support