### PR TITLE
docs(hardware-back-button): IonRouterOutlet is an optional provider

### DIFF
--- a/docs/developing/hardware-back-button.md
+++ b/docs/developing/hardware-back-button.md
@@ -274,7 +274,7 @@ import { App } from '@capacitor/app';
 
 constructor(
   private platform: Platform,
-  @Optional() private readonly routerOutlet?: IonRouterOutlet
+  @Optional() private routerOutlet?: IonRouterOutlet
 ) {
   this.platform.backButton.subscribeWithPriority(-1, () => {
     if (!this.routerOutlet.canGoBack()) {

--- a/docs/developing/hardware-back-button.md
+++ b/docs/developing/hardware-back-button.md
@@ -266,6 +266,7 @@ document.addEventListener('ionBackButton', (ev: BackButtonEvent) => {
 <TabItem value="angular">
 
 ```tsx
+import { Optional } from '@angular/core';
 import { IonRouterOutlet, Platform } from '@ionic/angular';
 import { App } from '@capacitor/app';
 
@@ -273,7 +274,7 @@ import { App } from '@capacitor/app';
 
 constructor(
   private platform: Platform,
-  private routerOutlet: IonRouterOutlet
+  @Optional() private readonly routerOutlet?: IonRouterOutlet
 ) {
   this.platform.backButton.subscribeWithPriority(-1, () => {
     if (!this.routerOutlet.canGoBack()) {


### PR DESCRIPTION
in `docs/developing/hardware-back-button.md` , I found the following code for Angular, to exit from an Ionic  app:

```
import { IonRouterOutlet, Platform } from '@ionic/angular';
import { App } from '@capacitor/app';
...
constructor(
  private platform: Platform,
  private routerOutlet: IonRouterOutlet
) {
  this.platform.backButton.subscribeWithPriority(-1, () => {
    if (!this.routerOutlet.canGoBack()) {
      App.exitApp();
    }
  });
}
```
The problem is when you run `ionic serve` with that code you will get the following error:

```
ERROR NullInjectorError: R3InjectorError(AppModule)[IonRouterOutlet -> IonRouterOutlet -> IonRouterOutlet]: 
  NullInjectorError: No provider for IonRouterOutlet!
```
so I searched for a solution and I founed this post https://forum.ionicframework.com/t/nullinjectorerror-no-provider-for-ionrouteroutlet/192058/6 , which adds the `Optional()` decorator to the constructor, and that's what I did in my PR.
