### PR TITLE
docs(toast): fix aria-live usage

### DIFF
--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -98,7 +98,7 @@ Toasts are intended to be subtle notifications and are not intended to interrupt
 
 `ion-toast` has `aria-live="polite"` and `aria-atomic="true"` set by default.
 
-`aria-live` causes screen readers to announce the content of the toast when it is presented. However, since the attribute is set to `'polite'`, screen readers generally do not interrupt the current task. Developers can customize this behavior by using the `htmlAttributes` property to set `aria-live` to `'assertive'`. This will cause screen readers to immediately notify the user when a toast is presented, potentially interrupting any previous updates.
+`aria-live` causes screen readers to announce the content of the toast when it is updated. However, since the attribute is set to `'polite'`, screen readers generally do not interrupt the current task. Developers can customize this behavior by using the `htmlAttributes` property to set `aria-live` to `'assertive'`. This will cause screen readers to immediately notify the user when a toast is updated, potentially interrupting any previous updates.
 
 `aria-atomic="true"` is set to ensure that the entire toast is announced as a single unit. This is useful when dynamically updating the content of the toast as it prevents screen readers from announcing only the content that has changed. 
 


### PR DESCRIPTION
aria-live controls how screen readers announce _updates_ to toast content. It does not handle the initial presentation (despite what VoiceOver may do on macOS/iOS).