### PR TITLE
fix(playground): use className instead of class

### DIFF
--- a/src/components/global/Playground/icons/IconDots.tsx
+++ b/src/components/global/Playground/icons/IconDots.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import './IconDots.css';
 
 export const IconDots = () => (
-  <div class="icon__dots">
+  <div className="icon__dots">
     <svg viewBox="0 0 64 64">
       <circle transform="translate(32,32)" r="6"></circle>
     </svg>


### PR DESCRIPTION
During development I noticed the following error in the console:

```
react-dom.development.js?ac89:67 Warning: Invalid DOM property `class`. Did you mean `className`?
    at div
    at IconDots
    at div
    at div
    at div
    at div
    at Playground (webpack-internal:///./src/components/global/Playground/index.tsx:23:35)
```

The dots icon component should use `className` instead of `class`.