### PR TITLE
docs(spinner): add component playgrounds

### DIFF
--- a/docs/api/spinner.md
+++ b/docs/api/spinner.md
@@ -39,6 +39,12 @@ import Colors from '@site/static/usage/spinner/theming/colors/index.md';
 
 <Colors />
 
+### CSS Custom Properties
+
+import CSSProps from '@site/static/usage/spinner/theming/css-properties/index.md';
+
+<CSSProps />
+
 
 ## Properties
 <Props />

--- a/docs/api/spinner.md
+++ b/docs/api/spinner.md
@@ -25,7 +25,7 @@ The Spinner component provides a variety of animated SVG spinners. Spinners are 
 
 ## Basic Usage
 
-The default spinner is based on the mode. When the mode is `ios` the spinner will be `"lines"`, and when the mode is `md` the spinner will be `"crescent"`. If the `name` property is set, then that spinner will be used instead of the mode specific spinner.
+The default spinner is based on the mode. When the mode is `ios` the spinner will be `"lines"`, and when the mode is `md` the spinner will be `"circular"`. If the `name` property is set, then that spinner will be used instead of the mode specific spinner.
 
 import Basic from '@site/static/usage/spinner/basic/index.md';
 

--- a/docs/api/spinner.md
+++ b/docs/api/spinner.md
@@ -1,13 +1,6 @@
 ---
 title: "ion-spinner"
-hide_table_of_contents: true
-demoUrl: "/docs/demos/api/spinner/index.html"
-demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/spinner/index.html"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TOCInline from '@theme/TOCInline';
-
 import Props from '@site/static/auto-generated/spinner/props.md';
 import Events from '@site/static/auto-generated/spinner/events.md';
 import Methods from '@site/static/auto-generated/spinner/methods.md';
@@ -26,215 +19,26 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <h2 className="table-of-contents__title">Contents</h2>
 
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
-
-
 
 The Spinner component provides a variety of animated SVG spinners. Spinners are visual indicators that the app is loading content or performing another process that the user needs to wait on.
 
-The default spinner to use is based on the platform. The default spinner for `ios` is `"lines"`, and the default for `android` is `"crescent"`. If the platform is not `ios` or `android`, the spinner will default to `crescent`. If the `name` property is set, then that spinner will be used instead of the platform specific spinner.
 
+## Basic Usage
 
+The default spinner is based on the mode. When the mode is `ios` the spinner will be `"lines"`, and when the mode is `md` the spinner will be `"crescent"`. If the `name` property is set, then that spinner will be used instead of the mode specific spinner.
 
+import Basic from '@site/static/usage/spinner/basic/index.md';
 
+<Basic />
 
-## Usage
+## Theming
 
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
+### Colors
 
-<TabItem value="angular">
+import Colors from '@site/static/usage/spinner/theming/colors/index.md';
 
-```html
-<!-- Default Spinner -->
-<ion-spinner></ion-spinner>
+<Colors />
 
-<!-- Lines -->
-<ion-spinner name="lines"></ion-spinner>
-
-<!-- Lines Small -->
-<ion-spinner name="lines-small"></ion-spinner>
-
-<!-- Dots -->
-<ion-spinner name="dots"></ion-spinner>
-
-<!-- Bubbles -->
-<ion-spinner name="bubbles"></ion-spinner>
-
-<!-- Circles -->
-<ion-spinner name="circles"></ion-spinner>
-
-<!-- Crescent -->
-<ion-spinner name="crescent"></ion-spinner>
-
-<!-- Paused Default Spinner -->
-<ion-spinner paused></ion-spinner>
-```
-
-
-</TabItem>
-
-
-<TabItem value="javascript">
-
-```html
-<!-- Default Spinner -->
-<ion-spinner></ion-spinner>
-
-<!-- Lines -->
-<ion-spinner name="lines"></ion-spinner>
-
-<!-- Lines Small -->
-<ion-spinner name="lines-small"></ion-spinner>
-
-<!-- Dots -->
-<ion-spinner name="dots"></ion-spinner>
-
-<!-- Bubbles -->
-<ion-spinner name="bubbles"></ion-spinner>
-
-<!-- Circles -->
-<ion-spinner name="circles"></ion-spinner>
-
-<!-- Crescent -->
-<ion-spinner name="crescent"></ion-spinner>
-
-<!-- Paused Default Spinner -->
-<ion-spinner paused></ion-spinner>
-```
-
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React from 'react';
-import { IonSpinner, IonContent } from '@ionic/react';
-
-export const SpinnerExample: React.FC = () => (
-  <IonContent>
-    {/*-- Default Spinner --*/}
-    <IonSpinner />
-
-    {/*-- Lines --*/}
-    <IonSpinner name="lines" />
-
-    {/*-- Lines Small --*/}
-    <IonSpinner name="lines-small" />
-
-    {/*-- Dots --*/}
-    <IonSpinner name="dots" />
-
-    {/*-- Bubbles --*/}
-    <IonSpinner name="bubbles" />
-
-    {/*-- Circles --*/}
-    <IonSpinner name="circles" />
-
-    {/*-- Crescent --*/}
-    <IonSpinner name="crescent" />
-
-    {/*-- Paused Default Spinner --*/}
-    <IonSpinner paused />
-  </IonContent>
-);
-```
-
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'spinner-example',
-  styleUrl: 'spinner-example.css'
-})
-export class SpinnerExample {
-  render() {
-    return [
-      // Default Spinner
-      <ion-spinner></ion-spinner>,
-
-      // Lines
-      <ion-spinner name="lines"></ion-spinner>,
-
-      // Lines Small
-      <ion-spinner name="lines-small"></ion-spinner>,
-
-      // Dots
-      <ion-spinner name="dots"></ion-spinner>,
-
-      // Bubbles
-      <ion-spinner name="bubbles"></ion-spinner>,
-
-      // Circles
-      <ion-spinner name="circles"></ion-spinner>,
-
-      // Crescent
-      <ion-spinner name="crescent"></ion-spinner>,
-
-      // Paused Default Spinner
-      <ion-spinner paused={true}></ion-spinner>
-    ];
-  }
-}
-```
-
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <!-- Default Spinner -->
-  <ion-spinner></ion-spinner>
-
-  <!-- Lines -->
-  <ion-spinner name="lines"></ion-spinner>
-
-  <!-- Lines Small -->
-  <ion-spinner name="lines-small"></ion-spinner>
-
-  <!-- Dots -->
-  <ion-spinner name="dots"></ion-spinner>
-
-  <!-- Bubbles -->
-  <ion-spinner name="bubbles"></ion-spinner>
-
-  <!-- Circles -->
-  <ion-spinner name="circles"></ion-spinner>
-
-  <!-- Crescent -->
-  <ion-spinner name="crescent"></ion-spinner>
-
-  <!-- Paused Default Spinner -->
-  <ion-spinner paused></ion-spinner>
-</template>
-
-<script>
-import { IonSpinner } from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: { IonSpinner }
-});
-</script>
-```
-
-
-</TabItem>
-
-</Tabs>
 
 ## Properties
 <Props />

--- a/static/usage/spinner/basic/angular.md
+++ b/static/usage/spinner/basic/angular.md
@@ -1,0 +1,36 @@
+```html
+<ion-item>
+  <ion-label>Default</ion-label>
+  <ion-spinner></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Dots</ion-label>
+  <ion-spinner name="dots"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Lines</ion-label>
+  <ion-spinner name="lines"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Lines Small</ion-label>
+  <ion-spinner name="lines-small"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Bubbles</ion-label>
+  <ion-spinner name="bubbles"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Circles</ion-label>
+  <ion-spinner name="circles"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Crescent</ion-label>
+  <ion-spinner name="crescent"></ion-spinner>
+</ion-item>
+```

--- a/static/usage/spinner/basic/angular.md
+++ b/static/usage/spinner/basic/angular.md
@@ -20,6 +20,16 @@
 </ion-item>
 
 <ion-item>
+  <ion-label>Lines Sharp</ion-label>
+  <ion-spinner name="lines-sharp"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Lines Sharp Small</ion-label>
+  <ion-spinner name="lines-sharp-small"></ion-spinner>
+</ion-item>
+
+<ion-item>
   <ion-label>Bubbles</ion-label>
   <ion-spinner name="bubbles"></ion-spinner>
 </ion-item>
@@ -27,6 +37,11 @@
 <ion-item>
   <ion-label>Circles</ion-label>
   <ion-spinner name="circles"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Circular</ion-label>
+  <ion-spinner name="circular"></ion-spinner>
 </ion-item>
 
 <ion-item>

--- a/static/usage/spinner/basic/demo.html
+++ b/static/usage/spinner/basic/demo.html
@@ -43,6 +43,16 @@
         </ion-item>
 
         <ion-item>
+          <ion-label>Lines Sharp</ion-label>
+          <ion-spinner name="lines-sharp"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Lines Sharp Small</ion-label>
+          <ion-spinner name="lines-sharp-small"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
           <ion-label>Bubbles</ion-label>
           <ion-spinner name="bubbles"></ion-spinner>
         </ion-item>
@@ -50,6 +60,11 @@
         <ion-item>
           <ion-label>Circles</ion-label>
           <ion-spinner name="circles"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Circular</ion-label>
+          <ion-spinner name="circular"></ion-spinner>
         </ion-item>
 
         <ion-item>

--- a/static/usage/spinner/basic/demo.html
+++ b/static/usage/spinner/basic/demo.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spinner</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      display: block;
+      flex-flow: column;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-item>
+          <ion-label>Default</ion-label>
+          <ion-spinner></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Dots</ion-label>
+          <ion-spinner name="dots"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Lines</ion-label>
+          <ion-spinner name="lines"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Lines Small</ion-label>
+          <ion-spinner name="lines-small"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Bubbles</ion-label>
+          <ion-spinner name="bubbles"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Circles</ion-label>
+          <ion-spinner name="circles"></ion-spinner>
+        </ion-item>
+
+        <ion-item>
+          <ion-label>Crescent</ion-label>
+          <ion-spinner name="crescent"></ion-spinner>
+        </ion-item>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/spinner/basic/index.md
+++ b/static/usage/spinner/basic/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/spinner/basic/demo.html" size="350px" />

--- a/static/usage/spinner/basic/index.md
+++ b/static/usage/spinner/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/spinner/basic/demo.html" size="350px" />
+<Playground code={{ javascript, react, vue, angular }} src="usage/spinner/basic/demo.html" size="500px" />

--- a/static/usage/spinner/basic/javascript.md
+++ b/static/usage/spinner/basic/javascript.md
@@ -1,0 +1,36 @@
+```html
+<ion-item>
+  <ion-label>Default</ion-label>
+  <ion-spinner></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Dots</ion-label>
+  <ion-spinner name="dots"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Lines</ion-label>
+  <ion-spinner name="lines"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Lines Small</ion-label>
+  <ion-spinner name="lines-small"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Bubbles</ion-label>
+  <ion-spinner name="bubbles"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Circles</ion-label>
+  <ion-spinner name="circles"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Crescent</ion-label>
+  <ion-spinner name="crescent"></ion-spinner>
+</ion-item>
+```

--- a/static/usage/spinner/basic/javascript.md
+++ b/static/usage/spinner/basic/javascript.md
@@ -20,6 +20,16 @@
 </ion-item>
 
 <ion-item>
+  <ion-label>Lines Sharp</ion-label>
+  <ion-spinner name="lines-sharp"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Lines Sharp Small</ion-label>
+  <ion-spinner name="lines-sharp-small"></ion-spinner>
+</ion-item>
+
+<ion-item>
   <ion-label>Bubbles</ion-label>
   <ion-spinner name="bubbles"></ion-spinner>
 </ion-item>
@@ -27,6 +37,11 @@
 <ion-item>
   <ion-label>Circles</ion-label>
   <ion-spinner name="circles"></ion-spinner>
+</ion-item>
+
+<ion-item>
+  <ion-label>Circular</ion-label>
+  <ion-spinner name="circular"></ion-spinner>
 </ion-item>
 
 <ion-item>

--- a/static/usage/spinner/basic/react.md
+++ b/static/usage/spinner/basic/react.md
@@ -1,0 +1,46 @@
+```tsx
+import React from 'react';
+import { IonItem, IonLabel, IonSpinner } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonItem>
+        <IonLabel>Default</IonLabel>
+        <IonSpinner></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Dots</IonLabel>
+        <IonSpinner name="dots"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Lines</IonLabel>
+        <IonSpinner name="lines"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Lines Small</IonLabel>
+        <IonSpinner name="lines-small"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Bubbles</IonLabel>
+        <IonSpinner name="bubbles"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Circles</IonLabel>
+        <IonSpinner name="circles"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Crescent</IonLabel>
+        <IonSpinner name="crescent"></IonSpinner>
+      </IonItem>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/spinner/basic/react.md
+++ b/static/usage/spinner/basic/react.md
@@ -26,6 +26,16 @@ function Example() {
       </IonItem>
 
       <IonItem>
+        <IonLabel>Lines Sharp</IonLabel>
+        <IonSpinner name="lines-sharp"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Lines Sharp Small</IonLabel>
+        <IonSpinner name="lines-sharp-small"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
         <IonLabel>Bubbles</IonLabel>
         <IonSpinner name="bubbles"></IonSpinner>
       </IonItem>
@@ -33,6 +43,11 @@ function Example() {
       <IonItem>
         <IonLabel>Circles</IonLabel>
         <IonSpinner name="circles"></IonSpinner>
+      </IonItem>
+
+      <IonItem>
+        <IonLabel>Circular</IonLabel>
+        <IonSpinner name="circular"></IonSpinner>
       </IonItem>
 
       <IonItem>

--- a/static/usage/spinner/basic/vue.md
+++ b/static/usage/spinner/basic/vue.md
@@ -21,6 +21,16 @@
   </ion-item>
 
   <ion-item>
+    <ion-label>Lines Sharp</ion-label>
+    <ion-spinner name="lines-sharp"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Lines Sharp Small</ion-label>
+    <ion-spinner name="lines-sharp-small"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
     <ion-label>Bubbles</ion-label>
     <ion-spinner name="bubbles"></ion-spinner>
   </ion-item>
@@ -28,6 +38,11 @@
   <ion-item>
     <ion-label>Circles</ion-label>
     <ion-spinner name="circles"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Circular</ion-label>
+    <ion-spinner name="circular"></ion-spinner>
   </ion-item>
 
   <ion-item>

--- a/static/usage/spinner/basic/vue.md
+++ b/static/usage/spinner/basic/vue.md
@@ -1,0 +1,47 @@
+```html
+<template>
+  <ion-item>
+    <ion-label>Default</ion-label>
+    <ion-spinner></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Dots</ion-label>
+    <ion-spinner name="dots"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Lines</ion-label>
+    <ion-spinner name="lines"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Lines Small</ion-label>
+    <ion-spinner name="lines-small"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Bubbles</ion-label>
+    <ion-spinner name="bubbles"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Circles</ion-label>
+    <ion-spinner name="circles"></ion-spinner>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Crescent</ion-label>
+    <ion-spinner name="crescent"></ion-spinner>
+  </ion-item>
+</template>
+
+<script lang="ts">
+  import { IonItem, IonLabel, IonSpinner } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonLabel, IonSpinner },
+  });
+</script>
+```

--- a/static/usage/spinner/theming/colors/angular.md
+++ b/static/usage/spinner/theming/colors/angular.md
@@ -1,0 +1,12 @@
+```html
+<ion-spinner></ion-spinner>
+<ion-spinner color="primary"></ion-spinner>
+<ion-spinner color="secondary"></ion-spinner>
+<ion-spinner color="tertiary"></ion-spinner>
+<ion-spinner color="success"></ion-spinner>
+<ion-spinner color="warning"></ion-spinner>
+<ion-spinner color="danger"></ion-spinner>
+<ion-spinner color="light"></ion-spinner>
+<ion-spinner color="medium"></ion-spinner>
+<ion-spinner color="dark"></ion-spinner>
+```

--- a/static/usage/spinner/theming/colors/demo.html
+++ b/static/usage/spinner/theming/colors/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spinner</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-spinner></ion-spinner>
+        <ion-spinner color="primary"></ion-spinner>
+        <ion-spinner color="secondary"></ion-spinner>
+        <ion-spinner color="tertiary"></ion-spinner>
+        <ion-spinner color="success"></ion-spinner>
+        <ion-spinner color="warning"></ion-spinner>
+        <ion-spinner color="danger"></ion-spinner>
+        <ion-spinner color="light"></ion-spinner>
+        <ion-spinner color="medium"></ion-spinner>
+        <ion-spinner color="dark"></ion-spinner>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/spinner/theming/colors/index.md
+++ b/static/usage/spinner/theming/colors/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/spinner/theming/colors/demo.html" size="100px" />

--- a/static/usage/spinner/theming/colors/javascript.md
+++ b/static/usage/spinner/theming/colors/javascript.md
@@ -1,0 +1,12 @@
+```html
+<ion-spinner></ion-spinner>
+<ion-spinner color="primary"></ion-spinner>
+<ion-spinner color="secondary"></ion-spinner>
+<ion-spinner color="tertiary"></ion-spinner>
+<ion-spinner color="success"></ion-spinner>
+<ion-spinner color="warning"></ion-spinner>
+<ion-spinner color="danger"></ion-spinner>
+<ion-spinner color="light"></ion-spinner>
+<ion-spinner color="medium"></ion-spinner>
+<ion-spinner color="dark"></ion-spinner>
+```

--- a/static/usage/spinner/theming/colors/react.md
+++ b/static/usage/spinner/theming/colors/react.md
@@ -1,0 +1,22 @@
+```tsx
+import React from 'react';
+import { IonSpinner } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonSpinner></IonSpinner>
+      <IonSpinner color="primary"></IonSpinner>
+      <IonSpinner color="secondary"></IonSpinner>
+      <IonSpinner color="tertiary"></IonSpinner>
+      <IonSpinner color="success"></IonSpinner>
+      <IonSpinner color="warning"></IonSpinner>
+      <IonSpinner color="danger"></IonSpinner>
+      <IonSpinner color="light"></IonSpinner>
+      <IonSpinner color="medium"></IonSpinner>
+      <IonSpinner color="dark"></IonSpinner>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/spinner/theming/colors/vue.md
+++ b/static/usage/spinner/theming/colors/vue.md
@@ -1,0 +1,23 @@
+```html
+<template>
+  <ion-spinner></ion-spinner>
+  <ion-spinner color="primary"></ion-spinner>
+  <ion-spinner color="secondary"></ion-spinner>
+  <ion-spinner color="tertiary"></ion-spinner>
+  <ion-spinner color="success"></ion-spinner>
+  <ion-spinner color="warning"></ion-spinner>
+  <ion-spinner color="danger"></ion-spinner>
+  <ion-spinner color="light"></ion-spinner>
+  <ion-spinner color="medium"></ion-spinner>
+  <ion-spinner color="dark"></ion-spinner>
+</template>
+
+<script lang="ts">
+  import { IonSpinner } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonSpinner },
+  });
+</script>
+```

--- a/static/usage/spinner/theming/css-properties/angular.md
+++ b/static/usage/spinner/theming/css-properties/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-spinner></ion-spinner>
+```

--- a/static/usage/spinner/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/spinner/theming/css-properties/angular/example_component_css.md
@@ -1,0 +1,5 @@
+```css
+ion-spinner {
+  --color: #54dc98;
+}
+```

--- a/static/usage/spinner/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/spinner/theming/css-properties/angular/example_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-spinner></ion-spinner>
+```

--- a/static/usage/spinner/theming/css-properties/demo.html
+++ b/static/usage/spinner/theming/css-properties/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spinner</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    ion-spinner {
+      --color: #54dc98;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-spinner></ion-spinner>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/spinner/theming/css-properties/index.md
+++ b/static/usage/spinner/theming/css-properties/index.md
@@ -1,0 +1,31 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTSX from './react/main_tsx.md';
+import reactCSS from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/example_component_html.md';
+import angularCSS from './angular/example_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTSX,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angularHTML,
+        'src/app/example.component.css': angularCSS
+      }
+    },
+  }}
+  src="usage/spinner/theming/css-properties/demo.html"
+/>

--- a/static/usage/spinner/theming/css-properties/javascript.md
+++ b/static/usage/spinner/theming/css-properties/javascript.md
@@ -1,0 +1,9 @@
+```html
+<ion-spinner></ion-spinner>
+
+<style>
+  ion-spinner {
+    --color: #54dc98;
+  }
+</style>
+```

--- a/static/usage/spinner/theming/css-properties/react.md
+++ b/static/usage/spinner/theming/css-properties/react.md
@@ -1,0 +1,13 @@
+```tsx
+import React from 'react';
+import { IonSpinner } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonSpinner></IonSpinner>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/spinner/theming/css-properties/react.md
+++ b/static/usage/spinner/theming/css-properties/react.md
@@ -4,9 +4,7 @@ import { IonSpinner } from '@ionic/react';
 
 function Example() {
   return (
-    <>
-      <IonSpinner></IonSpinner>
-    </>
+    <IonSpinner></IonSpinner>
   );
 }
 export default Example;

--- a/static/usage/spinner/theming/css-properties/react/main_css.md
+++ b/static/usage/spinner/theming/css-properties/react/main_css.md
@@ -1,0 +1,5 @@
+```css
+ion-spinner {
+  --color: #54dc98;
+}
+```

--- a/static/usage/spinner/theming/css-properties/react/main_tsx.md
+++ b/static/usage/spinner/theming/css-properties/react/main_tsx.md
@@ -1,0 +1,15 @@
+```tsx
+import React from 'react';
+import { IonSpinner } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <>
+      <IonSpinner></IonSpinner>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/spinner/theming/css-properties/vue.md
+++ b/static/usage/spinner/theming/css-properties/vue.md
@@ -1,0 +1,20 @@
+```html
+<template>
+  <ion-spinner></ion-spinner>
+</template>
+
+<script lang="ts">
+  import { IonSpinner } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonSpinner },
+  });
+</script>
+
+<style scoped>
+  ion-spinner {
+    --color: #54dc98;
+  }
+</style>
+```


### PR DESCRIPTION
Adds playgrounds for:

- Basic Usage
- Theming
  - Colors
  - CSS Custom Properties

At first I had both playgrounds with the spinners in a list, but I changed the colors one to be more simple. If you think the first one shouldn't use a list either, or they both should, let me know. 

Corrects the usage section which stated the default for Material Design was `crescent` as it is now `circular`.

https://ionic-docs-git-fw-1265-ionic1.vercel.app/docs/api/spinner