### PR TITLE
refactor(): remove unneeded Tabs imports

### DIFF
--- a/docs/api/accordion-group.md
+++ b/docs/api/accordion-group.md
@@ -2,8 +2,6 @@
 title: "ion-accordion-group"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/accordion-group/props.md';

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-accordion"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/accordion/props.md';
 import Events from '@site/static/auto-generated/accordion/events.md';
 import Methods from '@site/static/auto-generated/accordion/methods.md';

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -2,8 +2,6 @@
 title: "ion-app"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/app/props.md';

--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-badge"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/badge/props.md';
 import Events from '@site/static/auto-generated/badge/events.md';
 import Methods from '@site/static/auto-generated/badge/methods.md';

--- a/docs/api/breadcrumb.md
+++ b/docs/api/breadcrumb.md
@@ -2,8 +2,6 @@
 title: "ion-breadcrumb"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/breadcrumb/props.md';

--- a/docs/api/breadcrumbs.md
+++ b/docs/api/breadcrumbs.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-breadcrumbs"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/breadcrumbs/props.md';
 import Events from '@site/static/auto-generated/breadcrumbs/events.md';
 import Methods from '@site/static/auto-generated/breadcrumbs/methods.md';

--- a/docs/api/card-content.md
+++ b/docs/api/card-content.md
@@ -2,8 +2,6 @@
 title: "ion-card-content"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/card-content/props.md';

--- a/docs/api/card-header.md
+++ b/docs/api/card-header.md
@@ -2,8 +2,6 @@
 title: "ion-card-header"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/card-header/props.md';

--- a/docs/api/card-subtitle.md
+++ b/docs/api/card-subtitle.md
@@ -2,8 +2,6 @@
 title: "ion-card-subtitle"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/card-subtitle/props.md';

--- a/docs/api/card-title.md
+++ b/docs/api/card-title.md
@@ -2,8 +2,6 @@
 title: "ion-card-title"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/card-title/props.md';

--- a/docs/api/col.md
+++ b/docs/api/col.md
@@ -2,8 +2,6 @@
 title: "ion-col"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/col/props.md';

--- a/docs/api/datetime-button.md
+++ b/docs/api/datetime-button.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-datetime-button"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/datetime-button/props.md';
 import Events from '@site/static/auto-generated/datetime-button/events.md';
 import Methods from '@site/static/auto-generated/datetime-button/methods.md';

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-datetime"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/datetime/props.md';
 import Events from '@site/static/auto-generated/datetime/events.md';
 import Methods from '@site/static/auto-generated/datetime/methods.md';

--- a/docs/api/item-option.md
+++ b/docs/api/item-option.md
@@ -2,8 +2,6 @@
 title: "ion-item-option"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/item-option/props.md';

--- a/docs/api/item-options.md
+++ b/docs/api/item-options.md
@@ -2,8 +2,6 @@
 title: "ion-item-options"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/item-options/props.md';

--- a/docs/api/menu-button.md
+++ b/docs/api/menu-button.md
@@ -2,8 +2,6 @@
 title: "ion-menu-button"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/menu-button/props.md';

--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-modal"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/modal/props.md';
 import Events from '@site/static/auto-generated/modal/events.md';
 import Methods from '@site/static/auto-generated/modal/methods.md';

--- a/docs/api/nav-link.md
+++ b/docs/api/nav-link.md
@@ -2,8 +2,6 @@
 title: "ion-nav-link"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/nav-link/props.md';

--- a/docs/api/nav.md
+++ b/docs/api/nav.md
@@ -1,8 +1,6 @@
 ---
 title: "ion-nav"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/nav/props.md';

--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-popover"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/popover/props.md';
 import Events from '@site/static/auto-generated/popover/events.md';
 import Methods from '@site/static/auto-generated/popover/methods.md';

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-range"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/range/props.md';
 import Events from '@site/static/auto-generated/range/events.md';
 import Methods from '@site/static/auto-generated/range/methods.md';

--- a/docs/api/refresher-content.md
+++ b/docs/api/refresher-content.md
@@ -2,8 +2,6 @@
 title: "ion-refresher-content"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/refresher-content/props.md';

--- a/docs/api/route-redirect.md
+++ b/docs/api/route-redirect.md
@@ -2,8 +2,6 @@
 title: "ion-route-redirect"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/route-redirect/props.md';

--- a/docs/api/router-link.md
+++ b/docs/api/router-link.md
@@ -4,8 +4,6 @@ hide_table_of_contents: true
 demoUrl: "/docs/demos/api/router-link/index.html"
 demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/router-link/index.html"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/router-link/props.md';

--- a/docs/api/router-outlet.md
+++ b/docs/api/router-outlet.md
@@ -2,8 +2,6 @@
 title: "ion-router-outlet"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/router-outlet/props.md';

--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -2,8 +2,6 @@
 title: "ion-router"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/router/props.md';

--- a/docs/api/row.md
+++ b/docs/api/row.md
@@ -2,8 +2,6 @@
 title: "ion-row"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/row/props.md';

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-select"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/select/props.md';
 import Events from '@site/static/auto-generated/select/events.md';
 import Methods from '@site/static/auto-generated/select/methods.md';

--- a/docs/api/skeleton-text.md
+++ b/docs/api/skeleton-text.md
@@ -1,9 +1,6 @@
 ---
 title: "ion-skeleton-text"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 import Props from '@site/static/auto-generated/skeleton-text/props.md';
 import Events from '@site/static/auto-generated/skeleton-text/events.md';
 import Methods from '@site/static/auto-generated/skeleton-text/methods.md';

--- a/docs/api/slide.md
+++ b/docs/api/slide.md
@@ -2,8 +2,6 @@
 title: "ion-slide"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/slide/props.md';

--- a/docs/api/tab.md
+++ b/docs/api/tab.md
@@ -2,8 +2,6 @@
 title: "ion-tab"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/tab/props.md';

--- a/docs/api/virtual-scroll.md
+++ b/docs/api/virtual-scroll.md
@@ -2,8 +2,6 @@
 title: "ion-virtual-scroll"
 hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/virtual-scroll/props.md';


### PR DESCRIPTION
Removes imports for `Tabs` and `TabItem` from component pages that don't use them. While some were likely a copy-paste issue from long, long ago, others are in here because the only tabs were the Usage section, which is being removed as we add playgrounds.