### PR TITLE
docs(progress-bar): add component playgrounds

### DIFF
--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -56,6 +56,13 @@ import Colors from '@site/static/usage/progress-bar/theming/colors/index.md';
 <Colors />
 
 
+### CSS Custom Properties
+
+import CSSProps from '@site/static/usage/progress-bar/theming/css-properties/index.md';
+
+<CSSProps />
+
+
 ## Properties
 <Props />
 

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -63,6 +63,13 @@ import CSSProps from '@site/static/usage/progress-bar/theming/css-properties/ind
 <CSSProps />
 
 
+### CSS Shadow Parts
+
+import CSSParts from '@site/static/usage/progress-bar/theming/css-shadow-parts/index.md';
+
+<CSSParts />
+
+
 ## Properties
 <Props />
 

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -47,6 +47,15 @@ import Indeterminate from '@site/static/usage/progress-bar/indeterminate/index.m
 <Indeterminate />
 
 
+## Theming
+
+### Colors
+
+import Colors from '@site/static/usage/progress-bar/theming/colors/index.md';
+
+<Colors />
+
+
 ## Properties
 <Props />
 

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -42,6 +42,10 @@ import Buffer from '@site/static/usage/progress-bar/buffer/index.md';
 
 The indeterminate type should be used when it is unknown how long the process will take. The progress bar is not tied to the `value`, instead it continually slides along the track until the process is complete.
 
+import Indeterminate from '@site/static/usage/progress-bar/indeterminate/index.md';
+
+<Indeterminate />
+
 
 ## Properties
 <Props />

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -1,13 +1,6 @@
 ---
 title: "ion-progress-bar"
-hide_table_of_contents: true
-demoUrl: "/docs/demos/api/progress-bar/index.html"
-demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/progress-bar/index.html"
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TOCInline from '@theme/TOCInline';
-
 import Props from '@site/static/auto-generated/progress-bar/props.md';
 import Events from '@site/static/auto-generated/progress-bar/events.md';
 import Methods from '@site/static/auto-generated/progress-bar/methods.md';
@@ -26,178 +19,29 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <h2 className="table-of-contents__title">Contents</h2>
 
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
-
-
-
 Progress bars inform users about the status of ongoing processes, such as loading an app, submitting a form, or saving updates. There are two types of progress bars: `determinate` and `indeterminate`.
 
-## Progress Type
-
-### Determinate
+## Determinate
 
 Determinate is the default type. It should be used when the percentage of an operation is known. The progress is represented by setting the `value` property. This can be used to show the progress increasing from 0 to 100% of the track.
 
+import Determinate from '@site/static/usage/progress-bar/determinate/index.md';
+
+<Determinate />
+
+### Buffer
+
 If the `buffer` property is set, a buffer stream will show with animated circles to indicate activity. The value of the `buffer` property will also be represented by how much visible track there is. If the value of `buffer` is less than the `value` property, there will be no visible track. If `buffer` is equal to `1` then the buffer stream will be hidden.
 
-### Indeterminate
+import Buffer from '@site/static/usage/progress-bar/buffer/index.md';
+
+<Buffer />
+
+
+## Indeterminate
 
 The indeterminate type should be used when it is unknown how long the process will take. The progress bar is not tied to the `value`, instead it continually slides along the track until the process is complete.
 
-
-
-## Usage
-
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
-
-<TabItem value="angular">
-
-```html
-<!-- Default Progressbar -->
-<ion-progress-bar></ion-progress-bar>
-
-<!-- Default Progressbar with 50 percent -->
-<ion-progress-bar value="0.5"></ion-progress-bar>
-
-<!-- Colorize Progressbar -->
-<ion-progress-bar color="primary" value="0.5"></ion-progress-bar>
-<ion-progress-bar color="secondary" value="0.5"></ion-progress-bar>
-
-<!-- Other types -->
-<ion-progress-bar value="0.25" buffer="0.5"></ion-progress-bar>
-<ion-progress-bar type="indeterminate"></ion-progress-bar>
-<ion-progress-bar type="indeterminate" reversed="true"></ion-progress-bar>
-```
-
-
-</TabItem>
-
-
-<TabItem value="javascript">
-
-```html
-<!-- Default Progressbar -->
-<ion-progress-bar></ion-progress-bar>
-
-<!-- Default Progressbar with 50 percent -->
-<ion-progress-bar value="0.5"></ion-progress-bar>
-
-<!-- Colorize Progressbar -->
-<ion-progress-bar color="primary" value="0.5"></ion-progress-bar>
-<ion-progress-bar color="secondary" value="0.5"></ion-progress-bar>
-
-<!-- Other types -->
-<ion-progress-bar value="0.25" buffer="0.5"></ion-progress-bar>
-<ion-progress-bar type="indeterminate"></ion-progress-bar>
-<ion-progress-bar type="indeterminate" reversed="true"></ion-progress-bar>
-```
-
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React from 'react';
-import { IonProgressBar, IonContent } from '@ionic/react';
-
-export const ProgressbarExample: React.FC = () => (
-  <IonContent>
-    {/*-- Default Progressbar --*/}
-    <IonProgressBar></IonProgressBar><br />
-
-    {/*-- Default Progressbar with 50 percent --*/}
-    <IonProgressBar value={0.5}></IonProgressBar><br />
-
-    {/*-- Colorize Progressbar --*/}
-    <IonProgressBar color="primary" value={0.5}></IonProgressBar><br />
-    <IonProgressBar color="secondary" value={0.5}></IonProgressBar><br />
-
-    {/*-- Other types --*/}
-    <IonProgressBar value={0.25} buffer={0.5}></IonProgressBar><br />
-    <IonProgressBar type="indeterminate"></IonProgressBar><br />
-    <IonProgressBar type="indeterminate" reversed={true}></IonProgressBar><br />
-  </IonContent>
-);
-```
-
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'progress-bar-example',
-  styleUrl: 'progress-bar-example.css'
-})
-export class ProgressBarExample {
-  render() {
-    return [
-      // Default Progressbar
-      <ion-progress-bar></ion-progress-bar>,
-
-      // Default Progressbar with 50 percent
-      <ion-progress-bar value={0.5}></ion-progress-bar>,
-
-      // Colorize Progressbar
-      <ion-progress-bar color="primary" value={0.5}></ion-progress-bar>,
-      <ion-progress-bar color="secondary" value={0.5}></ion-progress-bar>,
-
-      // Other types
-      <ion-progress-bar value={0.25} buffer={0.5}></ion-progress-bar>,
-      <ion-progress-bar type="indeterminate"></ion-progress-bar>,
-      <ion-progress-bar type="indeterminate" reversed={true}></ion-progress-bar>
-    ];
-  }
-}
-```
-
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <!-- Default Progressbar -->
-  <ion-progress-bar></ion-progress-bar>
-
-  <!-- Default Progressbar with 50 percent -->
-  <ion-progress-bar value="0.5"></ion-progress-bar>
-
-  <!-- Colorize Progressbar -->
-  <ion-progress-bar color="primary" value="0.5"></ion-progress-bar>
-  <ion-progress-bar color="secondary" value="0.5"></ion-progress-bar>
-
-  <!-- Other types -->
-  <ion-progress-bar value="0.25" buffer="0.5"></ion-progress-bar>
-  <ion-progress-bar type="indeterminate"></ion-progress-bar>
-  <ion-progress-bar type="indeterminate" reversed="true"></ion-progress-bar>
-</template>
-
-<script>
-import { IonProgressBar } from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: { IonProgressBar }
-});
-</script>
-```
-
-
-</TabItem>
-
-</Tabs>
 
 ## Properties
 <Props />

--- a/static/usage/progress-bar/buffer/angular/example_component_html.md
+++ b/static/usage/progress-bar/buffer/angular/example_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-progress-bar [buffer]="buffer" [value]="progress"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/buffer/angular/example_component_ts.md
+++ b/static/usage/progress-bar/buffer/angular/example_component_ts.md
@@ -1,0 +1,29 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css']
+})
+export class ExampleComponent {
+  public buffer = 0.06;
+  public progress = 0;
+
+  constructor() {
+    setInterval(() => {
+      this.buffer += 0.06;
+      this.progress += 0.06;
+
+      // Reset the progress bar when it reaches 100%
+      // to continuously show the demo
+      if (this.progress > 1) {
+        setTimeout(() => {
+          this.buffer = 0.06;
+          this.progress = 0;
+        }, 1000);
+      }
+    }, 1000);
+  }
+}
+```

--- a/static/usage/progress-bar/buffer/demo.html
+++ b/static/usage/progress-bar/buffer/demo.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Progress Bar</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-progress-bar></ion-progress-bar>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+<script>
+  let buffer = 0.06;
+  let progress = 0;
+
+  let progressBar = document.querySelector('ion-progress-bar');
+  progressBar.buffer = buffer;
+
+  setInterval(() => {
+    progressBar.buffer = buffer += 0.06;
+    progressBar.value = progress += 0.06;
+
+    // Reset the progress bar when it reaches 100%
+    // to continuously show the demo
+    if (progress > 1) {
+      setTimeout(() => {
+        progressBar.buffer = buffer = 0.06;
+        progressBar.value = progress = 0;
+      }, 1000);
+    }
+  }, 1000);
+</script>
+
+</html>

--- a/static/usage/progress-bar/buffer/index.md
+++ b/static/usage/progress-bar/buffer/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+
+import react from './react.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/progress-bar/buffer/demo.html"
+/>

--- a/static/usage/progress-bar/buffer/javascript.md
+++ b/static/usage/progress-bar/buffer/javascript.md
@@ -1,0 +1,25 @@
+```html
+<ion-progress-bar></ion-progress-bar>
+
+<script>
+  let buffer = 0.06;
+  let progress = 0;
+
+  let progressBar = document.querySelector('ion-progress-bar');
+  progressBar.buffer = buffer;
+
+  setInterval(() => {
+    progressBar.buffer = buffer += 0.06;
+    progressBar.value = progress += 0.06;
+
+    // Reset the progress bar when it reaches 100%
+    // to continuously show the demo
+    if (progress > 1) {
+      setTimeout(() => {
+        progressBar.buffer = buffer = 0.06;
+        progressBar.value = progress = 0;
+      }, 1000);
+    }
+  }, 1000);
+</script>
+```

--- a/static/usage/progress-bar/buffer/react.md
+++ b/static/usage/progress-bar/buffer/react.md
@@ -16,7 +16,7 @@ function Example() {
   }, []);
 
   if (progress > 1) {
-    const timer = setTimeout(() => {
+    setTimeout(() => {
       setBuffer(0.06);
       setProgress(0);
     }, 1000);

--- a/static/usage/progress-bar/buffer/react.md
+++ b/static/usage/progress-bar/buffer/react.md
@@ -1,0 +1,30 @@
+```tsx
+import React, { useEffect, useState } from 'react';
+import { IonProgressBar } from '@ionic/react';
+
+function Example() {
+  const [buffer, setBuffer] = useState(0.06);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setBuffer((prevBuffer) => prevBuffer + 0.06);
+      setProgress((prevProgress) => prevProgress + 0.06);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (progress > 1) {
+    const timer = setTimeout(() => {
+      setBuffer(0.06);
+      setProgress(0);
+    }, 1000);
+  }
+
+  return (
+    <IonProgressBar buffer={buffer} value={progress}></IonProgressBar>
+  );
+}
+export default Example;
+```

--- a/static/usage/progress-bar/buffer/vue.md
+++ b/static/usage/progress-bar/buffer/vue.md
@@ -1,0 +1,38 @@
+```html
+<template>
+  <ion-progress-bar :buffer="buffer" :value="progress"></ion-progress-bar>
+</template>
+
+<script lang="ts">
+  import { IonProgressBar } from '@ionic/vue';
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    components: { IonProgressBar },
+    setup() {
+      let buffer = ref(0.06);
+      let progress = ref(0);
+
+      return {
+        buffer,
+        progress
+      };
+    },
+    mounted() {
+      setInterval(() => {
+        this.buffer += 0.06;
+        this.progress += 0.06;
+
+        // Reset the progress bar when it reaches 100%
+        // to continuously show the demo
+        if (this.progress > 1) {
+          setTimeout(() => {
+            this.buffer = 0.06;
+            this.progress = 0;
+          }, 1000);
+        }
+      }, 1000);
+    }
+  });
+</script>
+```

--- a/static/usage/progress-bar/determinate/angular/example_component_html.md
+++ b/static/usage/progress-bar/determinate/angular/example_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-progress-bar [value]="progress"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/determinate/angular/example_component_ts.md
+++ b/static/usage/progress-bar/determinate/angular/example_component_ts.md
@@ -1,0 +1,26 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css']
+})
+export class ExampleComponent {
+  public progress = 0;
+
+  constructor() {
+    setInterval(() => {
+      this.progress += 0.01;
+
+      // Reset the progress bar when it reaches 100%
+      // to continuously show the demo
+      if (this.progress > 1) {
+        setTimeout(() => {
+          this.progress = 0;
+        }, 1000);
+      }
+    }, 50);
+  }
+}
+```

--- a/static/usage/progress-bar/determinate/demo.html
+++ b/static/usage/progress-bar/determinate/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Progress Bar</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-progress-bar></ion-progress-bar>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+<script>
+  let progress = 0;
+  let progressBar = document.querySelector('ion-progress-bar');
+
+  setInterval(() => {
+    progressBar.value = progress += 0.01;
+
+    // Reset the progress bar when it reaches 100%
+    // to continuously show the demo
+    if (progress > 1) {
+      setTimeout(() => {
+        progressBar.value = progress = 0;
+      }, 1000);
+    }
+  }, 50);
+</script>
+
+</html>

--- a/static/usage/progress-bar/determinate/index.md
+++ b/static/usage/progress-bar/determinate/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+
+import react from './react.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/progress-bar/determinate/demo.html"
+/>

--- a/static/usage/progress-bar/determinate/javascript.md
+++ b/static/usage/progress-bar/determinate/javascript.md
@@ -1,0 +1,20 @@
+```html
+<ion-progress-bar></ion-progress-bar>
+
+<script>
+  let progress = 0;
+  let progressBar = document.querySelector('ion-progress-bar');
+
+  setInterval(() => {
+    progressBar.value = progress += 0.01;
+
+    // Reset the progress bar when it reaches 100%
+    // to continuously show the demo
+    if (progress > 1) {
+      setTimeout(() => {
+        progressBar.value = progress = 0;
+      }, 1000);
+    }
+  }, 50);
+</script>
+```

--- a/static/usage/progress-bar/determinate/react.md
+++ b/static/usage/progress-bar/determinate/react.md
@@ -1,0 +1,27 @@
+```tsx
+import React, { useEffect, useState } from 'react';
+import { IonProgressBar } from '@ionic/react';
+
+function Example() {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setProgress((prevProgress) => prevProgress + 0.01);
+    }, 50);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (progress > 1) {
+    const timer = setTimeout(() => {
+      setProgress(0);
+    }, 1000);
+  }
+
+  return (
+    <IonProgressBar value={progress}></IonProgressBar>
+  );
+}
+export default Example;
+```

--- a/static/usage/progress-bar/determinate/react.md
+++ b/static/usage/progress-bar/determinate/react.md
@@ -14,7 +14,7 @@ function Example() {
   }, []);
 
   if (progress > 1) {
-    const timer = setTimeout(() => {
+    setTimeout(() => {
       setProgress(0);
     }, 1000);
   }

--- a/static/usage/progress-bar/determinate/vue.md
+++ b/static/usage/progress-bar/determinate/vue.md
@@ -1,0 +1,34 @@
+```html
+<template>
+  <ion-progress-bar :value="progress"></ion-progress-bar>
+</template>
+
+<script lang="ts">
+  import { IonProgressBar } from '@ionic/vue';
+  import { defineComponent, ref } from 'vue';
+
+  export default defineComponent({
+    components: { IonProgressBar },
+    setup() {
+      let progress = ref(0);
+
+      return {
+        progress
+      };
+    },
+    mounted() {
+      setInterval(() => {
+        this.progress += 0.01;
+
+        // Reset the progress bar when it reaches 100%
+        // to continuously show the demo
+        if (this.progress > 1) {
+          setTimeout(() => {
+            this.progress = 0;
+          }, 1000);
+        }
+      }, 50);
+    }
+  });
+</script>
+```

--- a/static/usage/progress-bar/indeterminate/angular.md
+++ b/static/usage/progress-bar/indeterminate/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-progress-bar type="indeterminate"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/indeterminate/demo.html
+++ b/static/usage/progress-bar/indeterminate/demo.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Progress Bar</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-progress-bar type="indeterminate"></ion-progress-bar>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/progress-bar/indeterminate/index.md
+++ b/static/usage/progress-bar/indeterminate/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/progress-bar/indeterminate/demo.html" />

--- a/static/usage/progress-bar/indeterminate/javascript.md
+++ b/static/usage/progress-bar/indeterminate/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-progress-bar type="indeterminate"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/indeterminate/react.md
+++ b/static/usage/progress-bar/indeterminate/react.md
@@ -4,9 +4,7 @@ import { IonProgressBar } from '@ionic/react';
 
 function Example() {
   return (
-    <>
-      <IonProgressBar type="indeterminate"></IonProgressBar>
-    </>
+    <IonProgressBar type="indeterminate"></IonProgressBar>
   );
 }
 export default Example;

--- a/static/usage/progress-bar/indeterminate/react.md
+++ b/static/usage/progress-bar/indeterminate/react.md
@@ -1,0 +1,13 @@
+```tsx
+import React from 'react';
+import { IonProgressBar } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonProgressBar type="indeterminate"></IonProgressBar>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/progress-bar/indeterminate/vue.md
+++ b/static/usage/progress-bar/indeterminate/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-progress-bar type="indeterminate"></ion-progress-bar>
+</template>
+
+<script lang="ts">
+  import { IonProgressBar } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonProgressBar },
+  });
+</script>
+```

--- a/static/usage/progress-bar/theming/colors/angular.md
+++ b/static/usage/progress-bar/theming/colors/angular.md
@@ -1,0 +1,11 @@
+```html
+<ion-progress-bar type="indeterminate" color="primary"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="secondary"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="tertiary"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="success"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="warning"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="danger"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="light"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="medium"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="dark"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/theming/colors/demo.html
+++ b/static/usage/progress-bar/theming/colors/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Progress Bar</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      flex-flow: column;
+    }
+
+    ion-progress-bar {
+      margin-top: 10px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-progress-bar type="indeterminate" color="primary"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="secondary"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="tertiary"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="success"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="warning"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="danger"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="light"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="medium"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate" color="dark"></ion-progress-bar>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/progress-bar/theming/colors/demo.html
+++ b/static/usage/progress-bar/theming/colors/demo.html
@@ -13,10 +13,7 @@
   <style>
     .container {
       flex-flow: column;
-    }
-
-    ion-progress-bar {
-      margin-top: 10px;
+      justify-content: space-evenly;
     }
   </style>
 </head>

--- a/static/usage/progress-bar/theming/colors/index.md
+++ b/static/usage/progress-bar/theming/colors/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/progress-bar/theming/colors/demo.html" />

--- a/static/usage/progress-bar/theming/colors/javascript.md
+++ b/static/usage/progress-bar/theming/colors/javascript.md
@@ -1,0 +1,11 @@
+```html
+<ion-progress-bar type="indeterminate" color="primary"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="secondary"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="tertiary"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="success"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="warning"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="danger"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="light"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="medium"></ion-progress-bar>
+<ion-progress-bar type="indeterminate" color="dark"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/theming/colors/react.md
+++ b/static/usage/progress-bar/theming/colors/react.md
@@ -1,0 +1,21 @@
+```tsx
+import React from 'react';
+import { IonProgressBar } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonProgressBar type="indeterminate" color="primary"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="secondary"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="tertiary"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="success"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="warning"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="danger"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="light"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="medium"></IonProgressBar>
+      <IonProgressBar type="indeterminate" color="dark"></IonProgressBar>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/progress-bar/theming/colors/vue.md
+++ b/static/usage/progress-bar/theming/colors/vue.md
@@ -1,0 +1,22 @@
+```html
+<template>
+  <ion-progress-bar type="indeterminate" color="primary"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="secondary"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="tertiary"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="success"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="warning"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="danger"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="light"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="medium"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate" color="dark"></ion-progress-bar>
+</template>
+
+<script lang="ts">
+  import { IonProgressBar } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonProgressBar },
+  });
+</script>
+```

--- a/static/usage/progress-bar/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/progress-bar/theming/css-properties/angular/example_component_css.md
@@ -1,0 +1,6 @@
+```css
+ion-progress-bar {
+  --background: #88f4be;
+  --progress-background: #09c567;
+}
+```

--- a/static/usage/progress-bar/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/progress-bar/theming/css-properties/angular/example_component_css.md
@@ -1,6 +1,6 @@
 ```css
 ion-progress-bar {
-  --background: #88f4be;
+  --background: #f3e895;
   --progress-background: #09c567;
 }
 ```

--- a/static/usage/progress-bar/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/progress-bar/theming/css-properties/angular/example_component_html.md
@@ -1,3 +1,4 @@
 ```html
 <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+<ion-progress-bar type="indeterminate"></ion-progress-bar>
 ```

--- a/static/usage/progress-bar/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/progress-bar/theming/css-properties/angular/example_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/theming/css-properties/demo.html
+++ b/static/usage/progress-bar/theming/css-properties/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Progress Bar</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    ion-progress-bar {
+      --background: #88f4be;
+      --progress-background: #09c567;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/progress-bar/theming/css-properties/demo.html
+++ b/static/usage/progress-bar/theming/css-properties/demo.html
@@ -11,6 +11,11 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
 
   <style>
+    .container {
+      flex-flow: column;
+      justify-content: space-evenly;
+    }
+
     ion-progress-bar {
       --background: #88f4be;
       --progress-background: #09c567;
@@ -23,6 +28,7 @@
     <ion-content>
       <div class="container">
         <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+        <ion-progress-bar type="indeterminate"></ion-progress-bar>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/progress-bar/theming/css-properties/index.md
+++ b/static/usage/progress-bar/theming/css-properties/index.md
@@ -1,0 +1,31 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTSX from './react/main_tsx.md';
+import reactCSS from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/example_component_html.md';
+import angularCSS from './angular/example_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTSX,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angularHTML,
+        'src/app/example.component.css': angularCSS
+      }
+    },
+  }}
+  src="usage/progress-bar/theming/css-properties/demo.html"
+/>

--- a/static/usage/progress-bar/theming/css-properties/javascript.md
+++ b/static/usage/progress-bar/theming/css-properties/javascript.md
@@ -7,4 +7,5 @@
 </style>
 
 <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+<ion-progress-bar type="indeterminate"></ion-progress-bar>
 ```

--- a/static/usage/progress-bar/theming/css-properties/javascript.md
+++ b/static/usage/progress-bar/theming/css-properties/javascript.md
@@ -1,0 +1,10 @@
+```html
+<style>
+  ion-progress-bar {
+    --background: #88f4be;
+    --progress-background: #09c567;
+  }
+</style>
+
+<ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/theming/css-properties/react/main_css.md
+++ b/static/usage/progress-bar/theming/css-properties/react/main_css.md
@@ -1,0 +1,6 @@
+```css
+ion-progress-bar {
+  --background: #88f4be;
+  --progress-background: #09c567;
+}
+```

--- a/static/usage/progress-bar/theming/css-properties/react/main_css.md
+++ b/static/usage/progress-bar/theming/css-properties/react/main_css.md
@@ -1,6 +1,6 @@
 ```css
 ion-progress-bar {
-  --background: #88f4be;
+  --background: #f3e895;
   --progress-background: #09c567;
 }
 ```

--- a/static/usage/progress-bar/theming/css-properties/react/main_tsx.md
+++ b/static/usage/progress-bar/theming/css-properties/react/main_tsx.md
@@ -1,0 +1,16 @@
+
+```tsx
+import React from 'react';
+import { IonProgressBar } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <>
+      <IonProgressBar value={.25} buffer={.5}></IonProgressBar>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/progress-bar/theming/css-properties/react/main_tsx.md
+++ b/static/usage/progress-bar/theming/css-properties/react/main_tsx.md
@@ -9,6 +9,7 @@ function Example() {
   return (
     <>
       <IonProgressBar value={.25} buffer={.5}></IonProgressBar>
+      <IonProgressBar type="indeterminate"></IonProgressBar>
     </>
   );
 }

--- a/static/usage/progress-bar/theming/css-properties/vue.md
+++ b/static/usage/progress-bar/theming/css-properties/vue.md
@@ -1,6 +1,7 @@
 ```html
 <template>
-  <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+  <ion-progress-bar :value=".25" :buffer=".5"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate"></ion-progress-bar>
 </template>
 
 <script lang="ts">

--- a/static/usage/progress-bar/theming/css-properties/vue.md
+++ b/static/usage/progress-bar/theming/css-properties/vue.md
@@ -15,7 +15,7 @@
 
 <style scoped>
   ion-progress-bar {
-    --background: #88f4be;
+    --background: #f3e895;
     --progress-background: #09c567;
   }
 </style>

--- a/static/usage/progress-bar/theming/css-properties/vue.md
+++ b/static/usage/progress-bar/theming/css-properties/vue.md
@@ -1,0 +1,21 @@
+```html
+<template>
+  <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+</template>
+
+<script lang="ts">
+  import { IonProgressBar } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonProgressBar }
+  });
+</script>
+
+<style scoped>
+  ion-progress-bar {
+    --background: #88f4be;
+    --progress-background: #09c567;
+  }
+</style>
+```

--- a/static/usage/progress-bar/theming/css-shadow-parts/angular/example_component_css.md
+++ b/static/usage/progress-bar/theming/css-shadow-parts/angular/example_component_css.md
@@ -1,0 +1,13 @@
+```css
+ion-progress-bar::part(track) {
+  background: #f3e895;
+}
+
+ion-progress-bar::part(progress) {
+  background: #09c567;
+}
+
+ion-progress-bar::part(stream) {
+  background-image: radial-gradient(ellipse at center, #e475f3 0%, #e475f3 30%, transparent 30%);
+}
+```

--- a/static/usage/progress-bar/theming/css-shadow-parts/angular/example_component_html.md
+++ b/static/usage/progress-bar/theming/css-shadow-parts/angular/example_component_html.md
@@ -1,11 +1,4 @@
 ```html
-<style>
-  ion-progress-bar {
-    --background: #f3e895;
-    --progress-background: #09c567;
-  }
-</style>
-
 <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
 <ion-progress-bar type="indeterminate"></ion-progress-bar>
 ```

--- a/static/usage/progress-bar/theming/css-shadow-parts/demo.html
+++ b/static/usage/progress-bar/theming/css-shadow-parts/demo.html
@@ -16,9 +16,16 @@
       justify-content: space-evenly;
     }
 
-    ion-progress-bar {
-      --background: #f3e895;
-      --progress-background: #09c567;
+    ion-progress-bar::part(track) {
+      background: #f3e895;
+    }
+
+    ion-progress-bar::part(progress) {
+      background: #09c567;
+    }
+
+    ion-progress-bar::part(stream) {
+      background-image: radial-gradient(ellipse at center, #e475f3 0%, #e475f3 30%, transparent 30%);
     }
   </style>
 </head>

--- a/static/usage/progress-bar/theming/css-shadow-parts/index.md
+++ b/static/usage/progress-bar/theming/css-shadow-parts/index.md
@@ -1,0 +1,31 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTSX from './react/main_tsx.md';
+import reactCSS from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/example_component_html.md';
+import angularCSS from './angular/example_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTSX,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angularHTML,
+        'src/app/example.component.css': angularCSS
+      }
+    },
+  }}
+  src="usage/progress-bar/theming/css-shadow-parts/demo.html"
+/>

--- a/static/usage/progress-bar/theming/css-shadow-parts/javascript.md
+++ b/static/usage/progress-bar/theming/css-shadow-parts/javascript.md
@@ -1,0 +1,18 @@
+```html
+<style>
+  ion-progress-bar::part(track) {
+    background: #f3e895;
+  }
+
+  ion-progress-bar::part(progress) {
+    background: #09c567;
+  }
+
+  ion-progress-bar::part(stream) {
+    background-image: radial-gradient(ellipse at center, #e475f3 0%, #e475f3 30%, transparent 30%);
+  }
+</style>
+
+<ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+<ion-progress-bar type="indeterminate"></ion-progress-bar>
+```

--- a/static/usage/progress-bar/theming/css-shadow-parts/react/main_css.md
+++ b/static/usage/progress-bar/theming/css-shadow-parts/react/main_css.md
@@ -1,0 +1,13 @@
+```css
+ion-progress-bar::part(track) {
+  background: #f3e895;
+}
+
+ion-progress-bar::part(progress) {
+  background: #09c567;
+}
+
+ion-progress-bar::part(stream) {
+  background-image: radial-gradient(ellipse at center, #e475f3 0%, #e475f3 30%, transparent 30%);
+}
+```

--- a/static/usage/progress-bar/theming/css-shadow-parts/react/main_tsx.md
+++ b/static/usage/progress-bar/theming/css-shadow-parts/react/main_tsx.md
@@ -1,0 +1,17 @@
+
+```tsx
+import React from 'react';
+import { IonProgressBar } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <>
+      <IonProgressBar value={.25} buffer={.5}></IonProgressBar>
+      <IonProgressBar type="indeterminate"></IonProgressBar>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/progress-bar/theming/css-shadow-parts/vue.md
+++ b/static/usage/progress-bar/theming/css-shadow-parts/vue.md
@@ -1,0 +1,29 @@
+```html
+<template>
+  <ion-progress-bar value=".25" buffer=".5"></ion-progress-bar>
+  <ion-progress-bar type="indeterminate"></ion-progress-bar>
+</template>
+
+<script lang="ts">
+  import { IonProgressBar } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonProgressBar }
+  });
+</script>
+
+<style scoped>
+  ion-progress-bar::part(track) {
+    background: #f3e895;
+  }
+
+  ion-progress-bar::part(progress) {
+    background: #09c567;
+  }
+
+  ion-progress-bar::part(stream) {
+    background-image: radial-gradient(ellipse at center, #e475f3 0%, #e475f3 30%, transparent 30%);
+  }
+</style>
+```


### PR DESCRIPTION
Adds playgrounds for the following sections:

- Determinate
  - Buffer
- Indeterminate
- Theming
  - Colors
  - CSS Custom Properties
  - CSS Shadow Parts

Note: I did not add a "Basic Usage" section because the default behavior is determinate and I thought it made more sense to just explain the two types separately. I also put "Buffer" under "Determinate" since it does not work with an "Indeterminate" type progress bar but if you think it should be a higher heading I can change this. 

https://ionic-docs-git-fw-1276-ionic1.vercel.app/docs/api/progress-bar