### PR TITLE
docs(template): fix validation typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,19 +7,19 @@ body:
     attributes:
       label: Describe the Bug
       description: A clear description of what the bug is and how it manifests.
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
       label: Expected Behavior
       description: A clear description of what you expected to happen.
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
       label: Steps to Reproduce
       description: Please explain the steps required to duplicate this issue.
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/content-issue.yml
+++ b/.github/ISSUE_TEMPLATE/content-issue.yml
@@ -7,11 +7,11 @@ body:
     attributes:
       label: URL
       description: The URL at which the content is missing or inaccurate
-    validation:
+    validations:
       required: true
   - type: textarea
     attributes:
       label: Issue Description
       description: What is missing or inaccurate about the content on this page?
-    validation:
+    validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Describe Problem
       description: A clear and concise description of what the problem is. Ex. I am always frustrated when [...]
-      validation:
+      validations:
         required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,8 +7,8 @@ body:
     attributes:
       label: Describe Problem
       description: A clear and concise description of what the problem is. Ex. I am always frustrated when [...]
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Describe Preferred Solution


### PR DESCRIPTION
The templates should say "validations" instead of "validation".