### PR TITLE
fix(playground): add ion-page class to angular stackbiltz code

### DIFF
--- a/static/code/stackblitz/angular/app.component.html
+++ b/static/code/stackblitz/angular/app.component.html
@@ -1,3 +1,3 @@
 <ion-app>
-  <app-example></app-example>
+  <app-example class="ion-page"></app-example>
 </ion-app>

--- a/static/code/stackblitz/angular/app.component.withContent.html
+++ b/static/code/stackblitz/angular/app.component.withContent.html
@@ -1,5 +1,5 @@
 <ion-app>
   <ion-content class="ion-padding">
-    <app-example></app-example>
+    <app-example class="ion-page"></app-example>
   </ion-content>
 </ion-app>

--- a/static/code/stackblitz/angular/app.component.withContent.html
+++ b/static/code/stackblitz/angular/app.component.withContent.html
@@ -1,5 +1,5 @@
 <ion-app>
   <ion-content class="ion-padding">
-    <app-example class="ion-page"></app-example>
+    <app-example></app-example>
   </ion-content>
 </ion-app>


### PR DESCRIPTION
This adds the `ion-page` class to the stackblitz code that is used for Angular projects when `includeIonContent={false}`. I didn't add it to the code that adds an `ion-content` wrapper because it will cause the content to cover up the padding area. It is required to properly position header, content, footer in the demos. 

Angular before fix:
![Screen Shot 2022-09-22 at 11 02 08 AM](https://user-images.githubusercontent.com/6577830/191791824-4ca70d0c-7173-4a2b-be70-d34628206e05.png)

JavaScript before fix:
![Screen Shot 2022-09-22 at 11 02 13 AM](https://user-images.githubusercontent.com/6577830/191791829-acf8801b-8f80-430e-a8a7-6c7971b2df70.png)
