### PR TITLE
docs(vue): remove extra 'overview' heading

### DIFF
--- a/docs/vue/overview.md
+++ b/docs/vue/overview.md
@@ -1,4 +1,5 @@
 ---
+title: 'Ionic Vue Overview'
 sidebar_label: Overview
 ---
 
@@ -12,8 +13,6 @@ sidebar_label: Overview
 
 import DocsCard from '@components/global/DocsCard';
 import DocsCards from '@components/global/DocsCards';
-
-# Ionic Vue Overview
 
 `@ionic/vue` combines the core Ionic Framework experience with the tooling and APIs that are tailored to Vue Developers.
 


### PR DESCRIPTION
There is an extra `overview` heading at https://ionicframework.com/docs/vue/overview

![Screen Shot 2022-09-22 at 3 16 23 PM](https://user-images.githubusercontent.com/6577830/191832671-78904a43-4b1f-4f09-b4eb-7f545df81774.png)

This PR removes that heading:

![Screen Shot 2022-09-22 at 3 18 53 PM](https://user-images.githubusercontent.com/6577830/191832856-e4cf961e-3785-46a8-8a37-c62cb347f3fe.png)
