### PR TITLE
docs(api): remove contents header from new api docs

### DIFF
--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -17,8 +17,6 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
 
 Accordions provide collapsible sections in your content to reduce vertical space while providing a way of organizing and grouping information. All `ion-accordion` components should be grouped inside `ion-accordion-group` components.
 
@@ -30,7 +28,7 @@ import Basic from '@site/static/usage/accordion/basic/index.md';
 
 ## Toggle Accordions
 
-Which accordion is open is controlled by setting the `value` property on `ion-accordion-group`. Setting this property allows developers to programmatically expand or collapse certain accordions. 
+Which accordion is open is controlled by setting the `value` property on `ion-accordion-group`. Setting this property allows developers to programmatically expand or collapse certain accordions.
 
 import Toggle from '@site/static/usage/accordion/toggle/index.md';
 

--- a/docs/api/item-divider.md
+++ b/docs/api/item-divider.md
@@ -17,7 +17,6 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
 
 Item dividers are block elements that can be used to separate [items](./item) in a list. They are similar to list headers, but instead of only being placed at the top of a list, they should go in between groups of items.
 

--- a/docs/api/item-group.md
+++ b/docs/api/item-group.md
@@ -15,7 +15,6 @@ import Slots from '@site/static/auto-generated/item-group/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
-<h2 className="table-of-contents__title">Contents</h2>
 
 Item groups are containers that organize similar [items](./item) together. They can contain [item dividers](./item-divider) to divide the items into multiple sections. They can also be used to group [sliding items](./item-sliding).
 

--- a/docs/api/item-sliding.md
+++ b/docs/api/item-sliding.md
@@ -15,8 +15,6 @@ import Slots from '@site/static/auto-generated/item-sliding/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
-<h2 className="table-of-contents__title">Contents</h2>
-
 
 A sliding item contains an item that can be dragged to reveal option buttons. It requires an [item](./item) component as a child. All options to reveal should be placed in the [item options](./item-options) element.
 

--- a/docs/api/list-header.md
+++ b/docs/api/list-header.md
@@ -12,7 +12,6 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
 
 List headers are block elements that are used to describe the contents of a [list](./list). Unlike [item dividers](./item-divider), list headers should only be used once at the top of a list of [items](./item).
 

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -16,15 +16,6 @@ import Slots from '@site/static/auto-generated/list/slots.md';
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 
-<h2 className="table-of-contents__title">Contents</h2>
-
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
-
-
-
 Lists are made up of multiple rows of [items](./item) which can contain text, buttons, toggles,
 icons, thumbnails, and much more. Lists generally contain items with similar data content, such as images and text.
 

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -17,7 +17,6 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
 
 Progress bars inform users about the status of ongoing processes, such as loading an app, submitting a form, or saving updates. There are two types of progress bars: `determinate` and `indeterminate`.
 

--- a/docs/api/segment-button.md
+++ b/docs/api/segment-button.md
@@ -17,7 +17,6 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
 
 Segment buttons are groups of related buttons inside of a [segment](segment.md). They are displayed in a horizontal row. A segment button can be selected by default by setting the `value` of the segment to the `value` of the segment button. Only one segment button can be selected at a time.
 

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -17,7 +17,6 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
 
 Segments display a group of related buttons, sometimes known as segmented controls, in a horizontal row. They can be displayed inside of a toolbar or the main content.
 

--- a/docs/api/spinner.md
+++ b/docs/api/spinner.md
@@ -17,8 +17,6 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
 
 The Spinner component provides a variety of animated SVG spinners. Spinners are visual indicators that the app is loading content or performing another process that the user needs to wait on.
 


### PR DESCRIPTION
The "Contents" header was missed when porting some api docs:

![Screen Shot 2022-09-23 at 11 45 08 AM](https://user-images.githubusercontent.com/6577830/192000490-a9f4a2ea-ea3a-4eb9-8bda-fc1292e596ed.png)

This PR removes it from the ones that have been moved over and no longer have a TOC