### PR TITLE
docs(developing): fix sdk uppercase directory

### DIFF
--- a/docs/developing/android.md
+++ b/docs/developing/android.md
@@ -1,4 +1,4 @@
----
+  ---
 title: Android Development
 sidebar_label: Developing for Android
 ---
@@ -48,11 +48,19 @@ In `~/.bashrc`, `~/.bash_profile`, or similar shell startup scripts, make the fo
 
 1. Set the `ANDROID_SDK_ROOT` environment variable. This path should be the **Android SDK Location** used in the previous section.
 
+   For Mac:
+
+   ```shell
+   $ export ANDROID_SDK_ROOT=$HOME/Android/sdk
+   ```
+
+   For Linux/Windows:
+
    ```shell
    $ export ANDROID_SDK_ROOT=$HOME/Android/Sdk
    ```
 
-1. Add the Android SDK command-line directories to `PATH`. Each directory corresponds to the category of <a href="https://developer.android.com/studio/command-line/" target="_blank">command-line tool</a>.
+2. Add the Android SDK command-line directories to `PATH`. Each directory corresponds to the category of <a href="https://developer.android.com/studio/command-line/" target="_blank">command-line tool</a>.
 
    ```shell-session
    $ # avdmanager, sdkmanager

--- a/docs/developing/android.md
+++ b/docs/developing/android.md
@@ -49,7 +49,7 @@ In `~/.bashrc`, `~/.bash_profile`, or similar shell startup scripts, make the fo
 1. Set the `ANDROID_SDK_ROOT` environment variable. This path should be the **Android SDK Location** used in the previous section.
 
    ```shell
-   $ export ANDROID_SDK_ROOT=$HOME/Library/Android/Sdk
+   $ export ANDROID_SDK_ROOT=$HOME/Android/Sdk
    ```
 
 1. Add the Android SDK command-line directories to `PATH`. Each directory corresponds to the category of <a href="https://developer.android.com/studio/command-line/" target="_blank">command-line tool</a>.

--- a/docs/developing/android.md
+++ b/docs/developing/android.md
@@ -49,7 +49,7 @@ In `~/.bashrc`, `~/.bash_profile`, or similar shell startup scripts, make the fo
 1. Set the `ANDROID_SDK_ROOT` environment variable. This path should be the **Android SDK Location** used in the previous section.
 
    ```shell
-   $ export ANDROID_SDK_ROOT=$HOME/Library/Android/sdk
+   $ export ANDROID_SDK_ROOT=$HOME/Library/Android/Sdk
    ```
 
 1. Add the Android SDK command-line directories to `PATH`. Each directory corresponds to the category of <a href="https://developer.android.com/studio/command-line/" target="_blank">command-line tool</a>.

--- a/docs/developing/android.md
+++ b/docs/developing/android.md
@@ -1,4 +1,4 @@
-  ---
+---
 title: Android Development
 sidebar_label: Developing for Android
 ---


### PR DESCRIPTION
Installing Android SDK today via Android Studio on Linux leads typically to "$HOME/Android/Sdk" and not "$HOME/Android/sdk".