### PR TITLE
fix(datetime-button): add fragment tags to React example

### DIFF
--- a/static/usage/datetime-button/basic/react.md
+++ b/static/usage/datetime-button/basic/react.md
@@ -3,11 +3,13 @@ import React from 'react';
 import { IonDatetime, IonDatetimeButton, IonModal } from '@ionic/react';
 function Example() {
   return (
-    <IonDatetimeButton datetime="datetime"></IonDatetimeButton>
-    
-    <IonModal keepContentsMounted={true}>
-      <IonDatetime id="datetime"></IonDatetime>
-    </IonModal>
+    <>
+      <IonDatetimeButton datetime="datetime"></IonDatetimeButton>
+      
+      <IonModal keepContentsMounted={true}>
+        <IonDatetime id="datetime"></IonDatetime>
+      </IonModal>
+    </>
   );
 }
 export default Example;


### PR DESCRIPTION
Currently, the basic usage playground for `ion-datetime-button` (https://ionicframework.com/docs/api/datetime-button) will error out in the React Stackblitz.

![error](https://i.gyazo.com/5baed482a11af223e3ddc3c50956d94d.png)

This PR adds fragment tags to resolve this error.

Preview shortcut: https://ionic-docs-git-datetime-button-react-fix-ionic1.vercel.app/docs/api/datetime-button