### PR TITLE
docs(modal): add canDismiss, deprecate swipeToClose

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -189,7 +189,12 @@ interface ModalOptions {
   backdropDismiss?: boolean;
   cssClass?: string | string[];
   animated?: boolean;
+  /**
+   * If `true`, the modal can be swiped to dismiss. Only applies in iOS mode.
+   * @deprecated - To prevent modals from dismissing, use canDismiss instead.
+   */
   swipeToClose?: boolean;
+  canDismiss?: boolean | (() => Promise<boolean>);
 
   mode?: 'ios' | 'md';
   keyboardClose?: boolean;


### PR DESCRIPTION
The `ModalOptions` interface is currently manually written. I forgot to add `canDismiss` and deprecate `swipeToClose` when the `canDismiss` feature was added.