### PR TITLE
docs(modal): fix angular card modal example

### DIFF
--- a/static/usage/modal/can-dismiss/function/angular/example_component_html.md
+++ b/static/usage/modal/can-dismiss/function/angular/example_component_html.md
@@ -7,7 +7,7 @@
   </ion-header>
   <ion-content class="ion-padding">
     <ion-button id="open-modal" expand="block">Open</ion-button>
-    <ion-modal #modal trigger="open-modal" [swipeToClose]="true" [canDismiss]="canDismiss">
+    <ion-modal #modal trigger="open-modal" [swipeToClose]="true" [canDismiss]="canDismiss" [presentingElement]="presentingElement">
       <ng-template>
         <ion-header>
           <ion-toolbar>


### PR DESCRIPTION
The `presentingElement` was never passed to the `ion-modal` element, so the card style was not activated.