### PR TITLE
chore(support): move v4 to end of support

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -24,7 +24,7 @@ The current status of each Ionic Framework version is:
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
 |   V6    |      **Active**       | Dec 8, 2021  |       TBD        |        TBD        |
 |   V5    | Extended Support Only | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
-|   V4    | Extended Support Only | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
+|   V4    |    End of Support     | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
 |   V3    |    End of Support     | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
 |   V2    |    End of Support     | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
 |   V1    |    End of Support     | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |


### PR DESCRIPTION
"Extended Support" for Ionic v4 ended on September 30, 2022. This PR updates the support table to reflect that.