### PR TITLE
docs(textarea): add playgrounds

### DIFF
--- a/docs/api/textarea.md
+++ b/docs/api/textarea.md
@@ -1,11 +1,6 @@
 ---
 title: "ion-textarea"
-hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TOCInline from '@theme/TOCInline';
-
 import Props from '@site/static/auto-generated/textarea/props.md';
 import Events from '@site/static/auto-generated/textarea/events.md';
 import Methods from '@site/static/auto-generated/textarea/methods.md';
@@ -22,20 +17,39 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="scoped" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
-
-
-
 The textarea component is used for multi-line text input. A native textarea element is rendered inside of the component. The user experience and interactivity of the textarea component is improved by having control over the native textarea.
 
 Unlike the native textarea element, the Ionic textarea does not support loading its value from the inner content. The textarea value should be set in the `value` attribute.
 
 The textarea component accepts the [native textarea attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) in addition to the Ionic properties.
+
+## Basic Usage
+
+import BasicPlayground from '@site/static/usage/textarea/basic/index.md';
+
+<BasicPlayground />
+
+## Autogrow
+
+When the `autoGrow` property is set to `true`, the textarea will grow and shrink based on its contents.
+
+import AutogrowPlayground from '@site/static/usage/textarea/autogrow/index.md';
+
+<AutogrowPlayground />
+
+## Clear on Edit
+
+Setting the `clearOnInput` property to `true` will clear the textarea after it has been blurred and then typed in again.
+
+import ClearOnEditPlayground from '@site/static/usage/textarea/clear-on-edit/index.md';
+
+<ClearOnEditPlayground />
+
+## Theming
+
+import ThemingPlayground from '@site/static/usage/textarea/theming/index.md';
+
+<ThemingPlayground />
 
 ## Interfaces
 
@@ -57,278 +71,6 @@ interface TextareaCustomEvent extends CustomEvent {
   target: HTMLIonTextareaElement;
 }
 ```
-
-
-
-## Usage
-
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
-
-<TabItem value="angular">
-
-```html
-<!-- Default textarea -->
-<ion-textarea></ion-textarea>
-
-<!-- Textarea in an item with a placeholder -->
-<ion-item>
-  <ion-textarea placeholder="Enter more information here..."></ion-textarea>
-</ion-item>
-
-<!-- Textarea in an item with a floating label -->
-<ion-item>
-  <ion-label position="floating">Description</ion-label>
-  <ion-textarea></ion-textarea>
-</ion-item>
-
-<!-- Disabled and readonly textarea in an item with a stacked label -->
-<ion-item>
-  <ion-label position="stacked">Summary</ion-label>
-  <ion-textarea
-    disabled
-    readonly
-    value="Ionic enables developers to build performant, high-quality mobile apps.">
-  </ion-textarea>
-</ion-item>
-
-<!-- Textarea that clears the value on edit -->
-<ion-item>
-  <ion-label>Comment</ion-label>
-  <ion-textarea clearOnEdit="true"></ion-textarea>
-</ion-item>
-
-<!-- Textarea with custom number of rows and cols -->
-<ion-item>
-  <ion-label>Notes</ion-label>
-  <ion-textarea rows="6" cols="20" placeholder="Enter any notes here..."></ion-textarea>
-</ion-item>
-```
-
-
-</TabItem>
-
-
-<TabItem value="javascript">
-
-```html
-<!-- Default textarea -->
-<ion-textarea></ion-textarea>
-
-<!-- Textarea in an item with a placeholder -->
-<ion-item>
-  <ion-textarea placeholder="Enter more information here..."></ion-textarea>
-</ion-item>
-
-<!-- Textarea in an item with a floating label -->
-<ion-item>
-  <ion-label position="floating">Description</ion-label>
-  <ion-textarea></ion-textarea>
-</ion-item>
-
-<!-- Disabled and readonly textarea in an item with a stacked label -->
-<ion-item>
-  <ion-label position="stacked">Summary</ion-label>
-  <ion-textarea
-    disabled
-    readonly
-    value="Ionic enables developers to build performant, high-quality mobile apps.">
-  </ion-textarea>
-</ion-item>
-
-<!-- Textarea that clears the value on edit -->
-<ion-item>
-  <ion-label>Comment</ion-label>
-  <ion-textarea clear-on-edit="true"></ion-textarea>
-</ion-item>
-
-<!-- Textarea with custom number of rows and cols -->
-<ion-item>
-  <ion-label>Notes</ion-label>
-  <ion-textarea rows="6" cols="20" placeholder="Enter any notes here..."></ion-textarea>
-</ion-item>
-```
-
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React, { useState } from 'react';
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonTextarea, IonItem, IonLabel, IonItemDivider, IonList } from '@ionic/react';
-
-export const TextAreaExamples: React.FC = () => {
-  const [text, setText] = useState<string>();
-
-  return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>TextArea Examples</IonTitle>
-        </IonToolbar>
-      </IonHeader>
-      <IonContent>
-        <IonList>
-          <IonItemDivider>Default textarea</IonItemDivider>          
-          <IonItem>
-            <IonTextarea value={text} onIonChange={e => setText(e.detail.value!)}></IonTextarea>
-          </IonItem>
-
-          <IonItemDivider>Textarea in an item with a placeholder</IonItemDivider>
-          <IonItem>
-            <IonTextarea placeholder="Enter more information here..." value={text} onIonChange={e => setText(e.detail.value!)}></IonTextarea>
-          </IonItem>
-
-          <IonItemDivider>Textarea in an item with a floating label</IonItemDivider>
-          <IonItem>
-            <IonLabel position="floating">Description</IonLabel>
-            <IonTextarea value={text} onIonChange={e => setText(e.detail.value!)}></IonTextarea>
-          </IonItem>
-
-          <IonItemDivider>Disabled and readonly textarea in an item with a stacked label</IonItemDivider>
-          <IonItem>
-            <IonLabel position="stacked">Summary</IonLabel>
-            <IonTextarea
-              disabled
-              readonly
-              value={text} onIonChange={e => setText(e.detail.value!)}>
-            </IonTextarea>
-          </IonItem>
-
-          <IonItemDivider>Textarea that clears the value on edit</IonItemDivider>
-          <IonItem>
-            <IonLabel>Comment</IonLabel>
-            <IonTextarea clearOnEdit={true} value={text} onIonChange={e => setText(e.detail.value!)}></IonTextarea>
-          </IonItem>
-
-          <IonItemDivider>Textarea with custom number of rows and cols</IonItemDivider>
-          <IonItem>
-            <IonLabel>Notes</IonLabel>
-            <IonTextarea rows={6} cols={20} placeholder="Enter any notes here..." value={text} onIonChange={e => setText(e.detail.value!)}></IonTextarea>
-          </IonItem>
-        </IonList>
-      </IonContent>
-    </IonPage>
-  );
-};
-```
-
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'textarea-example',
-  styleUrl: 'textarea-example.css'
-})
-export class TextareaExample {
-  render() {
-    return [
-      // Default textarea
-      <ion-textarea></ion-textarea>,
-
-      // Textarea in an item with a placeholder
-      <ion-item>
-        <ion-textarea placeholder="Enter more information here..."></ion-textarea>
-      </ion-item>,
-
-      // Textarea in an item with a floating label
-      <ion-item>
-        <ion-label position="floating">Description</ion-label>
-        <ion-textarea></ion-textarea>
-      </ion-item>,
-
-      // Disabled and readonly textarea in an item with a stacked label
-      <ion-item>
-        <ion-label position="stacked">Summary</ion-label>
-        <ion-textarea
-          disabled
-          readonly
-          value="Ionic enables developers to build performant, high-quality mobile apps.">
-        </ion-textarea>
-      </ion-item>,
-
-      // Textarea that clears the value on edit
-      <ion-item>
-        <ion-label>Comment</ion-label>
-        <ion-textarea clearOnEdit={true}></ion-textarea>
-      </ion-item>,
-
-      // Textarea with custom number of rows and cols
-      <ion-item>
-        <ion-label>Notes</ion-label>
-        <ion-textarea rows={6} cols={20} placeholder="Enter any notes here..."></ion-textarea>
-      </ion-item>
-    ];
-  }
-}
-```
-
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <!-- Default textarea -->
-  <ion-textarea></ion-textarea>
-
-  <!-- Textarea in an item with a placeholder -->
-  <ion-item>
-    <ion-textarea placeholder="Enter more information here..."></ion-textarea>
-  </ion-item>
-
-  <!-- Textarea in an item with a floating label -->
-  <ion-item>
-    <ion-label position="floating">Description</ion-label>
-    <ion-textarea></ion-textarea>
-  </ion-item>
-
-  <!-- Disabled and readonly textarea in an item with a stacked label -->
-  <ion-item>
-    <ion-label position="stacked">Summary</ion-label>
-    <ion-textarea
-      disabled
-      readonly
-      value="Ionic enables developers to build performant, high-quality mobile apps.">
-    </ion-textarea>
-  </ion-item>
-
-  <!-- Textarea that clears the value on edit -->
-  <ion-item>
-    <ion-label>Comment</ion-label>
-    <ion-textarea clear-on-edit="true"></ion-textarea>
-  </ion-item>
-
-  <!-- Textarea with custom number of rows and cols -->
-  <ion-item>
-    <ion-label>Notes</ion-label>
-    <ion-textarea rows="6" cols="20" placeholder="Enter any notes here..."></ion-textarea>
-  </ion-item>
-</template>
-
-<script>
-import { IonItem, IonLabel, IonTextarea } from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: { IonItem, IonLabel, IonTextarea }
-});
-</script>
-```
-
-
-</TabItem>
-
-</Tabs>
 
 ## Properties
 <Props />

--- a/docs/api/textarea.md
+++ b/docs/api/textarea.md
@@ -39,7 +39,7 @@ import AutogrowPlayground from '@site/static/usage/textarea/autogrow/index.md';
 
 ## Clear on Edit
 
-Setting the `clearOnInput` property to `true` will clear the textarea after it has been blurred and then typed in again.
+Setting the `clearOnEdit` property to `true` will clear the textarea after it has been blurred and then typed in again.
 
 import ClearOnEditPlayground from '@site/static/usage/textarea/clear-on-edit/index.md';
 

--- a/static/usage/textarea/autogrow/angular.md
+++ b/static/usage/textarea/autogrow/angular.md
@@ -1,6 +1,6 @@
 ```html
 <ion-item>
-  <ion-textarea placeholder="Type something here" auto-grow="true"
+  <ion-textarea placeholder="Type something here" [autoGrow]="true"
     value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum.">
   </ion-textarea>
 </ion-item>

--- a/static/usage/textarea/autogrow/angular.md
+++ b/static/usage/textarea/autogrow/angular.md
@@ -1,0 +1,7 @@
+```html
+<ion-textarea
+  placeholder="Type something here"
+  auto-grow="true"
+  value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
+></ion-textarea>
+```

--- a/static/usage/textarea/autogrow/angular.md
+++ b/static/usage/textarea/autogrow/angular.md
@@ -1,7 +1,7 @@
 ```html
-<ion-textarea
-  placeholder="Type something here"
-  auto-grow="true"
-  value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
-></ion-textarea>
+<ion-item>
+  <ion-textarea placeholder="Type something here" auto-grow="true"
+    value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum.">
+  </ion-textarea>
+</ion-item>
 ```

--- a/static/usage/textarea/autogrow/demo.html
+++ b/static/usage/textarea/autogrow/demo.html
@@ -14,6 +14,10 @@
     .container {
       padding: 0 40px;
     }
+
+    ion-item {
+      width: 100%;
+    }
   </style>
 </head>
 
@@ -21,11 +25,11 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-textarea
-          placeholder="Type something here"
-          auto-grow="true"
-          value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
-        ></ion-textarea>
+        <ion-item>
+          <ion-textarea placeholder="Type something here" auto-grow="true"
+            value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum.">
+          </ion-textarea>
+        </ion-item>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/textarea/autogrow/demo.html
+++ b/static/usage/textarea/autogrow/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Textarea - Autogrow</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      padding: 0 40px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-textarea
+          placeholder="Type something here"
+          auto-grow="true"
+          value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
+        ></ion-textarea>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/textarea/autogrow/index.md
+++ b/static/usage/textarea/autogrow/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  size="small"
+  code={{ javascript, react, vue, angular }}
+  src="usage/textarea/autogrow/demo.html"
+/>

--- a/static/usage/textarea/autogrow/javascript.md
+++ b/static/usage/textarea/autogrow/javascript.md
@@ -1,0 +1,7 @@
+```html
+<ion-textarea
+  placeholder="Type something here"
+  auto-grow="true"
+  value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
+></ion-textarea>
+```

--- a/static/usage/textarea/autogrow/javascript.md
+++ b/static/usage/textarea/autogrow/javascript.md
@@ -1,7 +1,7 @@
 ```html
-<ion-textarea
-  placeholder="Type something here"
-  auto-grow="true"
-  value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
-></ion-textarea>
+<ion-item>
+  <ion-textarea placeholder="Type something here" auto-grow="true"
+    value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum.">
+  </ion-textarea>
+</ion-item>
 ```

--- a/static/usage/textarea/autogrow/react.md
+++ b/static/usage/textarea/autogrow/react.md
@@ -1,13 +1,15 @@
 ```tsx
 import React from 'react';
-import { IonTextarea } from '@ionic/react';
+import { IonItem, IonTextarea } from '@ionic/react';
 function Example() {
   return (
-    <IonTextarea
-      placeholder="Type something here"
-      autoGrow={true}
-      value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
-    ></IonTextarea>
+    <IonItem>
+      <IonTextarea
+        placeholder="Type something here"
+        autoGrow={true}
+        value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
+      ></IonTextarea>
+    </IonItem>
   );
 }
 export default Example;

--- a/static/usage/textarea/autogrow/react.md
+++ b/static/usage/textarea/autogrow/react.md
@@ -1,0 +1,14 @@
+```tsx
+import React from 'react';
+import { IonTextarea } from '@ionic/react';
+function Example() {
+  return (
+    <IonTextarea
+      placeholder="Type something here"
+      autoGrow={true}
+      value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
+    ></IonTextarea>
+  );
+}
+export default Example;
+```

--- a/static/usage/textarea/autogrow/vue.md
+++ b/static/usage/textarea/autogrow/vue.md
@@ -1,7 +1,7 @@
 ```html
 <template>
   <ion-item>
-    <ion-textarea placeholder="Type something here" auto-grow="true"
+    <ion-textarea placeholder="Type something here" :auto-grow="true"
       value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum.">
     </ion-textarea>
   </ion-item>

--- a/static/usage/textarea/autogrow/vue.md
+++ b/static/usage/textarea/autogrow/vue.md
@@ -1,0 +1,18 @@
+```html
+<template>
+  <ion-textarea
+    placeholder="Type something here"
+    :auto-grow="true"
+    value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
+  ></ion-textarea>
+</template>
+
+<script>
+  import { IonTextarea } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonTextarea },
+  });
+</script>
+```

--- a/static/usage/textarea/autogrow/vue.md
+++ b/static/usage/textarea/autogrow/vue.md
@@ -1,18 +1,18 @@
 ```html
 <template>
-  <ion-textarea
-    placeholder="Type something here"
-    :auto-grow="true"
-    value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum."
-  ></ion-textarea>
+  <ion-item>
+    <ion-textarea placeholder="Type something here" auto-grow="true"
+      value="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris tellus sem, auctor accumsan egestas sed, venenatis at ex. Nam consequat ex odio, suscipit rhoncus orci dictum eget. Aenean sit amet ligula varius felis facilisis lacinia nec volutpat nulla. Duis ullamcorper sit amet turpis sed blandit. Integer pretium massa eu faucibus interdum.">
+    </ion-textarea>
+  </ion-item>
 </template>
 
 <script>
-  import { IonTextarea } from '@ionic/vue';
+  import { IonItem, IonTextarea } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonTextarea },
+    components: { IonItem, IonTextarea },
   });
 </script>
 ```

--- a/static/usage/textarea/basic/angular.md
+++ b/static/usage/textarea/basic/angular.md
@@ -1,3 +1,16 @@
 ```html
-<ion-textarea placeholder="Type something here"></ion-textarea>
+<ion-list>
+  <ion-item>
+    <ion-label>Regular textarea</ion-label>
+    <ion-textarea placeholder="Type something here"></ion-textarea>
+  </ion-item>
+  <ion-item>
+    <ion-label>Readonly textarea</ion-label>
+    <ion-textarea readonly="true" placeholder="Can't edit this"></ion-textarea>
+  </ion-item>
+  <ion-item>
+    <ion-label>Disabled textarea</ion-label>
+    <ion-textarea disabled="true" placeholder="Can't type here"></ion-textarea>
+  </ion-item>
+</ion-list>
 ```

--- a/static/usage/textarea/basic/angular.md
+++ b/static/usage/textarea/basic/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-textarea placeholder="Type something here"></ion-textarea>
+```

--- a/static/usage/textarea/basic/angular.md
+++ b/static/usage/textarea/basic/angular.md
@@ -6,11 +6,11 @@
   </ion-item>
   <ion-item>
     <ion-label>Readonly textarea</ion-label>
-    <ion-textarea readonly="true" placeholder="Can't edit this"></ion-textarea>
+    <ion-textarea [readonly]="true" placeholder="Can't edit this"></ion-textarea>
   </ion-item>
   <ion-item>
     <ion-label>Disabled textarea</ion-label>
-    <ion-textarea disabled="true" placeholder="Can't type here"></ion-textarea>
+    <ion-textarea [disabled]="true" placeholder="Can't type here"></ion-textarea>
   </ion-item>
 </ion-list>
 ```

--- a/static/usage/textarea/basic/demo.html
+++ b/static/usage/textarea/basic/demo.html
@@ -11,8 +11,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
 
   <style>
-    .container {
-      padding: 0 40px;
+    ion-list {
+      width: calc(100% - 20px);
     }
   </style>
 </head>
@@ -21,7 +21,20 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-textarea placeholder="Type something here"></ion-textarea>
+        <ion-list>
+          <ion-item>
+            <ion-label>Regular textarea</ion-label>
+            <ion-textarea placeholder="Type something here"></ion-textarea>
+          </ion-item>
+          <ion-item>
+            <ion-label>Readonly textarea</ion-label>
+            <ion-textarea readonly="true" placeholder="Can't edit this"></ion-textarea>
+          </ion-item>
+          <ion-item>
+            <ion-label>Disabled textarea</ion-label>
+            <ion-textarea disabled="true" placeholder="Can't type here"></ion-textarea>
+          </ion-item>
+        </ion-list>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/textarea/basic/demo.html
+++ b/static/usage/textarea/basic/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Textarea - Basic Usage</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      padding: 0 40px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-textarea placeholder="Type something here"></ion-textarea>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/textarea/basic/index.md
+++ b/static/usage/textarea/basic/index.md
@@ -6,7 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
-  size="xsmall"
+  size="250px"
   code={{ javascript, react, vue, angular }}
   src="usage/textarea/basic/demo.html"
 />

--- a/static/usage/textarea/basic/index.md
+++ b/static/usage/textarea/basic/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  size="xsmall"
+  code={{ javascript, react, vue, angular }}
+  src="usage/textarea/basic/demo.html"
+/>

--- a/static/usage/textarea/basic/javascript.md
+++ b/static/usage/textarea/basic/javascript.md
@@ -1,3 +1,16 @@
 ```html
-<ion-textarea placeholder="Type something here"></ion-textarea>
+<ion-list>
+  <ion-item>
+    <ion-label>Regular textarea</ion-label>
+    <ion-textarea placeholder="Type something here"></ion-textarea>
+  </ion-item>
+  <ion-item>
+    <ion-label>Readonly textarea</ion-label>
+    <ion-textarea readonly="true" placeholder="Can't edit this"></ion-textarea>
+  </ion-item>
+  <ion-item>
+    <ion-label>Disabled textarea</ion-label>
+    <ion-textarea disabled="true" placeholder="Can't type here"></ion-textarea>
+  </ion-item>
+</ion-list>
 ```

--- a/static/usage/textarea/basic/javascript.md
+++ b/static/usage/textarea/basic/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-textarea placeholder="Type something here"></ion-textarea>
+```

--- a/static/usage/textarea/basic/react.md
+++ b/static/usage/textarea/basic/react.md
@@ -1,9 +1,22 @@
 ```tsx
 import React from 'react';
-import { IonTextarea } from '@ionic/react';
+import { IonItem, IonLabel, IonList, IonTextarea } from '@ionic/react';
 function Example() {
   return (
-    <IonTextarea placeholder="Type something here"></IonTextarea>
+    <IonList>
+      <IonItem>
+        <IonLabel>Regular textarea</IonLabel>
+        <IonTextarea placeholder="Type something here"></IonTextarea>
+      </IonItem>
+      <IonItem>
+        <IonLabel>Readonly textarea</IonLabel>
+        <IonTextarea readonly={true} placeholder="Can't edit this"></IonTextarea>
+      </IonItem>
+      <IonItem>
+        <IonLabel>Disabled textarea</IonLabel>
+        <IonTextarea disabled={true} placeholder="Can't type here"></IonTextarea>
+      </IonItem>
+    </IonList>
   );
 }
 export default Example;

--- a/static/usage/textarea/basic/react.md
+++ b/static/usage/textarea/basic/react.md
@@ -1,0 +1,10 @@
+```tsx
+import React from 'react';
+import { IonTextarea } from '@ionic/react';
+function Example() {
+  return (
+    <IonTextarea placeholder="Type something here"></IonTextarea>
+  );
+}
+export default Example;
+```

--- a/static/usage/textarea/basic/vue.md
+++ b/static/usage/textarea/basic/vue.md
@@ -1,14 +1,27 @@
 ```html
 <template>
-  <ion-textarea placeholder="Type something here"></ion-textarea>
+  <ion-list>
+    <ion-item>
+      <ion-label>Regular textarea</ion-label>
+      <ion-textarea placeholder="Type something here"></ion-textarea>
+    </ion-item>
+    <ion-item>
+      <ion-label>Readonly textarea</ion-label>
+      <ion-textarea :readonly="true" placeholder="Can't edit this"></ion-textarea>
+    </ion-item>
+    <ion-item>
+      <ion-label>Disabled textarea</ion-label>
+      <ion-textarea :disabled="true" placeholder="Can't type here"></ion-textarea>
+    </ion-item>
+  </ion-list>
 </template>
 
 <script>
-  import { IonTextarea } from '@ionic/vue';
+  import { IonItem, IonLabel, IonList, IonTextarea } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonTextarea },
+    components: { IonItem, IonLabel, IonList, IonTextarea },
   });
 </script>
 ```

--- a/static/usage/textarea/basic/vue.md
+++ b/static/usage/textarea/basic/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-textarea placeholder="Type something here"></ion-textarea>
+</template>
+
+<script>
+  import { IonTextarea } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonTextarea },
+  });
+</script>
+```

--- a/static/usage/textarea/clear-on-edit/angular.md
+++ b/static/usage/textarea/clear-on-edit/angular.md
@@ -1,0 +1,6 @@
+```html
+<ion-textarea
+  placeholder="Enter text, leave the textarea, come back, and type to clear"
+  clear-on-edit="true"
+></ion-textarea>
+```

--- a/static/usage/textarea/clear-on-edit/angular.md
+++ b/static/usage/textarea/clear-on-edit/angular.md
@@ -1,6 +1,6 @@
 ```html
 <ion-textarea
   placeholder="Enter text, leave the textarea, come back, and type to clear"
-  clear-on-edit="true"
+  [clearOnEdit]="true"
 ></ion-textarea>
 ```

--- a/static/usage/textarea/clear-on-edit/demo.html
+++ b/static/usage/textarea/clear-on-edit/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Textarea - Clear on Edit</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      padding: 0 40px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-textarea
+          placeholder="Enter text, leave the textarea, come back, and type to clear"
+          clear-on-edit="true"
+        ></ion-textarea>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/textarea/clear-on-edit/index.md
+++ b/static/usage/textarea/clear-on-edit/index.md
@@ -1,0 +1,12 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  size="xsmall"
+  code={{ javascript, react, vue, angular }}
+  src="usage/textarea/clear-on-edit/demo.html"
+/>

--- a/static/usage/textarea/clear-on-edit/javascript.md
+++ b/static/usage/textarea/clear-on-edit/javascript.md
@@ -1,0 +1,6 @@
+```html
+<ion-textarea
+  placeholder="Enter text, leave the textarea, come back, and type to clear"
+  clear-on-edit="true"
+></ion-textarea>
+```

--- a/static/usage/textarea/clear-on-edit/react.md
+++ b/static/usage/textarea/clear-on-edit/react.md
@@ -1,0 +1,13 @@
+```tsx
+import React from 'react';
+import { IonTextarea } from '@ionic/react';
+function Example() {
+  return (
+    <IonTextarea
+      placeholder="Enter text, leave the textarea, come back, and type to clear"
+      clearOnEdit={true}
+    ></IonTextarea>
+  );
+}
+export default Example;
+```

--- a/static/usage/textarea/clear-on-edit/vue.md
+++ b/static/usage/textarea/clear-on-edit/vue.md
@@ -1,0 +1,17 @@
+```html
+<template>
+  <ion-textarea
+    placeholder="Enter text, leave the textarea, come back, and type to clear"
+    :clear-on-edit="true"
+  ></ion-textarea>
+</template>
+
+<script>
+  import { IonTextarea } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonTextarea },
+  });
+</script>
+```

--- a/static/usage/textarea/theming/angular/example_component_css.md
+++ b/static/usage/textarea/theming/angular/example_component_css.md
@@ -1,0 +1,10 @@
+```css
+ion-textarea.custom-textarea {
+  --background: #373737;
+  --color: #fff;
+  --padding-end: 10px;
+  --padding-start: 10px;
+  --placeholder-color: #ddd;
+  --placeholder-opacity: 0.8;
+}
+```

--- a/static/usage/textarea/theming/angular/example_component_html.md
+++ b/static/usage/textarea/theming/angular/example_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+```

--- a/static/usage/textarea/theming/demo.html
+++ b/static/usage/textarea/theming/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Textarea - Theming</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <style>
+    .container {
+      padding: 0 40px;
+    }
+
+    ion-textarea.custom-textarea {
+      --background: #373737;
+      --color: #fff;
+      --padding-end: 10px;
+      --padding-start: 10px;
+      --placeholder-color: #ddd;
+      --placeholder-opacity: 0.8;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/textarea/theming/index.md
+++ b/static/usage/textarea/theming/index.md
@@ -1,0 +1,32 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
+
+<Playground
+  size="xsmall"
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.css': react_main_css,
+        'src/main.tsx': react_main_tsx,
+      },
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.html': angular_example_component_html,
+      },
+    },
+  }}
+  src="usage/textarea/theming/demo.html"
+/>

--- a/static/usage/textarea/theming/javascript.md
+++ b/static/usage/textarea/theming/javascript.md
@@ -1,0 +1,14 @@
+```html
+<ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+
+<style>
+  ion-textarea.custom-textarea {
+    --background: #373737;
+    --color: #fff;
+    --padding-end: 10px;
+    --padding-start: 10px;
+    --placeholder-color: #ddd;
+    --placeholder-opacity: 0.8;
+  }
+</style>
+```

--- a/static/usage/textarea/theming/react/main_css.md
+++ b/static/usage/textarea/theming/react/main_css.md
@@ -1,0 +1,10 @@
+```css
+ion-textarea.custom-textarea {
+  --background: #373737;
+  --color: #fff;
+  --padding-end: 10px;
+  --padding-start: 10px;
+  --placeholder-color: #ddd;
+  --placeholder-opacity: 0.8;
+}
+```

--- a/static/usage/textarea/theming/react/main_tsx.md
+++ b/static/usage/textarea/theming/react/main_tsx.md
@@ -1,0 +1,11 @@
+```tsx
+import React from 'react';
+import { IonTextarea } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return <IonTextarea class="custom-textarea" placeholder="Type something here"></IonTextarea>;
+}
+export default Example;
+```

--- a/static/usage/textarea/theming/react/main_tsx.md
+++ b/static/usage/textarea/theming/react/main_tsx.md
@@ -5,7 +5,7 @@ import { IonTextarea } from '@ionic/react';
 import './main.css';
 
 function Example() {
-  return <IonTextarea class="custom-textarea" placeholder="Type something here"></IonTextarea>;
+  return <IonTextarea className="custom-textarea" placeholder="Type something here"></IonTextarea>;
 }
 export default Example;
 ```

--- a/static/usage/textarea/theming/vue.md
+++ b/static/usage/textarea/theming/vue.md
@@ -1,0 +1,25 @@
+```html
+<style>
+  ion-textarea.custom-textarea {
+    --background: #373737;
+    --color: #fff;
+    --padding-end: 10px;
+    --padding-start: 10px;
+    --placeholder-color: #ddd;
+    --placeholder-opacity: 0.8;
+  }
+</style>
+
+<template>
+  <ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+</template>
+
+<script lang="ts">
+  import { IonTextarea } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonTextarea },
+  });
+</script>
+```


### PR DESCRIPTION
Adds the following playgrounds for `ion-textarea`:
- Basic Usage
- Autogrow
- Clear on Edit
- Theming

For the Clear on Edit playground, I elected to leave off the default `value` since the `clearOnEdit` behavior currently requires focusing the input, blurring it, and then focusing it again. This will be resolved in Ionic v7.