### PR TITLE
feat(playground): add support for opening in StackBlitz in ios mode

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -249,6 +249,7 @@ export default function Playground({
       title,
       description,
       includeIonContent,
+      mode: isIOS ? 'ios' : 'md'
     };
 
     let codeBlock;

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -28,6 +28,11 @@ export interface EditorOptions {
    */
   includeIonContent: boolean;
 
+  /**
+   * The mode of the Stackblitz example.
+   */
+  mode?: string;
+
   angularModuleOptions?: {
     imports: string[];
     declarations?: string[];
@@ -50,7 +55,7 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
     title: options?.title ?? DEFAULT_EDITOR_TITLE,
     description: options?.description ?? DEFAULT_EDITOR_DESCRIPTION,
     files: {
-      'index.html': index_html.replace(/{{ TEMPLATE }}/g, code),
+      'index.html': index_html.replace(/{{ TEMPLATE }}/g, code).replace(/{{ MODE }}/g, options?.mode),
       'index.ts': index_ts,
       ...options?.files
     },
@@ -82,6 +87,8 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
       app_module_ts = app_module_ts.replace('/* CUSTOM_DECLARATIONS */', options.angularModuleOptions.declarations.map(d => `\n  ${d}`).join(','));
     }
   }
+
+  app_module_ts = app_module_ts.replace('{{ MODE }}', options?.mode);
 
   sdk.openProject({
     template: 'angular-cli',
@@ -119,13 +126,15 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
 }
 
 const openReactEditor = async (code: string, options?: EditorOptions) => {
-  const [index_tsx, app_tsx, ts_config_json, package_json, package_lock_json] = await loadSourceFiles([
+  let [index_tsx, app_tsx, ts_config_json, package_json, package_lock_json] = await loadSourceFiles([
     'react/index.tsx',
     options?.includeIonContent ? 'react/app.withContent.tsx' : 'react/app.tsx',
     'react/tsconfig.json',
     'react/package.json',
     'react/package-lock.json'
   ]);
+
+  app_tsx = app_tsx.replace('{{ MODE }}', options?.mode);
 
   sdk.openProject({
     template: 'node',
@@ -148,7 +157,7 @@ const openReactEditor = async (code: string, options?: EditorOptions) => {
 }
 
 const openVueEditor = async (code: string, options?: EditorOptions) => {
-  const [package_json, package_lock_json, index_html, vite_config_ts, main_ts, app_vue, tsconfig_json, tsconfig_node_json, env_d_ts] = await loadSourceFiles([
+  let [package_json, package_lock_json, index_html, vite_config_ts, main_ts, app_vue, tsconfig_json, tsconfig_node_json, env_d_ts] = await loadSourceFiles([
     'vue/package.json',
     'vue/package-lock.json',
     'vue/index.html',
@@ -159,6 +168,9 @@ const openVueEditor = async (code: string, options?: EditorOptions) => {
     'vue/tsconfig.node.json',
     'vue/env.d.ts'
   ]);
+
+  main_ts = main_ts.replace('{{ MODE }}', options?.mode);
+
   /**
    * We have to use Stackblitz web containers here (node template), due
    * to multiple issues with Vite, Vue/Vue Router and Vue 3's script setup.

--- a/static/code/stackblitz/angular/app.module.ts
+++ b/static/code/stackblitz/angular/app.module.ts
@@ -9,7 +9,9 @@ import { AppComponent } from './app.component';
 import { ExampleComponent } from './example.component';
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, RouterModule.forRoot([]), IonicModule.forRoot({})],
+  imports: [BrowserModule, FormsModule, RouterModule.forRoot([]), IonicModule.forRoot({
+    mode: '{{ MODE }}'
+  })],
   declarations: [AppComponent, ExampleComponent],
   bootstrap: [AppComponent],
 })

--- a/static/code/stackblitz/html/index.html
+++ b/static/code/stackblitz/html/index.html
@@ -3,6 +3,14 @@
 <head>
   <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/core.css" />
   <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/ionic.bundle.css" />
+
+  <script>
+    window.Ionic = {
+      config: {
+        mode: '{{ MODE }}'
+      }
+    }
+  </script>
 </head>
 
 <body>

--- a/static/code/stackblitz/html/index.withContent.html
+++ b/static/code/stackblitz/html/index.withContent.html
@@ -3,6 +3,14 @@
 <head>
   <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/core.css" />
   <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/ionic.bundle.css" />
+
+  <script>
+    window.Ionic = {
+      config: {
+        mode: '{{ MODE }}'
+      }
+    }
+  </script>
 </head>
 
 <body>

--- a/static/code/stackblitz/react/app.tsx
+++ b/static/code/stackblitz/react/app.tsx
@@ -15,7 +15,9 @@ import '@ionic/react/css/flex-utils.css';
 
 import Example from './main';
 
-setupIonicReact();
+setupIonicReact({
+  mode: '{{ MODE }}',
+});
 
 export default function App() {
   return (

--- a/static/code/stackblitz/react/app.withContent.tsx
+++ b/static/code/stackblitz/react/app.withContent.tsx
@@ -15,7 +15,9 @@ import '@ionic/react/css/flex-utils.css';
 
 import Example from './main';
 
-setupIonicReact();
+setupIonicReact({
+  mode: '{{ MODE }}',
+});
 
 export default function App() {
   return (

--- a/static/code/stackblitz/vue/main.ts
+++ b/static/code/stackblitz/vue/main.ts
@@ -19,4 +19,6 @@ import '@ionic/vue/css/text-transformation.css';
 import '@ionic/vue/css/flex-utils.css';
 import '@ionic/vue/css/display.css';
 
-createApp(App).use(IonicVue).mount('#app');
+createApp(App).use(IonicVue, {
+  mode: '{{ MODE }}'
+}).mount('#app');


### PR DESCRIPTION
This PR passes the mode from the `ios` / `md` toggle on the playground to StackBlitz so you can see the examples in the same mode you have selected.

I know we discussed doing this by setting it on `ion-app` but I found two issues with that approach:

1) It doesn't work at all for React 
2) The styling is actually slightly off with it set on `ion-app`, see below

Buttons with `<ion-app mode="ios">`:
![Screen Shot 2022-10-06 at 5 24 31 PM](https://user-images.githubusercontent.com/6577830/194421457-72cfcc32-91d9-4411-b57b-6597f4fe67e3.png)

Buttons with mode set via the config:
![Screen Shot 2022-10-06 at 5 24 52 PM](https://user-images.githubusercontent.com/6577830/194421460-f1aad032-319c-4689-81cf-e8aa3b181bd1.png)

So that's why I decided to set it via the config for all of the examples. Let me know if you think there's a better way. 