### PR TITLE
docs(ripple-effect): add component playgrounds

### DIFF
--- a/docs/api/ripple-effect.md
+++ b/docs/api/ripple-effect.md
@@ -1,11 +1,6 @@
 ---
 title: "ion-ripple-effect"
-hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TOCInline from '@theme/TOCInline';
-
 import Props from '@site/static/auto-generated/ripple-effect/props.md';
 import Events from '@site/static/auto-generated/ripple-effect/events.md';
 import Methods from '@site/static/auto-generated/ripple-effect/methods.md';
@@ -22,246 +17,36 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
 
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
+The ripple effect component adds the [Material Design ink ripple interaction effect](https://material.io/develop/web/supporting/ripple). This component can only be used inside of an `<ion-app>` and can be added inside of any element.
+
+It's important to set [relative positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/position) on the parent element because the ripple effect is absolutely positioned and will cover its closest parent that has relative positioning. The parent element should also be given the `ion-activatable` class, which tells the ripple effect that the element is clickable. It's recommended to add `overflow: hidden` to the parent element if the ripple is overflowing its container.
 
 
+## Basic Usage
 
-The ripple effect component adds the [Material Design ink ripple interaction effect](https://material.io/develop/web/supporting/ripple). This component can only be used inside of an `<ion-app>` and can be added to any component.
+import Basic from '@site/static/usage/ripple-effect/basic/index.md';
 
-It's important to note that the parent should have [relative positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/position) because the ripple effect is absolutely positioned and will cover the closest parent with relative positioning. The parent element should also be given the `ion-activatable` class, which tells the ripple effect that the element is clickable.
-
-The default type, `"bounded"`, will expand the ripple effect from the click position outwards. To add a ripple effect that always starts in the center of the element and expands in a circle, add an `"unbounded"` type. It's recommended to add `overflow: hidden` to the parent element to avoid the ripple overflowing its container, especially with an unbounded ripple.
-
+<Basic />
 
 
-## Usage
+## Type
 
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
+There are two types of ripple effects: `"bounded"` and `"unbounded"`. The default type, `"bounded"`, will expand the ripple effect from the click position outwards. To add a ripple effect that always starts in the center of the element and expands in a circle, set the type to `"unbounded"`.
 
-<TabItem value="angular">
+import Type from '@site/static/usage/ripple-effect/type/index.md';
 
-```html
-<ion-app>
-  <ion-content>
-    <div class="ion-activatable ripple-parent">
-      A plain div with a bounded ripple effect
-      <ion-ripple-effect></ion-ripple-effect>
-    </div>
-
-    <button class="ion-activatable ripple-parent">
-      A button with a bounded ripple effect
-      <ion-ripple-effect></ion-ripple-effect>
-    </button>
-
-    <div class="ion-activatable ripple-parent">
-      A plain div with an unbounded ripple effect
-      <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-    </div>
-
-    <button class="ion-activatable ripple-parent">
-      A button with an unbounded ripple effect
-      <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-    </button>
-  </ion-content>
-</ion-app>
-```
-
-```css
-.ripple-parent {
-  position: relative;
-  overflow: hidden;
-}
-```
-
-</TabItem>
+<Type />
 
 
-<TabItem value="javascript">
+## Customizing
 
-```html
-<ion-app>
-  <ion-content>
-    <div class="ion-activatable ripple-parent">
-      A plain div with a bounded ripple effect
-      <ion-ripple-effect></ion-ripple-effect>
-    </div>
+The ripple can be customized to a different color through CSS. By default the ripple color is set to inherit the text color, which is generally the body color. This can be changed by setting the CSS `color` on the parent or the ripple effect itself.
 
-    <button class="ion-activatable ripple-parent">
-      A button with a bounded ripple effect
-      <ion-ripple-effect></ion-ripple-effect>
-    </button>
+import Customizing from '@site/static/usage/ripple-effect/customizing/index.md';
 
-    <div class="ion-activatable ripple-parent">
-      A plain div with an unbounded ripple effect
-      <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-    </div>
+<Customizing />
 
-    <button class="ion-activatable ripple-parent">
-      A button with an unbounded ripple effect
-      <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-    </button>
-  </ion-content>
-</ion-app>
-```
-
-```css
-.ripple-parent {
-  position: relative;
-  overflow: hidden;
-}
-```
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React from 'react';
-import { IonApp, IonContent, IonRippleEffect } from '@ionic/react';
-import './RippleEffectExample.css';
-
-export const RippleExample: React.FC = () => (
-  <IonApp>
-   <IonContent>
-      <div className="ion-activatable ripple-parent">
-        A plain div with a bounded ripple effect
-        <IonRippleEffect></IonRippleEffect>
-      </div>
-
-      <button className="ion-activatable ripple-parent">
-        A button with a bounded ripple effect
-        <IonRippleEffect></IonRippleEffect>
-      </button>
-
-      <div className="ion-activatable ripple-parent">
-        A plain div with an unbounded ripple effect
-        <IonRippleEffect type="unbounded"></IonRippleEffect>
-      </div>
-
-      <button className="ion-activatable ripple-parent">
-        A button with an unbounded ripple effect
-        <IonRippleEffect type="unbounded"></IonRippleEffect>
-      </button>
-    </IonContent>
-  </IonApp>
-);
-```
-
-```css
-.ripple-parent {
-  position: relative;
-  overflow: hidden;
-}
-```
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'ripple-effect-example',
-  styleUrl: 'ripple-effect-example.css'
-})
-export class RippleEffectExample {
-  render() {
-    return [
-      <ion-app>
-        <ion-content>
-          <div class="ion-activatable ripple-parent">
-            A plain div with a bounded ripple effect
-            <ion-ripple-effect></ion-ripple-effect>
-          </div>
-
-          <button class="ion-activatable ripple-parent">
-            A button with a bounded ripple effect
-            <ion-ripple-effect></ion-ripple-effect>
-          </button>
-
-          <div class="ion-activatable ripple-parent">
-            A plain div with an unbounded ripple effect
-            <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-          </div>
-
-          <button class="ion-activatable ripple-parent">
-            A button with an unbounded ripple effect
-            <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-          </button>
-        </ion-content>
-      </ion-app>
-    ];
-  }
-}
-```
-
-```css
-.ripple-parent {
-  position: relative;
-  overflow: hidden;
-}
-```
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <ion-app>
-    <ion-content>
-      <div class="ion-activatable ripple-parent">
-        A plain div with a bounded ripple effect
-        <ion-ripple-effect></ion-ripple-effect>
-      </div>
-
-      <button class="ion-activatable ripple-parent">
-        A button with a bounded ripple effect
-        <ion-ripple-effect></ion-ripple-effect>
-      </button>
-
-      <div class="ion-activatable ripple-parent">
-        A plain div with an unbounded ripple effect
-        <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-      </div>
-
-      <button class="ion-activatable ripple-parent">
-        A button with an unbounded ripple effect
-        <ion-ripple-effect type="unbounded"></ion-ripple-effect>
-      </button>
-    </ion-content>
-  </ion-app>
-</template>
-
-<style>
-  .ripple-parent {
-    position: relative;
-    overflow: hidden;
-  }
-</style>
-
-<script>
-import { IonApp, IonContent, IonRippleEffect } from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: { IonApp, IonContent, IonRippleEffect }
-});
-</script>
-```
-
-</TabItem>
-
-</Tabs>
 
 ## Properties
 <Props />

--- a/static/usage/ripple-effect/basic/angular/example_component_css.md
+++ b/static/usage/ripple-effect/basic/angular/example_component_css.md
@@ -1,0 +1,25 @@
+```css
+.ripple-parent {
+  position: relative;
+  overflow: hidden;
+
+  border: 1px solid #ddd;
+}
+
+.rectangle {
+  width: 300px;
+  height: 150px;
+}
+
+.rounded-rectangle {
+  width: 185px;
+  height: 65px;
+  border-radius: 8px;
+}
+
+.circle {
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+}
+```

--- a/static/usage/ripple-effect/basic/angular/example_component_css.md
+++ b/static/usage/ripple-effect/basic/angular/example_component_css.md
@@ -1,4 +1,22 @@
 ```css
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+
+  height: 300px;
+  width: 300px;
+
+  margin: 0 auto;
+}
+
+b {
+  width: 100%;
+}
+
 .ripple-parent {
   position: relative;
   overflow: hidden;

--- a/static/usage/ripple-effect/basic/angular/example_component_html.md
+++ b/static/usage/ripple-effect/basic/angular/example_component_html.md
@@ -1,15 +1,17 @@
 ```html
-<b>Click on a shape to see the ripple</b>
+<div class="wrapper">
+  <b>Click on a shape to see the ripple</b>
 
-<div class="ion-activatable ripple-parent rectangle">
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent rectangle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent rounded-rectangle">
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent rounded-rectangle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent circle">
-  <ion-ripple-effect></ion-ripple-effect>
+  <div class="ion-activatable ripple-parent circle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 </div>
 ```

--- a/static/usage/ripple-effect/basic/angular/example_component_html.md
+++ b/static/usage/ripple-effect/basic/angular/example_component_html.md
@@ -1,0 +1,15 @@
+```html
+<b>Click on a shape to see the ripple</b>
+
+<div class="ion-activatable ripple-parent rectangle">
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent rounded-rectangle">
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent circle">
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+```

--- a/static/usage/ripple-effect/basic/demo.html
+++ b/static/usage/ripple-effect/basic/demo.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ripple Effect</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      width: 300px;
+      margin: 0 auto;
+
+      flex-wrap: wrap;
+      justify-content: space-between;
+
+      text-align: center;
+    }
+
+    b {
+      width: 100%;
+    }
+
+    .ripple-parent {
+      position: relative;
+      overflow: hidden;
+
+      border: 1px solid #ddd;
+    }
+
+    .rectangle {
+      width: 300px;
+      height: 150px;
+    }
+
+    .rounded-rectangle {
+      width: 185px;
+      height: 65px;
+      border-radius: 8px;
+    }
+
+    .circle {
+      width: 90px;
+      height: 90px;
+      border-radius: 50%;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <b>Click on a shape to see the ripple</b>
+
+        <div class="ion-activatable ripple-parent rectangle">
+          <ion-ripple-effect></ion-ripple-effect>
+        </div>
+
+        <div class="ion-activatable ripple-parent rounded-rectangle">
+          <ion-ripple-effect></ion-ripple-effect>
+        </div>
+
+        <div class="ion-activatable ripple-parent circle">
+          <ion-ripple-effect></ion-ripple-effect>
+        </div>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/ripple-effect/basic/demo.html
+++ b/static/usage/ripple-effect/basic/demo.html
@@ -11,14 +11,18 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
 
   <style>
-    .container {
-      width: 300px;
-      margin: 0 auto;
-
+    .wrapper {
+      display: flex;
       flex-wrap: wrap;
-      justify-content: space-between;
 
+      align-items: center;
+      justify-content: space-between;
       text-align: center;
+
+      height: 300px;
+      width: 300px;
+
+      margin: 0 auto;
     }
 
     b {
@@ -55,18 +59,20 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <b>Click on a shape to see the ripple</b>
+        <div class="wrapper">
+          <b>Click on a shape to see the ripple</b>
 
-        <div class="ion-activatable ripple-parent rectangle">
-          <ion-ripple-effect></ion-ripple-effect>
-        </div>
+          <div class="ion-activatable ripple-parent rectangle">
+            <ion-ripple-effect></ion-ripple-effect>
+          </div>
 
-        <div class="ion-activatable ripple-parent rounded-rectangle">
-          <ion-ripple-effect></ion-ripple-effect>
-        </div>
+          <div class="ion-activatable ripple-parent rounded-rectangle">
+            <ion-ripple-effect></ion-ripple-effect>
+          </div>
 
-        <div class="ion-activatable ripple-parent circle">
-          <ion-ripple-effect></ion-ripple-effect>
+          <div class="ion-activatable ripple-parent circle">
+            <ion-ripple-effect></ion-ripple-effect>
+          </div>
         </div>
       </div>
     </ion-content>

--- a/static/usage/ripple-effect/basic/index.md
+++ b/static/usage/ripple-effect/basic/index.md
@@ -2,28 +2,28 @@ import Playground from '@site/src/components/global/Playground';
 
 import javascript from './javascript.md';
 
-import reactTSX from './react/main_tsx.md';
-import reactCSS from './react/main_css.md';
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
 
 import vue from './vue.md';
 
-import angularHTML from './angular/example_component_html.md';
-import angularCSS from './angular/example_component_css.md';
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
   code={{
     javascript,
     react: {
       files: {
-        'src/main.tsx': reactTSX,
-        'src/main.css': reactCSS
+        'src/main.tsx': react_main_tsx,
+        'src/main.css': react_main_css
       }
     },
     vue,
     angular: {
       files: {
-        'src/app/example.component.html': angularHTML,
-        'src/app/example.component.css': angularCSS
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.css': angular_example_component_css
       }
     },
   }}

--- a/static/usage/ripple-effect/basic/index.md
+++ b/static/usage/ripple-effect/basic/index.md
@@ -1,0 +1,32 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTSX from './react/main_tsx.md';
+import reactCSS from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/example_component_html.md';
+import angularCSS from './angular/example_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTSX,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angularHTML,
+        'src/app/example.component.css': angularCSS
+      }
+    },
+  }}
+  src="usage/ripple-effect/basic/demo.html"
+  size="300px"
+/>

--- a/static/usage/ripple-effect/basic/javascript.md
+++ b/static/usage/ripple-effect/basic/javascript.md
@@ -1,0 +1,41 @@
+```html
+<b>Click on a shape to see the ripple</b>
+
+<div class="ion-activatable ripple-parent rectangle">
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent rounded-rectangle">
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent circle">
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<style>
+  .ripple-parent {
+    position: relative;
+    overflow: hidden;
+
+    border: 1px solid #ddd;
+  }
+
+  .rectangle {
+    width: 300px;
+    height: 150px;
+  }
+
+  .rounded-rectangle {
+    width: 185px;
+    height: 65px;
+    border-radius: 8px;
+  }
+
+  .circle {
+    width: 90px;
+    height: 90px;
+    border-radius: 50%;
+  }
+</style>
+```

--- a/static/usage/ripple-effect/basic/javascript.md
+++ b/static/usage/ripple-effect/basic/javascript.md
@@ -1,19 +1,39 @@
 ```html
-<b>Click on a shape to see the ripple</b>
+<div class="wrapper">
+  <b>Click on a shape to see the ripple</b>
 
-<div class="ion-activatable ripple-parent rectangle">
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent rectangle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent rounded-rectangle">
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent rounded-rectangle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent circle">
-  <ion-ripple-effect></ion-ripple-effect>
+  <div class="ion-activatable ripple-parent circle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 </div>
 
 <style>
+  .wrapper {
+    display: flex;
+    flex-wrap: wrap;
+
+    align-items: center;
+    justify-content: space-between;
+    text-align: center;
+
+    height: 300px;
+    width: 300px;
+
+    margin: 0 auto;
+  }
+
+  b {
+    width: 100%;
+  }
+
   .ripple-parent {
     position: relative;
     overflow: hidden;

--- a/static/usage/ripple-effect/basic/react/main_css.md
+++ b/static/usage/ripple-effect/basic/react/main_css.md
@@ -1,0 +1,25 @@
+```css
+.ripple-parent {
+  position: relative;
+  overflow: hidden;
+
+  border: 1px solid #ddd;
+}
+
+.rectangle {
+  width: 300px;
+  height: 150px;
+}
+
+.rounded-rectangle {
+  width: 185px;
+  height: 65px;
+  border-radius: 8px;
+}
+
+.circle {
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+}
+```

--- a/static/usage/ripple-effect/basic/react/main_css.md
+++ b/static/usage/ripple-effect/basic/react/main_css.md
@@ -1,4 +1,22 @@
 ```css
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+
+  height: 300px;
+  width: 300px;
+
+  margin: 0 auto;
+}
+
+b {
+  width: 100%;
+}
+
 .ripple-parent {
   position: relative;
   overflow: hidden;

--- a/static/usage/ripple-effect/basic/react/main_tsx.md
+++ b/static/usage/ripple-effect/basic/react/main_tsx.md
@@ -6,7 +6,7 @@ import './main.css';
 
 function Example() {
   return (
-    <>
+    <div className="wrapper">
       <b>Click on a shape to see the ripple</b>
 
       <div className="ion-activatable ripple-parent rectangle">
@@ -20,7 +20,7 @@ function Example() {
       <div className="ion-activatable ripple-parent circle">
         <IonRippleEffect></IonRippleEffect>
       </div>
-    </>
+    </div>
   );
 }
 export default Example;

--- a/static/usage/ripple-effect/basic/react/main_tsx.md
+++ b/static/usage/ripple-effect/basic/react/main_tsx.md
@@ -1,0 +1,27 @@
+```tsx
+import React from 'react';
+import { IonRippleEffect } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <>
+      <b>Click on a shape to see the ripple</b>
+
+      <div className="ion-activatable ripple-parent rectangle">
+        <IonRippleEffect></IonRippleEffect>
+      </div>
+
+      <div className="ion-activatable ripple-parent rounded-rectangle">
+        <IonRippleEffect></IonRippleEffect>
+      </div>
+
+      <div className="ion-activatable ripple-parent circle">
+        <IonRippleEffect></IonRippleEffect>
+      </div>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/ripple-effect/basic/vue.md
+++ b/static/usage/ripple-effect/basic/vue.md
@@ -1,17 +1,19 @@
 ```html
 <template>
-  <b>Click on a shape to see the ripple</b>
+  <div class="wrapper">
+    <b>Click on a shape to see the ripple</b>
 
-  <div class="ion-activatable ripple-parent rectangle">
-    <ion-ripple-effect></ion-ripple-effect>
-  </div>
+    <div class="ion-activatable ripple-parent rectangle">
+      <ion-ripple-effect></ion-ripple-effect>
+    </div>
 
-  <div class="ion-activatable ripple-parent rounded-rectangle">
-    <ion-ripple-effect></ion-ripple-effect>
-  </div>
+    <div class="ion-activatable ripple-parent rounded-rectangle">
+      <ion-ripple-effect></ion-ripple-effect>
+    </div>
 
-  <div class="ion-activatable ripple-parent circle">
-    <ion-ripple-effect></ion-ripple-effect>
+    <div class="ion-activatable ripple-parent circle">
+      <ion-ripple-effect></ion-ripple-effect>
+    </div>
   </div>
 </template>
 
@@ -25,6 +27,24 @@
 </script>
 
 <style scoped>
+  .wrapper {
+    display: flex;
+    flex-wrap: wrap;
+
+    align-items: center;
+    justify-content: space-between;
+    text-align: center;
+
+    height: 300px;
+    width: 300px;
+
+    margin: 0 auto;
+  }
+
+  b {
+    width: 100%;
+  }
+
   .ripple-parent {
     position: relative;
     overflow: hidden;

--- a/static/usage/ripple-effect/basic/vue.md
+++ b/static/usage/ripple-effect/basic/vue.md
@@ -1,0 +1,52 @@
+```html
+<template>
+  <b>Click on a shape to see the ripple</b>
+
+  <div class="ion-activatable ripple-parent rectangle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
+
+  <div class="ion-activatable ripple-parent rounded-rectangle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
+
+  <div class="ion-activatable ripple-parent circle">
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
+</template>
+
+<script lang="ts">
+  import { IonRippleEffect } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRippleEffect },
+  });
+</script>
+
+<style scoped>
+  .ripple-parent {
+    position: relative;
+    overflow: hidden;
+
+    border: 1px solid #ddd;
+  }
+
+  .rectangle {
+    width: 300px;
+    height: 150px;
+  }
+
+  .rounded-rectangle {
+    width: 185px;
+    height: 65px;
+    border-radius: 8px;
+  }
+
+  .circle {
+    width: 90px;
+    height: 90px;
+    border-radius: 50%;
+  }
+</style>
+```

--- a/static/usage/ripple-effect/customizing/angular/example_component_css.md
+++ b/static/usage/ripple-effect/customizing/angular/example_component_css.md
@@ -1,4 +1,22 @@
 ```css
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+
+  height: 170px;
+  width: 400px;
+
+  margin: 0 auto;
+}
+
+b {
+  width: 100%;
+}
+
 .ripple-parent {
   display: flex;
   align-items: center;

--- a/static/usage/ripple-effect/customizing/angular/example_component_css.md
+++ b/static/usage/ripple-effect/customizing/angular/example_component_css.md
@@ -1,0 +1,26 @@
+```css
+.ripple-parent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  position: relative;
+  overflow: hidden;
+
+  border: 1px solid #ddd;
+
+  user-select: none;
+
+  width: 100%;
+  height: 50px;
+  border-radius: 8px;
+}
+
+.custom-parent {
+  color: #de1e7e;
+}
+
+.custom-ripple {
+  color: #c0ffee;
+}
+```

--- a/static/usage/ripple-effect/customizing/angular/example_component_css.md
+++ b/static/usage/ripple-effect/customizing/angular/example_component_css.md
@@ -21,6 +21,6 @@
 }
 
 .custom-ripple {
-  color: #c0ffee;
+  color: #501ace;
 }
 ```

--- a/static/usage/ripple-effect/customizing/angular/example_component_html.md
+++ b/static/usage/ripple-effect/customizing/angular/example_component_html.md
@@ -1,13 +1,15 @@
 ```html
-<b>Click on a shape to see the ripple</b>
+<div class="wrapper">
+  <b>Click on a shape to see the ripple</b>
 
-<div class="ion-activatable ripple-parent custom-parent">
-  Custom Parent Color
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent custom-parent">
+    Custom Parent Color
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent">
-  Custom Ripple Color
-  <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+  <div class="ion-activatable ripple-parent">
+    Custom Ripple Color
+    <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+  </div>
 </div>
 ```

--- a/static/usage/ripple-effect/customizing/angular/example_component_html.md
+++ b/static/usage/ripple-effect/customizing/angular/example_component_html.md
@@ -1,0 +1,13 @@
+```html
+<b>Click on a shape to see the ripple</b>
+
+<div class="ion-activatable ripple-parent custom-parent">
+  Custom Parent Color
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent">
+  Custom Ripple Color
+  <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+</div>
+```

--- a/static/usage/ripple-effect/customizing/demo.html
+++ b/static/usage/ripple-effect/customizing/demo.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ripple Effect</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      width: 400px;
+      margin: 0 auto;
+
+      flex-direction: column;
+      justify-content: space-evenly;
+
+      text-align: center;
+    }
+
+    .ripple-parent {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      position: relative;
+      overflow: hidden;
+
+      border: 1px solid #ddd;
+
+      user-select: none;
+
+      width: 100%;
+      height: 50px;
+      border-radius: 8px;
+    }
+
+    .custom-parent {
+      color: #de1e7e;
+    }
+
+    .custom-ripple {
+      color: #c0ffee;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <b>Click on a shape to see the ripple</b>
+
+        <div class="ion-activatable ripple-parent custom-parent">
+          Custom Parent Color
+          <ion-ripple-effect></ion-ripple-effect>
+        </div>
+
+        <div class="ion-activatable ripple-parent">
+          Custom Ripple Color
+          <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+        </div>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/ripple-effect/customizing/demo.html
+++ b/static/usage/ripple-effect/customizing/demo.html
@@ -11,14 +11,22 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
 
   <style>
-    .container {
-      width: 400px;
-      margin: 0 auto;
+    .wrapper {
+      display: flex;
+      flex-wrap: wrap;
 
-      flex-direction: column;
-      justify-content: space-evenly;
-
+      align-items: center;
+      justify-content: space-between;
       text-align: center;
+
+      height: 170px;
+      width: 400px;
+
+      margin: 0 auto;
+    }
+
+    b {
+      width: 100%;
     }
 
     .ripple-parent {
@@ -52,16 +60,18 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <b>Click on a shape to see the ripple</b>
+        <div class="wrapper">
+          <b>Click on a shape to see the ripple</b>
 
-        <div class="ion-activatable ripple-parent custom-parent">
-          Custom Parent Color
-          <ion-ripple-effect></ion-ripple-effect>
-        </div>
+          <div class="ion-activatable ripple-parent custom-parent">
+            Custom Parent Color
+            <ion-ripple-effect></ion-ripple-effect>
+          </div>
 
-        <div class="ion-activatable ripple-parent">
-          Custom Ripple Color
-          <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+          <div class="ion-activatable ripple-parent">
+            Custom Ripple Color
+            <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+          </div>
         </div>
       </div>
     </ion-content>

--- a/static/usage/ripple-effect/customizing/demo.html
+++ b/static/usage/ripple-effect/customizing/demo.html
@@ -43,7 +43,7 @@
     }
 
     .custom-ripple {
-      color: #c0ffee;
+      color: #501ace;
     }
   </style>
 </head>

--- a/static/usage/ripple-effect/customizing/index.md
+++ b/static/usage/ripple-effect/customizing/index.md
@@ -2,28 +2,28 @@ import Playground from '@site/src/components/global/Playground';
 
 import javascript from './javascript.md';
 
-import reactTSX from './react/main_tsx.md';
-import reactCSS from './react/main_css.md';
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
 
 import vue from './vue.md';
 
-import angularHTML from './angular/example_component_html.md';
-import angularCSS from './angular/example_component_css.md';
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
   code={{
     javascript,
     react: {
       files: {
-        'src/main.tsx': reactTSX,
-        'src/main.css': reactCSS
+        'src/main.tsx': react_main_tsx,
+        'src/main.css': react_main_css
       }
     },
     vue,
     angular: {
       files: {
-        'src/app/example.component.html': angularHTML,
-        'src/app/example.component.css': angularCSS
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.css': angular_example_component_css
       }
     },
   }}

--- a/static/usage/ripple-effect/customizing/index.md
+++ b/static/usage/ripple-effect/customizing/index.md
@@ -1,0 +1,32 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTSX from './react/main_tsx.md';
+import reactCSS from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/example_component_html.md';
+import angularCSS from './angular/example_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTSX,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angularHTML,
+        'src/app/example.component.css': angularCSS
+      }
+    },
+  }}
+  src="usage/ripple-effect/customizing/demo.html"
+  size="175px"
+/>

--- a/static/usage/ripple-effect/customizing/javascript.md
+++ b/static/usage/ripple-effect/customizing/javascript.md
@@ -34,7 +34,7 @@
   }
 
   .custom-ripple {
-    color: #c0ffee;
+    color: #501ace;
   }
 </style>
 ```

--- a/static/usage/ripple-effect/customizing/javascript.md
+++ b/static/usage/ripple-effect/customizing/javascript.md
@@ -1,17 +1,37 @@
 ```html
-<b>Click on a shape to see the ripple</b>
+<div class="wrapper">
+  <b>Click on a shape to see the ripple</b>
 
-<div class="ion-activatable ripple-parent custom-parent">
-  Custom Parent Color
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent custom-parent">
+    Custom Parent Color
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent">
-  Custom Ripple Color
-  <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+  <div class="ion-activatable ripple-parent">
+    Custom Ripple Color
+    <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+  </div>
 </div>
 
 <style>
+  .wrapper {
+    display: flex;
+    flex-wrap: wrap;
+
+    align-items: center;
+    justify-content: space-between;
+    text-align: center;
+
+    height: 170px;
+    width: 400px;
+
+    margin: 0 auto;
+  }
+
+  b {
+    width: 100%;
+  }
+
   .ripple-parent {
     display: flex;
     align-items: center;

--- a/static/usage/ripple-effect/customizing/javascript.md
+++ b/static/usage/ripple-effect/customizing/javascript.md
@@ -1,0 +1,40 @@
+```html
+<b>Click on a shape to see the ripple</b>
+
+<div class="ion-activatable ripple-parent custom-parent">
+  Custom Parent Color
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent">
+  Custom Ripple Color
+  <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+</div>
+
+<style>
+  .ripple-parent {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    position: relative;
+    overflow: hidden;
+
+    border: 1px solid #ddd;
+
+    user-select: none;
+
+    width: 100%;
+    height: 50px;
+    border-radius: 8px;
+  }
+
+  .custom-parent {
+    color: #de1e7e;
+  }
+
+  .custom-ripple {
+    color: #c0ffee;
+  }
+</style>
+```

--- a/static/usage/ripple-effect/customizing/react/main_css.md
+++ b/static/usage/ripple-effect/customizing/react/main_css.md
@@ -1,4 +1,22 @@
 ```css
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+
+  height: 170px;
+  width: 400px;
+
+  margin: 0 auto;
+}
+
+b {
+  width: 100%;
+}
+
 .ripple-parent {
   display: flex;
   align-items: center;

--- a/static/usage/ripple-effect/customizing/react/main_css.md
+++ b/static/usage/ripple-effect/customizing/react/main_css.md
@@ -1,0 +1,26 @@
+```css
+.ripple-parent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  position: relative;
+  overflow: hidden;
+
+  border: 1px solid #ddd;
+
+  user-select: none;
+
+  width: 100%;
+  height: 50px;
+  border-radius: 8px;
+}
+
+.custom-parent {
+  color: #de1e7e;
+}
+
+.custom-ripple {
+  color: #c0ffee;
+}
+```

--- a/static/usage/ripple-effect/customizing/react/main_css.md
+++ b/static/usage/ripple-effect/customizing/react/main_css.md
@@ -21,6 +21,6 @@
 }
 
 .custom-ripple {
-  color: #c0ffee;
+  color: #501ace;
 }
 ```

--- a/static/usage/ripple-effect/customizing/react/main_tsx.md
+++ b/static/usage/ripple-effect/customizing/react/main_tsx.md
@@ -6,7 +6,7 @@ import './main.css';
 
 function Example() {
   return (
-    <>
+    <div className="wrapper">
       <b>Click on a shape to see the ripple</b>
 
       <div className="ion-activatable ripple-parent custom-parent">
@@ -18,7 +18,7 @@ function Example() {
         Custom Ripple Color
         <IonRippleEffect className="custom-ripple"></IonRippleEffect>
       </div>
-    </>
+    </div>
   );
 }
 export default Example;

--- a/static/usage/ripple-effect/customizing/react/main_tsx.md
+++ b/static/usage/ripple-effect/customizing/react/main_tsx.md
@@ -1,0 +1,25 @@
+```tsx
+import React from 'react';
+import { IonRippleEffect } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <>
+      <b>Click on a shape to see the ripple</b>
+
+      <div className="ion-activatable ripple-parent custom-parent">
+        Custom Parent Color
+        <IonRippleEffect></IonRippleEffect>
+      </div>
+
+      <div className="ion-activatable ripple-parent">
+        Custom Ripple Color
+        <IonRippleEffect className="custom-ripple"></IonRippleEffect>
+      </div>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/ripple-effect/customizing/vue.md
+++ b/static/usage/ripple-effect/customizing/vue.md
@@ -1,15 +1,17 @@
 ```html
 <template>
-  <b>Click on a shape to see the ripple</b>
+  <div class="wrapper">
+    <b>Click on a shape to see the ripple</b>
 
-  <div class="ion-activatable ripple-parent custom-parent">
-    Custom Parent Color
-    <ion-ripple-effect></ion-ripple-effect>
-  </div>
+    <div class="ion-activatable ripple-parent custom-parent">
+      Custom Parent Color
+      <ion-ripple-effect></ion-ripple-effect>
+    </div>
 
-  <div class="ion-activatable ripple-parent">
-    Custom Ripple Color
-    <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+    <div class="ion-activatable ripple-parent">
+      Custom Ripple Color
+      <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+    </div>
   </div>
 </template>
 
@@ -23,6 +25,24 @@
 </script>
 
 <style scoped>
+  .wrapper {
+    display: flex;
+    flex-wrap: wrap;
+
+    align-items: center;
+    justify-content: space-between;
+    text-align: center;
+
+    height: 170px;
+    width: 400px;
+
+    margin: 0 auto;
+  }
+
+  b {
+    width: 100%;
+  }
+
   .ripple-parent {
     display: flex;
     align-items: center;

--- a/static/usage/ripple-effect/customizing/vue.md
+++ b/static/usage/ripple-effect/customizing/vue.md
@@ -45,7 +45,7 @@
   }
 
   .custom-ripple {
-    color: #c0ffee;
+    color: #501ace;
   }
 </style>
 ```

--- a/static/usage/ripple-effect/customizing/vue.md
+++ b/static/usage/ripple-effect/customizing/vue.md
@@ -1,0 +1,51 @@
+```html
+<template>
+  <b>Click on a shape to see the ripple</b>
+
+  <div class="ion-activatable ripple-parent custom-parent">
+    Custom Parent Color
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
+
+  <div class="ion-activatable ripple-parent">
+    Custom Ripple Color
+    <ion-ripple-effect class="custom-ripple"></ion-ripple-effect>
+  </div>
+</template>
+
+<script lang="ts">
+  import { IonRippleEffect } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRippleEffect },
+  });
+</script>
+
+<style scoped>
+  .ripple-parent {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    position: relative;
+    overflow: hidden;
+
+    border: 1px solid #ddd;
+
+    user-select: none;
+
+    width: 100%;
+    height: 50px;
+    border-radius: 8px;
+  }
+
+  .custom-parent {
+    color: #de1e7e;
+  }
+
+  .custom-ripple {
+    color: #c0ffee;
+  }
+</style>
+```

--- a/static/usage/ripple-effect/type/angular/example_component_css.md
+++ b/static/usage/ripple-effect/type/angular/example_component_css.md
@@ -1,4 +1,22 @@
 ```css
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+
+  height: 170px;
+  width: 400px;
+
+  margin: 0 auto;
+}
+
+b {
+  width: 100%;
+}
+
 .ripple-parent {
   display: flex;
   align-items: center;

--- a/static/usage/ripple-effect/type/angular/example_component_css.md
+++ b/static/usage/ripple-effect/type/angular/example_component_css.md
@@ -1,0 +1,26 @@
+```css
+.ripple-parent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  position: relative;
+  overflow: hidden;
+
+  border: 1px solid #ddd;
+
+  user-select: none;
+}
+
+.rounded-rectangle {
+  width: 250px;
+  height: 75px;
+  border-radius: 8px;
+}
+
+.circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+}
+```

--- a/static/usage/ripple-effect/type/angular/example_component_html.md
+++ b/static/usage/ripple-effect/type/angular/example_component_html.md
@@ -1,0 +1,13 @@
+```html
+<b>Click on a shape to see the ripple</b>
+
+<div class="ion-activatable ripple-parent rounded-rectangle">
+  Bounded
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent circle">
+  Unbounded
+  <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+</div>
+```

--- a/static/usage/ripple-effect/type/angular/example_component_html.md
+++ b/static/usage/ripple-effect/type/angular/example_component_html.md
@@ -1,13 +1,15 @@
 ```html
-<b>Click on a shape to see the ripple</b>
+<div class="wrapper">
+  <b>Click on a shape to see the ripple</b>
 
-<div class="ion-activatable ripple-parent rounded-rectangle">
-  Bounded
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent rounded-rectangle">
+    Bounded
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent circle">
-  Unbounded
-  <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+  <div class="ion-activatable ripple-parent circle">
+    Unbounded
+    <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+  </div>
 </div>
 ```

--- a/static/usage/ripple-effect/type/demo.html
+++ b/static/usage/ripple-effect/type/demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ripple Effect</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      width: 400px;
+      margin: 0 auto;
+
+      flex-wrap: wrap;
+      justify-content: space-between;
+
+      text-align: center;
+    }
+
+    b {
+      width: 100%;
+    }
+
+    .ripple-parent {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      position: relative;
+      overflow: hidden;
+
+      border: 1px solid #ddd;
+
+      user-select: none;
+    }
+
+    .rounded-rectangle {
+      width: 250px;
+      height: 75px;
+      border-radius: 8px;
+    }
+
+    .circle {
+      width: 120px;
+      height: 120px;
+      border-radius: 50%;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <b>Click on a shape to see the ripple</b>
+
+        <div class="ion-activatable ripple-parent rounded-rectangle">
+          Bounded
+          <ion-ripple-effect></ion-ripple-effect>
+        </div>
+
+        <div class="ion-activatable ripple-parent circle">
+          Unbounded
+          <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+        </div>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/ripple-effect/type/demo.html
+++ b/static/usage/ripple-effect/type/demo.html
@@ -11,14 +11,18 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
 
   <style>
-    .container {
-      width: 400px;
-      margin: 0 auto;
-
+    .wrapper {
+      display: flex;
       flex-wrap: wrap;
-      justify-content: space-between;
 
+      align-items: center;
+      justify-content: space-between;
       text-align: center;
+
+      height: 170px;
+      width: 400px;
+
+      margin: 0 auto;
     }
 
     b {
@@ -56,16 +60,18 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <b>Click on a shape to see the ripple</b>
+        <div class="wrapper">
+          <b>Click on a shape to see the ripple</b>
 
-        <div class="ion-activatable ripple-parent rounded-rectangle">
-          Bounded
-          <ion-ripple-effect></ion-ripple-effect>
-        </div>
+          <div class="ion-activatable ripple-parent rounded-rectangle">
+            Bounded
+            <ion-ripple-effect></ion-ripple-effect>
+          </div>
 
-        <div class="ion-activatable ripple-parent circle">
-          Unbounded
-          <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+          <div class="ion-activatable ripple-parent circle">
+            Unbounded
+            <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+          </div>
         </div>
       </div>
     </ion-content>

--- a/static/usage/ripple-effect/type/index.md
+++ b/static/usage/ripple-effect/type/index.md
@@ -2,28 +2,28 @@ import Playground from '@site/src/components/global/Playground';
 
 import javascript from './javascript.md';
 
-import reactTSX from './react/main_tsx.md';
-import reactCSS from './react/main_css.md';
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
 
 import vue from './vue.md';
 
-import angularHTML from './angular/example_component_html.md';
-import angularCSS from './angular/example_component_css.md';
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
   code={{
     javascript,
     react: {
       files: {
-        'src/main.tsx': reactTSX,
-        'src/main.css': reactCSS
+        'src/main.tsx': react_main_tsx,
+        'src/main.css': react_main_css
       }
     },
     vue,
     angular: {
       files: {
-        'src/app/example.component.html': angularHTML,
-        'src/app/example.component.css': angularCSS
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.css': angular_example_component_css
       }
     },
   }}

--- a/static/usage/ripple-effect/type/index.md
+++ b/static/usage/ripple-effect/type/index.md
@@ -1,0 +1,32 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import reactTSX from './react/main_tsx.md';
+import reactCSS from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angularHTML from './angular/example_component_html.md';
+import angularCSS from './angular/example_component_css.md';
+
+<Playground
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': reactTSX,
+        'src/main.css': reactCSS
+      }
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angularHTML,
+        'src/app/example.component.css': angularCSS
+      }
+    },
+  }}
+  src="usage/ripple-effect/type/demo.html"
+  size="175px"
+/>

--- a/static/usage/ripple-effect/type/javascript.md
+++ b/static/usage/ripple-effect/type/javascript.md
@@ -1,0 +1,40 @@
+```html
+<b>Click on a shape to see the ripple</b>
+
+<div class="ion-activatable ripple-parent rounded-rectangle">
+  Bounded
+  <ion-ripple-effect></ion-ripple-effect>
+</div>
+
+<div class="ion-activatable ripple-parent circle">
+  Unbounded
+  <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+</div>
+
+<style>
+  .ripple-parent {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    position: relative;
+    overflow: hidden;
+
+    border: 1px solid #ddd;
+
+    user-select: none;
+  }
+
+  .rounded-rectangle {
+    width: 250px;
+    height: 75px;
+    border-radius: 8px;
+  }
+
+  .circle {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+  }
+</style>
+```

--- a/static/usage/ripple-effect/type/javascript.md
+++ b/static/usage/ripple-effect/type/javascript.md
@@ -1,17 +1,37 @@
 ```html
-<b>Click on a shape to see the ripple</b>
+<div class="wrapper">
+  <b>Click on a shape to see the ripple</b>
 
-<div class="ion-activatable ripple-parent rounded-rectangle">
-  Bounded
-  <ion-ripple-effect></ion-ripple-effect>
-</div>
+  <div class="ion-activatable ripple-parent rounded-rectangle">
+    Bounded
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
 
-<div class="ion-activatable ripple-parent circle">
-  Unbounded
-  <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+  <div class="ion-activatable ripple-parent circle">
+    Unbounded
+    <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+  </div>
 </div>
 
 <style>
+  .wrapper {
+    display: flex;
+    flex-wrap: wrap;
+
+    align-items: center;
+    justify-content: space-between;
+    text-align: center;
+
+    height: 170px;
+    width: 400px;
+
+    margin: 0 auto;
+  }
+
+  b {
+    width: 100%;
+  }
+
   .ripple-parent {
     display: flex;
     align-items: center;

--- a/static/usage/ripple-effect/type/react/main_css.md
+++ b/static/usage/ripple-effect/type/react/main_css.md
@@ -1,4 +1,22 @@
 ```css
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+
+  height: 170px;
+  width: 400px;
+
+  margin: 0 auto;
+}
+
+b {
+  width: 100%;
+}
+
 .ripple-parent {
   display: flex;
   align-items: center;

--- a/static/usage/ripple-effect/type/react/main_css.md
+++ b/static/usage/ripple-effect/type/react/main_css.md
@@ -1,0 +1,26 @@
+```css
+.ripple-parent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  position: relative;
+  overflow: hidden;
+
+  border: 1px solid #ddd;
+
+  user-select: none;
+}
+
+.rounded-rectangle {
+  width: 250px;
+  height: 75px;
+  border-radius: 8px;
+}
+
+.circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+}
+```

--- a/static/usage/ripple-effect/type/react/main_tsx.md
+++ b/static/usage/ripple-effect/type/react/main_tsx.md
@@ -6,7 +6,7 @@ import './main.css';
 
 function Example() {
   return (
-    <>
+    <div className="wrapper">
       <b>Click on a shape to see the ripple</b>
 
       <div className="ion-activatable ripple-parent rounded-rectangle">
@@ -18,7 +18,7 @@ function Example() {
         Unbounded
         <IonRippleEffect type="unbounded"></IonRippleEffect>
       </div>
-    </>
+    </div>
   );
 }
 export default Example;

--- a/static/usage/ripple-effect/type/react/main_tsx.md
+++ b/static/usage/ripple-effect/type/react/main_tsx.md
@@ -1,0 +1,25 @@
+```tsx
+import React from 'react';
+import { IonRippleEffect } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <>
+      <b>Click on a shape to see the ripple</b>
+
+      <div className="ion-activatable ripple-parent rounded-rectangle">
+        Bounded
+        <IonRippleEffect></IonRippleEffect>
+      </div>
+
+      <div className="ion-activatable ripple-parent circle">
+        Unbounded
+        <IonRippleEffect type="unbounded"></IonRippleEffect>
+      </div>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/ripple-effect/type/vue.md
+++ b/static/usage/ripple-effect/type/vue.md
@@ -1,0 +1,51 @@
+```html
+<template>
+  <b>Click on a shape to see the ripple</b>
+
+  <div class="ion-activatable ripple-parent rounded-rectangle">
+    Bounded
+    <ion-ripple-effect></ion-ripple-effect>
+  </div>
+
+  <div class="ion-activatable ripple-parent circle">
+    Unbounded
+    <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+  </div>
+</template>
+
+<script lang="ts">
+  import { IonRippleEffect } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRippleEffect },
+  });
+</script>
+
+<style scoped>
+  .ripple-parent {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    position: relative;
+    overflow: hidden;
+
+    border: 1px solid #ddd;
+
+    user-select: none;
+  }
+
+  .rounded-rectangle {
+    width: 250px;
+    height: 75px;
+    border-radius: 8px;
+  }
+
+  .circle {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+  }
+</style>
+```

--- a/static/usage/ripple-effect/type/vue.md
+++ b/static/usage/ripple-effect/type/vue.md
@@ -1,15 +1,17 @@
 ```html
 <template>
-  <b>Click on a shape to see the ripple</b>
+  <div class="wrapper">
+    <b>Click on a shape to see the ripple</b>
 
-  <div class="ion-activatable ripple-parent rounded-rectangle">
-    Bounded
-    <ion-ripple-effect></ion-ripple-effect>
-  </div>
+    <div class="ion-activatable ripple-parent rounded-rectangle">
+      Bounded
+      <ion-ripple-effect></ion-ripple-effect>
+    </div>
 
-  <div class="ion-activatable ripple-parent circle">
-    Unbounded
-    <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+    <div class="ion-activatable ripple-parent circle">
+      Unbounded
+      <ion-ripple-effect type="unbounded"></ion-ripple-effect>
+    </div>
   </div>
 </template>
 
@@ -23,6 +25,24 @@
 </script>
 
 <style scoped>
+  .wrapper {
+    display: flex;
+    flex-wrap: wrap;
+
+    align-items: center;
+    justify-content: space-between;
+    text-align: center;
+
+    height: 170px;
+    width: 400px;
+
+    margin: 0 auto;
+  }
+
+  b {
+    width: 100%;
+  }
+
   .ripple-parent {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Adds the following playgrounds for ripple effect:

- Basic Usage
- Type
- Customizing

I got the idea to use shapes for the examples from Material Design here: https://material.io/develop/ios/supporting/ripple

Preview: https://ionic-docs-git-fw-1271-ionic1.vercel.app/docs/api/ripple-effect