### PR TITLE
docs(angular): config provider usage and content updates

### DIFF
--- a/docs/angular/config.md
+++ b/docs/angular/config.md
@@ -14,30 +14,28 @@ Ionic Config provides a way to change the properties of components globally acro
 
 ## Global Config
 
-To override the initial Ionic config for the app, provide a config in `IonicModule.forRoot` in the `app.module.ts` file.
+To override the default Ionic configurations for your application, provide your own custom config to `IonicModule.forRoot(...)`. The available config keys can be found in the [`IonicConfig`](#ionicconfig) interface.
 
-```tsx
+For example, to disable ripple effects and default the mode to Material Design:
+
+```tsx title="app.module.ts"
 import { IonicModule } from '@ionic/angular';
 
 @NgModule({
   ...
   imports: [
-    BrowserModule,
     IonicModule.forRoot({
       rippleEffect: false,
       mode: 'md'
-    }),
-    AppRoutingModule
+    })
   ],
   ...
 })
 ```
 
-In the above example, we are disabling the Material Design ripple effect across the app, as well as forcing the mode to be Material Design.
-
 ## Per-Component Config
 
-Ionic Config is not reactive, so it is recommended to use a component's properties when you want to override its default behavior rather than set its config globally.
+Ionic Config is not reactive. It is recommended to use a component's properties or a directive when you want to override its default behavior.
 
 ```tsx
 import { IonicModule } from '@ionic/angular';
@@ -45,11 +43,10 @@ import { IonicModule } from '@ionic/angular';
 @NgModule({
   ...
   imports: [
-    BrowserModule,
     IonicModule.forRoot({
+      // Not recommended when you require reactive values
       backButtonText: 'Go Back'
-    }),
-    AppRoutingModule
+    })
   ],
   ...
 })
@@ -62,6 +59,12 @@ This will set the default text for `ion-back-button` to `Go Back`. However, if y
 ```
 
 In this example we have used our `ion-back-button` in such a way that the text can be dynamically updated if there were to be a change that warranted it, such as a language or locale change. The `getBackButtonText` method would be responsible for returning the correct text.
+
+:::note
+
+When binding a function to a property, it is recommended to use `ChangeDetectionStrategy.OnPush`.
+
+:::
 
 ## Per-Platform Config
 
@@ -78,17 +81,15 @@ import { isPlatform, IonicModule } from '@ionic/angular';
 @NgModule({
   ...
   imports: [
-    BrowserModule,
     IonicModule.forRoot({
       animated: !isPlatform('mobileweb')
-    }),
-    AppRoutingModule
+    })
   ],
   ...
 })
 ```
 
-The next example allows you to set an entirely different configuration based upon the platform, falling back to a default config if no platforms match:
+**Per-platform config with fallback for unmatched platforms:**
 
 ```tsx
 import { isPlatform, IonicModule } from '@ionic/angular';
@@ -108,15 +109,13 @@ const getConfig = () => {
 @NgModule({
   ...
   imports: [
-    BrowserModule,
-    IonicModule.forRoot(getConfig()),
-    AppRoutingModule
+    IonicModule.forRoot(getConfig())
   ],
   ...
 })
 ```
 
-Finally, this example allows you to accumulate a config object based upon different platform requirements:
+**Per-platform config overrides:**
 
 ```tsx
 import { isPlatform, IonicModule } from '@ionic/angular';
@@ -138,49 +137,217 @@ const getConfig = () => {
 @NgModule({
   ...
   imports: [
-    BrowserModule,
-    IonicModule.forRoot(getConfig()),
-    AppRoutingModule
+    IonicModule.forRoot(getConfig())
   ],
   ...
 })
 ```
 
-## Config Options
+## API Reference
 
-Below is a list of config options that Ionic uses.
+### get
 
-| Config                   | Type                                                                              | Description                                                                                              |
-| ------------------------ | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `actionSheetEnter`       | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-action-sheet`, overriding the default "animation".        |
-| `actionSheetLeave`       | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-action-sheet`, overriding the default "animation".        |
-| `alertEnter`             | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-alert`, overriding the default "animation".               |
-| `alertLeave`             | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-alert`, overriding the default "animation".               |
-| `animated`               | `boolean`                                                                         | If `true`, Ionic will enable all animations and transitions across the app.                              |
-| `backButtonIcon`         | `string`                                                                          | Overrides the default icon in all `<ion-back-button>` components.                                        |
-| `backButtonText`         | `string`                                                                          | Overrides the default text in all `<ion-back-button>` components.                                        |
-| `hardwareBackButton`     | `boolean`                                                                         | If `true`, Ionic will respond to the hardware back button in an Android device.                          |
-| `infiniteLoadingSpinner` | `SpinnerTypes`                                                                    | Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.                    |
-| `loadingEnter`           | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-loading`, overriding the default "animation".             |
-| `loadingLeave`           | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-loading`, overriding the default "animation".             |
-| `loadingSpinner`         | `SpinnerTypes`                                                                    | Overrides the default spinner for all `ion-loading` overlays.                                            |
-| `menuIcon`               | `string`                                                                          | Overrides the default icon in all `<ion-menu-button>` components.                                        |
-| `menuType`               | `string`                                                                          | Overrides the default menu type for all `<ion-menu>` components.                                         |
-| `modalEnter`             | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-modal`, overriding the default "animation".               |
-| `modalLeave`             | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-modal`, overriding the default "animation".               |
-| `mode`                   | `Mode`                                                                            | The mode determines which platform styles to use for the whole application.                              |
-| `navAnimation`           | `AnimationBuilder`                                                                | Overrides the default "animation" of all `ion-nav` and `ion-router-outlet` across the whole application. |
-| `pickerEnter`            | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-picker`, overriding the default "animation".              |
-| `pickerLeave`            | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-picker`, overriding the default "animation".              |
-| `platform`               | [`PlatformConfig`](/docs/angular/platform#customizing-platform-detection-methods) | Overrides the default platform detection methods.                                                        |
-| `popoverEnter`           | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-popover`, overriding the default "animation".             |
-| `popoverLeave`           | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-popover`, overriding the default "animation".             |
-| `refreshingIcon`         | `string`                                                                          | Overrides the default icon in all `<ion-refresh-content>` components.                                    |
-| `refreshingSpinner`      | `SpinnerTypes`                                                                    | Overrides the default spinner type in all `<ion-refresh-content>` components.                            |
-| `sanitizerEnabled`       | `boolean`                                                                         | If `true`, Ionic will enable a basic DOM sanitizer on component properties that accept custom HTML.      |
-| `spinner`                | `SpinnerTypes`                                                                    | Overrides the default spinner in all `<ion-spinner>` components.                                         |
-| `statusTap`              | `boolean`                                                                         | If `true`, clicking or tapping the status bar will cause the content to scroll to the top.               |
-| `swipeBackEnabled`       | `boolean`                                                                         | If `true`, Ionic will enable the "swipe-to-go-back" gesture across the application.                      |
-| `tabButtonLayout`        | `TabButtonLayout`                                                                 | Overrides the default "layout" of all `ion-bar-button` across the whole application.                     |
-| `toastEnter`             | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-toast`, overriding the default "animation".               |
-| `toastLeave`             | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-toast`, overriding the default "animation".               |
+▸ **get**(key: string, fallback?: any): `any`
+
+Returns a config value as an `any`. Returns `null` if the config is not defined.
+
+```ts
+import { Config } from '@ionic/angular';
+
+@Component(...)
+class AppComponent {
+  constructor(config: Config) {
+    const mode = config.get('mode');
+  }
+}
+```
+
+### getBoolean
+
+▸ **getBoolean**(key: string, fallback?: boolean): `boolean`
+
+Returns a config value as a `boolean`. Returns `false` if the config is not defined.
+
+```ts
+import { Config } from '@ionic/angular';
+
+@Component(...)
+class AppComponent {
+  constructor(config: Config) {
+    const swipeBackEnabled = config.getBoolean('swipeBackEnabled');
+  }
+}
+```
+
+### getNumber
+
+▸ **getNumber**(key: string, fallback?: number): `number`
+
+Returns a config value as a `number`. Returns `0` if the config is not defined.
+
+```ts
+import { Config } from '@ionic/angular';
+
+@Component(...)
+class AppComponent {
+  constructor(config: Config) {
+    const keyboardHeight = config.getNumber('keyboardHeight');
+  }
+}
+```
+
+## Interfaces
+
+### IonicConfig
+
+Below is the config options that Ionic uses.
+
+```ts
+interface IonicConfig {
+  /**
+   * When it's set to `false`, disables all animation and transition across the app.
+   * Can be useful to make ionic smoother in slow devices, when animations can't run smoothly.
+   */
+  animated?: boolean;
+  /**
+   * When it's set to `false`, it disables all material-design ripple-effects across the app.
+   * Defaults to `true`.
+   */
+  rippleEffect?: boolean;
+  /**
+   * The mode determines which platform styles to use for the whole application.
+   */
+  mode?: Mode;
+  /**
+   * Wherever ionic will respond to hardware go back buttons in an Android device.
+   * Defaults to `true` when ionic runs in a mobile device.
+   */
+  hardwareBackButton?: boolean;
+  /**
+   * Whenever clicking the top status bar should cause the scroll to top in an application.
+   * Defaults to `true` when ionic runs in a mobile device.
+   */
+  statusTap?: boolean;
+  /**
+   * Overrides the default icon in all `<ion-back-button>` components.
+   */
+  backButtonIcon?: string;
+  /**
+   * Overrides the default text in all `<ion-back-button>` components.
+   */
+  backButtonText?: string;
+  /**
+   * Overrides the default defaultHref in all `<ion-back-button>` components.
+   */
+  backButtonDefaultHref?: string;
+  /**
+   * Overrides the default icon in all `<ion-menu-button>` components.
+   */
+  menuIcon?: string;
+  /**
+   * Overrides the default menu type for all `<ion-menu>` components.
+   * By default the menu type is chosen based in the app's mode.
+   */
+  menuType?: string;
+  /**
+   * Overrides the default spinner in all `<ion-spinner>` components.
+   * By default the spinner type is chosen based in the mode (ios or md).
+   */
+  spinner?: SpinnerTypes;
+  /**
+   * Overrides the default spinner for all `ion-loading` overlays, ie. the ones
+   * created with `ion-loading-controller`.
+   */
+  loadingSpinner?: SpinnerTypes | null;
+  /**
+   * Overrides the default icon in all `<ion-refresh-content>` components.
+   */
+  refreshingIcon?: string;
+  /**
+   * Overrides the default spinner type in all `<ion-refresh-content>` components.
+   */
+  refreshingSpinner?: SpinnerTypes | null;
+  /**
+   * Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.
+   */
+  infiniteLoadingSpinner?: SpinnerTypes | null;
+  /**
+   * Global switch that disables or enables "swipe-to-go-back" gesture across all
+   * `ion-nav` in your application.
+   */
+  swipeBackEnabled?: boolean;
+  /**
+   * Overrides the default "layout" of all `ion-bar-button` across the whole application.
+   */
+  tabButtonLayout?: TabButtonLayout;
+  /**
+   * Overrides the default "animation" of all `ion-nav` and `ion-router-outlet` across the whole application.
+   * This prop allows to replace the default transition and provide a custom one that applies to all navigation outlets.
+   */
+  navAnimation?: AnimationBuilder;
+  /**
+   * Provides a custom enter animation for all `ion-action-sheet`, overriding the default "animation".
+   */
+  actionSheetEnter?: AnimationBuilder;
+  /**
+   * Provides a custom enter animation for all `ion-alert`, overriding the default "animation".
+   */
+  alertEnter?: AnimationBuilder;
+  /**
+   * Provides a custom enter animation for all `ion-loading`, overriding the default "animation".
+   */
+  loadingEnter?: AnimationBuilder;
+  /**
+   * Provides a custom enter animation for all `ion-modal`, overriding the default "animation".
+   */
+  modalEnter?: AnimationBuilder;
+  /**
+   * Provides a custom enter animation for all `ion-popover`, overriding the default "animation".
+   */
+  popoverEnter?: AnimationBuilder;
+  /**
+   * Provides a custom enter animation for all `ion-toast`, overriding the default "animation".
+   */
+  toastEnter?: AnimationBuilder;
+  /**
+   * Provides a custom enter animation for all `ion-picker`, overriding the default "animation".
+   */
+  pickerEnter?: AnimationBuilder;
+  /**
+   * Provides a custom leave animation for all `ion-action-sheet`, overriding the default "animation".
+   */
+  actionSheetLeave?: AnimationBuilder;
+  /**
+   * Provides a custom leave animation for all `ion-alert`, overriding the default "animation".
+   */
+  alertLeave?: AnimationBuilder;
+  /**
+   * Provides a custom leave animation for all `ion-loading`, overriding the default "animation".
+   */
+  loadingLeave?: AnimationBuilder;
+  /**
+   * Provides a custom leave animation for all `ion-modal`, overriding the default "animation".
+   */
+  modalLeave?: AnimationBuilder;
+  /**
+   * Provides a custom leave animation for all `ion-popover`, overriding the default "animation".
+   */
+  popoverLeave?: AnimationBuilder;
+  /**
+   * Provides a custom leave animation for all `ion-toast`, overriding the default "animation".
+   */
+  toastLeave?: AnimationBuilder;
+  /**
+   * Provides a custom leave animation for all `ion-picker`, overriding the default "animation".
+   */
+  pickerLeave?: AnimationBuilder;
+  /**
+   * If `true`, Ionic will enable a basic DOM sanitizer on component properties that accept custom HTML.
+   */
+  sanitizerEnabled?: boolean;
+  /**
+   * Overrides the default platform detection methods.
+   */
+  platform?: PlatformConfig;
+}
+```

--- a/docs/angular/config.md
+++ b/docs/angular/config.md
@@ -14,7 +14,7 @@ Ionic Config provides a way to change the properties of components globally acro
 
 ## Global Config
 
-To override the default Ionic configurations for your application, provide your own custom config to `IonicModule.forRoot(...)`. The available config keys can be found in the [`IonicConfig`](#ionicconfig) interface.
+To override the default Ionic configurations for your app, provide your own custom config to `IonicModule.forRoot(...)`. The available config keys can be found in the [`IonicConfig`](#ionicconfig) interface.
 
 For example, to disable ripple effects and default the mode to Material Design:
 
@@ -35,16 +35,18 @@ import { IonicModule } from '@ionic/angular';
 
 ## Per-Component Config
 
-Ionic Config is not reactive. It is recommended to use a component's properties or a directive when you want to override its default behavior.
+Ionic Config is not reactive. Updating the config's value after the component has rendered will result in the previous value. It is recommended to use a component's properties instead of updating the config, when you require reactive values.
 
-```tsx
+**Not recommended**
+
+```ts
 import { IonicModule } from '@ionic/angular';
 
 @NgModule({
   ...
   imports: [
     IonicModule.forRoot({
-      // Not recommended when you require reactive values
+      // Not recommended when your app requires reactive values
       backButtonText: 'Go Back'
     })
   ],
@@ -52,19 +54,27 @@ import { IonicModule } from '@ionic/angular';
 })
 ```
 
-This will set the default text for `ion-back-button` to `Go Back`. However, if you were to change the value of the `backButtonText` config to `Do Not Go Back`, the `ion-back-button` default text would still default to `Go Back` as the component has already been initialized and rendered. Instead, it is recommended to use the `text` property on `ion-back-button`.
+**Recommended**
 
 ```html
-<ion-back-button [text]="getBackButtonText()"></ion-back-button>
+<ion-back-button [text]="backButtonText"></ion-back-button>
 ```
 
-In this example we have used our `ion-back-button` in such a way that the text can be dynamically updated if there were to be a change that warranted it, such as a language or locale change. The `getBackButtonText` method would be responsible for returning the correct text.
+```ts
+@Component(...)
+class MyComponent {
+  backButtonText = this.config.get('backButtonText');
 
-:::note
+  constructor(private config: Config) { }
 
-When binding a function to a property, it is recommended to use `ChangeDetectionStrategy.OnPush`.
+  localeChanged(locale: string) {
+    if (locale === 'es_ES') {
+      this.backButtonText = 'Devolver';
+    }
+  }
 
-:::
+}
+```
 
 ## Per-Platform Config
 

--- a/docs/angular/config.md
+++ b/docs/angular/config.md
@@ -219,7 +219,7 @@ class AppComponent {
 
 ### IonicConfig
 
-Below is the config options that Ionic uses.
+Below are the config options that Ionic uses.
 
 | Config                   | Type                                                                              | Description                                                                                              |
 | ------------------------ | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/docs/angular/config.md
+++ b/docs/angular/config.md
@@ -153,13 +153,14 @@ const getConfig = () => {
 })
 ```
 
-## API Reference
+## Methods
 
 ### get
 
-▸ **get**(key: string, fallback?: any): `any`
-
-Returns a config value as an `any`. Returns `null` if the config is not defined.
+|                 |                                                                                  |
+| --------------- | -------------------------------------------------------------------------------- |
+| **Description** | Returns a config value as an `any`. Returns `null` if the config is not defined. |
+| **Signature**   | `get(key: string, fallback?: any): any`                                          |
 
 ```ts
 import { Config } from '@ionic/angular';
@@ -174,9 +175,10 @@ class AppComponent {
 
 ### getBoolean
 
-▸ **getBoolean**(key: string, fallback?: boolean): `boolean`
-
-Returns a config value as a `boolean`. Returns `false` if the config is not defined.
+|                 |                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------ |
+| **Description** | Returns a config value as a `boolean`. Returns `false` if the config is not defined. |
+| **Signature**   | `getBoolean(key: string, fallback?: boolean): boolean`                               |
 
 ```ts
 import { Config } from '@ionic/angular';
@@ -191,9 +193,10 @@ class AppComponent {
 
 ### getNumber
 
-▸ **getNumber**(key: string, fallback?: number): `number`
-
-Returns a config value as a `number`. Returns `0` if the config is not defined.
+|                 |                                                                                 |
+| --------------- | ------------------------------------------------------------------------------- |
+| **Description** | Returns a config value as a `number`. Returns `0` if the config is not defined. |
+| **Signature**   | `getNumber(key: string, fallback?: number): number`                             |
 
 ```ts
 import { Config } from '@ionic/angular';

--- a/docs/angular/config.md
+++ b/docs/angular/config.md
@@ -162,6 +162,8 @@ const getConfig = () => {
 | **Description** | Returns a config value as an `any`. Returns `null` if the config is not defined. |
 | **Signature**   | `get(key: string, fallback?: any): any`                                          |
 
+#### Examples
+
 ```ts
 import { Config } from '@ionic/angular';
 
@@ -180,6 +182,8 @@ class AppComponent {
 | **Description** | Returns a config value as a `boolean`. Returns `false` if the config is not defined. |
 | **Signature**   | `getBoolean(key: string, fallback?: boolean): boolean`                               |
 
+#### Examples
+
 ```ts
 import { Config } from '@ionic/angular';
 
@@ -197,6 +201,8 @@ class AppComponent {
 | --------------- | ------------------------------------------------------------------------------- |
 | **Description** | Returns a config value as a `number`. Returns `0` if the config is not defined. |
 | **Signature**   | `getNumber(key: string, fallback?: number): number`                             |
+
+#### Examples
 
 ```ts
 import { Config } from '@ionic/angular';

--- a/docs/angular/config.md
+++ b/docs/angular/config.md
@@ -160,7 +160,7 @@ const getConfig = () => {
 |                 |                                                                                  |
 | --------------- | -------------------------------------------------------------------------------- |
 | **Description** | Returns a config value as an `any`. Returns `null` if the config is not defined. |
-| **Signature**   | `get(key: string, fallback?: any): any`                                          |
+| **Signature**   | `get(key: string, fallback?: any) => any`                                          |
 
 #### Examples
 
@@ -180,7 +180,7 @@ class AppComponent {
 |                 |                                                                                      |
 | --------------- | ------------------------------------------------------------------------------------ |
 | **Description** | Returns a config value as a `boolean`. Returns `false` if the config is not defined. |
-| **Signature**   | `getBoolean(key: string, fallback?: boolean): boolean`                               |
+| **Signature**   | `getBoolean(key: string, fallback?: boolean) => boolean`                               |
 
 #### Examples
 
@@ -200,7 +200,7 @@ class AppComponent {
 |                 |                                                                                 |
 | --------------- | ------------------------------------------------------------------------------- |
 | **Description** | Returns a config value as a `number`. Returns `0` if the config is not defined. |
-| **Signature**   | `getNumber(key: string, fallback?: number): number`                             |
+| **Signature**   | `getNumber(key: string, fallback?: number) => number`                             |
 
 #### Examples
 

--- a/docs/angular/config.md
+++ b/docs/angular/config.md
@@ -221,152 +221,37 @@ class AppComponent {
 
 Below is the config options that Ionic uses.
 
-```ts
-interface IonicConfig {
-  /**
-   * When it's set to `false`, disables all animation and transition across the app.
-   * Can be useful to make ionic smoother in slow devices, when animations can't run smoothly.
-   */
-  animated?: boolean;
-  /**
-   * When it's set to `false`, it disables all material-design ripple-effects across the app.
-   * Defaults to `true`.
-   */
-  rippleEffect?: boolean;
-  /**
-   * The mode determines which platform styles to use for the whole application.
-   */
-  mode?: Mode;
-  /**
-   * Wherever ionic will respond to hardware go back buttons in an Android device.
-   * Defaults to `true` when ionic runs in a mobile device.
-   */
-  hardwareBackButton?: boolean;
-  /**
-   * Whenever clicking the top status bar should cause the scroll to top in an application.
-   * Defaults to `true` when ionic runs in a mobile device.
-   */
-  statusTap?: boolean;
-  /**
-   * Overrides the default icon in all `<ion-back-button>` components.
-   */
-  backButtonIcon?: string;
-  /**
-   * Overrides the default text in all `<ion-back-button>` components.
-   */
-  backButtonText?: string;
-  /**
-   * Overrides the default defaultHref in all `<ion-back-button>` components.
-   */
-  backButtonDefaultHref?: string;
-  /**
-   * Overrides the default icon in all `<ion-menu-button>` components.
-   */
-  menuIcon?: string;
-  /**
-   * Overrides the default menu type for all `<ion-menu>` components.
-   * By default the menu type is chosen based in the app's mode.
-   */
-  menuType?: string;
-  /**
-   * Overrides the default spinner in all `<ion-spinner>` components.
-   * By default the spinner type is chosen based in the mode (ios or md).
-   */
-  spinner?: SpinnerTypes;
-  /**
-   * Overrides the default spinner for all `ion-loading` overlays, ie. the ones
-   * created with `ion-loading-controller`.
-   */
-  loadingSpinner?: SpinnerTypes | null;
-  /**
-   * Overrides the default icon in all `<ion-refresh-content>` components.
-   */
-  refreshingIcon?: string;
-  /**
-   * Overrides the default spinner type in all `<ion-refresh-content>` components.
-   */
-  refreshingSpinner?: SpinnerTypes | null;
-  /**
-   * Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.
-   */
-  infiniteLoadingSpinner?: SpinnerTypes | null;
-  /**
-   * Global switch that disables or enables "swipe-to-go-back" gesture across all
-   * `ion-nav` in your application.
-   */
-  swipeBackEnabled?: boolean;
-  /**
-   * Overrides the default "layout" of all `ion-bar-button` across the whole application.
-   */
-  tabButtonLayout?: TabButtonLayout;
-  /**
-   * Overrides the default "animation" of all `ion-nav` and `ion-router-outlet` across the whole application.
-   * This prop allows to replace the default transition and provide a custom one that applies to all navigation outlets.
-   */
-  navAnimation?: AnimationBuilder;
-  /**
-   * Provides a custom enter animation for all `ion-action-sheet`, overriding the default "animation".
-   */
-  actionSheetEnter?: AnimationBuilder;
-  /**
-   * Provides a custom enter animation for all `ion-alert`, overriding the default "animation".
-   */
-  alertEnter?: AnimationBuilder;
-  /**
-   * Provides a custom enter animation for all `ion-loading`, overriding the default "animation".
-   */
-  loadingEnter?: AnimationBuilder;
-  /**
-   * Provides a custom enter animation for all `ion-modal`, overriding the default "animation".
-   */
-  modalEnter?: AnimationBuilder;
-  /**
-   * Provides a custom enter animation for all `ion-popover`, overriding the default "animation".
-   */
-  popoverEnter?: AnimationBuilder;
-  /**
-   * Provides a custom enter animation for all `ion-toast`, overriding the default "animation".
-   */
-  toastEnter?: AnimationBuilder;
-  /**
-   * Provides a custom enter animation for all `ion-picker`, overriding the default "animation".
-   */
-  pickerEnter?: AnimationBuilder;
-  /**
-   * Provides a custom leave animation for all `ion-action-sheet`, overriding the default "animation".
-   */
-  actionSheetLeave?: AnimationBuilder;
-  /**
-   * Provides a custom leave animation for all `ion-alert`, overriding the default "animation".
-   */
-  alertLeave?: AnimationBuilder;
-  /**
-   * Provides a custom leave animation for all `ion-loading`, overriding the default "animation".
-   */
-  loadingLeave?: AnimationBuilder;
-  /**
-   * Provides a custom leave animation for all `ion-modal`, overriding the default "animation".
-   */
-  modalLeave?: AnimationBuilder;
-  /**
-   * Provides a custom leave animation for all `ion-popover`, overriding the default "animation".
-   */
-  popoverLeave?: AnimationBuilder;
-  /**
-   * Provides a custom leave animation for all `ion-toast`, overriding the default "animation".
-   */
-  toastLeave?: AnimationBuilder;
-  /**
-   * Provides a custom leave animation for all `ion-picker`, overriding the default "animation".
-   */
-  pickerLeave?: AnimationBuilder;
-  /**
-   * If `true`, Ionic will enable a basic DOM sanitizer on component properties that accept custom HTML.
-   */
-  sanitizerEnabled?: boolean;
-  /**
-   * Overrides the default platform detection methods.
-   */
-  platform?: PlatformConfig;
-}
-```
+| Config                   | Type                                                                              | Description                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `actionSheetEnter`       | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-action-sheet`, overriding the default "animation".        |
+| `actionSheetLeave`       | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-action-sheet`, overriding the default "animation".        |
+| `alertEnter`             | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-alert`, overriding the default "animation".               |
+| `alertLeave`             | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-alert`, overriding the default "animation".               |
+| `animated`               | `boolean`                                                                         | If `true`, Ionic will enable all animations and transitions across the app.                              |
+| `backButtonIcon`         | `string`                                                                          | Overrides the default icon in all `<ion-back-button>` components.                                        |
+| `backButtonText`         | `string`                                                                          | Overrides the default text in all `<ion-back-button>` components.                                        |
+| `hardwareBackButton`     | `boolean`                                                                         | If `true`, Ionic will respond to the hardware back button in an Android device.                          |
+| `infiniteLoadingSpinner` | `SpinnerTypes`                                                                    | Overrides the default spinner type in all `<ion-infinite-scroll-content>` components.                    |
+| `loadingEnter`           | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-loading`, overriding the default "animation".             |
+| `loadingLeave`           | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-loading`, overriding the default "animation".             |
+| `loadingSpinner`         | `SpinnerTypes`                                                                    | Overrides the default spinner for all `ion-loading` overlays.                                            |
+| `menuIcon`               | `string`                                                                          | Overrides the default icon in all `<ion-menu-button>` components.                                        |
+| `menuType`               | `string`                                                                          | Overrides the default menu type for all `<ion-menu>` components.                                         |
+| `modalEnter`             | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-modal`, overriding the default "animation".               |
+| `modalLeave`             | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-modal`, overriding the default "animation".               |
+| `mode`                   | `Mode`                                                                            | The mode determines which platform styles to use for the whole application.                              |
+| `navAnimation`           | `AnimationBuilder`                                                                | Overrides the default "animation" of all `ion-nav` and `ion-router-outlet` across the whole application. |
+| `pickerEnter`            | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-picker`, overriding the default "animation".              |
+| `pickerLeave`            | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-picker`, overriding the default "animation".              |
+| `platform`               | [`PlatformConfig`](/docs/angular/platform#customizing-platform-detection-methods) | Overrides the default platform detection methods.                                                        |
+| `popoverEnter`           | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-popover`, overriding the default "animation".             |
+| `popoverLeave`           | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-popover`, overriding the default "animation".             |
+| `refreshingIcon`         | `string`                                                                          | Overrides the default icon in all `<ion-refresh-content>` components.                                    |
+| `refreshingSpinner`      | `SpinnerTypes`                                                                    | Overrides the default spinner type in all `<ion-refresh-content>` components.                            |
+| `sanitizerEnabled`       | `boolean`                                                                         | If `true`, Ionic will enable a basic DOM sanitizer on component properties that accept custom HTML.      |
+| `spinner`                | `SpinnerTypes`                                                                    | Overrides the default spinner in all `<ion-spinner>` components.                                         |
+| `statusTap`              | `boolean`                                                                         | If `true`, clicking or tapping the status bar will cause the content to scroll to the top.               |
+| `swipeBackEnabled`       | `boolean`                                                                         | If `true`, Ionic will enable the "swipe-to-go-back" gesture across the application.                      |
+| `tabButtonLayout`        | `TabButtonLayout`                                                                 | Overrides the default "layout" of all `ion-bar-button` across the whole application.                     |
+| `toastEnter`             | `AnimationBuilder`                                                                | Provides a custom enter animation for all `ion-toast`, overriding the default "animation".               |
+| `toastLeave`             | `AnimationBuilder`                                                                | Provides a custom leave animation for all `ion-toast`, overriding the default "animation".               |


### PR DESCRIPTION
Revamps the documentation surrounding the `Config` provider and usage in Angular. If we agree with the general layout and content adjustments, I can make similar changes to React and Vue.

Related issues: #2580

Quick preview: https://ionic-docs-git-docs-angular-config-ionic1.vercel.app/docs/angular/config