### PR TITLE
docs(react/vue): heading levels for interfaces and IonicConfig

### DIFF
--- a/docs/react/config.md
+++ b/docs/react/config.md
@@ -73,9 +73,11 @@ const getConfig = () => {
 setupIonicReact(getConfig());
 ```
 
-## Config Options
+## Interfaces
 
-Below is a list of config options that Ionic uses.
+### IonicConfig
+
+Below are the config options that Ionic uses.
 
 | Config                   | Type                                                                            | Description                                                                                              |
 | ------------------------ | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/docs/vue/config.md
+++ b/docs/vue/config.md
@@ -74,9 +74,11 @@ const getConfig = () => {
 createApp(App).use(IonicVue, getConfig());
 ```
 
-## Config Options
+## Interfaces
 
-Below is a list of config options that Ionic uses.
+### IonicConfig
+
+Below are the config options that Ionic uses.
 
 | Config                   | Type                                                                          | Description                                                                                              |
 | ------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Aligns the headings for the "Config" page to match the changes in: https://github.com/ionic-team/ionic-docs/pull/2614

Preview links:
 - React: https://ionic-docs-git-docs-config-toc-ionic1.vercel.app/docs/react/config#interfaces
 - Vue: https://ionic-docs-git-docs-config-toc-ionic1.vercel.app/docs/vue/config#interfaces