### PR TITLE
chore(playground): update react/vue lock dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ src/components/page/reference/ReleaseNotes/release-notes.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+static/**/node_modules/

--- a/static/code/stackblitz/react/package-lock.json
+++ b/static/code/stackblitz/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "create-react-app-typescript",
       "version": "0.1.0",
       "dependencies": {
-        "@ionic/react": "^6.2.0",
+        "@ionic/react": "^6.3.2",
         "@types/node": "^16.11.35",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
@@ -2201,21 +2201,21 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@ionic/core": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.2.2.tgz",
-      "integrity": "sha512-neE+JhtQ7Kb4nGoKR3e55edHQot5BZTw+woV9+pbyCXP1jGeyFeWWPYBYYOkm05TSEkHgh0v6NkV9y31k8GTNw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.3.2.tgz",
+      "integrity": "sha512-L4xqJyixmGApwYc5fQgGoK80wXGCrbjL8vGfeNbjYqxxP0ZIKGAhURPoMAtSTqLLK9gdhh4Mv6gw4gNKvxodPA==",
       "dependencies": {
-        "@stencil/core": "^2.16.0",
-        "ionicons": "^6.0.2",
+        "@stencil/core": "^2.18.0",
+        "ionicons": "^6.0.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@ionic/react": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.2.2.tgz",
-      "integrity": "sha512-CRuDJbNDn9bbDba37/5v9aZ2gd450XGklGqXmsxEfadh1iq7iWmqcgw14S0ZDAXQt0aE/J+TeKhTyjyutjsAww==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.3.2.tgz",
+      "integrity": "sha512-+YZkUlOvygnowTmtEACd+B1fhmets3sSazr5Ipnv/O/genGgcY5llpxI+LeqvrWt0ECAtiNdF3c35M1IcoAuxA==",
       "dependencies": {
-        "@ionic/core": "^6.2.2",
+        "@ionic/core": "^6.3.2",
         "ionicons": "^6.0.2",
         "tslib": "*"
       },
@@ -3138,9 +3138,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.3.tgz",
-      "integrity": "sha512-qw2DZzOpyaltLLEfYRTj3n+XbvRtkmv4QQimYDJubC6jMY0NXK9r6H2+VyszdbbVmvK1D9GqZtyvY0NmOrztsg==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
+      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -8402,9 +8402,9 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.2.tgz",
-      "integrity": "sha512-AyKfFaUKVoBz4eB8XkU7H1R5HFnVsgq5ijqSdbXC0lES9PDK/J6LUQz6XUJq0mVVQF5k9kczSPOLMW3mszG0mQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.3.tgz",
+      "integrity": "sha512-kVOWER991EMqLiVShrCSWKMHkgHZP7XfVdyN6YPMuoO33W7pc5CPNVNfR8OMe/I8rYEbaunyBs6dXNYpR6gGZw==",
       "dependencies": {
         "@stencil/core": "~2.16.0"
       }
@@ -17714,21 +17714,21 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "@ionic/core": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.2.2.tgz",
-      "integrity": "sha512-neE+JhtQ7Kb4nGoKR3e55edHQot5BZTw+woV9+pbyCXP1jGeyFeWWPYBYYOkm05TSEkHgh0v6NkV9y31k8GTNw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.3.2.tgz",
+      "integrity": "sha512-L4xqJyixmGApwYc5fQgGoK80wXGCrbjL8vGfeNbjYqxxP0ZIKGAhURPoMAtSTqLLK9gdhh4Mv6gw4gNKvxodPA==",
       "requires": {
-        "@stencil/core": "^2.16.0",
-        "ionicons": "^6.0.2",
+        "@stencil/core": "^2.18.0",
+        "ionicons": "^6.0.3",
         "tslib": "^2.1.0"
       }
     },
     "@ionic/react": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.2.2.tgz",
-      "integrity": "sha512-CRuDJbNDn9bbDba37/5v9aZ2gd450XGklGqXmsxEfadh1iq7iWmqcgw14S0ZDAXQt0aE/J+TeKhTyjyutjsAww==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-6.3.2.tgz",
+      "integrity": "sha512-+YZkUlOvygnowTmtEACd+B1fhmets3sSazr5Ipnv/O/genGgcY5llpxI+LeqvrWt0ECAtiNdF3c35M1IcoAuxA==",
       "requires": {
-        "@ionic/core": "^6.2.2",
+        "@ionic/core": "^6.3.2",
         "ionicons": "^6.0.2",
         "tslib": "*"
       }
@@ -18393,9 +18393,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.3.tgz",
-      "integrity": "sha512-qw2DZzOpyaltLLEfYRTj3n+XbvRtkmv4QQimYDJubC6jMY0NXK9r6H2+VyszdbbVmvK1D9GqZtyvY0NmOrztsg=="
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
+      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw=="
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -22229,9 +22229,9 @@
       }
     },
     "ionicons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.2.tgz",
-      "integrity": "sha512-AyKfFaUKVoBz4eB8XkU7H1R5HFnVsgq5ijqSdbXC0lES9PDK/J6LUQz6XUJq0mVVQF5k9kczSPOLMW3mszG0mQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.3.tgz",
+      "integrity": "sha512-kVOWER991EMqLiVShrCSWKMHkgHZP7XfVdyN6YPMuoO33W7pc5CPNVNfR8OMe/I8rYEbaunyBs6dXNYpR6gGZw==",
       "requires": {
         "@stencil/core": "~2.16.0"
       },

--- a/static/code/stackblitz/vue/package-lock.json
+++ b/static/code/stackblitz/vue/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vite-vue-starter",
       "version": "0.0.0",
       "dependencies": {
-        "@ionic/vue": "^6.0.0",
+        "@ionic/vue": "^6.3.2",
         "vue": "^3.2.25",
         "vue-router": "4.0.13"
       },
@@ -31,28 +31,28 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.2.0.tgz",
-      "integrity": "sha512-3qUNsVcSAdrjhIhPr5M2RRnh+1xuc9RFaxoeUgI9xQ0YjTmn2FWiH4urDCXuE/rZAwnvHF4X17P0L2EqCPSfWA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.3.2.tgz",
+      "integrity": "sha512-L4xqJyixmGApwYc5fQgGoK80wXGCrbjL8vGfeNbjYqxxP0ZIKGAhURPoMAtSTqLLK9gdhh4Mv6gw4gNKvxodPA==",
       "dependencies": {
-        "@stencil/core": "^2.16.0",
-        "ionicons": "^6.0.2",
+        "@stencil/core": "^2.18.0",
+        "ionicons": "^6.0.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@ionic/vue": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-6.2.0.tgz",
-      "integrity": "sha512-tF+922bNLBTrN204CRUBDDRc6E+ygkMExxH2RX/QlXyRaVbSbmVlYXFe56nCu8caZgFlX711lHhHL1D+FsnOng==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-6.3.2.tgz",
+      "integrity": "sha512-jvcqcVG6cgFBP+JtLW1dg8a77wYLsFpx1vcC0LK59OmFVLkEIcE6TodhXmfaJVglkXTVMbzPRvO7xIUVHydQzQ==",
       "dependencies": {
-        "@ionic/core": "^6.2.0",
+        "@ionic/core": "^6.3.2",
         "ionicons": "^6.0.2"
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.1.tgz",
-      "integrity": "sha512-ErjQsNALgZQ9SYeBHhqwL1UO+Zbptwl3kwrRJC2tGlc3G/T6UvPuaKr+PGsqI+CZGia+0+R5EELQvFu74mYeIg==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
+      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/ionicons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.2.tgz",
-      "integrity": "sha512-AyKfFaUKVoBz4eB8XkU7H1R5HFnVsgq5ijqSdbXC0lES9PDK/J6LUQz6XUJq0mVVQF5k9kczSPOLMW3mszG0mQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.3.tgz",
+      "integrity": "sha512-kVOWER991EMqLiVShrCSWKMHkgHZP7XfVdyN6YPMuoO33W7pc5CPNVNfR8OMe/I8rYEbaunyBs6dXNYpR6gGZw==",
       "dependencies": {
         "@stencil/core": "~2.16.0"
       }
@@ -873,28 +873,28 @@
       "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg=="
     },
     "@ionic/core": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.2.0.tgz",
-      "integrity": "sha512-3qUNsVcSAdrjhIhPr5M2RRnh+1xuc9RFaxoeUgI9xQ0YjTmn2FWiH4urDCXuE/rZAwnvHF4X17P0L2EqCPSfWA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-6.3.2.tgz",
+      "integrity": "sha512-L4xqJyixmGApwYc5fQgGoK80wXGCrbjL8vGfeNbjYqxxP0ZIKGAhURPoMAtSTqLLK9gdhh4Mv6gw4gNKvxodPA==",
       "requires": {
-        "@stencil/core": "^2.16.0",
-        "ionicons": "^6.0.2",
+        "@stencil/core": "^2.18.0",
+        "ionicons": "^6.0.3",
         "tslib": "^2.1.0"
       }
     },
     "@ionic/vue": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-6.2.0.tgz",
-      "integrity": "sha512-tF+922bNLBTrN204CRUBDDRc6E+ygkMExxH2RX/QlXyRaVbSbmVlYXFe56nCu8caZgFlX711lHhHL1D+FsnOng==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-6.3.2.tgz",
+      "integrity": "sha512-jvcqcVG6cgFBP+JtLW1dg8a77wYLsFpx1vcC0LK59OmFVLkEIcE6TodhXmfaJVglkXTVMbzPRvO7xIUVHydQzQ==",
       "requires": {
-        "@ionic/core": "^6.2.0",
+        "@ionic/core": "^6.3.2",
         "ionicons": "^6.0.2"
       }
     },
     "@stencil/core": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.17.1.tgz",
-      "integrity": "sha512-ErjQsNALgZQ9SYeBHhqwL1UO+Zbptwl3kwrRJC2tGlc3G/T6UvPuaKr+PGsqI+CZGia+0+R5EELQvFu74mYeIg=="
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.18.1.tgz",
+      "integrity": "sha512-/fXkh1lwZ+X9JQCw50mPjhBogzEHOBvVC5pLoDLZqodVYK0DGWILM2YLV4dcIUBNEK8/HMDpO/Rq81/rS3mNOw=="
     },
     "@vitejs/plugin-vue": {
       "version": "2.3.3",
@@ -1248,9 +1248,9 @@
       }
     },
     "ionicons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.2.tgz",
-      "integrity": "sha512-AyKfFaUKVoBz4eB8XkU7H1R5HFnVsgq5ijqSdbXC0lES9PDK/J6LUQz6XUJq0mVVQF5k9kczSPOLMW3mszG0mQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-6.0.3.tgz",
+      "integrity": "sha512-kVOWER991EMqLiVShrCSWKMHkgHZP7XfVdyN6YPMuoO33W7pc5CPNVNfR8OMe/I8rYEbaunyBs6dXNYpR6gGZw==",
       "requires": {
         "@stencil/core": "~2.16.0"
       },


### PR DESCRIPTION
Updates the dependency lock files used by the React and Vue Stackblitz examples.