### PR TITLE
fix(playground): use visibility hidden to hide iframe for proper loading

### DIFF
--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -204,11 +204,8 @@
 }
 
 .playground .frame-hidden {
-  display: none;
-}
-
-.playground .frame-visible {
-  width: 100%;
+  visibility: hidden;
+  width: 0%;
 }
 
 /** Tabs **/


### PR DESCRIPTION
While working on https://github.com/ionic-team/ionic-docs/pull/2622 I noticed that the `fullscreen` property would only apply to the first iframe that gets loaded, so usually `ios` only and not `md`. This can be reproduced on the live documentation too.

**Steps to reproduce:**

1) Go to https://ionicframework.com/docs/api/footer#translucent-footer
2) Scroll down in the demo on `ios` mode, you'll see the footer is translucent and content is behind it.
3) Switch to `md` mode, scroll to the very bottom and you'll see the scrollbar ends above the footer. This should be behind the footer. 

**An easier way to see** it is by running the documentation locally on `main` and adding the following CSS to the test at `static/usage/footer/translucent/demo.html`:

```
<style>
  ion-content {
    --background: red;
  }

  ion-toolbar {
    --opacity: .5;
  }
</style>
```

Then when you view the test at http://localhost:3000/docs/api/footer#translucent-footer, you will be able to switch between the modes and see that the red from the content is not behind the toolbar. If you change the mode then click the `Reset Demo` icon on the playground, you will see the toolbar is properly transparent. 

This bug is caused by the `iframe` being set to `display: none` when the content does the `fullscreen` calculations. In order to fix it I have changed the iframe to `visibility: hidden` and also set the width to `0` so it doesn't take up any space.

I don't know what this CSS was there for but it adds a horizontal scroll in `ios` mode if I leave it in:

```
.playground .frame-visible {
  width: 100%;
}
```
