### PR TITLE
docs(img): add playground

### DIFF
--- a/docs/api/img.md
+++ b/docs/api/img.md
@@ -21,8 +21,11 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 Img is a tag that will lazily load an image when ever the tag is in the viewport. This is extremely useful when generating a large list as images are only loaded when they're visible. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browser, but falls back to a `setTimeout` when it is not supported.
 
+## Basic Usage
 
+import Basic from '@site/static/usage/img/basic/index.md';
 
+<Basic />
 
 ## Properties
 <Props />

--- a/docs/api/img.md
+++ b/docs/api/img.md
@@ -19,7 +19,7 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 <EncapsulationPill type="shadow" />
 
 
-Img is a tag that will lazily load an image when ever the tag is in the viewport. This is extremely useful when generating a large list as images are only loaded when they're visible. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browser, but falls back to a `setTimeout` when it is not supported.
+Img is a tag that will lazily load an image whenever the tag is in the viewport. This is extremely useful when generating a large list as images are only loaded when they're visible. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browsers, but falls back to a `setTimeout` when it is not supported.
 
 ## Basic Usage
 

--- a/docs/api/img.md
+++ b/docs/api/img.md
@@ -1,10 +1,6 @@
 ---
 title: "ion-img"
-hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/img/props.md';
 import Events from '@site/static/auto-generated/img/events.md';
@@ -22,154 +18,11 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
-
-
 
 Img is a tag that will lazily load an image when ever the tag is in the viewport. This is extremely useful when generating a large list as images are only loaded when they're visible. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browser, but falls back to a `setTimeout` when it is not supported.
 
 
 
-
-## Usage
-
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
-
-<TabItem value="angular">
-
-```html
-<ion-list>
-  <ion-item *ngFor="let item of items">
-    <ion-thumbnail slot="start">
-      <ion-img [src]="item.src"></ion-img>
-    </ion-thumbnail>
-    <ion-label>{{item.text}}</ion-label>
-  </ion-item>
-</ion-list>
-```
-
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React from 'react';
-import { IonList, IonItem, IonThumbnail, IonImg, IonLabel, IonContent } from '@ionic/react';
-
-type Item = {
-  src: string;
-  text: string;
-};
-const items: Item[] = [{ src: 'http://placekitten.com/g/200/300', text: 'a picture of a cat' }];
-
-export const ImgExample: React.FC = () => (
-  <IonContent>
-    <IonList>
-      {items.map((image, i) => (
-        <IonItem key={i}>
-          <IonThumbnail slot="start">
-            <IonImg src={image.src} />
-          </IonThumbnail>
-          <IonLabel>{image.text}</IonLabel>
-        </IonItem>
-      ))}
-    </IonList>
-  </IonContent>
-);
-```
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'img-example',
-  styleUrl: 'img-example.css'
-})
-export class ImgExample {
-  private items = [{
-    'text': 'Item 1',
-    'src': '/path/to/external/file.png'
-  }, {
-    'text': 'Item 2',
-    'src': '/path/to/external/file.png'
-  }, {
-    'text': 'Item 3',
-    'src': '/path/to/external/file.png'
-  }];
-
-  render() {
-    return [
-      <ion-list>
-        {this.items.map(item =>
-          <ion-item>
-            <ion-thumbnail slot="start">
-              <ion-img src={item.src}></ion-img>
-            </ion-thumbnail>
-            <ion-label>{item.text}</ion-label>
-          </ion-item>
-        )}
-      </ion-list>
-    ];
-  }
-}
-```
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <ion-list>
-    <ion-item v-for="item in items" :key="item.src">
-      <ion-thumbnail slot="start">
-        <ion-img :src="item.src"></ion-img>
-      </ion-thumbnail>
-      <ion-label>{{item.text}}</ion-label>
-    </ion-item>
-  </ion-list>
-</template>
-
-<script>
-import { IonImg, IonItem, IonLabel, IonList, IonThumbnail } from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: { IonImg, IonItem, IonLabel, IonList, IonThumbnail },
-  setup() {
-    const items = [{
-      'text': 'Item 1',
-      'src': '/path/to/external/file.png'
-    }, {
-      'text': 'Item 2',
-      'src': '/path/to/external/file.png'
-    }, {
-      'text': 'Item 3',
-      'src': '/path/to/external/file.png'
-    }];
-    return { items }
-  }
-});
-</script>
-```
-
-
-</TabItem>
-
-</Tabs>
 
 ## Properties
 <Props />

--- a/static/usage/img/basic/angular.md
+++ b/static/usage/img/basic/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-img src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
+```

--- a/static/usage/img/basic/demo.html
+++ b/static/usage/img/basic/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+  <style>
+    ion-img {
+      width: 300px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-img src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/img/basic/index.md
+++ b/static/usage/img/basic/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/img/basic/demo.html" />

--- a/static/usage/img/basic/javascript.md
+++ b/static/usage/img/basic/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-img src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
+```

--- a/static/usage/img/basic/react.md
+++ b/static/usage/img/basic/react.md
@@ -1,0 +1,11 @@
+```tsx
+import React from 'react';
+import { IonImg } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonImg src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></IonImg>
+  );
+}
+export default Example;
+```

--- a/static/usage/img/basic/vue.md
+++ b/static/usage/img/basic/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-img src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
+</template>
+
+<script lang="ts">
+  import { IonImg } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonImg },
+  });
+</script>
+```


### PR DESCRIPTION
This PR removes the old Usage tabs and the inline TOC. It also adds a basic usage playground that shows how to use the `src` and `alt` properties on `ion-img`.