### PR TITLE
docs(react): provide unique key instead of index

### DIFF
--- a/docs/react/your-first-app/2-taking-photos.md
+++ b/docs/react/your-first-app/2-taking-photos.md
@@ -131,7 +131,7 @@ With the photo(s) stored into the main array we can display the images on the sc
   <IonGrid>
     <IonRow>
       {photos.map((photo, index) => (
-        <IonCol size="6" key={index}>
+        <IonCol size="6" key={photo.filepath}>
           <IonImg src={photo.webviewPath} />
         </IonCol>
       ))}


### PR DESCRIPTION
As providing index as keys is a bad practice, this commit modifies the key value to be `photo.filepath` which will be unique and consistent while adding new photos.


[Keys - react docs](https://reactjs.org/docs/lists-and-keys.html#keys) 
[An example for why it is not recommended](https://robinpokorny.com/blog/index-as-a-key-is-an-anti-pattern/)