### PR TITLE
docs(datetime): confirmation buttons use the confirm api

### DIFF
--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -265,7 +265,7 @@ By default, `ionChange` is emitted with the new datetime value whenever a new da
 
 ### Showing Confirmation Buttons
 
-The default Done and Cancel buttons are already preconfigured to call the `confirm` and `cancel` methods, respectively.
+The default Done and Cancel buttons are already preconfigured to call the [`confirm`](#confirm) and [`cancel`](#cancel) methods, respectively.
 
 <ShowingConfirmationButtons />
 

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -265,7 +265,7 @@ By default, `ionChange` is emitted with the new datetime value whenever a new da
 
 ### Showing Confirmation Buttons
 
-The default Done and Cancel buttons are already preconfigured to call the `done` and `cancel` methods, respectively.
+The default Done and Cancel buttons are already preconfigured to call the `confirm` and `cancel` methods, respectively.
 
 <ShowingConfirmationButtons />
 


### PR DESCRIPTION
The `ion-datetime` documentation refers to the `done` API, which does not exist. This was a typo and was meant to reference the `confirm` API. I've additionally linked to these APIs to help developers navigating the docs. 

Resolves #2637