### PR TITLE
docs(list-header): lines playground example

### DIFF
--- a/static/usage/list-header/lines/angular.md
+++ b/static/usage/list-header/lines/angular.md
@@ -1,22 +1,37 @@
 ```html
 <ion-list>
   <ion-list-header>
-    <ion-label>Video Games</ion-label>
+    <ion-label>Default</ion-label>
   </ion-list-header>
   <ion-item>
-    <ion-label>Pokémon Yellow</ion-label>
+    <ion-label>Item</ion-label>
   </ion-item>
   <ion-item>
-    <ion-label>Mega Man X</ion-label>
+    <ion-label>Item</ion-label>
+  </ion-item>
+</ion-list>
+
+<ion-list>
+  <ion-list-header lines="inset">
+    <ion-label>Inset</ion-label>
+  </ion-list-header>
+  <ion-item>
+    <ion-label>Item</ion-label>
   </ion-item>
   <ion-item>
-    <ion-label>The Legend of Zelda</ion-label>
+    <ion-label>Item</ion-label>
+  </ion-item>
+</ion-list>
+
+<ion-list>
+  <ion-list-header lines="full">
+    <ion-label>Full</ion-label>
+  </ion-list-header>
+  <ion-item>
+    <ion-label>Item</ion-label>
   </ion-item>
   <ion-item>
-    <ion-label>Pac-Man</ion-label>
-  </ion-item>
-  <ion-item>
-    <ion-label>Super Mario World</ion-label>
+    <ion-label>Item</ion-label>
   </ion-item>
 </ion-list>
 ```

--- a/static/usage/list-header/lines/javascript.md
+++ b/static/usage/list-header/lines/javascript.md
@@ -1,22 +1,37 @@
 ```html
 <ion-list>
   <ion-list-header>
-    <ion-label>Video Games</ion-label>
+    <ion-label>Default</ion-label>
   </ion-list-header>
   <ion-item>
-    <ion-label>Pokémon Yellow</ion-label>
+    <ion-label>Item</ion-label>
   </ion-item>
   <ion-item>
-    <ion-label>Mega Man X</ion-label>
+    <ion-label>Item</ion-label>
+  </ion-item>
+</ion-list>
+
+<ion-list>
+  <ion-list-header lines="inset">
+    <ion-label>Inset</ion-label>
+  </ion-list-header>
+  <ion-item>
+    <ion-label>Item</ion-label>
   </ion-item>
   <ion-item>
-    <ion-label>The Legend of Zelda</ion-label>
+    <ion-label>Item</ion-label>
+  </ion-item>
+</ion-list>
+
+<ion-list>
+  <ion-list-header lines="full">
+    <ion-label>Full</ion-label>
+  </ion-list-header>
+  <ion-item>
+    <ion-label>Item</ion-label>
   </ion-item>
   <ion-item>
-    <ion-label>Pac-Man</ion-label>
-  </ion-item>
-  <ion-item>
-    <ion-label>Super Mario World</ion-label>
+    <ion-label>Item</ion-label>
   </ion-item>
 </ion-list>
 ```

--- a/static/usage/list-header/lines/react.md
+++ b/static/usage/list-header/lines/react.md
@@ -4,26 +4,43 @@ import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/react';
 
 function Example() {
   return (
-    <IonList>
-      <IonListHeader>
-        <IonLabel>Video Games</IonLabel>
-      </IonListHeader>
-      <IonItem>
-        <IonLabel>Pokémon Yellow</IonLabel>
-      </IonItem>
-      <IonItem>
-        <IonLabel>Mega Man X</IonLabel>
-      </IonItem>
-      <IonItem>
-        <IonLabel>The Legend of Zelda</IonLabel>
-      </IonItem>
-      <IonItem>
-        <IonLabel>Pac-Man</IonLabel>
-      </IonItem>
-      <IonItem>
-        <IonLabel>Super Mario World</IonLabel>
-      </IonItem>
-    </IonList>
+    <>
+      <IonList>
+        <IonListHeader>
+          <IonLabel>Default</IonLabel>
+        </IonListHeader>
+        <IonItem>
+          <IonLabel>Item</IonLabel>
+        </IonItem>
+        <ion-item>
+          <IonLabel>Item</IonLabel>
+        </ion-item>
+      </IonList>
+
+      <IonList>
+        <IonListHeader lines="inset">
+          <IonLabel>Inset</IonLabel>
+        </IonListHeader>
+        <IonItem>
+          <IonLabel>Item</IonLabel>
+        </IonItem>
+        <IonItem>
+          <IonLabel>Item</IonLabel>
+        </IonItem>
+      </IonList>
+
+      <IonList>
+        <IonListHeader lines="full">
+          <IonLabel>Full</IonLabel>
+        </IonListHeader>
+        <IonItem>
+          <IonLabel>Item</IonLabel>
+        </IonItem>
+        <IonItem>
+          <IonLabel>Item</IonLabel>
+        </IonItem>
+      </IonList>
+    </>
   );
 }
 export default Example;

--- a/static/usage/list-header/lines/react.md
+++ b/static/usage/list-header/lines/react.md
@@ -12,9 +12,9 @@ function Example() {
         <IonItem>
           <IonLabel>Item</IonLabel>
         </IonItem>
-        <ion-item>
+        <IonItem>
           <IonLabel>Item</IonLabel>
-        </ion-item>
+        </IonItem>
       </IonList>
 
       <IonList>

--- a/static/usage/list-header/lines/vue.md
+++ b/static/usage/list-header/lines/vue.md
@@ -2,22 +2,37 @@
 <template>
   <ion-list>
     <ion-list-header>
-      <ion-label>Video Games</ion-label>
+      <ion-label>Default</ion-label>
     </ion-list-header>
     <ion-item>
-      <ion-label>Pokémon Yellow</ion-label>
+      <ion-label>Item</ion-label>
     </ion-item>
     <ion-item>
-      <ion-label>Mega Man X</ion-label>
+      <ion-label>Item</ion-label>
+    </ion-item>
+  </ion-list>
+
+  <ion-list>
+    <ion-list-header lines="inset">
+      <ion-label>Inset</ion-label>
+    </ion-list-header>
+    <ion-item>
+      <ion-label>Item</ion-label>
     </ion-item>
     <ion-item>
-      <ion-label>The Legend of Zelda</ion-label>
+      <ion-label>Item</ion-label>
+    </ion-item>
+  </ion-list>
+
+  <ion-list>
+    <ion-list-header lines="full">
+      <ion-label>Full</ion-label>
+    </ion-list-header>
+    <ion-item>
+      <ion-label>Item</ion-label>
     </ion-item>
     <ion-item>
-      <ion-label>Pac-Man</ion-label>
-    </ion-item>
-    <ion-item>
-      <ion-label>Super Mario World</ion-label>
+      <ion-label>Item</ion-label>
     </ion-item>
   </ion-list>
 </template>


### PR DESCRIPTION
The playground example for [List Header Lines](https://ionicframework.com/docs/api/list-header#list-header-lines) is incorrect from the demo.

This PR updates the usage code snippets to match the rendered demo. 

Resolves: #2638