### PR TITLE
fix(docs): deprecated message for props

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -60,21 +60,24 @@ function renderProperties({ props: properties }) {
   // NOTE: replaces | with U+FF5C since MDX renders \| in tables incorrectly
   return `
 ${properties
-  .map(
-    (prop) => `
-### ${prop.name}
+  .map((prop) => {
+    const isDeprecated = prop.deprecation !== undefined;
+
+    const docs = isDeprecated ? `${prop.docs}\n_Deprecated_ ${prop.deprecation}` : prop.docs;
+
+    return `
+### ${prop.name} ${isDeprecated ? '(deprecated)' : ''}
 
 | | |
 | --- | --- |
-| **Description** | ${formatMultiline(prop.docs)} |
+| **Description** | ${formatMultiline(docs)} |
 | **Attribute** | \`${prop.attr}\` |
 | **Type** | \`${prop.type.replace(/\|/g, '\uff5c')}\` |
 | **Default** | \`${prop.default}\` |
 
-`
-  )
-  .join('\n')}
 `;
+  })
+  .join('\n')}`;
 }
 
 function renderEvents({ events }) {


### PR DESCRIPTION
Currently the deprecated messages in our property documentation is not displaying in the generated output: https://ionicframework.com/docs/api/modal#swipetoclose

This PR adds support for adding ` (deprecated)` to the title of deprecated properties as well as displaying the deprecation message in the description. 

Quick-preview: https://ionic-docs-git-fix-deprecated-docs-ionic1.vercel.app/docs/api/modal#swipetoclose-deprecated