### PR TITLE
docs(select-option): reference select for usage

### DIFF
--- a/docs/api/select-option.md
+++ b/docs/api/select-option.md
@@ -1,8 +1,6 @@
 ---
 title: "ion-select-option"
 ---
-import TOCInline from '@theme/TOCInline';
-
 import Props from '@site/static/auto-generated/select-option/props.md';
 import Events from '@site/static/auto-generated/select-option/events.md';
 import Methods from '@site/static/auto-generated/select-option/methods.md';


### PR DESCRIPTION
This PR removes the usage examples in favor of the playgrounds in the `ion-select` documentation. It also removes the Inline TOC in favor of the sidebar TOC.

Preview: https://ionic-docs-git-fw-1432-ionic1.vercel.app/docs/api/select-option