### PR TITLE
fix(docs): redirect for layout to grid

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -309,6 +309,17 @@ module.exports = {
         },
       };
     },
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            to: '/docs/api/grid',
+            from: '/docs/layout/grid'
+          }
+        ]
+      }
+    ]
   ],
   themes: [
     [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "0.0.0-4192",
         "@docusaurus/mdx-loader": "0.0.0-4192",
-        "@docusaurus/plugin-client-redirects": "0.0.0-4192",
+        "@docusaurus/plugin-client-redirects": "^0.0.0-4192",
         "@docusaurus/plugin-content-docs": "0.0.0-4192",
         "@docusaurus/plugin-content-pages": "0.0.0-4192",
         "@docusaurus/plugin-debug": "0.0.0-4192",
@@ -1954,7 +1954,8 @@
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
       "version": "0.0.0-4192",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-0.0.0-4192.tgz",
+      "integrity": "sha512-sVJii4n7j3kywSn98JGnsNgJOS0g2SqzIiJg5M3hLGg2X0Yvicg5DTkogMJHVUQmjvq0VGNgSmFdOaxD/dQ3rQ==",
       "dependencies": {
         "@docusaurus/core": "0.0.0-4192",
         "@docusaurus/types": "0.0.0-4192",
@@ -14055,6 +14056,8 @@
     },
     "@docusaurus/plugin-client-redirects": {
       "version": "0.0.0-4192",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-0.0.0-4192.tgz",
+      "integrity": "sha512-sVJii4n7j3kywSn98JGnsNgJOS0g2SqzIiJg5M3hLGg2X0Yvicg5DTkogMJHVUQmjvq0VGNgSmFdOaxD/dQ3rQ==",
       "requires": {
         "@docusaurus/core": "0.0.0-4192",
         "@docusaurus/types": "0.0.0-4192",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@docusaurus/core": "0.0.0-4192",
     "@docusaurus/mdx-loader": "0.0.0-4192",
-    "@docusaurus/plugin-client-redirects": "0.0.0-4192",
+    "@docusaurus/plugin-client-redirects": "^0.0.0-4192",
     "@docusaurus/plugin-content-docs": "0.0.0-4192",
     "@docusaurus/plugin-content-pages": "0.0.0-4192",
     "@docusaurus/plugin-debug": "0.0.0-4192",


### PR DESCRIPTION
The 301 redirect in nginx handles the server request when directly accessing the URL, but when using a client-side feature such as search; the redirect for `/docs/layout/grid` does not correctly redirect to `/docs/api/grid`. 

Resolves #2648