### PR TITLE
docs(split-pane): add basic usage

### DIFF
--- a/docs/api/split-pane.md
+++ b/docs/api/split-pane.md
@@ -1,10 +1,6 @@
 ---
 title: "ion-split-pane"
-hide_table_of_contents: true
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import TOCInline from '@theme/TOCInline';
 
 import Props from '@site/static/auto-generated/split-pane/props.md';
 import Events from '@site/static/auto-generated/split-pane/events.md';
@@ -22,20 +18,14 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
-
-
-
 A split pane is useful when creating multi-view layouts. It allows UI elements, like menus, to be
 displayed as the viewport width increases.
 
 If the device's screen width is below a certain size, the split pane will collapse and the menu will be hidden. This is ideal for creating an app that will be served in a browser and deployed through the app store to phones and tablets.
 
+## Basic Usage
+
+TODO
 
 ## Setting Breakpoints
 
@@ -58,179 +48,11 @@ By default, the split pane will expand when the screen is larger than 992px. To 
  | `md` | `(min-width: 768px)`  | Show the split-pane when the min-width is 768px                       |
  | `lg` | `(min-width: 992px)`  | Show the split-pane when the min-width is 992px (default break point) |
  | `xl` | `(min-width: 1200px)` | Show the split-pane when the min-width is 1200px                      |
+## Theming
 
+### CSS Custom Properties
 
-
-
-## Usage
-
-<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
-
-<TabItem value="angular">
-
-```html
-<ion-split-pane contentId="main">
-  <!--  the side menu  -->
-  <ion-menu contentId="main">
-    <ion-header>
-      <ion-toolbar>
-        <ion-title>Menu</ion-title>
-      </ion-toolbar>
-    </ion-header>
-  </ion-menu>
-
-  <!-- the main content -->
-  <ion-router-outlet id="main"></ion-router-outlet>
-</ion-split-pane>
-```
-
-
-</TabItem>
-
-
-<TabItem value="javascript">
-
-```html
-<ion-split-pane content-id="main">
-  <!--  the side menu  -->
-  <ion-menu content-id="main">
-    <ion-header>
-      <ion-toolbar>
-        <ion-title>Menu</ion-title>
-      </ion-toolbar>
-    </ion-header>
-  </ion-menu>
-
-  <!-- the main content -->
-  <ion-content id="main">
-    <h1>Hello</h1>
-  </ion-content>
-</ion-split-pane>
-```
-
-
-</TabItem>
-
-
-<TabItem value="react">
-
-```tsx
-import React from 'react';
-import {
-  IonSplitPane,
-  IonMenu,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
-  IonRouterOutlet,
-  IonContent,
-  IonPage
-} from '@ionic/react';
-
-export const SplitPlaneExample: React.SFC<{}> = () => (
-  <IonContent>
-    <IonSplitPane contentId="main">
-      {/*--  the side menu  --*/}
-      <IonMenu contentId="main">
-        <IonHeader>
-          <IonToolbar>
-            <IonTitle>Menu</IonTitle>
-          </IonToolbar>
-        </IonHeader>
-      </IonMenu>
-
-      {/*-- the main content --*/}
-      <IonPage id="main"/>
-    </IonSplitPane>
-  </IonContent>
-);
-```
-
-
-</TabItem>
-
-
-<TabItem value="stencil">
-
-```tsx
-import { Component, h } from '@stencil/core';
-
-@Component({
-  tag: 'split-pane-example',
-  styleUrl: 'split-pane-example.css'
-})
-export class SplitPaneExample {
-  render() {
-    return [
-      <ion-split-pane content-id="main">
-        {/*  the side menu */}
-        <ion-menu content-id="main">
-          <ion-header>
-            <ion-toolbar>
-              <ion-title>Menu</ion-title>
-            </ion-toolbar>
-          </ion-header>
-        </ion-menu>
-
-        {/* the main content */}
-        <ion-router-outlet id="main"></ion-router-outlet>
-      </ion-split-pane>
-    ];
-  }
-}
-```
-
-
-</TabItem>
-
-
-<TabItem value="vue">
-
-```html
-<template>
-  <ion-split-pane content-id="main">
-    <!--  the side menu  -->
-    <ion-menu content-id="main">
-      <ion-header>
-        <ion-toolbar>
-          <ion-title>Menu</ion-title>
-        </ion-toolbar>
-      </ion-header>
-    </ion-menu>
-
-    <!-- the main content -->
-    <ion-router-outlet id="main"></ion-router-outlet>
-  </ion-split-pane>
-</template>
-
-<script>
-import { 
-  IonHeader, 
-  IonMenu, 
-  IonRouterOutlet, 
-  IonSplitPane, 
-  IonTitle, 
-  IonToolbar
-} from '@ionic/vue';
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  components: {
-    IonHeader, 
-    IonMenu, 
-    IonRouterOutlet, 
-    IonSplitPane, 
-    IonTitle, 
-    IonToolbar
-  }
-});
-</script>
-```
-
-
-</TabItem>
-
-</Tabs>
+TODO
 
 ## Properties
 <Props />

--- a/docs/api/split-pane.md
+++ b/docs/api/split-pane.md
@@ -25,7 +25,13 @@ If the device's screen width is below a certain size, the split pane will collap
 
 ## Basic Usage
 
-TODO
+:::note
+This demo sets the `when` property to `'xs'` so the split pane always shows up. Your Ionic application does not need this if you want the split pane to collapse on smaller viewports. See [Setting Breakpoints](#setting-breakpoints) for more information. 
+:::
+
+import Basic from '@site/static/usage/split-pane/basic/index.md';
+
+<Basic />
 
 ## Setting Breakpoints
 

--- a/static/usage/split-pane/basic/angular.md
+++ b/static/usage/split-pane/basic/angular.md
@@ -1,0 +1,25 @@
+```html
+<ion-split-pane when="xs" contentId="main">
+  <ion-menu contentId="main">
+    <ion-header>
+      <ion-toolbar color="tertiary">
+        <ion-title>Menu</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      Menu Content
+    </ion-content>
+  </ion-menu>
+
+  <div class="ion-page" id="main">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Main View</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      Main View Content
+    </ion-content>
+  </div>
+</ion-split-pane>
+```

--- a/static/usage/split-pane/basic/demo.html
+++ b/static/usage/split-pane/basic/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spinner</title>
+  <link rel="stylesheet" href="../../common.css" />
+  <script src="../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+</head>
+  <body>
+    <ion-app>
+      <ion-split-pane when="xs" content-id="main">
+        <ion-menu content-id="main">
+          <ion-header>
+            <ion-toolbar color="tertiary">
+              <ion-title>Menu</ion-title>
+            </ion-toolbar>
+          </ion-header>
+          <ion-content class="ion-padding">
+            Menu Content
+          </ion-content>
+        </ion-menu>
+
+        <div class="ion-page" id="main">
+          <ion-header>
+            <ion-toolbar>
+              <ion-title>Main View</ion-title>
+            </ion-toolbar>
+          </ion-header>
+          <ion-content class="ion-padding">
+            Main View Content
+          </ion-content>
+        </div>
+      </ion-split-pane>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/split-pane/basic/index.md
+++ b/static/usage/split-pane/basic/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground code={{ javascript, react, vue, angular }} src="usage/split-pane/basic/demo.html" size="500px" />

--- a/static/usage/split-pane/basic/javascript.md
+++ b/static/usage/split-pane/basic/javascript.md
@@ -1,0 +1,25 @@
+```html
+<ion-split-pane when="xs" content-id="main">
+  <ion-menu content-id="main">
+    <ion-header>
+      <ion-toolbar color="tertiary">
+        <ion-title>Menu</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      Menu Content
+    </ion-content>
+  </ion-menu>
+
+  <div class="ion-page" id="main">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Main View</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      Main View Content
+    </ion-content>
+  </div>
+</ion-split-pane>
+```

--- a/static/usage/split-pane/basic/react.md
+++ b/static/usage/split-pane/basic/react.md
@@ -1,0 +1,33 @@
+```tsx
+import React from 'react';
+import { IonContent, IonHeader, IonMenu, IonSplitPane, IonTitle, IonToolbar } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonSplitPane when="xs" contentId="main">
+      <IonMenu contentId="main">
+        <IonHeader>
+          <IonToolbar color="tertiary">
+            <IonTitle>Menu</IonTitle>
+          </IonToolbar>
+        </IonHeader>
+        <IonContent className="ion-padding">
+          Menu Content
+        </IonContent>
+      </IonMenu>
+    
+      <div className="ion-page" id="main">
+        <IonHeader>
+          <IonToolbar>
+            <IonTitle>Main View</IonTitle>
+          </IonToolbar>
+        </IonHeader>
+        <IonContent className="ion-padding">
+          Main View Content
+        </IonContent>
+      </div>
+    </IonSplitPane>
+  );
+}
+export default Example;
+```

--- a/static/usage/split-pane/basic/vue.md
+++ b/static/usage/split-pane/basic/vue.md
@@ -1,0 +1,36 @@
+```html
+<template>
+  <ion-split-pane when="xs" content-id="main">
+    <ion-menu content-id="main">
+      <ion-header>
+        <ion-toolbar color="tertiary">
+          <ion-title>Menu</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        Menu Content
+      </ion-content>
+    </ion-menu>
+  
+    <div class="ion-page" id="main">
+      <ion-header>
+        <ion-toolbar>
+          <ion-title>Main View</ion-title>
+        </ion-toolbar>
+      </ion-header>
+      <ion-content class="ion-padding">
+        Main View Content
+      </ion-content>
+    </div>
+  </ion-split-pane>
+</template>
+
+<script lang="ts">
+  import { IonContent, IonHeader, IonMenu, IonSplitPane, IonTitle, IonToolbar } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonContent, IonHeader, IonMenu, IonSplitPane, IonTitle, IonToolbar  },
+  });
+</script>
+```


### PR DESCRIPTION
- Adds basic usage for spit pane.
I opted to set `when="xs"` on the split pane otherwise it would also be collapsed in the playground

Preview: https://ionic-docs-git-1264-basic-ionic1.vercel.app/docs/api/split-pane#basic-usage