### PR TITLE
docs(content): code example comments

### DIFF
--- a/static/usage/content/scroll-methods/angular/example_component_ts.md
+++ b/static/usage/content/scroll-methods/angular/example_component_ts.md
@@ -17,7 +17,7 @@ export class ExampleComponent {
 
   scrollToTop() {
     // Passing a duration to the method makes it so the scroll slowly
-    // goes to the bottom instead of instantly
+    // goes to the top instead of instantly
     this.content.scrollToTop(500);
   }
 }

--- a/static/usage/content/scroll-methods/demo.html
+++ b/static/usage/content/scroll-methods/demo.html
@@ -39,7 +39,7 @@
 
     function scrollToTop() {
       // Passing a duration to the method makes it so the scroll slowly
-      // goes to the bottom instead of instantly
+      // goes to the top instead of instantly
       content.scrollToTop(500);
     }
   </script>

--- a/static/usage/content/scroll-methods/javascript.md
+++ b/static/usage/content/scroll-methods/javascript.md
@@ -24,7 +24,7 @@
 
   function scrollToTop() {
     // Passing a duration to the method makes it so the scroll slowly
-    // goes to the bottom instead of instantly
+    // goes to the top instead of instantly
     content.scrollToTop(500);
   }
 </script>

--- a/static/usage/content/scroll-methods/react.md
+++ b/static/usage/content/scroll-methods/react.md
@@ -13,7 +13,7 @@ function Example() {
 
   function scrollToTop() {
     // Passing a duration to the method makes it so the scroll slowly
-    // goes to the bottom instead of instantly
+    // goes to the top instead of instantly
     contentRef.current?.scrollToTop(500);
   }
 

--- a/static/usage/content/scroll-methods/vue.md
+++ b/static/usage/content/scroll-methods/vue.md
@@ -23,9 +23,13 @@
     components: { IonButton, IonContent },
     methods: {
       scrollToBottom() {
+        // Passing a duration to the method makes it so the scroll slowly
+        // goes to the bottom instead of instantly
         this.$refs.content.$el.scrollToBottom(500);
       },
       scrollToTop() {
+        // Passing a duration to the method makes it so the scroll slowly
+        // goes to the top instead of instantly
         this.$refs.content.$el.scrollToTop(500);
       },
     }


### PR DESCRIPTION
The commented description of the `ion-content` component has been corrected by fixing the typo (and by adding for the example of Vue.js).