### PR TITLE
docs(vue): specify lang attribute for quickstart example

### DIFF
--- a/docs/vue/quickstart.md
+++ b/docs/vue/quickstart.md
@@ -479,7 +479,7 @@ Let's fill the `NewItem.vue` file with some placeholder content for the moment.
   </ion-page>
 </template>
 
-<script>
+<script lang="ts">
   import { IonBackButton, IonButtons, IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
   import { defineComponent } from 'vue';
 


### PR DESCRIPTION
Hi awesome people :)

Found a tiny syntax error when going through the Quickstart for Vue. The example just needed a Typescript lang attribute value.

Cheers and amazing work!