### PR TITLE
docs(theming): update vendor prefixed line height

### DIFF
--- a/docs/theming/css-shadow-parts.md
+++ b/docs/theming/css-shadow-parts.md
@@ -123,10 +123,12 @@ CSS Shadow Parts are supported in the recent versions of all of the major browse
 
 ### Vendor Prefixed Pseudo-Elements
 
+<p>
 <a href="https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix" target="_blank" rel="noopener noreferrer">
   Vendor prefixed
 </a> pseudo-elements are not supported at this time. An example of this would be any of the `::-webkit-scrollbar` pseudo-elements:
-
+</p>
+  
 ```css
 /* Does NOT work */
 my-component::part(scroll)::-webkit-scrollbar {


### PR DESCRIPTION
The [Vendor Prefixes](https://ionicframework.com/docs/theming/css-shadow-parts#vendor-prefixed-pseudo-elements) section in the docs has incorrect line height, apparently because it starts with `<a>` tag:

![paragraph](https://user-images.githubusercontent.com/10589913/204583593-103e64fc-f714-4968-8c8c-7d28da83b851.png)

Added the markup for the paragraph using `<p>` elements, hopefully this helps to fix it.