### PR TITLE
fix(playground): warn if version not specified

### DIFF
--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -54,9 +54,9 @@ By adding the `multiple` attribute to select, users are able to select multiple 
 
 Note: the `action-sheet` and `popover` interfaces will not work with multiple selection.
 
-import MulipleSelectionExample from '@site/static/usage/v7/select/basic/multiple-selection/index.md';
+import MultipleSelectionExample from '@site/static/usage/v7/select/basic/multiple-selection/index.md';
 
-<MulipleSelectionExample />
+<MultipleSelectionExample />
 
 ## Responding to Interaction
 

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -96,11 +96,6 @@ interface UsageTargetOptions {
      */
     declarations?: string[];
   };
-  /**
-   * The major version of Ionic to use in the generated Stackblitz examples.
-   * This will also load assets for Stackblitz from the specified version directory.
-   */
-  version?: number;
 }
 
 /**
@@ -120,7 +115,7 @@ export default function Playground({
   mode,
   devicePreview,
   includeIonContent = true,
-  version = 6,
+  version,
 }: {
   code: { [key in UsageTarget]?: MdxContent | UsageTargetOptions };
   title?: string;
@@ -135,6 +130,10 @@ export default function Playground({
   description?: string;
   devicePreview?: boolean;
   includeIonContent: boolean;
+  /**
+   * The major version of Ionic to use in the generated Stackblitz examples.
+   * This will also load assets for Stackblitz from the specified version directory.
+   */
   version: number;
 }) {
   if (!code || Object.keys(code).length === 0) {
@@ -143,6 +142,10 @@ export default function Playground({
   }
   if (typeof mode !== 'undefined' && mode !== 'ios' && mode !== 'md') {
     console.warn(`Invalid mode provided: ${mode}. Accepted values are: "ios" or "md".`);
+    return;
+  }
+  if (typeof version === 'undefined') {
+    console.warn('You must specify a `version` for the Playground example. For example: <Playground version="7" />');
     return;
   }
 

--- a/static/usage/v6/accordion/accessibility/animations/index.md
+++ b/static/usage/v6/accordion/accessibility/animations/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/basic/index.md
+++ b/static/usage/v6/accordion/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/customization/advanced-expansion-styles/index.md
+++ b/static/usage/v6/accordion/customization/advanced-expansion-styles/index.md
@@ -12,6 +12,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/accordion/customization/expansion-styles/index.md
+++ b/static/usage/v6/accordion/customization/expansion-styles/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/customization/icons/index.md
+++ b/static/usage/v6/accordion/customization/icons/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/customization/theming/index.md
+++ b/static/usage/v6/accordion/customization/theming/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/accordion/disable-group/index.md
+++ b/static/usage/v6/accordion/disable-group/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/disable/group/index.md
+++ b/static/usage/v6/accordion/disable/group/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/disable/individual/index.md
+++ b/static/usage/v6/accordion/disable/individual/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/listen-changes/index.md
+++ b/static/usage/v6/accordion/listen-changes/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/multiple/index.md
+++ b/static/usage/v6/accordion/multiple/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/readonly/group/index.md
+++ b/static/usage/v6/accordion/readonly/group/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/readonly/individual/index.md
+++ b/static/usage/v6/accordion/readonly/individual/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/accordion/toggle/index.md
+++ b/static/usage/v6/accordion/toggle/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/action-sheet/basic/index.md
+++ b/static/usage/v6/action-sheet/basic/index.md
@@ -12,6 +12,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/action-sheet/theming/css-properties/index.md
+++ b/static/usage/v6/action-sheet/theming/css-properties/index.md
@@ -12,6 +12,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/action-sheet/theming/styling/index.md
+++ b/static/usage/v6/action-sheet/theming/styling/index.md
@@ -12,6 +12,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/alert/buttons/index.md
+++ b/static/usage/v6/alert/buttons/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/alert/customization/index.md
+++ b/static/usage/v6/alert/customization/index.md
@@ -11,6 +11,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/alert/inputs/radios/index.md
+++ b/static/usage/v6/alert/inputs/radios/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{
     javascript,

--- a/static/usage/v6/alert/inputs/text-inputs/index.md
+++ b/static/usage/v6/alert/inputs/text-inputs/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="450px"
   code={{
     javascript,

--- a/static/usage/v6/alert/presenting/controller/index.md
+++ b/static/usage/v6/alert/presenting/controller/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/avatar/basic/index.md
+++ b/static/usage/v6/avatar/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/avatar/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/avatar/basic/demo.html" />

--- a/static/usage/v6/avatar/chip/index.md
+++ b/static/usage/v6/avatar/chip/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/avatar/chip/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/avatar/chip/demo.html" />

--- a/static/usage/v6/avatar/item/index.md
+++ b/static/usage/v6/avatar/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/avatar/item/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/avatar/item/demo.html" />

--- a/static/usage/v6/avatar/theming/css-properties/index.md
+++ b/static/usage/v6/avatar/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/back-button/basic/index.md
+++ b/static/usage/v6/back-button/basic/index.md
@@ -17,6 +17,7 @@ import vue_page_one from './vue/page_one_vue.md';
 import vue_page_two from './vue/page_two_vue.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     angular: {

--- a/static/usage/v6/back-button/custom/index.md
+++ b/static/usage/v6/back-button/custom/index.md
@@ -17,6 +17,7 @@ import vue_page_one from './vue/page_one_vue.md';
 import vue_page_two from './vue/page_two_vue.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     angular: {

--- a/static/usage/v6/backdrop/basic/index.md
+++ b/static/usage/v6/backdrop/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/backdrop/basic/demo.html" devicePreview={true} />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/backdrop/basic/demo.html"
+  devicePreview={true}
+/>

--- a/static/usage/v6/backdrop/styling/index.md
+++ b/static/usage/v6/backdrop/styling/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/badge/basic/index.md
+++ b/static/usage/v6/badge/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/badge/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/badge/basic/demo.html" />

--- a/static/usage/v6/badge/theming/colors/index.md
+++ b/static/usage/v6/badge/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="medium" code={{ javascript, react, vue, angular }} src="usage/v6/badge/theming/colors/demo.html" />
+<Playground
+  version="6"
+  size="medium"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/badge/theming/colors/demo.html"
+/>

--- a/static/usage/v6/badge/theming/css-properties/index.md
+++ b/static/usage/v6/badge/theming/css-properties/index.md
@@ -10,6 +10,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/breadcrumbs/basic/index.md
+++ b/static/usage/v6/breadcrumbs/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/breadcrumbs/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/breadcrumbs/basic/demo.html" />

--- a/static/usage/v6/breadcrumbs/collapsing-items/expand-on-click/index.md
+++ b/static/usage/v6/breadcrumbs/collapsing-items/expand-on-click/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/breadcrumbs/collapsing-items/items-before-after/index.md
+++ b/static/usage/v6/breadcrumbs/collapsing-items/items-before-after/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/breadcrumbs/collapsing-items/items-before-after/demo.html"

--- a/static/usage/v6/breadcrumbs/collapsing-items/max-items/index.md
+++ b/static/usage/v6/breadcrumbs/collapsing-items/max-items/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/breadcrumbs/collapsing-items/max-items/demo.html"
 />

--- a/static/usage/v6/breadcrumbs/collapsing-items/popover-on-click/index.md
+++ b/static/usage/v6/breadcrumbs/collapsing-items/popover-on-click/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="500px"
   code={{
     javascript,

--- a/static/usage/v6/breadcrumbs/icons/custom-separators/index.md
+++ b/static/usage/v6/breadcrumbs/icons/custom-separators/index.md
@@ -5,4 +5,8 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/breadcrumbs/icons/custom-separators/demo.html" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/breadcrumbs/icons/custom-separators/demo.html"
+/>

--- a/static/usage/v6/breadcrumbs/icons/icons-on-items/index.md
+++ b/static/usage/v6/breadcrumbs/icons/icons-on-items/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/breadcrumbs/icons/icons-on-items/demo.html"

--- a/static/usage/v6/breadcrumbs/theming/colors/index.md
+++ b/static/usage/v6/breadcrumbs/theming/colors/index.md
@@ -5,4 +5,8 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/breadcrumbs/theming/colors/demo.html" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/breadcrumbs/theming/colors/demo.html"
+/>

--- a/static/usage/v6/breadcrumbs/theming/css-properties/index.md
+++ b/static/usage/v6/breadcrumbs/theming/css-properties/index.md
@@ -10,6 +10,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/button/basic/index.md
+++ b/static/usage/v6/button/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/button/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/button/basic/demo.html" />

--- a/static/usage/v6/button/expand/index.md
+++ b/static/usage/v6/button/expand/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/button/expand/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/button/expand/demo.html" />

--- a/static/usage/v6/button/fill/index.md
+++ b/static/usage/v6/button/fill/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/button/fill/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/button/fill/demo.html" />

--- a/static/usage/v6/button/icons/index.md
+++ b/static/usage/v6/button/icons/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/button/icons/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/button/icons/demo.html" />

--- a/static/usage/v6/button/shape/index.md
+++ b/static/usage/v6/button/shape/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/button/shape/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/button/shape/demo.html" />

--- a/static/usage/v6/button/size/index.md
+++ b/static/usage/v6/button/size/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/button/size/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/button/size/demo.html" />

--- a/static/usage/v6/button/theming/colors/index.md
+++ b/static/usage/v6/button/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/button/theming/colors/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/button/theming/colors/demo.html" />

--- a/static/usage/v6/button/theming/css-properties/index.md
+++ b/static/usage/v6/button/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/buttons/basic/index.md
+++ b/static/usage/v6/buttons/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/buttons/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/buttons/basic/demo.html" />

--- a/static/usage/v6/buttons/placement/index.md
+++ b/static/usage/v6/buttons/placement/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/buttons/placement/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/buttons/placement/demo.html" />

--- a/static/usage/v6/buttons/types/index.md
+++ b/static/usage/v6/buttons/types/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/buttons/types/demo.html" size="medium" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/buttons/types/demo.html"
+  size="medium"
+/>

--- a/static/usage/v6/card/basic/index.md
+++ b/static/usage/v6/card/basic/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/card/buttons/index.md
+++ b/static/usage/v6/card/buttons/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/card/list/index.md
+++ b/static/usage/v6/card/list/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/card/media/index.md
+++ b/static/usage/v6/card/media/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/card/theming/colors/index.md
+++ b/static/usage/v6/card/theming/colors/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/card/theming/css-properties/index.md
+++ b/static/usage/v6/card/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/checkbox/basic/index.md
+++ b/static/usage/v6/checkbox/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/checkbox/indeterminate/index.md
+++ b/static/usage/v6/checkbox/indeterminate/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/checkbox/theming/css-properties/index.md
+++ b/static/usage/v6/checkbox/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/chip/basic/index.md
+++ b/static/usage/v6/chip/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/chip/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/chip/basic/demo.html" />

--- a/static/usage/v6/chip/slots/index.md
+++ b/static/usage/v6/chip/slots/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/chip/slots/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/chip/slots/demo.html" />

--- a/static/usage/v6/chip/theming/colors/index.md
+++ b/static/usage/v6/chip/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/chip/theming/colors/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/chip/theming/colors/demo.html" />

--- a/static/usage/v6/chip/theming/css-properties/index.md
+++ b/static/usage/v6/chip/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/content/basic/index.md
+++ b/static/usage/v6/content/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/content/basic/demo.html"
   includeIonContent={false}

--- a/static/usage/v6/content/fixed/index.md
+++ b/static/usage/v6/content/fixed/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/content/fullscreen/index.md
+++ b/static/usage/v6/content/fullscreen/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/content/header-footer/index.md
+++ b/static/usage/v6/content/header-footer/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/content/header-footer/demo.html"
   includeIonContent={false}

--- a/static/usage/v6/content/scroll-events/index.md
+++ b/static/usage/v6/content/scroll-events/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/content/scroll-methods/index.md
+++ b/static/usage/v6/content/scroll-methods/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/content/theming/colors/index.md
+++ b/static/usage/v6/content/theming/colors/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/content/theming/colors/demo.html"
   includeIonContent={false}

--- a/static/usage/v6/content/theming/css-properties/index.md
+++ b/static/usage/v6/content/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/content/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/content/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/datetime-button/basic/index.md
+++ b/static/usage/v6/datetime-button/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="medium" code={{ javascript, react, vue, angular }} src="usage/v6/datetime-button/basic/demo.html" />
+<Playground
+  version="6"
+  size="medium"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/datetime-button/basic/demo.html"
+/>

--- a/static/usage/v6/datetime/basic/index.md
+++ b/static/usage/v6/datetime/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="medium" code={{ javascript, react, vue, angular }} src="usage/v6/datetime/basic/demo.html" />
+<Playground
+  version="6"
+  size="medium"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/datetime/basic/demo.html"
+/>

--- a/static/usage/v6/datetime/buttons/customizing-button-texts/index.md
+++ b/static/usage/v6/datetime/buttons/customizing-button-texts/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="500px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/buttons/customizing-button-texts/demo.html"

--- a/static/usage/v6/datetime/buttons/customizing-buttons/index.md
+++ b/static/usage/v6/datetime/buttons/customizing-buttons/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="500px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/buttons/customizing-buttons/demo.html"

--- a/static/usage/v6/datetime/buttons/showing-confirmation-buttons/index.md
+++ b/static/usage/v6/datetime/buttons/showing-confirmation-buttons/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="500px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/buttons/showing-confirmation-buttons/demo.html"

--- a/static/usage/v6/datetime/date-constraints/advanced/index.md
+++ b/static/usage/v6/datetime/date-constraints/advanced/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{
     javascript,

--- a/static/usage/v6/datetime/date-constraints/max-min/index.md
+++ b/static/usage/v6/datetime/date-constraints/max-min/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/date-constraints/max-min/demo.html"

--- a/static/usage/v6/datetime/date-constraints/values/index.md
+++ b/static/usage/v6/datetime/date-constraints/values/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/date-constraints/values/demo.html"

--- a/static/usage/v6/datetime/localization/custom-locale/index.md
+++ b/static/usage/v6/datetime/localization/custom-locale/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/localization/custom-locale/demo.html"

--- a/static/usage/v6/datetime/localization/first-day-of-week/index.md
+++ b/static/usage/v6/datetime/localization/first-day-of-week/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/localization/first-day-of-week/demo.html"

--- a/static/usage/v6/datetime/localization/hour-cycle/index.md
+++ b/static/usage/v6/datetime/localization/hour-cycle/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/localization/hour-cycle/demo.html"

--- a/static/usage/v6/datetime/localization/locale-extension-tags/index.md
+++ b/static/usage/v6/datetime/localization/locale-extension-tags/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/localization/locale-extension-tags/demo.html"

--- a/static/usage/v6/datetime/localization/time-label/index.md
+++ b/static/usage/v6/datetime/localization/time-label/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/localization/time-label/demo.html"

--- a/static/usage/v6/datetime/multiple/index.md
+++ b/static/usage/v6/datetime/multiple/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="medium" code={{ javascript, react, vue, angular }} src="usage/v6/datetime/multiple/demo.html" />
+<Playground
+  version="6"
+  size="medium"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/datetime/multiple/demo.html"
+/>

--- a/static/usage/v6/datetime/presentation/date/index.md
+++ b/static/usage/v6/datetime/presentation/date/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/presentation/date/demo.html"

--- a/static/usage/v6/datetime/presentation/month-and-year/index.md
+++ b/static/usage/v6/datetime/presentation/month-and-year/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="240px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/presentation/month-and-year/demo.html"

--- a/static/usage/v6/datetime/presentation/time/index.md
+++ b/static/usage/v6/datetime/presentation/time/index.md
@@ -5,4 +5,8 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/datetime/presentation/time/demo.html" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/datetime/presentation/time/demo.html"
+/>

--- a/static/usage/v6/datetime/presentation/wheel/index.md
+++ b/static/usage/v6/datetime/presentation/wheel/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/presentation/wheel/demo.html"

--- a/static/usage/v6/datetime/theming/index.md
+++ b/static/usage/v6/datetime/theming/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   size="450px"
   code={{
     javascript,

--- a/static/usage/v6/datetime/title/customizing-title/index.md
+++ b/static/usage/v6/datetime/title/customizing-title/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="large"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/title/customizing-title/demo.html"

--- a/static/usage/v6/datetime/title/showing-default-title/index.md
+++ b/static/usage/v6/datetime/title/showing-default-title/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="large"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/datetime/title/showing-default-title/demo.html"

--- a/static/usage/v6/fab/basic/index.md
+++ b/static/usage/v6/fab/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/fab/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/fab/basic/demo.html" />

--- a/static/usage/v6/fab/button-sizing/index.md
+++ b/static/usage/v6/fab/button-sizing/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/fab/button-sizing/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/fab/button-sizing/demo.html" />

--- a/static/usage/v6/fab/list-side/index.md
+++ b/static/usage/v6/fab/list-side/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/fab/list-side/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/fab/list-side/demo.html" />

--- a/static/usage/v6/fab/positioning/index.md
+++ b/static/usage/v6/fab/positioning/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/fab/positioning/demo.html"
   includeIonContent={false}

--- a/static/usage/v6/fab/theming/colors/index.md
+++ b/static/usage/v6/fab/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/fab/theming/colors/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/fab/theming/colors/demo.html" />

--- a/static/usage/v6/fab/theming/css-custom-properties/index.md
+++ b/static/usage/v6/fab/theming/css-custom-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/fab/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/fab/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/footer/basic/index.md
+++ b/static/usage/v6/footer/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/footer/basic/demo.html"
   devicePreview

--- a/static/usage/v6/footer/custom-scroll-target/index.md
+++ b/static/usage/v6/footer/custom-scroll-target/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/footer/fade/index.md
+++ b/static/usage/v6/footer/fade/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/footer/fade/demo.html"
   devicePreview

--- a/static/usage/v6/footer/no-border/index.md
+++ b/static/usage/v6/footer/no-border/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/footer/no-border/demo.html"
   devicePreview

--- a/static/usage/v6/footer/translucent/index.md
+++ b/static/usage/v6/footer/translucent/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/footer/translucent/demo.html"
   devicePreview

--- a/static/usage/v6/grid/basic/index.md
+++ b/static/usage/v6/grid/basic/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/customizing/column-number/index.md
+++ b/static/usage/v6/grid/customizing/column-number/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/customizing/padding/index.md
+++ b/static/usage/v6/grid/customizing/padding/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/customizing/width/index.md
+++ b/static/usage/v6/grid/customizing/width/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/fixed/index.md
+++ b/static/usage/v6/grid/fixed/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/horizontal-alignment/index.md
+++ b/static/usage/v6/grid/horizontal-alignment/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/offset-responsive/index.md
+++ b/static/usage/v6/grid/offset-responsive/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/offset/index.md
+++ b/static/usage/v6/grid/offset/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/push-pull-responsive/index.md
+++ b/static/usage/v6/grid/push-pull-responsive/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/push-pull/index.md
+++ b/static/usage/v6/grid/push-pull/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/size-auto/index.md
+++ b/static/usage/v6/grid/size-auto/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/size-responsive/index.md
+++ b/static/usage/v6/grid/size-responsive/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/size/index.md
+++ b/static/usage/v6/grid/size/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/grid/vertical-alignment/index.md
+++ b/static/usage/v6/grid/vertical-alignment/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/header/basic/index.md
+++ b/static/usage/v6/header/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/header/basic/demo.html"
   devicePreview

--- a/static/usage/v6/header/condense/index.md
+++ b/static/usage/v6/header/condense/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/header/condense/demo.html"
   devicePreview

--- a/static/usage/v6/header/custom-scroll-target/index.md
+++ b/static/usage/v6/header/custom-scroll-target/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/header/fade/index.md
+++ b/static/usage/v6/header/fade/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/header/fade/demo.html"
   devicePreview

--- a/static/usage/v6/header/no-border/index.md
+++ b/static/usage/v6/header/no-border/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/header/no-border/demo.html"
   devicePreview

--- a/static/usage/v6/header/translucent/index.md
+++ b/static/usage/v6/header/translucent/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/header/translucent/demo.html"
   devicePreview

--- a/static/usage/v6/img/basic/index.md
+++ b/static/usage/v6/img/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/img/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/img/basic/demo.html" />

--- a/static/usage/v6/infinite-scroll/basic/index.md
+++ b/static/usage/v6/infinite-scroll/basic/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/infinite-scroll/custom-infinite-scroll-content/index.md
+++ b/static/usage/v6/infinite-scroll/custom-infinite-scroll-content/index.md
@@ -12,6 +12,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/infinite-scroll/infinite-scroll-content/index.md
+++ b/static/usage/v6/infinite-scroll/infinite-scroll-content/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/input/basic/index.md
+++ b/static/usage/v6/input/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/input/basic/demo.html" size="300px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/input/basic/demo.html" size="300px" />

--- a/static/usage/v6/input/clear/index.md
+++ b/static/usage/v6/input/clear/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/input/clear/demo.html" size="250px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/input/clear/demo.html" size="250px" />

--- a/static/usage/v6/input/fill/index.md
+++ b/static/usage/v6/input/fill/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/input/fill/demo.html"
   size="250px"

--- a/static/usage/v6/input/labels/index.md
+++ b/static/usage/v6/input/labels/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/input/labels/demo.html" size="300px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/input/labels/demo.html" size="300px" />

--- a/static/usage/v6/input/theming/colors/index.md
+++ b/static/usage/v6/input/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/input/theming/colors/demo.html" size="200px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/input/theming/colors/demo.html"
+  size="200px"
+/>

--- a/static/usage/v6/input/theming/css-properties/index.md
+++ b/static/usage/v6/input/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/input/types/index.md
+++ b/static/usage/v6/input/types/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/input/types/demo.html" size="300px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/input/types/demo.html" size="300px" />

--- a/static/usage/v6/item-divider/basic/index.md
+++ b/static/usage/v6/item-divider/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item-divider/basic/demo.html" size="medium" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/item-divider/basic/demo.html"
+  size="medium"
+/>

--- a/static/usage/v6/item-divider/theming/colors/index.md
+++ b/static/usage/v6/item-divider/theming/colors/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/item-divider/theming/colors/demo.html"
   size="medium"

--- a/static/usage/v6/item-divider/theming/css-properties/index.md
+++ b/static/usage/v6/item-divider/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/item-group/basic/index.md
+++ b/static/usage/v6/item-group/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item-group/basic/demo.html" size="medium" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/item-group/basic/demo.html"
+  size="medium"
+/>

--- a/static/usage/v6/item-group/sliding-items/index.md
+++ b/static/usage/v6/item-group/sliding-items/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/item-group/sliding-items/demo.html"
   size="medium"

--- a/static/usage/v6/item-sliding/basic/index.md
+++ b/static/usage/v6/item-sliding/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item-sliding/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item-sliding/basic/demo.html" />

--- a/static/usage/v6/item-sliding/expandable/index.md
+++ b/static/usage/v6/item-sliding/expandable/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item-sliding/expandable/demo.html" size="100px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/item-sliding/expandable/demo.html"
+  size="100px"
+/>

--- a/static/usage/v6/item-sliding/icons/index.md
+++ b/static/usage/v6/item-sliding/icons/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item-sliding/icons/demo.html" size="300px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/item-sliding/icons/demo.html"
+  size="300px"
+/>

--- a/static/usage/v6/item/basic/index.md
+++ b/static/usage/v6/item/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/basic/demo.html" size="medium" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item/basic/demo.html" size="medium" />

--- a/static/usage/v6/item/buttons/index.md
+++ b/static/usage/v6/item/buttons/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/buttons/demo.html" size="250px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item/buttons/demo.html" size="250px" />

--- a/static/usage/v6/item/clickable/index.md
+++ b/static/usage/v6/item/clickable/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/clickable/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item/clickable/demo.html" />

--- a/static/usage/v6/item/counter/index.md
+++ b/static/usage/v6/item/counter/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/item/detail-arrows/index.md
+++ b/static/usage/v6/item/detail-arrows/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/detail-arrows/demo.html" size="350px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/item/detail-arrows/demo.html"
+  size="350px"
+/>

--- a/static/usage/v6/item/helper-error/index.md
+++ b/static/usage/v6/item/helper-error/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/item/icons/index.md
+++ b/static/usage/v6/item/icons/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/icons/demo.html" size="250px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item/icons/demo.html" size="250px" />

--- a/static/usage/v6/item/inputs/index.md
+++ b/static/usage/v6/item/inputs/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/inputs/demo.html" size="large" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item/inputs/demo.html" size="large" />

--- a/static/usage/v6/item/lines/index.md
+++ b/static/usage/v6/item/lines/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/lines/demo.html" size="medium" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item/lines/demo.html" size="medium" />

--- a/static/usage/v6/item/media/index.md
+++ b/static/usage/v6/item/media/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/media/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/item/media/demo.html" />

--- a/static/usage/v6/item/theming/colors/index.md
+++ b/static/usage/v6/item/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/item/theming/colors/demo.html" size="500px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/item/theming/colors/demo.html"
+  size="500px"
+/>

--- a/static/usage/v6/item/theming/css-properties/index.md
+++ b/static/usage/v6/item/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/item/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/item/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/item/theming/input-highlight/index.md
+++ b/static/usage/v6/item/theming/input-highlight/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/label/basic/index.md
+++ b/static/usage/v6/label/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/label/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/label/basic/demo.html" />

--- a/static/usage/v6/label/input/index.md
+++ b/static/usage/v6/label/input/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/label/input/demo.html" size="medium" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/label/input/demo.html" size="medium" />

--- a/static/usage/v6/label/item/index.md
+++ b/static/usage/v6/label/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/label/item/demo.html" size="medium" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/label/item/demo.html" size="medium" />

--- a/static/usage/v6/label/theming/colors/index.md
+++ b/static/usage/v6/label/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/label/theming/colors/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/label/theming/colors/demo.html" />

--- a/static/usage/v6/list-header/basic/index.md
+++ b/static/usage/v6/list-header/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/list-header/basic/demo.html" size="325px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/list-header/basic/demo.html"
+  size="325px"
+/>

--- a/static/usage/v6/list-header/buttons/index.md
+++ b/static/usage/v6/list-header/buttons/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/list-header/buttons/demo.html" size="325px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/list-header/buttons/demo.html"
+  size="325px"
+/>

--- a/static/usage/v6/list-header/lines/index.md
+++ b/static/usage/v6/list-header/lines/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/list-header/lines/demo.html" size="500px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/list-header/lines/demo.html"
+  size="500px"
+/>

--- a/static/usage/v6/list-header/theming/colors/index.md
+++ b/static/usage/v6/list-header/theming/colors/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/list-header/theming/colors/demo.html"
   size="650px"

--- a/static/usage/v6/list-header/theming/css-properties/index.md
+++ b/static/usage/v6/list-header/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/list/basic/index.md
+++ b/static/usage/v6/list/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/list/basic/demo.html" size="300px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/list/basic/demo.html" size="300px" />

--- a/static/usage/v6/list/inset/index.md
+++ b/static/usage/v6/list/inset/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/list/inset/demo.html" size="350px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/list/inset/demo.html" size="350px" />

--- a/static/usage/v6/list/lines/index.md
+++ b/static/usage/v6/list/lines/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/list/lines/demo.html" size="500px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/list/lines/demo.html" size="500px" />

--- a/static/usage/v6/loading/controller/index.md
+++ b/static/usage/v6/loading/controller/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/loading/spinners/index.md
+++ b/static/usage/v6/loading/spinners/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/loading/theming/index.md
+++ b/static/usage/v6/loading/theming/index.md
@@ -12,6 +12,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/menu/basic/index.md
+++ b/static/usage/v6/menu/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/menu/theming/index.md
+++ b/static/usage/v6/menu/theming/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/menu/toggle/index.md
+++ b/static/usage/v6/menu/toggle/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/menu/type/index.md
+++ b/static/usage/v6/menu/type/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/can-dismiss/boolean/index.md
+++ b/static/usage/v6/modal/can-dismiss/boolean/index.md
@@ -9,6 +9,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/can-dismiss/function/index.md
+++ b/static/usage/v6/modal/can-dismiss/function/index.md
@@ -9,6 +9,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/card/basic/index.md
+++ b/static/usage/v6/modal/card/basic/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/controller/index.md
+++ b/static/usage/v6/modal/controller/index.md
@@ -13,6 +13,7 @@ import angular_modal_example_component_ts from './angular/modal-example_componen
 import angular_modal_example_component_html from './angular/modal-example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/custom-dialogs/index.md
+++ b/static/usage/v6/modal/custom-dialogs/index.md
@@ -10,6 +10,7 @@ import angular_global_css from './angular/global_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     vue,

--- a/static/usage/v6/modal/inline/basic/index.md
+++ b/static/usage/v6/modal/inline/basic/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/inline/is-open/index.md
+++ b/static/usage/v6/modal/inline/is-open/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/performance/mount/index.md
+++ b/static/usage/v6/modal/performance/mount/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/sheet/background-content/index.md
+++ b/static/usage/v6/modal/sheet/background-content/index.md
@@ -9,6 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/sheet/basic/index.md
+++ b/static/usage/v6/modal/sheet/basic/index.md
@@ -6,6 +6,7 @@ import react from './react.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/sheet/handle-behavior/index.md
+++ b/static/usage/v6/modal/sheet/handle-behavior/index.md
@@ -6,6 +6,7 @@ import react from './react.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/modal/styling/animations/index.md
+++ b/static/usage/v6/modal/styling/animations/index.md
@@ -10,6 +10,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript: {
       files: {

--- a/static/usage/v6/modal/styling/theming/index.md
+++ b/static/usage/v6/modal/styling/theming/index.md
@@ -10,6 +10,7 @@ import angular_global_css from './angular/global_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     vue,

--- a/static/usage/v6/nav/modal-navigation/index.md
+++ b/static/usage/v6/nav/modal-navigation/index.md
@@ -20,6 +20,7 @@ import vue_page_two from './vue/page_two_vue.md';
 import vue_page_three from './vue/page_three_vue.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     angular: {

--- a/static/usage/v6/nav/nav-link/index.md
+++ b/static/usage/v6/nav/nav-link/index.md
@@ -20,6 +20,7 @@ import vue_page_two from './vue/page_two_vue.md';
 import vue_page_three from './vue/page_three_vue.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     angular: {

--- a/static/usage/v6/note/basic/index.md
+++ b/static/usage/v6/note/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/note/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/note/basic/demo.html" />

--- a/static/usage/v6/note/item/index.md
+++ b/static/usage/v6/note/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/note/item/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/note/item/demo.html" />

--- a/static/usage/v6/note/theming/colors/index.md
+++ b/static/usage/v6/note/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/note/theming/colors/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/note/theming/colors/demo.html" />

--- a/static/usage/v6/note/theming/css-properties/index.md
+++ b/static/usage/v6/note/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/picker/multiple-column/index.md
+++ b/static/usage/v6/picker/multiple-column/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/picker/single-column/index.md
+++ b/static/usage/v6/picker/single-column/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/popover/customization/positioning/index.md
+++ b/static/usage/v6/popover/customization/positioning/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="400px"
   code={{
     javascript,

--- a/static/usage/v6/popover/customization/sizing/index.md
+++ b/static/usage/v6/popover/customization/sizing/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/popover/customization/sizing/demo.html"

--- a/static/usage/v6/popover/customization/styling/index.md
+++ b/static/usage/v6/popover/customization/styling/index.md
@@ -10,6 +10,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/popover/nested/index.md
+++ b/static/usage/v6/popover/nested/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="medium" code={{ javascript, react, vue, angular }} src="usage/v6/popover/nested/demo.html" />
+<Playground
+  version="6"
+  size="medium"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/popover/nested/demo.html"
+/>

--- a/static/usage/v6/popover/performance/mount/index.md
+++ b/static/usage/v6/popover/performance/mount/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/popover/presenting/controller/index.md
+++ b/static/usage/v6/popover/presenting/controller/index.md
@@ -13,6 +13,7 @@ import angular_popover_component_ts from './angular/popover_component_ts.md';
 import angular_app_module from './angular/app_module_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/popover/presenting/inline-isopen/index.md
+++ b/static/usage/v6/popover/presenting/inline-isopen/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/popover/presenting/inline-trigger/index.md
+++ b/static/usage/v6/popover/presenting/inline-trigger/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/popover/presenting/inline-trigger/demo.html"

--- a/static/usage/v6/progress-bar/buffer/index.md
+++ b/static/usage/v6/progress-bar/buffer/index.md
@@ -9,6 +9,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/progress-bar/determinate/index.md
+++ b/static/usage/v6/progress-bar/determinate/index.md
@@ -9,6 +9,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/progress-bar/indeterminate/index.md
+++ b/static/usage/v6/progress-bar/indeterminate/index.md
@@ -5,4 +5,8 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/progress-bar/indeterminate/demo.html" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/progress-bar/indeterminate/demo.html"
+/>

--- a/static/usage/v6/progress-bar/theming/colors/index.md
+++ b/static/usage/v6/progress-bar/theming/colors/index.md
@@ -5,4 +5,8 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/progress-bar/theming/colors/demo.html" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/progress-bar/theming/colors/demo.html"
+/>

--- a/static/usage/v6/progress-bar/theming/css-properties/index.md
+++ b/static/usage/v6/progress-bar/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/progress-bar/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/progress-bar/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/radio/basic/index.md
+++ b/static/usage/v6/radio/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/radio/basic/demo.html" size="250px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/radio/basic/demo.html" size="250px" />

--- a/static/usage/v6/radio/empty-selection/index.md
+++ b/static/usage/v6/radio/empty-selection/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/radio/empty-selection/demo.html" size="250px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/radio/empty-selection/demo.html"
+  size="250px"
+/>

--- a/static/usage/v6/radio/theming/colors/index.md
+++ b/static/usage/v6/radio/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/radio/theming/colors/demo.html" size="100px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/radio/theming/colors/demo.html"
+  size="100px"
+/>

--- a/static/usage/v6/radio/theming/css-properties/index.md
+++ b/static/usage/v6/radio/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/radio/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/radio/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/range/basic/index.md
+++ b/static/usage/v6/range/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/range/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/range/basic/demo.html" />

--- a/static/usage/v6/range/dual-knobs/index.md
+++ b/static/usage/v6/range/dual-knobs/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/range/dual-knobs/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/range/dual-knobs/demo.html" />

--- a/static/usage/v6/range/ion-change-event/index.md
+++ b/static/usage/v6/range/ion-change-event/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/range/ion-knob-move-event/index.md
+++ b/static/usage/v6/range/ion-knob-move-event/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/range/pins/index.md
+++ b/static/usage/v6/range/pins/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/range/slots/index.md
+++ b/static/usage/v6/range/slots/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/range/slots/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/range/slots/demo.html" />

--- a/static/usage/v6/range/snapping-ticks/index.md
+++ b/static/usage/v6/range/snapping-ticks/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/range/snapping-ticks/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/range/snapping-ticks/demo.html" />

--- a/static/usage/v6/range/theming/css-properties/index.md
+++ b/static/usage/v6/range/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/range/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/range/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/refresher/advanced/index.md
+++ b/static/usage/v6/refresher/advanced/index.md
@@ -12,6 +12,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/refresher/basic/index.md
+++ b/static/usage/v6/refresher/basic/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/refresher/custom-content/index.md
+++ b/static/usage/v6/refresher/custom-content/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/refresher/custom-scroll-target/index.md
+++ b/static/usage/v6/refresher/custom-scroll-target/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/refresher/pull-properties/index.md
+++ b/static/usage/v6/refresher/pull-properties/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/reorder/basic/index.md
+++ b/static/usage/v6/reorder/basic/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/reorder/custom-icon/index.md
+++ b/static/usage/v6/reorder/custom-icon/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/reorder/custom-scroll-target/index.md
+++ b/static/usage/v6/reorder/custom-scroll-target/index.md
@@ -12,6 +12,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/reorder/toggling-disabled/index.md
+++ b/static/usage/v6/reorder/toggling-disabled/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/reorder/updating-data/index.md
+++ b/static/usage/v6/reorder/updating-data/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/reorder/wrapper/index.md
+++ b/static/usage/v6/reorder/wrapper/index.md
@@ -8,6 +8,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/ripple-effect/basic/index.md
+++ b/static/usage/v6/ripple-effect/basic/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/ripple-effect/customizing/index.md
+++ b/static/usage/v6/ripple-effect/customizing/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/ripple-effect/type/index.md
+++ b/static/usage/v6/ripple-effect/type/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/router/basic/index.md
+++ b/static/usage/v6/router/basic/index.md
@@ -3,6 +3,7 @@ import Playground from '@site/src/components/global/Playground';
 import javascript from './javascript.md';
 
 <Playground
+  version="6"
   code={{ javascript }}
   src="usage/v6/router/basic/demo.html"
   devicePreview={true}

--- a/static/usage/v6/searchbar/basic/index.md
+++ b/static/usage/v6/searchbar/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/searchbar/basic/demo.html" size="300px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/searchbar/basic/demo.html"
+  size="300px"
+/>

--- a/static/usage/v6/searchbar/cancel-button/index.md
+++ b/static/usage/v6/searchbar/cancel-button/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/searchbar/cancel-button/demo.html" size="250px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/searchbar/cancel-button/demo.html"
+  size="250px"
+/>

--- a/static/usage/v6/searchbar/clear-button/index.md
+++ b/static/usage/v6/searchbar/clear-button/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/searchbar/clear-button/demo.html" size="250px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/searchbar/clear-button/demo.html"
+  size="250px"
+/>

--- a/static/usage/v6/searchbar/debounce/index.md
+++ b/static/usage/v6/searchbar/debounce/index.md
@@ -9,6 +9,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/searchbar/search-icon/index.md
+++ b/static/usage/v6/searchbar/search-icon/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/searchbar/search-icon/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/searchbar/search-icon/demo.html" />

--- a/static/usage/v6/searchbar/theming/colors/index.md
+++ b/static/usage/v6/searchbar/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/searchbar/theming/colors/demo.html" size="large" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/searchbar/theming/colors/demo.html"
+  size="large"
+/>

--- a/static/usage/v6/searchbar/theming/css-properties/index.md
+++ b/static/usage/v6/searchbar/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/segment-button/basic/index.md
+++ b/static/usage/v6/segment-button/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/segment-button/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/segment-button/basic/demo.html" />

--- a/static/usage/v6/segment-button/layout/index.md
+++ b/static/usage/v6/segment-button/layout/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/segment-button/layout/demo.html" size="medium" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/segment-button/layout/demo.html"
+  size="medium"
+/>

--- a/static/usage/v6/segment-button/theming/css-properties/index.md
+++ b/static/usage/v6/segment-button/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/segment-button/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/segment-button/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/segment/basic/index.md
+++ b/static/usage/v6/segment/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/segment/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/segment/basic/demo.html" />

--- a/static/usage/v6/segment/scrollable/index.md
+++ b/static/usage/v6/segment/scrollable/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/segment/scrollable/demo.html" size="100px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/segment/scrollable/demo.html"
+  size="100px"
+/>

--- a/static/usage/v6/segment/theming/colors/index.md
+++ b/static/usage/v6/segment/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/segment/theming/colors/demo.html" size="large" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/segment/theming/colors/demo.html"
+  size="large"
+/>

--- a/static/usage/v6/segment/theming/css-properties/index.md
+++ b/static/usage/v6/segment/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/select/basic/multiple-selection/index.md
+++ b/static/usage/v6/select/basic/multiple-selection/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/select/basic/multiple-selection/demo.html"

--- a/static/usage/v6/select/basic/responding-to-interaction/index.md
+++ b/static/usage/v6/select/basic/responding-to-interaction/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/select/basic/single-selection/index.md
+++ b/static/usage/v6/select/basic/single-selection/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/select/basic/single-selection/demo.html"

--- a/static/usage/v6/select/customization/button-text/index.md
+++ b/static/usage/v6/select/customization/button-text/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="350px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/select/customization/button-text/demo.html"

--- a/static/usage/v6/select/customization/interface-options/index.md
+++ b/static/usage/v6/select/customization/interface-options/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="large"
   code={{
     javascript,

--- a/static/usage/v6/select/customization/styling-select/index.md
+++ b/static/usage/v6/select/customization/styling-select/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/select/interfaces/action-sheet/index.md
+++ b/static/usage/v6/select/interfaces/action-sheet/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="medium"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/select/interfaces/action-sheet/demo.html"

--- a/static/usage/v6/select/interfaces/popover/index.md
+++ b/static/usage/v6/select/interfaces/popover/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   size="400px"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/select/interfaces/popover/demo.html"

--- a/static/usage/v6/select/objects-as-values/multiple-selection/index.md
+++ b/static/usage/v6/select/objects-as-values/multiple-selection/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/select/objects-as-values/using-comparewith/index.md
+++ b/static/usage/v6/select/objects-as-values/using-comparewith/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   size="300px"
   code={{
     javascript,

--- a/static/usage/v6/select/typeahead/index.md
+++ b/static/usage/v6/select/typeahead/index.md
@@ -18,6 +18,7 @@ import angular_modal_example_component_html from './angular/modal-example_compon
 import angular_types_ts from './angular/angular_types_ts.md';
 
 <Playground
+  version="6"
   code={{ 
     javascript, 
     react: {

--- a/static/usage/v6/skeleton-text/basic/index.md
+++ b/static/usage/v6/skeleton-text/basic/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/skeleton-text/theming/css-properties/index.md
+++ b/static/usage/v6/skeleton-text/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/spinner/basic/index.md
+++ b/static/usage/v6/spinner/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/spinner/basic/demo.html" size="500px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/spinner/basic/demo.html"
+  size="500px"
+/>

--- a/static/usage/v6/spinner/theming/colors/index.md
+++ b/static/usage/v6/spinner/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/spinner/theming/colors/demo.html" size="100px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/spinner/theming/colors/demo.html"
+  size="100px"
+/>

--- a/static/usage/v6/spinner/theming/css-properties/index.md
+++ b/static/usage/v6/spinner/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/split-pane/basic/index.md
+++ b/static/usage/v6/split-pane/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/split-pane/basic/demo.html" size="500px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/split-pane/basic/demo.html"
+  size="500px"
+/>

--- a/static/usage/v6/split-pane/theming/css-properties/index.md
+++ b/static/usage/v6/split-pane/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/text/basic/index.md
+++ b/static/usage/v6/text/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/text/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/text/basic/demo.html" />

--- a/static/usage/v6/textarea/autogrow/index.md
+++ b/static/usage/v6/textarea/autogrow/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="small" code={{ javascript, react, vue, angular }} src="usage/v6/textarea/autogrow/demo.html" />
+<Playground
+  version="6"
+  size="small"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/textarea/autogrow/demo.html"
+/>

--- a/static/usage/v6/textarea/basic/index.md
+++ b/static/usage/v6/textarea/basic/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="250px" code={{ javascript, react, vue, angular }} src="usage/v6/textarea/basic/demo.html" />
+<Playground
+  version="6"
+  size="250px"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/textarea/basic/demo.html"
+/>

--- a/static/usage/v6/textarea/clear-on-edit/index.md
+++ b/static/usage/v6/textarea/clear-on-edit/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v6/textarea/clear-on-edit/demo.html" />
+<Playground
+  version="6"
+  size="xsmall"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/textarea/clear-on-edit/demo.html"
+/>

--- a/static/usage/v6/textarea/theming/index.md
+++ b/static/usage/v6/textarea/theming/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   size="xsmall"
   code={{
     javascript,

--- a/static/usage/v6/thumbnail/basic/index.md
+++ b/static/usage/v6/thumbnail/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/thumbnail/basic/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/thumbnail/basic/demo.html" />

--- a/static/usage/v6/thumbnail/item/index.md
+++ b/static/usage/v6/thumbnail/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/thumbnail/item/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/thumbnail/item/demo.html" />

--- a/static/usage/v6/thumbnail/theming/css-properties/index.md
+++ b/static/usage/v6/thumbnail/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/title/basic/index.md
+++ b/static/usage/v6/title/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/title/basic/demo.html"
   devicePreview={true}

--- a/static/usage/v6/title/collapsible-large-title/basic/index.md
+++ b/static/usage/v6/title/collapsible-large-title/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   mode="ios"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/title/collapsible-large-title/basic/demo.html"

--- a/static/usage/v6/title/collapsible-large-title/buttons/index.md
+++ b/static/usage/v6/title/collapsible-large-title/buttons/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   mode="ios"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/title/collapsible-large-title/buttons/demo.html"

--- a/static/usage/v6/title/theming/css-properties/index.md
+++ b/static/usage/v6/title/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/toast/buttons/index.md
+++ b/static/usage/v6/toast/buttons/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   devicePreview
   code={{
     javascript,

--- a/static/usage/v6/toast/icon/index.md
+++ b/static/usage/v6/toast/icon/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   devicePreview
   code={{
     javascript,

--- a/static/usage/v6/toast/presenting/controller/index.md
+++ b/static/usage/v6/toast/presenting/controller/index.md
@@ -8,6 +8,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
+  version="6"
   devicePreview
   code={{
     javascript,

--- a/static/usage/v6/toast/theming/index.md
+++ b/static/usage/v6/toast/theming/index.md
@@ -11,6 +11,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 import angular_global_css from './angular/global_css.md';
 
 <Playground
+  version="6"
   devicePreview
   code={{
     javascript,

--- a/static/usage/v6/toggle/basic/index.md
+++ b/static/usage/v6/toggle/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/toggle/basic/demo.html" size="250px" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/toggle/basic/demo.html" size="250px" />

--- a/static/usage/v6/toggle/on-off/index.md
+++ b/static/usage/v6/toggle/on-off/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/toggle/on-off/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/toggle/on-off/demo.html" />

--- a/static/usage/v6/toggle/theming/colors/index.md
+++ b/static/usage/v6/toggle/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/toggle/theming/colors/demo.html" />
+<Playground version="6" code={{ javascript, react, vue, angular }} src="usage/v6/toggle/theming/colors/demo.html" />

--- a/static/usage/v6/toggle/theming/css-properties/index.md
+++ b/static/usage/v6/toggle/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/toggle/theming/css-shadow-parts/index.md
+++ b/static/usage/v6/toggle/theming/css-shadow-parts/index.md
@@ -11,6 +11,7 @@ import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v6/toolbar/basic/index.md
+++ b/static/usage/v6/toolbar/basic/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/toolbar/basic/demo.html"
   devicePreview

--- a/static/usage/v6/toolbar/buttons/index.md
+++ b/static/usage/v6/toolbar/buttons/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/toolbar/buttons/demo.html" size="500px" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/toolbar/buttons/demo.html"
+  size="500px"
+/>

--- a/static/usage/v6/toolbar/progress-bars/index.md
+++ b/static/usage/v6/toolbar/progress-bars/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/toolbar/progress-bars/demo.html"
   devicePreview

--- a/static/usage/v6/toolbar/searchbars/index.md
+++ b/static/usage/v6/toolbar/searchbars/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/toolbar/searchbars/demo.html"
   devicePreview

--- a/static/usage/v6/toolbar/segments/index.md
+++ b/static/usage/v6/toolbar/segments/index.md
@@ -6,6 +6,7 @@ import vue from './vue.md';
 import angular from './angular.md';
 
 <Playground
+  version="6"
   code={{ javascript, react, vue, angular }}
   src="usage/v6/toolbar/segments/demo.html"
   devicePreview

--- a/static/usage/v6/toolbar/theming/colors/index.md
+++ b/static/usage/v6/toolbar/theming/colors/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/toolbar/theming/colors/demo.html" size="large" />
+<Playground
+  version="6"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/toolbar/theming/colors/demo.html"
+  size="large"
+/>

--- a/static/usage/v6/toolbar/theming/css-properties/index.md
+++ b/static/usage/v6/toolbar/theming/css-properties/index.md
@@ -11,6 +11,7 @@ import angular_example_component_html from './angular/example_component_html.md'
 import angular_example_component_css from './angular/example_component_css.md';
 
 <Playground
+  version="6"
   code={{
     javascript,
     react: {

--- a/static/usage/v7/back-button/basic/index.md
+++ b/static/usage/v7/back-button/basic/index.md
@@ -17,6 +17,7 @@ import vue_page_one from './vue/page_one_vue.md';
 import vue_page_two from './vue/page_two_vue.md';
 
 <Playground
+  version="7"
   code={{
     javascript,
     angular: {

--- a/static/usage/v7/back-button/custom/index.md
+++ b/static/usage/v7/back-button/custom/index.md
@@ -17,6 +17,7 @@ import vue_page_one from './vue/page_one_vue.md';
 import vue_page_two from './vue/page_two_vue.md';
 
 <Playground
+  version="7"
   code={{
     javascript,
     angular: {

--- a/static/usage/v7/router/basic/index.md
+++ b/static/usage/v7/router/basic/index.md
@@ -3,6 +3,7 @@ import Playground from '@site/src/components/global/Playground';
 import javascript from './javascript.md';
 
 <Playground
+  version="7"
   code={{ javascript }}
   src="usage/v7/router/basic/demo.html"
   devicePreview={true}

--- a/static/usage/v7/select/typeahead/index.md
+++ b/static/usage/v7/select/typeahead/index.md
@@ -18,6 +18,7 @@ import angular_modal_example_component_html from './angular/modal-example_compon
 import angular_types_ts from './angular/angular_types_ts.md';
 
 <Playground
+  version="7"
   code={{ 
     javascript, 
     react: {


### PR DESCRIPTION
- Statically assigns the `version` for the v6 playground examples
- Removes the default `version` value for the `<Playground />` component
  - Not providing a version will result in a warning in the console.


Note: In the previous PR I incorrectly had the `version` typed applied to the `UsageTargetOptions`, instead of the playground properties. 