### PR TITLE
chore(support): move v5 to end of extended support

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -23,7 +23,7 @@ The current status of each Ionic Framework version is:
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
 |   V6    |      **Active**       | Dec 8, 2021  |       TBD        |        TBD        |
-|   V5    | Extended Support Only | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
+|   V5    |    End of Support     | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
 |   V4    |    End of Support     | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
 |   V3    |    End of Support     | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
 |   V2    |    End of Support     | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |


### PR DESCRIPTION
Extended Support on v5 ended Dec 8th, 2022. This PR updates the support document to reflect this.