### PR TITLE
docs(tabs): vue usage includes router outlet

### DIFF
--- a/docs/api/tabs.md
+++ b/docs/api/tabs.md
@@ -393,6 +393,7 @@ import {
   IonIcon, 
   IonLabel, 
   IonPage,
+  IonRouterOutlet,
   IonTabBar, 
   IonTabButton, 
   IonTabs
@@ -400,7 +401,7 @@ import {
 import { calendar, personCircle } from 'ionicons/icons';
 
 export default defineComponent({
-  components: { IonIcon, IonLabel, IonPage, IonTabBar, IonTabButton, IonTabs },
+  components: { IonIcon, IonLabel, IonPage, IonRouterOutlet, IonTabBar, IonTabButton, IonTabs },
   setup() {
     const beforeTabChange = () => {
       // do something before tab change

--- a/docs/api/tabs.md
+++ b/docs/api/tabs.md
@@ -369,6 +369,8 @@ will match the following tab:
 <template>
   <ion-page>
     <ion-tabs @ionTabsWillChange="beforeTabChange" @ionTabsDidChange="afterTabChange">
+      <!-- https://ionicframework.com/docs/vue/navigation#working-with-tabs -->
+      <ion-router-outlet></ion-router-outlet>
       <ion-tab-bar slot="bottom">
         <ion-tab-button tab="schedule" href="/tabs/schedule">
           <ion-icon :icon="calendar"></ion-icon>


### PR DESCRIPTION
this isn't an edit about wrong stuff or not, but it's not clear why is it missing the ion-router-outlet while if I added it as-is it warns me of the lack of an ion router outlet. and it's confusing for why it's not referenced here. in addition to that it's not clear where should I add the tabs component and the schedule component etc