### PR TITLE
docs(modal): canDismiss type definition

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -194,7 +194,7 @@ interface ModalOptions {
    * @deprecated - To prevent modals from dismissing, use canDismiss instead.
    */
   swipeToClose?: boolean;
-  canDismiss?: boolean | (() => Promise<boolean>);
+  canDismiss?: boolean | ((data?: any, role?: string) => Promise<boolean>);
 
   mode?: 'ios' | 'md';
   keyboardClose?: boolean;


### PR DESCRIPTION
Adds updated type definition for `canDismiss` from Ionic 6.4.0.

Related issue: https://github.com/ionic-team/ionic-framework/issues/26544