### PR TITLE
docs(vue): bring the photo gallery app up to date

### DIFF
--- a/docs/vue/your-first-app.md
+++ b/docs/vue/your-first-app.md
@@ -56,7 +56,7 @@ To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
 :::
 
 ```shell
-npm install -g @ionic/cli@latest native-run cordova-res
+npm install -g @ionic/cli@latest native-run
 ```
 
 :::note
@@ -70,7 +70,7 @@ Consider setting up npm to operate globally without elevated permissions. See [R
 Next, create an Ionic Vue app that uses the "Tabs" starter template and adds Capacitor for native functionality:
 
 ```shell
-ionic start photo-gallery tabs --type vue --capacitor
+ionic start photo-gallery tabs --type vue
 ```
 
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
@@ -162,13 +162,13 @@ We put the visual aspects of our app into `<ion-content>`. In this case, it’s 
 import ExploreContainer from '@/components/ExploreContainer.vue';
 ```
 
-Next, remove the component name (`ExploreContainer`) from the `components` list in the Default Export and the HTML:
+Next, remove the `ExploreContainer` node from the HTML markup in the `template`.
 
 ```html
 <ExploreContainer name="Tab 2 page" />
 ```
 
-We'll replace it with a [floating action button](https://ionicframework.com/docs/api/fab) (FAB). First, update the imports within the `<script>` tag to include the Camera icon as well as some of the Ionic components we'll use shortly:
+We'll replace it with a [floating action button](https://ionicframework.com/docs/api/fab) (FAB). First, update the imports within the `<script setup>`  tag to include the Camera icon as well as some of the Ionic components we'll use shortly:
 
 ```tsx
 import { camera, trash, close } from 'ionicons/icons';
@@ -188,36 +188,9 @@ import {
 } from '@ionic/vue';
 ```
 
-Next, add the new Ionic components we'll be using to the default export as well as returning the Ionicons in the `setup()` method (part of the [Composition API](https://v3.vuejs.org/api/composition-api.html#setup)):
+Since our pages are generated as [Vue Single File Components](https://vuejs.org/api/sfc-spec.html) using the [`<script setup>`](https://vuejs.org/api/sfc-script-setup.html#script-setup) syntax these items are now exposed for use in our template.
 
-```tsx
-export default {
-  name: 'Tab2',
-  components: {
-    IonPage,
-    IonHeader,
-    IonFab,
-    IonFabButton,
-    IonIcon,
-    IonToolbar,
-    IonTitle,
-    IonContent,
-    IonGrid,
-    IonRow,
-    IonCol,
-    IonImg,
-  },
-  setup() {
-    return {
-      camera,
-      trash,
-      close,
-    };
-  },
-};
-```
-
-Then, add the FAB to the bottom of the page. Use the camera image as the icon, and call the `takePhoto()` function when this button is clicked (to be implemented soon):
+Add the FAB to the bottom of the page. Use the camera image as the icon, and call the `takePhoto()` function when this button is clicked (to be implemented soon):
 
 ```html
 <ion-content :fullscreen="true">
@@ -244,18 +217,6 @@ Within the tab bar (`<ion-tab-bar>`), change the label to "Photos" and the `elli
   <ion-icon :icon="images" />
   <ion-label>Photos</ion-label>
 </ion-tab-button>
-```
-
-Finally replace `ellipse` with `images` in the `setup()` method.
-
-```typescript
-  setup() {
-    return {
-      images,
-      square,
-      triangle,
-    }
-  }
 ```
 
 That’s just the start of all the cool things we can do with Ionic. Up next, implementing camera taking functionality on the web, then building for iOS and Android.

--- a/docs/vue/your-first-app/2-taking-photos.md
+++ b/docs/vue/your-first-app/2-taking-photos.md
@@ -16,7 +16,7 @@ Create a new file at `src/composables/usePhotoGallery.ts` and open it up.
 
 We will start by importing the various utilities we will use from Vue core and Capacitor:
 
-```tsx
+```typescript
 import { ref, onMounted, watch } from 'vue';
 import { Camera, CameraResultType, CameraSource, Photo } from '@capacitor/camera';
 import { Filesystem, Directory } from '@capacitor/filesystem';
@@ -25,8 +25,8 @@ import { Preferences } from '@capacitor/preferences';
 
 Next, create a function named usePhotoGallery:
 
-```tsx
-export function usePhotoGallery() {
+```typescript
+export const usePhotoGallery = () => {
   const takePhoto = async () => {
     const photo = await Camera.getPhoto({
       resultType: CameraResultType.Uri,
@@ -45,40 +45,38 @@ Our `usePhotoGallery` function exposes a method called takePhoto, which in turn 
 
 Notice the magic here: there's no platform-specific code (web, iOS, or Android)! The Capacitor Camera plugin abstracts that away for us, leaving just one method call - `getPhoto()` - that will open up the device's camera and allow us to take photos.
 
-The last step we need to take is to use the new function from the Tab2 page. Go back to Tab2.vue and import it:
+The last step we need to take is to use the new function from the Tab2 page. Go back to `Tab2Page.vue` and import it:
 
 ```tsx
 import { usePhotoGallery } from '@/composables/usePhotoGallery';
 ```
 
-Next, within the default export, add a setup method, part of the [Composition API](https://v3.vuejs.org/guide/composition-api-setup.html#setup). Destructure the `takePhoto` function from `usePhotoGallery`, then return it:
+Destructure the `takePhoto` function from `usePhotoGallery` so we can use it in our `template`:
 
 ```tsx
-<script lang="ts">
+<script setup lang="ts">
+import {
+  IonContent,
+  IonCol,
+  IonFab,
+  IonFabButton,
+  IonGrid,
+  IonPage,
+  IonHeader,
+  IonIcon,
+  IonImg,
+  IonRow,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/vue';
 import { camera, trash, close } from 'ionicons/icons';
-import { IonPage, IonHeader, IonFab, IonFabButton, IonIcon,
-         IonToolbar, IonTitle, IonContent, IonGrid, IonRow,
-         IonCol, IonImg } from '@ionic/vue';
 import { usePhotoGallery } from '@/composables/usePhotoGallery';
 
-export default  {
-  name: 'Tab2',
-  components: { IonPage, IonHeader, IonFab, IonFabButton, IonIcon,
-         IonToolbar, IonTitle, IonContent, IonGrid, IonRow,
-         IonCol, IonImg },
-  setup() {
-    const { takePhoto } = usePhotoGallery();
-
-    return {
-      takePhoto,
-      camera, trash, close
-    }
-  }
-}
+const { takePhoto } = usePhotoGallery();
 </script>
 ```
 
-Save the file, and if you’re not already, restart the development server in your browser by running `ionic serve`. On the Photo Gallery tab, click the Camera button. If your computer has a webcam of any sort, a modal window appears. Take a selfie!
+Save the file. Start the development server via `ionic serve` if it is not already running. In your browser, on the Photo Gallery tab, click the Camera button. If your computer has a webcam of any sort, a modal window appears. Take a selfie!
 
 ![Camera API on the web](/img/guides/first-app-cap-ng/camera-web.png)
 
@@ -97,13 +95,13 @@ export interface UserPhoto {
 }
 ```
 
-Back at the top of the function (right after referencing the Capacitor Camera plugin), define an array so we can store each photo captured with the Camera. Make it a reactive variable using Vue's [ref function](https://v3.vuejs.org/guide/composition-api-introduction.html#reactive-variables-with-ref).
+At the top of the `usePhotoGallery` function, define an array so we can store each photo captured with the Camera. Make it a reactive variable using Vue's [ref function](https://v3.vuejs.org/guide/composition-api-introduction.html#reactive-variables-with-ref).
 
 ```tsx
 const photos = ref<UserPhoto[]>([]);
 ```
 
-When the camera is done taking a picture, the resulting `Photo` returned from Capacitor will be added to the `photos` array. Update the `takePhoto` method, adding this code after the `Camera.getPhoto` line:
+When the camera is done taking a picture, the resulting `Photo` returned from Capacitor will be added to the `photos` array. Update the `takePhoto` function, adding this code after the `Camera.getPhoto` line:
 
 ```tsx
 const fileName = new Date().getTime() + '.jpeg';
@@ -134,18 +132,6 @@ Then, get access to the photos array:
 
 ```tsx
 const { photos, takePhoto } = usePhotoGallery();
-```
-
-Last, add `photos` to `setup()` return:
-
-```tsx
-return {
-  photos,
-  takePhoto,
-  camera,
-  trash,
-  close,
-};
 ```
 
 With the photo(s) stored into the main array we can now display the images on the screen. Add a [Grid component](https://ionicframework.com/docs/api/grid) so that each photo will display nicely as they are added to the gallery, and loop through each photo in the Photos array, adding an Image component (`<ion-img>`) for each. Point the `src` (source) to the photo's path:

--- a/docs/vue/your-first-app/3-saving-photos.md
+++ b/docs/vue/your-first-app/3-saving-photos.md
@@ -8,9 +8,9 @@ We’re now able to take multiple photos and display them in a photo gallery on 
 
 ## Filesystem API
 
-Fortunately, saving them to the filesystem only takes a few steps. Begin by opening the `usePhotoGallery` function (`src/composables/usePhotoGallery.ts`), and get access to the `writeFile` method from the `Filesystem` class:
+Fortunately, saving them to the filesystem only takes a few steps. Begin by opening the `usePhotoGallery` function (`src/composables/usePhotoGallery.ts`).
 
-Next, create a couple of new functions. The Filesystem API requires that files written to disk are passed in as base64 data, so this helper function will be used in a moment to assist with that:
+The Filesystem API requires that files written to disk are passed in as base64 data, so this helper function will be used in a moment to assist with that:
 
 ```tsx
 const convertBlobToBase64 = (blob: Blob) =>
@@ -30,12 +30,10 @@ Next we use the Capacitor [Filesystem API](https://capacitorjs.com/docs/apis/fil
 
 ```tsx
 const savePicture = async (photo: Photo, fileName: string): Promise<UserPhoto> => {
-  let base64Data: string;
-
   // Fetch the photo, read as a blob, then convert to base64 format
   const response = await fetch(photo.webPath!);
   const blob = await response.blob();
-  base64Data = (await convertBlobToBase64(blob)) as string;
+  const base64Data = (await convertBlobToBase64(blob)) as string;
 
   const savedFile = await Filesystem.writeFile({
     path: fileName,

--- a/docs/vue/your-first-app/4-loading-photos.md
+++ b/docs/vue/your-first-app/4-loading-photos.md
@@ -54,13 +54,13 @@ const loadSaved = async () => {
 
 On mobile (coming up next!), we can directly set the source of an image tag - `<img src="x" />` - to each photo file on the Filesystem, displaying them automatically. On the web, however, we must read each image from the Filesystem into base64 format, because the Filesystem API stores them in base64 within [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) under the hood.
 
-Finally, we need a way to call the `loadSaved` function when the Photo Gallery page is loaded. To do so, use the Vue [mounted lifecycle hook](https://v3.vuejs.org/guide/composition-api-introduction.html#lifecycle-hook-registration-inside-setup). First, import `onMounted` from Vue:
+Finally, we need a way to call the `loadSaved` function when the Photo Gallery page is loaded. To do so, use the Vue [mounted lifecycle hook](https://v3.vuejs.org/guide/composition-api-introduction.html#lifecycle-hook-registration-inside-setup). Earlier we had already imported `onMounted` from Vue:
 
 ```tsx
 import { ref, onMounted, watch } from 'vue';
 ```
 
-Then, within the `usePhotoGallery` function, add the `onMounted` function and call `loadSaved`:
+Within the `usePhotoGallery` function, add the `onMounted` function and call `loadSaved`:
 
 ```tsx
 onMounted(loadSaved);

--- a/docs/vue/your-first-app/5-adding-mobile.md
+++ b/docs/vue/your-first-app/5-adding-mobile.md
@@ -6,10 +6,11 @@ Let’s start with making some small code changes - then our app will "just work
 
 ## Platform-specific Logic
 
-First, we’ll update the photo saving functionality to support mobile. We'll run slightly different code depending on the platform - mobile or web. Import the `Platform` API from Ionic Vue:
+First, we’ll update the photo saving functionality to support mobile. We'll run slightly different code depending on the platform - mobile or web. Import the `Platform` API from Ionic Vue and `Capacitor` from Capacitor's `core` package:
 
 ```tsx
 import { isPlatform } from '@ionic/vue';
+import { Capacitor } from '@capacitor/core';
 ```
 
 In the `savePicture` function, check which platform the app is running on. If it’s "hybrid" (Capacitor, the native runtime), then read the photo file into base64 format using the `readFile` method. Also, return the complete file path to the photo using the Filesystem API. When setting the `webviewPath`, use the special `Capacitor.convertFileSrc` method ([details here](https://capacitorjs.com/docs/basics/utilities#convertfilesrc)). Otherwise, use the same logic as before when running the app on the web.

--- a/docs/vue/your-first-app/7-live-reload.md
+++ b/docs/vue/your-first-app/7-live-reload.md
@@ -26,7 +26,7 @@ The Live Reload server will start up, and the native IDE of choice will open if 
 
 ## Deleting Photos
 
-With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2.vue` then import the `actionSheetController`. We'll display an [IonActionSheet](https://ionicframework.com/docs/api/action-sheet) with the option to delete a photo:
+With Live Reload running and the app is open on your device, let’s implement photo deletion functionality. Open `Tab2Page.vue` then import the `actionSheetController`. We'll display an [IonActionSheet](https://ionicframework.com/docs/api/action-sheet) with the option to delete a photo:
 
 ```tsx
 import {
@@ -50,9 +50,7 @@ import {
 Next, reference the `deletePhoto` function, which we'll create soon:
 
 ```tsx
-setup() {}
-  const { photos, takePhoto, deletePhoto } = usePhotoGallery();
-}
+const { photos, takePhoto, deletePhoto } = usePhotoGallery();
 ```
 
 When a user clicks/taps on an image, we will show the action sheet. Add a click handler to the `<ion-img>` element:
@@ -61,7 +59,7 @@ When a user clicks/taps on an image, we will show the action sheet. Add a click 
 <ion-img :src="photo.webviewPath" @click="showActionSheet(photo)"></ion-img>
 ```
 
-Next, within `setup()`, call the `create` function to open a dialog with the option to either delete the selected photo or cancel (close) the dialog:
+Next, within `script setup`, call the `create` function to open a dialog with the option to either delete the selected photo or cancel (close) the dialog:
 
 ```tsx
 const showActionSheet = async (photo: UserPhoto) => {
@@ -87,19 +85,6 @@ const showActionSheet = async (photo: UserPhoto) => {
     ],
   });
   await actionSheet.present();
-};
-```
-
-Next, return the `showActionSheet` function:
-
-```tsx
-return {
-  photos,
-  takePhoto,
-  showActionSheet,
-  camera,
-  trash,
-  close,
 };
 ```
 


### PR DESCRIPTION
Since this tutorial was written, a few changes have happened:

1. File naming in the starters changed (Tab2.vue -> Tab2Page.vue)
2. We switched to `script setup` syntax in SFCs
3. The Vue tooling got tighter with regard to linting errors, so some steps actually caused temporary build issues since Vue does a lint as part of the serve

This is an attempt to bring the tutorial itself in line with these changes.