### PR TITLE
docs(button): clarify display behavior for expand

### DIFF
--- a/docs/api/button.md
+++ b/docs/api/button.md
@@ -27,7 +27,7 @@ import Basic from '@site/static/usage/button/basic/index.md';
 
 ## Expand
 
-This property lets you specify how wide the button should be. By default, buttons are inline blocks, but setting this property will change the button to a full-width block element.
+This property lets you specify how wide the button should be. By default, buttons have `display: inline-block`, but setting this property will change the button to a full-width element with `display: block`.
 
 import Expand from '@site/static/usage/button/expand/index.md';
 


### PR DESCRIPTION
A developer noted that the usage of "block" terms is confusing: https://github.com/ionic-team/ionic-framework/issues/26565

I updated the "expand" docs to clarify the difference between "block" as a CSS keyword and "block" as a value in the `expand` property