### PR TITLE
fix(cli): Handle deprecated commands, replace tables with formatting similar to Capacitor CLI docs

### DIFF
--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -20,17 +20,17 @@ function writePage(page) {
   const data = [
     renderFrontmatter(page),
     renderIntro(page),
-    renderExamples(page),
     renderInputs(page),
     renderOptions(page),
     renderAdvancedOptions(page),
+    renderExamples(page),
   ].join('');
 
   const path = `docs/cli/commands/${commandToKebab(page.name)}.md`;
   fs.writeFileSync(path, data);
 }
 
-function renderFrontmatter({ name }) {
+function renderFrontmatter({ name, groups }) {
   const shortName = name.replace('ionic ', '');
   const slug = commandToKebab(shortName);
 
@@ -39,21 +39,37 @@ function renderFrontmatter({ name }) {
     sidebar_label: shortName,
   };
 
+  const deprecated = groups.includes('deprecated')
+    ? ':::warning\nThis command has been deprecated and will be removed in an upcoming major release of the Ionic CLI.\n:::'
+    : '';
+
   return `---
 ${Object.entries(frontmatter)
   .map(([key, value]) => `${key}: ${typeof value === 'string' ? `"${value.replace('"', '\\"')}"` : value}`)
   .join('\n')}
 ---
 ${utils.getHeadTag(cliOverrides[slug])}
+
+${deprecated}
 `;
 }
 
-function renderIntro({ description, summary, name }) {
+function renderIntro({ description, summary, name, options, inputs }) {
+  let args = '';
+  if (inputs && inputs.length > 0) {
+    for (let input of inputs) {
+      args += ` [${input.name}]`;
+    }
+  }
+  if (options && options.length > 0) {
+    args += ' [options]';
+  }
+
   return `
 ${summary}
 
 \`\`\`shell
-$ ${name} [options]
+$ ${name}${args}
 \`\`\`
 
 ${description}`;
@@ -78,15 +94,7 @@ function renderInputs({ inputs }) {
     return '';
   }
 
-  return `
-## Inputs
-
-${utils.renderReference(inputs, {
-  Head: (input) => input.name,
-  Description: (input) => utils.renderMarkdown(input.summary),
-})}
-
-`;
+  return utils.renderList('Inputs', inputs);
 }
 
 function renderOptions({ options }) {
@@ -95,19 +103,7 @@ function renderOptions({ options }) {
   if (options.length === 0) {
     return '';
   }
-
-  return `
-## Options
-
-${utils.renderReference(options, {
-  Head: (option) => utils.renderOptionSpec(option),
-  Description: (option) => utils.renderMarkdown(option.summary),
-  Aliases: (option) =>
-    option.aliases.length > 0 ? option.aliases.map((alias) => `<code>-${alias}</code>`).join(' ') : null,
-  Default: (option) => (option.default && option.type === 'string' ? option.default : null),
-})}
-
-`;
+  return utils.renderOptions('Options', options);
 }
 
 function renderAdvancedOptions({ options }) {
@@ -116,19 +112,7 @@ function renderAdvancedOptions({ options }) {
   if (options.length === 0) {
     return '';
   }
-
-  return `
-## Advanced Options
-
-${utils.renderReference(options, {
-  Head: (option) => utils.renderOptionSpec(option),
-  Description: (option) => `<div>${utils.renderMarkdown(option.summary)}</div>`,
-  Aliases: (option) =>
-    option.aliases.length > 0 ? option.aliases.map((alias) => `<code>-${alias}</code>`).join(' ') : null,
-  Default: (option) => (option.default && option.type === 'string' ? option.default : null),
-})}
-
-`;
+  return utils.renderOptions('Advanced Options', options);
 }
 
 // function renderProperties({ props: properties }) {

--- a/scripts/data/cli.json
+++ b/scripts/data/cli.json
@@ -29,7 +29,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -150,7 +150,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -221,7 +221,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -409,7 +409,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -480,7 +480,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -815,7 +815,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -1068,7 +1068,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -1311,7 +1311,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -1559,7 +1559,7 @@
         {
           "name": "configuration",
           "type": "string",
-          "summary": "Specify the configuration to use.",
+          "summary": "Specify the configuration to use",
           "groups": ["advanced", "cordova"],
           "aliases": ["c"],
           "spec": {
@@ -1923,7 +1923,7 @@
       "summary": "Check the health of your Ionic project",
       "description": "This command detects and prints common issues and suggested steps to fix them.\n\nSome issues can be fixed automatically. See `ionic doctor treat --help`.\n\nOptionally supply the `id` argument to check a single issue. Use `ionic doctor list` to list all known issues.",
       "footnotes": [],
-      "groups": [],
+      "groups": ["deprecated"],
       "exampleCommands": ["ionic doctor check ", "ionic doctor check git-not-used"],
       "aliases": ["ionic doctor checkup", "ionic doctor validate"],
       "inputs": [
@@ -1942,7 +1942,7 @@
       "summary": "List all issues and their identifiers",
       "description": "Issues can have various tags:\n- **treatable**: `ionic doctor treat` can attempt to fix the issue\n- **ignored**: configured not to be detected in `ionic doctor check` or `ionic doctor treat`\n- **explicit-detection**: issue is only detected explicitly with `ionic doctor check <issue-id>`\n\nYou can flip whether an issue is ignored or not by using `ionic config set -g doctor.issues.<issue-id>.ignored true/false`, where `<issue-id>` matches an ID listed with this command.",
       "footnotes": [],
-      "groups": [],
+      "groups": ["deprecated"],
       "exampleCommands": [],
       "aliases": ["ionic doctor ls"],
       "inputs": [],
@@ -1955,7 +1955,7 @@
       "summary": "Attempt to fix issues in your Ionic project",
       "description": "This command detects and attempts to fix common issues. Before a fix is attempted, the steps are printed and a confirmation prompt is displayed.\n\nOptionally supply the `id` argument to attempt to fix a single issue. Use `ionic doctor list` to list all known issues.",
       "footnotes": [],
-      "groups": [],
+      "groups": ["deprecated"],
       "exampleCommands": ["ionic doctor treat ", "ionic doctor treat git-not-used"],
       "aliases": ["ionic doctor fix"],
       "inputs": [
@@ -2515,12 +2515,7 @@
       "description": "Easily spin up a development server which launches in your browser. It watches for changes in your source files and automatically reloads with the updated build.\n\nBy default, `ionic serve` boots up a development server on `localhost`. To serve to your LAN, specify the `--external` option, which will use all network interfaces and print the external address(es) on which your app is being served.\n\nTry the `--lab` option to see multiple platforms at once.\n\n`ionic serve` uses the Angular CLI. Use `ng serve --help` to list all Angular CLI options for serving your app. See the `ng serve` [docs](https://angular.io/cli/serve) for explanations. Options not listed below are considered advanced and can be passed to the Angular CLI using the `--` separator after the Ionic CLI arguments. See the examples.\n\nThe dev server can use HTTPS via the `--ssl` option **(experimental)**. There are several known issues with HTTPS. See issue [#3305](https://github.com/ionic-team/ionic-cli/issues/3305).",
       "footnotes": [],
       "groups": [],
-      "exampleCommands": [
-        "ionic serve ",
-        "ionic serve --external",
-        "ionic serve --lab",
-        "ionic serve -- --proxy-config proxy.conf.json"
-      ],
+      "exampleCommands": ["ionic serve ", "ionic serve --external", "ionic serve -- --proxy-config proxy.conf.json"],
       "aliases": ["ionic s"],
       "inputs": [],
       "options": [
@@ -2638,28 +2633,6 @@
           }
         },
         {
-          "name": "lab-host",
-          "type": "string",
-          "summary": "Use specific host for Ionic Lab server",
-          "default": "localhost",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "host"
-          }
-        },
-        {
-          "name": "lab-port",
-          "type": "string",
-          "summary": "Use specific port for Ionic Lab server",
-          "default": "8200",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "port"
-          }
-        },
-        {
           "name": "open",
           "type": "boolean",
           "summary": "Do not open a browser window",
@@ -2688,16 +2661,6 @@
           "aliases": ["o"],
           "spec": {
             "value": "path"
-          }
-        },
-        {
-          "name": "lab",
-          "type": "boolean",
-          "summary": "Test your apps on multiple platform types in the browser",
-          "groups": [],
-          "aliases": ["l"],
-          "spec": {
-            "value": "true/false"
           }
         }
       ],

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -10,48 +10,59 @@ function renderMarkdown(markdownString) {
 // https://github.com/ionic-team/ionic-docs/blob/master/src/components/reference/reference.tsx
 function renderReference(data, methodKeys) {
   return `
-<table className="reference-table">
+
   ${data
     .map((item) => {
       const { Head, ...keys } = methodKeys;
 
       return `
-      <thead>
-        <tr>
-          <th colSpan="2">
-            <h3>${Head(item)}</h3>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
+### ${Head(item)}
         ${Object.keys(keys)
           .map((name) => {
             const content = keys[name](item);
             if (content) {
               return `
-              <tr>
-                <th>${name}</th>
-                <td>${content}</td>
-              </tr>
+- \`${name}\`: ${content}
             `;
             }
           })
           .join(' ')}
-      </tbody>`;
+      `;
     })
     .join('')}
-</table>
 `;
 }
 
-// a String equivalent to this functional component
-// https://github.com/ionic-team/ionic-docs/blob/master/src/components/page/templates/cli.tsx#L146-L157
-function renderOptionSpec(option) {
+function renderList(title, data) {
   return `
-<a href="#option-${option.name}" id="option-${option.name}">
-  --${option.type === 'boolean' && option.default === true ? `no-${option.name}` : option.name}
-  ${option.type === 'string' ? `<span class="option-spec"> =&lt;${option.spec.value}&gt;</span>` : ''}
-</a>`.replace('\n', '');
+${data
+  .map((item) => {
+    return `
+### ${item.name}
+${item.summary}
+
+`;
+  })
+  .join('')}
+`;
+}
+
+function renderOptions(title, data) {
+  return `
+
+### ${title}
+${data
+  .map((item) => {
+    console.log(item);
+    const alias = item.aliases.length > 0 ? '(or ' + item.aliases.map((alias) => `\`-${alias}\``).join(' ') + ')' : '';
+    let name = item.type === 'boolean' && item.default === true ? `no-${item.name}` : item.name;
+    if (item.type === 'string') name += `=<${item.spec.value}>`;
+    return `
+ - \`--${name}\`: ${item.summary} ${alias}
+      `;
+  })
+  .join('')}
+`;
 }
 
 function gitBranchSVG() {
@@ -69,8 +80,9 @@ function getHeadTag({ title: metaTitle, description: metaDescription } = {}) {
 
 module.exports = {
   gitBranchSVG,
-  renderOptionSpec,
   renderMarkdown,
   renderReference,
+  renderOptions,
+  renderList,
   getHeadTag,
 };


### PR DESCRIPTION
- Commands that do not have options wont have examples like `ionic signup [options]`
- Option for `--lab` has been removed from description of ionic serve
- Option for `--lab-port` has been removed from ionic serve
- Tables for options and advanced options replaced with standard headers and text
- Any inputs to commands are shown as arguments. Eg `ionic cordova build [platform]` rather than `ionic cordova build [inputs]`
- `doctor` commands now have a deprecation warning