### PR TITLE
docs(toggle): migrate playgrounds to new usage

### DIFF
--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -35,6 +35,7 @@ import OnOff from '@site/static/usage/v7/toggle/on-off/index.md';
 
 <OnOff />
 
+
 ## Toggles in a List
 
 Toggles can also be used in a list view by using the [Item](./item) and [List](./list) components.
@@ -42,6 +43,15 @@ Toggles can also be used in a list view by using the [Item](./item) and [List](.
 import List from '@site/static/usage/v7/toggle/list/index.md';
 
 <List />
+
+
+## Label Placement
+
+Developers can use the `labelPlacement` property to control how the label is placed relative to the control.
+
+import LabelPlacement from '@site/static/usage/v7/toggle/label-placement/index.md';
+
+<LabelPlacement />
 
 ## Theming
 

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -56,7 +56,7 @@ import LabelPlacement from '@site/static/usage/v7/toggle/label-placement/index.m
 
 ## Justification
 
-Developers can use the `justify` property to control how the label and control are packed on the line.
+Developers can use the `justify` property to control how the label and control are packed on a line.
 
 import Justify from '@site/static/usage/v7/toggle/justify/index.md';
 

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -35,6 +35,13 @@ import OnOff from '@site/static/usage/v7/toggle/on-off/index.md';
 
 <OnOff />
 
+## Toggles in a List
+
+Toggles can also be used in a list view by using the [Item](./item) and [List](./list) components.
+
+import List from '@site/static/usage/v7/toggle/list/index.md';
+
+<List />
 
 ## Theming
 

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -53,6 +53,16 @@ import LabelPlacement from '@site/static/usage/v7/toggle/label-placement/index.m
 
 <LabelPlacement />
 
+
+## Justification
+
+Developers can use the `justify` property to control how the label and control are packed on the line.
+
+import Justify from '@site/static/usage/v7/toggle/justify/index.md';
+
+<Justify />
+
+
 ## Theming
 
 ### Colors

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -67,6 +67,28 @@ import CSSParts from '@site/static/usage/v7/toggle/theming/css-shadow-parts/inde
 
 <CSSParts />
 
+## Migrating from Legacy Toggle Syntax
+
+A simpler toggle syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an toggle, resolves accessibility issues, and improves the developer experience.
+
+While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
+
+### Using the Modern Syntax
+
+Using the modern syntax involves removing the `ion-label` and passing the label directly inside of `ion-toggle`. The placement of the label can be configured using the `labelPlacement` property on `ion-toggle`. The way the label and the control are packed on a line can be controlled using the `justify` property on `ion-toggle`.
+
+import Migration from '@site/static/usage/v7/toggle/migration/index.md';
+
+<Migration />
+  
+
+:::note
+In past versions of Ionic, `ion-item` was required for `ion-toggle` to function properly. Starting in Ionic 7.0, `ion-toggle` should only be used in an `ion-item` when the item is placed in an `ion-list`. Additionally, `ion-item` is no longer required for `ion-toggle` to function properly.
+:::
+
+### Using the Legacy Syntax
+
+Ionic uses heuristics to detect if an app is using the modern toggle syntax. In some instances, it may be preferable to continue using the legacy syntax. Developers can set the `legacy` property on `ion-toggle` to `true` to force that instance of the toggle to use the legacy syntax.
 
 ## Interfaces
 

--- a/static/usage/v7/toggle/basic/angular.md
+++ b/static/usage/v7/toggle/basic/angular.md
@@ -1,20 +1,6 @@
 ```html
-<ion-list>
-  <ion-item>
-    <ion-label>Default Toggle</ion-label>
-    <ion-toggle slot="end"></ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-label>Checked Toggle</ion-label>
-    <ion-toggle slot="end" [checked]="true"></ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-label>Disabled Toggle</ion-label>
-    <ion-toggle slot="end" [disabled]="true"></ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-label>Disabled Checked Toggle</ion-label>
-    <ion-toggle slot="end" [checked]="true" [disabled]="true"></ion-toggle>
-  </ion-item>
-</ion-list>
+<ion-toggle>Default Toggle</ion-toggle><br /><br />
+<ion-toggle [checked]="true">Checked Toggle</ion-toggle><br /><br />
+<ion-toggle [disabled]="true">Disabled Toggle</ion-toggle><br /><br />
+<ion-toggle [checked]="true" [disabled]="true">Disabled Checked Toggle</ion-toggle>
 ```

--- a/static/usage/v7/toggle/basic/demo.html
+++ b/static/usage/v7/toggle/basic/demo.html
@@ -9,12 +9,6 @@
   <script src="../../../common.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
-
-  <style>
-    ion-list {
-      width: 100%;
-    }
-  </style>
 </head>
 
 <body>

--- a/static/usage/v7/toggle/basic/demo.html
+++ b/static/usage/v7/toggle/basic/demo.html
@@ -7,8 +7,8 @@
   <title>Toggle</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
 
   <style>
     ion-list {
@@ -21,24 +21,12 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-list>
-          <ion-item>
-            <ion-label>Default Toggle</ion-label>
-            <ion-toggle slot="end"></ion-toggle>
-          </ion-item>
-          <ion-item>
-            <ion-label>Checked Toggle</ion-label>
-            <ion-toggle slot="end" checked="true"></ion-toggle>
-          </ion-item>
-          <ion-item>
-            <ion-label>Disabled Toggle</ion-label>
-            <ion-toggle slot="end" disabled="true"></ion-toggle>
-          </ion-item>
-          <ion-item>
-            <ion-label>Disabled Checked Toggle</ion-label>
-            <ion-toggle slot="end" checked="true" disabled="true"></ion-toggle>
-          </ion-item>
-        </ion-list>
+        <div>
+          <ion-toggle>Default Toggle</ion-toggle><br /><br />
+          <ion-toggle checked="true">Checked Toggle</ion-toggle><br /><br />
+          <ion-toggle disabled="true">Disabled Toggle</ion-toggle><br /><br />
+          <ion-toggle checked="true" disabled="true">Disabled Checked Toggle</ion-toggle>
+        </div>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/toggle/basic/index.md
+++ b/static/usage/v7/toggle/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/basic/demo.html" size="250px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/basic/demo.html" />

--- a/static/usage/v7/toggle/basic/javascript.md
+++ b/static/usage/v7/toggle/basic/javascript.md
@@ -1,20 +1,6 @@
 ```html
-<ion-list>
-  <ion-item>
-    <ion-label>Default Toggle</ion-label>
-    <ion-toggle slot="end"></ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-label>Checked Toggle</ion-label>
-    <ion-toggle slot="end" checked="true"></ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-label>Disabled Toggle</ion-label>
-    <ion-toggle slot="end" disabled="true"></ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-label>Disabled Checked Toggle</ion-label>
-    <ion-toggle slot="end" checked="true" disabled="true"></ion-toggle>
-  </ion-item>
-</ion-list>
+<ion-toggle>Default Toggle</ion-toggle><br /><br />
+<ion-toggle checked="true">Checked Toggle</ion-toggle><br /><br />
+<ion-toggle disabled="true">Disabled Toggle</ion-toggle><br /><br />
+<ion-toggle checked="true" disabled="true">Disabled Checked Toggle</ion-toggle>
 ```

--- a/static/usage/v7/toggle/basic/react.md
+++ b/static/usage/v7/toggle/basic/react.md
@@ -1,27 +1,13 @@
 ```tsx
 import React from 'react';
-import { IonItem, IonLabel, IonList, IonToggle } from '@ionic/react';
+import { IonToggle } from '@ionic/react';
 
 function Example() {
   return (
-    <IonList>
-      <IonItem>
-        <IonLabel>Default Toggle</IonLabel>
-        <IonToggle slot="end"></IonToggle>
-      </IonItem>
-      <IonItem>
-        <IonLabel>Checked Toggle</IonLabel>
-        <IonToggle slot="end" checked={true}></IonToggle>
-      </IonItem>
-      <IonItem>
-        <IonLabel>Disabled Toggle</IonLabel>
-        <IonToggle slot="end" disabled={true}></IonToggle>
-      </IonItem>
-      <IonItem>
-        <IonLabel>Disabled Checked Toggle</IonLabel>
-        <IonToggle slot="end" checked={true} disabled={true}></IonToggle>
-      </IonItem>
-    </IonList>
+    <IonToggle>Default Toggle</IonToggle><br /><br />
+    <IonToggle checked={true}>Checked Toggle</IonToggle><br /><br />
+    <IonToggle disabled={true}>Disabled Toggle</IonToggle><br /><br />
+    <IonToggle checked={true} disabled={true}>Disabled Checked Toggle</IonToggle>
   );
 }
 export default Example;

--- a/static/usage/v7/toggle/basic/react.md
+++ b/static/usage/v7/toggle/basic/react.md
@@ -4,10 +4,12 @@ import { IonToggle } from '@ionic/react';
 
 function Example() {
   return (
-    <IonToggle>Default Toggle</IonToggle><br /><br />
-    <IonToggle checked={true}>Checked Toggle</IonToggle><br /><br />
-    <IonToggle disabled={true}>Disabled Toggle</IonToggle><br /><br />
-    <IonToggle checked={true} disabled={true}>Disabled Checked Toggle</IonToggle>
+    <>
+      <IonToggle>Default Toggle</IonToggle><br /><br />
+      <IonToggle checked={true}>Checked Toggle</IonToggle><br /><br />
+      <IonToggle disabled={true}>Disabled Toggle</IonToggle><br /><br />
+      <IonToggle checked={true} disabled={true}>Disabled Checked Toggle</IonToggle>
+    </>
   );
 }
 export default Example;

--- a/static/usage/v7/toggle/basic/vue.md
+++ b/static/usage/v7/toggle/basic/vue.md
@@ -1,31 +1,17 @@
 ```html
 <template>
-  <ion-list>
-    <ion-item>
-      <ion-label>Default Toggle</ion-label>
-      <ion-toggle slot="end"></ion-toggle>
-    </ion-item>
-    <ion-item>
-      <ion-label>Checked Toggle</ion-label>
-      <ion-toggle slot="end" :checked="true"></ion-toggle>
-    </ion-item>
-    <ion-item>
-      <ion-label>Disabled Toggle</ion-label>
-      <ion-toggle slot="end" :disabled="true"></ion-toggle>
-    </ion-item>
-    <ion-item>
-      <ion-label>Disabled Checked Toggle</ion-label>
-      <ion-toggle slot="end" :checked="true" :disabled="true"></ion-toggle>
-    </ion-item>
-  </ion-list>
+  <ion-toggle>Default Toggle</ion-toggle><br /><br />
+  <ion-toggle :checked="true">Checked Toggle</ion-toggle><br /><br />
+  <ion-toggle :disabled="true">Disabled Toggle</ion-toggle><br /><br />
+  <ion-toggle :checked="true" :disabled="true">Disabled Checked Toggle</ion-toggle>
 </template>
 
 <script lang="ts">
-  import { IonItem, IonLabel, IonList, IonToggle } from '@ionic/vue';
+  import { IonToggle } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonItem, IonLabel, IonList, IonToggle },
+    components: { IonToggle },
   });
 </script>
 ```

--- a/static/usage/v7/toggle/justify/angular.md
+++ b/static/usage/v7/toggle/justify/angular.md
@@ -1,0 +1,5 @@
+```html
+<ion-toggle labelPlacement="start">Label at the Start</ion-toggle><br /><br />
+<ion-toggle labelPlacement="end">Label at the End</ion-toggle><br /><br />
+<ion-toggle labelPlacement="fixed">Fixed Width Label</ion-toggle><br /><br />
+```

--- a/static/usage/v7/toggle/justify/angular.md
+++ b/static/usage/v7/toggle/justify/angular.md
@@ -1,5 +1,13 @@
 ```html
-<ion-toggle labelPlacement="start">Label at the Start</ion-toggle><br /><br />
-<ion-toggle labelPlacement="end">Label at the End</ion-toggle><br /><br />
-<ion-toggle labelPlacement="fixed">Fixed Width Label</ion-toggle><br /><br />
+<ion-list>
+  <ion-item>
+    <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
+  </ion-item>
+</ion-list>
 ```

--- a/static/usage/v7/toggle/justify/demo.html
+++ b/static/usage/v7/toggle/justify/demo.html
@@ -9,20 +9,30 @@
   <script src="../../../common.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
+
+  <style>
+    ion-list {
+      width: 100%;
+    }
+  </style>
 </head>
-
-<body>
-  <ion-app>
-    <ion-content>
-      <div class="container">
-        <div>
-          <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
-          <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
-          <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
+            </ion-item>
+            <ion-item>
+              <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
+            </ion-item>
+            <ion-item>
+              <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
+            </ion-item>
+          </ion-list>
         </div>
-      </div>
-    </ion-content>
-  </ion-app>
-</body>
-
+      </ion-content>
+    </ion-app>
+  </body>
 </html>

--- a/static/usage/v7/toggle/justify/demo.html
+++ b/static/usage/v7/toggle/justify/demo.html
@@ -9,12 +9,6 @@
   <script src="../../../common.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
-
-  <style>
-    ion-list {
-      width: 100%;
-    }
-  </style>
 </head>
 
 <body>

--- a/static/usage/v7/toggle/justify/demo.html
+++ b/static/usage/v7/toggle/justify/demo.html
@@ -16,23 +16,19 @@
     }
   </style>
 </head>
-  <body>
-    <ion-app>
-      <ion-content>
-        <div class="container">
-          <ion-list>
-            <ion-item>
-              <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
-            </ion-item>
-            <ion-item>
-              <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
-            </ion-item>
-            <ion-item>
-              <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
-            </ion-item>
-          </ion-list>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div>
+          <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+          <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+          <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
         </div>
-      </ion-content>
-    </ion-app>
-  </body>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
 </html>

--- a/static/usage/v7/toggle/justify/index.md
+++ b/static/usage/v7/toggle/justify/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/label-placement/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/justify/demo.html" />

--- a/static/usage/v7/toggle/justify/index.md
+++ b/static/usage/v7/toggle/justify/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/justify/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/label-placement/demo.html" />

--- a/static/usage/v7/toggle/justify/javascript.md
+++ b/static/usage/v7/toggle/justify/javascript.md
@@ -1,0 +1,5 @@
+```html
+<ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+<ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+<ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+```

--- a/static/usage/v7/toggle/justify/javascript.md
+++ b/static/usage/v7/toggle/justify/javascript.md
@@ -1,5 +1,13 @@
 ```html
-<ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
-<ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
-<ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+<ion-list>
+  <ion-item>
+    <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
+  </ion-item>
+</ion-list>
 ```

--- a/static/usage/v7/toggle/justify/react.md
+++ b/static/usage/v7/toggle/justify/react.md
@@ -1,0 +1,13 @@
+```tsx
+import React from 'react';
+import { IonToggle } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonToggle labelPlacement="start">Label at the Start</IonToggle><br /><br />
+    <IonToggle labelPlacement="end">Label at the End</IonToggle><br /><br />
+    <IonToggle labelPlacement="fixed">Fixed Width Label</IonToggle><br /><br />
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/toggle/justify/react.md
+++ b/static/usage/v7/toggle/justify/react.md
@@ -1,12 +1,20 @@
 ```tsx
 import React from 'react';
-import { IonToggle } from '@ionic/react';
+import { IonItem, IonList, IonToggle } from '@ionic/react';
 
 function Example() {
   return (
-    <IonToggle labelPlacement="start">Label at the Start</IonToggle><br /><br />
-    <IonToggle labelPlacement="end">Label at the End</IonToggle><br /><br />
-    <IonToggle labelPlacement="fixed">Fixed Width Label</IonToggle><br /><br />
+    <IonList>
+      <IonItem>
+        <IonToggle justify="start">Packed at the Start of Line</IonToggle>
+      </IonItem>
+      <IonItem>
+        <IonToggle justify="end">Packed at the End of Line</IonToggle>
+      </IonItem>
+      <IonItem>
+        <IonToggle justify="space-between">Space Between Label and Control</IonToggle>
+      </IonItem>
+    </IonList>
   );
 }
 export default Example;

--- a/static/usage/v7/toggle/justify/vue.md
+++ b/static/usage/v7/toggle/justify/vue.md
@@ -1,0 +1,16 @@
+```html
+<template>
+  <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+  <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+  <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+</template>
+
+<script lang="ts">
+  import { IonToggle } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonToggle },
+  });
+</script>
+```

--- a/static/usage/v7/toggle/justify/vue.md
+++ b/static/usage/v7/toggle/justify/vue.md
@@ -1,16 +1,24 @@
 ```html
 <template>
-  <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
-  <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
-  <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+  <ion-list>
+    <ion-item>
+      <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
+    </ion-item>
+    <ion-item>
+      <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
+    </ion-item>
+    <ion-item>
+      <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
+    </ion-item>
+  </ion-list>
 </template>
 
 <script lang="ts">
-  import { IonToggle } from '@ionic/vue';
+  import { IonItem, IonList, IonToggle } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonToggle },
+    components: { IonItem, IonList, IonToggle },
   });
 </script>
 ```

--- a/static/usage/v7/toggle/label-placement/angular.md
+++ b/static/usage/v7/toggle/label-placement/angular.md
@@ -1,0 +1,5 @@
+```html
+<ion-toggle labelPlacement="start">Label at the Start</ion-toggle><br /><br />
+<ion-toggle labelPlacement="end">Label at the End</ion-toggle><br /><br />
+<ion-toggle labelPlacement="fixed">Fixed Width Label</ion-toggle><br /><br />
+```

--- a/static/usage/v7/toggle/label-placement/angular.md
+++ b/static/usage/v7/toggle/label-placement/angular.md
@@ -1,5 +1,13 @@
 ```html
-<ion-toggle labelPlacement="start">Label at the Start</ion-toggle><br /><br />
-<ion-toggle labelPlacement="end">Label at the End</ion-toggle><br /><br />
-<ion-toggle labelPlacement="fixed">Fixed Width Label</ion-toggle><br /><br />
+<ion-list>
+  <ion-item>
+    <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
+  </ion-item>
+</ion-list>
 ```

--- a/static/usage/v7/toggle/label-placement/angular.md
+++ b/static/usage/v7/toggle/label-placement/angular.md
@@ -1,13 +1,5 @@
 ```html
-<ion-list>
-  <ion-item>
-    <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
-  </ion-item>
-</ion-list>
+<ion-toggle labelPlacement="start">Label at the Start</ion-toggle><br /><br />
+<ion-toggle labelPlacement="end">Label at the End</ion-toggle><br /><br />
+<ion-toggle labelPlacement="fixed">Fixed Width Label</ion-toggle><br /><br />
 ```

--- a/static/usage/v7/toggle/label-placement/demo.html
+++ b/static/usage/v7/toggle/label-placement/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toggle</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
+
+  <style>
+    ion-list {
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div>
+          <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+          <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+          <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+        </div>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v7/toggle/label-placement/demo.html
+++ b/static/usage/v7/toggle/label-placement/demo.html
@@ -9,30 +9,20 @@
   <script src="../../../common.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
-
-  <style>
-    ion-list {
-      width: 100%;
-    }
-  </style>
 </head>
-  <body>
-    <ion-app>
-      <ion-content>
-        <div class="container">
-          <ion-list>
-            <ion-item>
-              <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
-            </ion-item>
-            <ion-item>
-              <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
-            </ion-item>
-            <ion-item>
-              <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
-            </ion-item>
-          </ion-list>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div>
+          <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+          <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+          <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
         </div>
-      </ion-content>
-    </ion-app>
-  </body>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
 </html>

--- a/static/usage/v7/toggle/label-placement/index.md
+++ b/static/usage/v7/toggle/label-placement/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/justify/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/label-placement/demo.html" />

--- a/static/usage/v7/toggle/label-placement/index.md
+++ b/static/usage/v7/toggle/label-placement/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/label-placement/demo.html" />

--- a/static/usage/v7/toggle/label-placement/javascript.md
+++ b/static/usage/v7/toggle/label-placement/javascript.md
@@ -1,13 +1,5 @@
 ```html
-<ion-list>
-  <ion-item>
-    <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
-  </ion-item>
-  <ion-item>
-    <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
-  </ion-item>
-</ion-list>
+<ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+<ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+<ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
 ```

--- a/static/usage/v7/toggle/label-placement/javascript.md
+++ b/static/usage/v7/toggle/label-placement/javascript.md
@@ -1,0 +1,5 @@
+```html
+<ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+<ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+<ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+```

--- a/static/usage/v7/toggle/label-placement/javascript.md
+++ b/static/usage/v7/toggle/label-placement/javascript.md
@@ -1,5 +1,13 @@
 ```html
-<ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
-<ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
-<ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+<ion-list>
+  <ion-item>
+    <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
+  </ion-item>
+</ion-list>
 ```

--- a/static/usage/v7/toggle/label-placement/react.md
+++ b/static/usage/v7/toggle/label-placement/react.md
@@ -1,0 +1,13 @@
+```tsx
+import React from 'react';
+import { IonToggle } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonToggle labelPlacement="start">Label at the Start</IonToggle><br /><br />
+    <IonToggle labelPlacement="end">Label at the End</IonToggle><br /><br />
+    <IonToggle labelPlacement="fixed">Fixed Width Label</IonToggle><br /><br />
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/toggle/label-placement/react.md
+++ b/static/usage/v7/toggle/label-placement/react.md
@@ -1,12 +1,20 @@
 ```tsx
 import React from 'react';
-import { IonToggle } from '@ionic/react';
+import { IonItem, IonList, IonToggle } from '@ionic/react';
 
 function Example() {
   return (
-    <IonToggle labelPlacement="start">Label at the Start</IonToggle><br /><br />
-    <IonToggle labelPlacement="end">Label at the End</IonToggle><br /><br />
-    <IonToggle labelPlacement="fixed">Fixed Width Label</IonToggle><br /><br />
+    <IonList>
+      <IonItem>
+        <IonToggle justify="start">Packed at the Start of Line</IonToggle>
+      </IonItem>
+      <IonItem>
+        <IonToggle justify="end">Packed at the End of Line</IonToggle>
+      </IonItem>
+      <IonItem>
+        <IonToggle justify="space-between">Space Between Label and Control</IonToggle>
+      </IonItem>
+    </IonList>
   );
 }
 export default Example;

--- a/static/usage/v7/toggle/label-placement/react.md
+++ b/static/usage/v7/toggle/label-placement/react.md
@@ -1,20 +1,12 @@
 ```tsx
 import React from 'react';
-import { IonItem, IonList, IonToggle } from '@ionic/react';
+import { IonToggle } from '@ionic/react';
 
 function Example() {
   return (
-    <IonList>
-      <IonItem>
-        <IonToggle justify="start">Packed at the Start of Line</IonToggle>
-      </IonItem>
-      <IonItem>
-        <IonToggle justify="end">Packed at the End of Line</IonToggle>
-      </IonItem>
-      <IonItem>
-        <IonToggle justify="space-between">Space Between Label and Control</IonToggle>
-      </IonItem>
-    </IonList>
+    <IonToggle labelPlacement="start">Label at the Start</IonToggle><br /><br />
+    <IonToggle labelPlacement="end">Label at the End</IonToggle><br /><br />
+    <IonToggle labelPlacement="fixed">Fixed Width Label</IonToggle><br /><br />
   );
 }
 export default Example;

--- a/static/usage/v7/toggle/label-placement/react.md
+++ b/static/usage/v7/toggle/label-placement/react.md
@@ -4,9 +4,11 @@ import { IonToggle } from '@ionic/react';
 
 function Example() {
   return (
-    <IonToggle labelPlacement="start">Label at the Start</IonToggle><br /><br />
-    <IonToggle labelPlacement="end">Label at the End</IonToggle><br /><br />
-    <IonToggle labelPlacement="fixed">Fixed Width Label</IonToggle><br /><br />
+    <>
+      <IonToggle labelPlacement="start">Label at the Start</IonToggle><br /><br />
+      <IonToggle labelPlacement="end">Label at the End</IonToggle><br /><br />
+      <IonToggle labelPlacement="fixed">Fixed Width Label</IonToggle><br /><br />
+    </>
   );
 }
 export default Example;

--- a/static/usage/v7/toggle/label-placement/vue.md
+++ b/static/usage/v7/toggle/label-placement/vue.md
@@ -1,24 +1,16 @@
 ```html
 <template>
-  <ion-list>
-    <ion-item>
-      <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
-    </ion-item>
-    <ion-item>
-      <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
-    </ion-item>
-    <ion-item>
-      <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
-    </ion-item>
-  </ion-list>
+  <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+  <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+  <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
 </template>
 
 <script lang="ts">
-  import { IonItem, IonList, IonToggle } from '@ionic/vue';
+  import { IonToggle } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonItem, IonList, IonToggle },
+    components: { IonToggle },
   });
 </script>
 ```

--- a/static/usage/v7/toggle/label-placement/vue.md
+++ b/static/usage/v7/toggle/label-placement/vue.md
@@ -1,0 +1,16 @@
+```html
+<template>
+  <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
+  <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
+  <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+</template>
+
+<script lang="ts">
+  import { IonToggle } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonToggle },
+  });
+</script>
+```

--- a/static/usage/v7/toggle/label-placement/vue.md
+++ b/static/usage/v7/toggle/label-placement/vue.md
@@ -1,16 +1,24 @@
 ```html
 <template>
-  <ion-toggle label-placement="start">Label at the Start</ion-toggle><br /><br />
-  <ion-toggle label-placement="end">Label at the End</ion-toggle><br /><br />
-  <ion-toggle label-placement="fixed">Fixed Width Label</ion-toggle><br /><br />
+  <ion-list>
+    <ion-item>
+      <ion-toggle justify="start">Packed at the Start of Line</ion-toggle>
+    </ion-item>
+    <ion-item>
+      <ion-toggle justify="end">Packed at the End of Line</ion-toggle>
+    </ion-item>
+    <ion-item>
+      <ion-toggle justify="space-between">Space Between Label and Control</ion-toggle>
+    </ion-item>
+  </ion-list>
 </template>
 
 <script lang="ts">
-  import { IonToggle } from '@ionic/vue';
+  import { IonItem, IonList, IonToggle } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonToggle },
+    components: { IonItem, IonList, IonToggle },
   });
 </script>
 ```

--- a/static/usage/v7/toggle/list/angular.md
+++ b/static/usage/v7/toggle/list/angular.md
@@ -1,0 +1,13 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-toggle>Receive Push Notifications</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle>Receive Emails</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle>Receive Text Messages</ion-toggle>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/toggle/list/demo.html
+++ b/static/usage/v7/toggle/list/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toggle</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
+
+</head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-toggle>Receive Push Notifications</ion-toggle>
+            </ion-item>
+            <ion-item>
+              <ion-toggle>Receive Emails</ion-toggle>
+            </ion-item>
+            <ion-item>
+              <ion-toggle>Receive Text Messages</ion-toggle>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/toggle/list/index.md
+++ b/static/usage/v7/toggle/list/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/list/demo.html" />

--- a/static/usage/v7/toggle/list/javascript.md
+++ b/static/usage/v7/toggle/list/javascript.md
@@ -1,0 +1,13 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-toggle>Receive Push Notifications</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle>Receive Emails</ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-toggle>Receive Text Messages</ion-toggle>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/toggle/list/react.md
+++ b/static/usage/v7/toggle/list/react.md
@@ -1,0 +1,21 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonToggle } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonToggle>Receive Push Notifications</IonToggle>
+      </IonItem>
+      <IonItem>
+        <IonToggle>Receive Emails</IonToggle>
+      </IonItem>
+      <IonItem>
+        <IonToggle>Receive Text Messages</IonToggle>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/toggle/list/vue.md
+++ b/static/usage/v7/toggle/list/vue.md
@@ -1,0 +1,24 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-toggle>Receive Push Notifications</ion-toggle>
+    </ion-item>
+    <ion-item>
+      <ion-toggle>Receive Emails</ion-toggle>
+    </ion-item>
+    <ion-item>
+      <ion-toggle>Receive Text Messages</ion-toggle>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonItem, IonList, IonToggle } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonToggle },
+  });
+</script>
+```

--- a/static/usage/v7/toggle/migration/index.md
+++ b/static/usage/v7/toggle/migration/index.md
@@ -137,7 +137,7 @@ import TabItem from '@theme/TabItem';
 
 {/* After */}
 <IonItem>
-  <IonToggle label-placement="end">Notifications</IonToggle>
+  <IonToggle labelPlacement="end">Notifications</IonToggle>
 </IonItem>
 ```
 </TabItem>

--- a/static/usage/v7/toggle/migration/index.md
+++ b/static/usage/v7/toggle/migration/index.md
@@ -1,0 +1,188 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+````mdx-code-block
+<Tabs
+  groupId="framework"
+  defaultValue="javascript"
+  values={[
+    { value: 'javascript', label: 'JavaScript' },
+    { value: 'angular', label: 'Angular' },
+    { value: 'react', label: 'React' },
+    { value: 'vue', label: 'Vue' },
+  ]
+}>
+<TabItem value="javascript">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Notifications</ion-label>
+  <ion-toggle></ion-toggle>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle>Notifications</ion-toggle>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Notifications</ion-label>
+  <ion-toggle></ion-toggle>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle label-placement="fixed">Notifications</ion-toggle>
+</ion-item>
+
+<!-- Toggle at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Notifications</ion-label>
+  <ion-input></ion-input>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle label-placement="end">Notifications</ion-toggle>
+</ion-item>
+```
+</TabItem>
+<TabItem value="angular">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Notifications</ion-label>
+  <ion-toggle></ion-toggle>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle>Notifications</ion-toggle>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Notifications</ion-label>
+  <ion-toggle></ion-toggle>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle label-placement="fixed">Notifications</ion-toggle>
+</ion-item>
+
+<!-- Toggle at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Notifications</ion-label>
+  <ion-input></ion-input>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle label-placement="end">Notifications</ion-toggle>
+</ion-item>
+```
+</TabItem>
+<TabItem value="react">
+
+```tsx
+{/* Basic */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel>Notifications</IonLabel>
+  <IonToggle></IonToggle>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonToggle>Notifications</IonToggle>
+</IonItem>
+
+{/* Fixed Labels */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel position="fixed">Notifications</IonLabel>
+  <IonToggle></IonToggle>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonToggle label-placement="fixed">Notifications</IonToggle>
+</IonItem>
+
+{/* Toggle at the start of line, Label at the end of line */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel slot="end">Notifications</IonLabel>
+  <ion-input></ion-input>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonToggle label-placement="end">Notifications</IonToggle>
+</IonItem>
+```
+</TabItem>
+<TabItem value="vue">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Notifications</ion-label>
+  <ion-toggle></ion-toggle>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle>Notifications</ion-toggle>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Notifications</ion-label>
+  <ion-toggle></ion-toggle>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle label-placement="fixed">Notifications</ion-toggle>
+</ion-item>
+
+<!-- Toggle at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Notifications</ion-label>
+  <ion-input></ion-input>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-toggle label-placement="end">Notifications</ion-toggle>
+</ion-item>
+```
+</TabItem>
+</Tabs>
+````

--- a/static/usage/v7/toggle/migration/index.md
+++ b/static/usage/v7/toggle/migration/index.md
@@ -124,7 +124,7 @@ import TabItem from '@theme/TabItem';
 
 {/* After */}
 <IonItem>
-  <IonToggle label-placement="fixed">Notifications</IonToggle>
+  <IonToggle labelPlacement="fixed">Notifications</IonToggle>
 </IonItem>
 
 {/* Toggle at the start of line, Label at the end of line */}

--- a/static/usage/v7/toggle/on-off/angular.md
+++ b/static/usage/v7/toggle/on-off/angular.md
@@ -1,3 +1,3 @@
 ```html
-<ion-toggle [enableOnOffLabels]="true"></ion-toggle>
+<ion-toggle [enableOnOffLabels]="true">Enable Notifications</ion-toggle>
 ```

--- a/static/usage/v7/toggle/on-off/demo.html
+++ b/static/usage/v7/toggle/on-off/demo.html
@@ -7,8 +7,8 @@
   <title>Toggle</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
 
 </head>
 
@@ -16,7 +16,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-toggle enable-on-off-labels="true"></ion-toggle>
+        <ion-toggle enable-on-off-labels="true">Enable Notifications</ion-toggle>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/toggle/on-off/javascript.md
+++ b/static/usage/v7/toggle/on-off/javascript.md
@@ -1,3 +1,3 @@
 ```html
-<ion-toggle enable-on-off-labels="true"></ion-toggle>
+<ion-toggle enable-on-off-labels="true">Enable Notifications</ion-toggle>
 ```

--- a/static/usage/v7/toggle/on-off/react.md
+++ b/static/usage/v7/toggle/on-off/react.md
@@ -4,7 +4,7 @@ import { IonToggle } from '@ionic/react';
 
 function Example() {
   return (
-    <IonToggle enableOnOffLabels={true}></IonToggle>
+    <IonToggle enableOnOffLabels={true}>Enable Notifications</IonToggle>
   );
 }
 export default Example;

--- a/static/usage/v7/toggle/on-off/vue.md
+++ b/static/usage/v7/toggle/on-off/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-toggle :enable-on-off-labels="true"></ion-toggle>
+  <ion-toggle :enable-on-off-labels="true">Enable Notifications</ion-toggle>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/toggle/theming/colors/angular.md
+++ b/static/usage/v7/toggle/theming/colors/angular.md
@@ -1,11 +1,11 @@
 ```html
-<ion-toggle color="primary" [checked]="true"></ion-toggle>
-<ion-toggle color="secondary" [checked]="true"></ion-toggle>
-<ion-toggle color="tertiary" [checked]="true"></ion-toggle>
-<ion-toggle color="success" [checked]="true"></ion-toggle>
-<ion-toggle color="warning" [checked]="true"></ion-toggle>
-<ion-toggle color="danger" [checked]="true"></ion-toggle>
-<ion-toggle color="light" [checked]="true"></ion-toggle>
-<ion-toggle color="medium" [checked]="true"></ion-toggle>
-<ion-toggle color="dark" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Primary toggle" color="primary" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Secondary toggle" color="secondary" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Tertiary toggle" color="tertiary" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Success toggle" color="success" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Warning toggle" color="warning" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Danger toggle" color="danger" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Light toggle" color="light" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Medium toggle" color="medium" [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Dark toggle" color="dark" [checked]="true"></ion-toggle>
 ```

--- a/static/usage/v7/toggle/theming/colors/demo.html
+++ b/static/usage/v7/toggle/theming/colors/demo.html
@@ -7,8 +7,8 @@
   <title>Toggle</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
 
 </head>
 
@@ -16,15 +16,15 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-toggle color="primary" checked="true"></ion-toggle>
-        <ion-toggle color="secondary" checked="true"></ion-toggle>
-        <ion-toggle color="tertiary" checked="true"></ion-toggle>
-        <ion-toggle color="success" checked="true"></ion-toggle>
-        <ion-toggle color="warning" checked="true"></ion-toggle>
-        <ion-toggle color="danger" checked="true"></ion-toggle>
-        <ion-toggle color="light" checked="true"></ion-toggle>
-        <ion-toggle color="medium" checked="true"></ion-toggle>
-        <ion-toggle color="dark" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Primary toggle" color="primary" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Secondary toggle" color="secondary" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Tertiary toggle" color="tertiary" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Success toggle" color="success" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Warning toggle" color="warning" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Danger toggle" color="danger" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Light toggle" color="light" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Medium toggle" color="medium" checked="true"></ion-toggle>
+        <ion-toggle aria-label="Dark toggle" color="dark" checked="true"></ion-toggle>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/toggle/theming/colors/javascript.md
+++ b/static/usage/v7/toggle/theming/colors/javascript.md
@@ -1,11 +1,11 @@
 ```html
-<ion-toggle color="primary" checked="true"></ion-toggle>
-<ion-toggle color="secondary" checked="true"></ion-toggle>
-<ion-toggle color="tertiary" checked="true"></ion-toggle>
-<ion-toggle color="success" checked="true"></ion-toggle>
-<ion-toggle color="warning" checked="true"></ion-toggle>
-<ion-toggle color="danger" checked="true"></ion-toggle>
-<ion-toggle color="light" checked="true"></ion-toggle>
-<ion-toggle color="medium" checked="true"></ion-toggle>
-<ion-toggle color="dark" checked="true"></ion-toggle>
+<ion-toggle aria-label="Primary toggle" color="primary" checked="true"></ion-toggle>
+<ion-toggle aria-label="Secondary toggle" color="secondary" checked="true"></ion-toggle>
+<ion-toggle aria-label="Tertiary toggle" color="tertiary" checked="true"></ion-toggle>
+<ion-toggle aria-label="Success toggle" color="success" checked="true"></ion-toggle>
+<ion-toggle aria-label="Warning toggle" color="warning" checked="true"></ion-toggle>
+<ion-toggle aria-label="Danger toggle" color="danger" checked="true"></ion-toggle>
+<ion-toggle aria-label="Light toggle" color="light" checked="true"></ion-toggle>
+<ion-toggle aria-label="Medium toggle" color="medium" checked="true"></ion-toggle>
+<ion-toggle aria-label="Dark toggle" color="dark" checked="true"></ion-toggle>
 ```

--- a/static/usage/v7/toggle/theming/colors/react.md
+++ b/static/usage/v7/toggle/theming/colors/react.md
@@ -5,15 +5,15 @@ import { IonToggle } from '@ionic/react';
 function Example() {
   return (
     <>
-      <IonToggle color="primary" checked={true}></IonToggle>
-      <IonToggle color="secondary" checked={true}></IonToggle>
-      <IonToggle color="tertiary" checked={true}></IonToggle>
-      <IonToggle color="success" checked={true}></IonToggle>
-      <IonToggle color="warning" checked={true}></IonToggle>
-      <IonToggle color="danger" checked={true}></IonToggle>
-      <IonToggle color="light" checked={true}></IonToggle>
-      <IonToggle color="medium" checked={true}></IonToggle>
-      <IonToggle color="dark" checked={true}></IonToggle>
+      <IonToggle aria-label="Primary toggle" color="primary" checked={true}></IonToggle>
+      <IonToggle aria-label="Secondary toggle" color="secondary" checked={true}></IonToggle>
+      <IonToggle aria-label="Tertiary toggle" color="tertiary" checked={true}></IonToggle>
+      <IonToggle aria-label="Success toggle" color="success" checked={true}></IonToggle>
+      <IonToggle aria-label="Warning toggle" color="warning" checked={true}></IonToggle>
+      <IonToggle aria-label="Danger toggle" color="danger" checked={true}></IonToggle>
+      <IonToggle aria-label="Light toggle" color="light" checked={true}></IonToggle>
+      <IonToggle aria-label="Medium toggle" color="medium" checked={true}></IonToggle>
+      <IonToggle aria-label="Dark toggle" color="dark" checked={true}></IonToggle>
     </>
   );
 }

--- a/static/usage/v7/toggle/theming/colors/vue.md
+++ b/static/usage/v7/toggle/theming/colors/vue.md
@@ -1,14 +1,14 @@
 ```html
 <template>
-  <ion-toggle color="primary" :checked="true"></ion-toggle>
-  <ion-toggle color="secondary" :checked="true"></ion-toggle>
-  <ion-toggle color="tertiary" :checked="true"></ion-toggle>
-  <ion-toggle color="success" :checked="true"></ion-toggle>
-  <ion-toggle color="warning" :checked="true"></ion-toggle>
-  <ion-toggle color="danger" :checked="true"></ion-toggle>
-  <ion-toggle color="light" :checked="true"></ion-toggle>
-  <ion-toggle color="medium" :checked="true"></ion-toggle>
-  <ion-toggle color="dark" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Primary toggle" color="primary" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Secondary toggle" color="secondary" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Tertiary toggle" color="tertiary" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Success toggle" color="success" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Warning toggle" color="warning" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Danger toggle" color="danger" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Light toggle" color="light" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Medium toggle" color="medium" :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Dark toggle" color="dark" :checked="true"></ion-toggle>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/toggle/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/v7/toggle/theming/css-properties/angular/example_component_css.md
@@ -1,12 +1,9 @@
 ```css
 ion-toggle {
-  height: 10px;
-  width: 65px;
-
   padding: 12px;
 
-  --background: #ddd;
-  --background-checked: #ddd;
+  --track-background: #ddd;
+  --track-background-checked: #ddd;
 
   --handle-background: #eb7769;
   --handle-background-checked: #95c34e;
@@ -18,9 +15,13 @@ ion-toggle {
 
   --handle-border-radius: 4px;
   --handle-box-shadow: none;
+}
+
+ion-toggle::part(track) {
+  height: 10px;
+  width: 65px;
 
   /* Required for iOS handle to overflow the height of the track */
   overflow: visible;
-  contain: none;
 }
 ```

--- a/static/usage/v7/toggle/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/v7/toggle/theming/css-properties/angular/example_component_html.md
@@ -1,4 +1,4 @@
 ```html
-<ion-toggle></ion-toggle>
-<ion-toggle [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Enable Notifications"></ion-toggle>
+<ion-toggle [checked]="true" aria-label="Enable Notifications"></ion-toggle>
 ```

--- a/static/usage/v7/toggle/theming/css-properties/demo.html
+++ b/static/usage/v7/toggle/theming/css-properties/demo.html
@@ -7,18 +7,15 @@
   <title>Item</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
 
   <style>
     ion-toggle {
-      height: 10px;
-      width: 65px;
-
       padding: 12px;
 
-      --background: #ddd;
-      --background-checked: #ddd;
+      --track-background: #ddd;
+      --track-background-checked: #ddd;
 
       --handle-background: #eb7769;
       --handle-background-checked: #95c34e;
@@ -30,10 +27,13 @@
 
       --handle-border-radius: 4px;
       --handle-box-shadow: none;
+    }
 
-      /* Required for iOS handle to overflow the height of the track */
+    ion-toggle::part(track) {
+      height: 10px;
+      width: 65px;
+
       overflow: visible;
-      contain: none;
     }
   </style>
 </head>
@@ -42,8 +42,8 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-toggle></ion-toggle>
-        <ion-toggle checked="true"></ion-toggle>
+        <ion-toggle aria-label="Enable Notifications"></ion-toggle>
+        <ion-toggle checked="true" aria-label="Enable Notifications"></ion-toggle>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/toggle/theming/css-properties/javascript.md
+++ b/static/usage/v7/toggle/theming/css-properties/javascript.md
@@ -1,31 +1,32 @@
 ```html
-<ion-toggle></ion-toggle>
-<ion-toggle checked="true"></ion-toggle>
+<ion-toggle aria-label="Enable Notifications"></ion-toggle>
+<ion-toggle checked="true" aria-label="Enable Notifications"></ion-toggle>
 
 <style>
   ion-toggle {
-    height: 10px;
-    width: 65px;
-
     padding: 12px;
-
-    --background: #ddd;
-    --background-checked: #ddd;
-
+  
+    --track-background: #ddd;
+    --track-background-checked: #ddd;
+  
     --handle-background: #eb7769;
     --handle-background-checked: #95c34e;
-
+  
     --handle-width: 25px;
     --handle-height: 27px;
     --handle-max-height: auto;
     --handle-spacing: 6px;
-
+  
     --handle-border-radius: 4px;
     --handle-box-shadow: none;
-
+  }
+  
+  ion-toggle::part(track) {
+    height: 10px;
+    width: 65px;
+  
     /* Required for iOS handle to overflow the height of the track */
     overflow: visible;
-    contain: none;
   }
 </style>
 ```

--- a/static/usage/v7/toggle/theming/css-properties/react/main_css.md
+++ b/static/usage/v7/toggle/theming/css-properties/react/main_css.md
@@ -1,12 +1,9 @@
 ```css
 ion-toggle {
-  height: 10px;
-  width: 65px;
-
   padding: 12px;
 
-  --background: #ddd;
-  --background-checked: #ddd;
+  --track-background: #ddd;
+  --track-background-checked: #ddd;
 
   --handle-background: #eb7769;
   --handle-background-checked: #95c34e;
@@ -18,9 +15,13 @@ ion-toggle {
 
   --handle-border-radius: 4px;
   --handle-box-shadow: none;
+}
+
+ion-toggle::part(track) {
+  height: 10px;
+  width: 65px;
 
   /* Required for iOS handle to overflow the height of the track */
   overflow: visible;
-  contain: none;
 }
 ```

--- a/static/usage/v7/toggle/theming/css-properties/react/main_tsx.md
+++ b/static/usage/v7/toggle/theming/css-properties/react/main_tsx.md
@@ -7,8 +7,8 @@ import './main.css';
 function Example() {
   return (
     <>
-      <IonToggle></IonToggle>
-      <IonToggle checked={true}></IonToggle>
+      <IonToggle aria-label="Enable Notifications"></IonToggle>
+      <IonToggle checked={true} aria-label="Enable Notifications"></IonToggle>
     </>
   );
 }

--- a/static/usage/v7/toggle/theming/css-properties/vue.md
+++ b/static/usage/v7/toggle/theming/css-properties/vue.md
@@ -1,7 +1,7 @@
 ```html
 <template>
-  <ion-toggle></ion-toggle>
-  <ion-toggle :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Enable Notifications"></ion-toggle>
+  <ion-toggle :checked="true" aria-label="Enable Notifications"></ion-toggle>
 </template>
 
 <script lang="ts">
@@ -15,28 +15,29 @@
 
 <style scoped>
   ion-toggle {
-    height: 10px;
-    width: 65px;
-
     padding: 12px;
-
-    --background: #ddd;
-    --background-checked: #ddd;
-
+  
+    --track-background: #ddd;
+    --track-background-checked: #ddd;
+  
     --handle-background: #eb7769;
     --handle-background-checked: #95c34e;
-
+  
     --handle-width: 25px;
     --handle-height: 27px;
     --handle-max-height: auto;
     --handle-spacing: 6px;
-
+  
     --handle-border-radius: 4px;
     --handle-box-shadow: none;
-
+  }
+  
+  ion-toggle::part(track) {
+    height: 10px;
+    width: 65px;
+  
     /* Required for iOS handle to overflow the height of the track */
     overflow: visible;
-    contain: none;
   }
 </style>
 ```

--- a/static/usage/v7/toggle/theming/css-shadow-parts/angular/example_component_css.md
+++ b/static/usage/v7/toggle/theming/css-shadow-parts/angular/example_component_css.md
@@ -1,8 +1,5 @@
 ```css
 ion-toggle {
-  height: 10px;
-  width: 65px;
-
   padding: 12px;
 
   --handle-width: 25px;
@@ -10,14 +7,18 @@ ion-toggle {
   --handle-max-height: auto;
   --handle-spacing: 6px;
 
-  /* Required for iOS handle to overflow the height of the track */
-  overflow: visible;
   contain: none;
 }
 
 ion-toggle::part(track),
 ion-toggle.toggle-checked::part(track) {
+  height: 10px;
+  width: 65px;
+
   background: #ddd;
+
+  /* Required for iOS handle to overflow the height of the track */
+  overflow: visible;
 }
 
 ion-toggle::part(handle) {

--- a/static/usage/v7/toggle/theming/css-shadow-parts/angular/example_component_html.md
+++ b/static/usage/v7/toggle/theming/css-shadow-parts/angular/example_component_html.md
@@ -1,4 +1,4 @@
 ```html
-<ion-toggle></ion-toggle>
-<ion-toggle [checked]="true"></ion-toggle>
+<ion-toggle aria-label="Enable Notifications"></ion-toggle>
+<ion-toggle [checked]="true" aria-label="Enable Notifications"></ion-toggle>
 ```

--- a/static/usage/v7/toggle/theming/css-shadow-parts/demo.html
+++ b/static/usage/v7/toggle/theming/css-shadow-parts/demo.html
@@ -7,14 +7,11 @@
   <title>Item</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.1-dev.11670949653.116404ab/css/ionic.bundle.css" />
 
   <style>
     ion-toggle {
-      height: 10px;
-      width: 65px;
-
       padding: 12px;
 
       --handle-width: 25px;
@@ -22,14 +19,18 @@
       --handle-max-height: auto;
       --handle-spacing: 6px;
 
-      /* Required for iOS handle to overflow the height of the track */
-      overflow: visible;
       contain: none;
     }
 
     ion-toggle::part(track),
     ion-toggle.toggle-checked::part(track) {
+      height: 10px;
+      width: 65px;
+
       background: #ddd;
+
+      /* Required for iOS handle to overflow the height of the track */
+      overflow: visible;
     }
 
     ion-toggle::part(handle) {
@@ -49,8 +50,8 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-toggle></ion-toggle>
-        <ion-toggle checked="true"></ion-toggle>
+        <ion-toggle aria-label="Enable Notifications"></ion-toggle>
+        <ion-toggle checked="true" aria-label="Enable Notifications"></ion-toggle>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/toggle/theming/css-shadow-parts/javascript.md
+++ b/static/usage/v7/toggle/theming/css-shadow-parts/javascript.md
@@ -1,27 +1,28 @@
 ```html
-<ion-toggle></ion-toggle>
-<ion-toggle checked="true"></ion-toggle>
+<ion-toggle aria-label="Enable Notifications"></ion-toggle>
+<ion-toggle checked="true" aria-label="Enable Notifications"></ion-toggle>
 
 <style>
   ion-toggle {
-    height: 10px;
-    width: 65px;
-
     padding: 12px;
-
+  
     --handle-width: 25px;
     --handle-height: 27px;
     --handle-max-height: auto;
     --handle-spacing: 6px;
-
-    /* Required for iOS handle to overflow the height of the track */
-    overflow: visible;
+  
     contain: none;
   }
-
+  
   ion-toggle::part(track),
   ion-toggle.toggle-checked::part(track) {
+    height: 10px;
+    width: 65px;
+  
     background: #ddd;
+  
+    /* Required for iOS handle to overflow the height of the track */
+    overflow: visible;
   }
 
   ion-toggle::part(handle) {

--- a/static/usage/v7/toggle/theming/css-shadow-parts/react/main_css.md
+++ b/static/usage/v7/toggle/theming/css-shadow-parts/react/main_css.md
@@ -1,8 +1,5 @@
 ```css
 ion-toggle {
-  height: 10px;
-  width: 65px;
-
   padding: 12px;
 
   --handle-width: 25px;
@@ -10,14 +7,18 @@ ion-toggle {
   --handle-max-height: auto;
   --handle-spacing: 6px;
 
-  /* Required for iOS handle to overflow the height of the track */
-  overflow: visible;
   contain: none;
 }
 
 ion-toggle::part(track),
 ion-toggle.toggle-checked::part(track) {
+  height: 10px;
+  width: 65px;
+
   background: #ddd;
+
+  /* Required for iOS handle to overflow the height of the track */
+  overflow: visible;
 }
 
 ion-toggle::part(handle) {

--- a/static/usage/v7/toggle/theming/css-shadow-parts/react/main_tsx.md
+++ b/static/usage/v7/toggle/theming/css-shadow-parts/react/main_tsx.md
@@ -7,8 +7,8 @@ import './main.css';
 function Example() {
   return (
     <>
-      <IonToggle></IonToggle>
-      <IonToggle checked={true}></IonToggle>
+      <IonToggle aria-label="Enable Notifications"></IonToggle>
+      <IonToggle checked={true} aria-label="Enable Notifications"></IonToggle>
     </>
   );
 }

--- a/static/usage/v7/toggle/theming/css-shadow-parts/vue.md
+++ b/static/usage/v7/toggle/theming/css-shadow-parts/vue.md
@@ -1,7 +1,7 @@
 ```html
 <template>
-  <ion-toggle></ion-toggle>
-  <ion-toggle :checked="true"></ion-toggle>
+  <ion-toggle aria-label="Enable Notifications"></ion-toggle>
+  <ion-toggle :checked="true" aria-label="Enable Notifications"></ion-toggle>
 </template>
 
 <script lang="ts">
@@ -15,24 +15,25 @@
 
 <style scoped>
   ion-toggle {
-    height: 10px;
-    width: 65px;
-
     padding: 12px;
-
+  
     --handle-width: 25px;
     --handle-height: 27px;
     --handle-max-height: auto;
     --handle-spacing: 6px;
-
-    /* Required for iOS handle to overflow the height of the track */
-    overflow: visible;
+  
     contain: none;
   }
-
+  
   ion-toggle::part(track),
   ion-toggle.toggle-checked::part(track) {
+    height: 10px;
+    width: 65px;
+  
     background: #ddd;
+  
+    /* Required for iOS handle to overflow the height of the track */
+    overflow: visible;
   }
 
   ion-toggle::part(handle) {


### PR DESCRIPTION
This PR does the following things:

- Migrates the Basic, On/Off Labels, Colors, CSS Custom Properties, and CSS Shadow Parts playgrounds to use the new syntax. As part of this, I also removed the `ion-item` usage as it was not necessary
- Since `ion-item` is no longer in the examples above, I added a playground that shows how to use toggle in a list.
- Adds migration guide to show how to use the modern syntax
- Adds playgrounds for new labelPlacement and justify properties
Preview: https://ionic-docs-8j9cuugzh-ionic1.vercel.app/docs/api/toggle