### PR TITLE
chore(modal, toast): remove unneeded controller imports

### DIFF
--- a/static/usage/v7/modal/performance/mount/demo.html
+++ b/static/usage/v7/modal/performance/mount/demo.html
@@ -9,10 +9,6 @@
   <script src="../../../../common.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
-  <script type="module">
-    import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/index.esm.js';
-    window.modalController = modalController;
-  </script>
 </head>
 
 <body>

--- a/static/usage/v7/toast/buttons/angular/example_component_ts.md
+++ b/static/usage/v7/toast/buttons/angular/example_component_ts.md
@@ -1,6 +1,5 @@
 ```ts
 import { Component } from '@angular/core';
-import { ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
@@ -21,8 +20,6 @@ export class ExampleComponent {
   ];
   handlerMessage = '';
   roleMessage = '';
-
-  constructor(private toastController: ToastController) {}
 
   setRoleMessage(ev) {
     const { role } = ev.detail


### PR DESCRIPTION
This PR removes a couple of leftover controller imports from playgrounds that have been migrated to show the new inline usage for their respective overlays.