### PR TITLE
docs(upgrade-guides): add v7 migration, new upgrade guide links

### DIFF
--- a/docs/intro/upgrading-to-ionic-7.md
+++ b/docs/intro/upgrading-to-ionic-7.md
@@ -1,0 +1,120 @@
+# Upgrading to Ionic 7
+
+Follow this guide to upgrade your Ionic 6 apps to Ionic 7.
+
+:::note
+Ionic 7 is in beta. Please report any issues on [the Ionic Framework GitHub Repo](https://github.com/ionic-team/ionic-framework).
+:::
+
+## Getting Started
+
+:::note
+This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Upgrading to Ionic 6 Guide](./upgrading-to-ionic-6) before starting this guide.
+:::
+
+### Angular
+
+1. Ionic 7 supports Angular 13+. Update to the latest version of Angular by following the [Angular Update Guide](https://update.angular.io/).
+2. Update to the latest version of Ionic 7:
+
+```shell
+npm install @ionic/angular@next
+```
+
+If you are using Ionic Angular Server, be sure to update that as well:
+
+```shell
+npm install @ionic/angular@next @ionic/angular-server@next
+```
+
+### React
+
+1. Ionic 7 supports React 17+. Update to the latest version of React:
+
+```shell
+npm install react@latest react-dom@latest
+```
+
+2. Update to the latest version of Ionic 7:
+
+```shell
+npm install @ionic/react@next @ionic/react-router@next
+```
+
+### Vue
+
+1. Ionic 7 supports Vue 3.0.6+. Update to the latest version of Vue:
+
+```shell
+npm install vue@latest vue-router@latest
+```
+
+3. Update to the latest version of Ionic 7:
+
+```shell
+npm install @ionic/vue@next @ionic/vue-router@next
+```
+
+### Core
+
+1. Update to the latest version of Ionic 7:
+
+```shell
+npm install @ionic/core@next
+```
+
+## Updating Your Code
+
+### Types
+
+1. `ActionSheetAttributes`, `AlertAttributes`, `AlertTextareaAttributes`, `AlertInputAttributes`, `LoadingAttributes`, `ModalAttributes`, `PickerAttributes`, `PopoverAttributes`, and `ToastAttributes` have been removed. Developers should use `{ [key: string]: any }` instead.
+
+
+### Checkbox
+
+1. Rename any usages of the `--background` and `--background-checked` CSS Variables to `--checkbox-background` and `--checkbox-background-checked`, respectively.
+
+### Datetime
+
+1. Remove any code that sets the `value` property to the empty string (`''`).
+2. Remove any code that accesses the time zone information on the `value` property. Datetime does not manage time zones, so any time zone information provided is ignored.
+
+### Modal
+
+1. Remove any usage of the `swipeToClose` property. Use the [canDismiss](https://ionicframework.com/docs/api/modal#preventing-a-modal-from-dismissing) property to control when a modal can dismiss.
+2. Remove any code that sets the `canDismiss` property to `undefined`. The `canDismiss` property now defaults to `true`, so this code is no longer needed.
+
+### Picker
+
+1. Remove any code that accesses `refresh` on `ion-picker-column`. Developers should use the `columns` property on `ion-picker` to refresh the view instead.
+
+### Segment
+
+1. Remove any code that sets the `value` property to `null`. Developers should use either `''` or `undefined` instead.
+
+### Slides
+
+1. Remove `ion-slides`, `ion-slide`, and any associated types. These components have been removed in favor of using Swiper.js directly. The guides below contain more information about this migration:
+
+[Angular Migration Guide](https://ionicframework.com/docs/angular/slides)<br />
+[React Migration Guide](https://ionicframework.com/docs/react/slides)<br />
+[Vue Migration Guide](https://ionicframework.com/docs/vue/slides)
+
+### Toggle
+
+1. Rename any usages of the `--background` and `--background-checked` CSS Variables to `--track-background` and `--track-background-checked`, respectively.
+
+### Virtual Scroll
+
+1. Remove `ion-virtual-scroll` and any associated types. This component has been removed in favor of using virtual scroll solutions provided by JavaScript Frameworks. The guides below contain more information about this migration:
+
+[Angular Migration Guide](https://ionicframework.com/docs/angular/virtual-scroll)<br />
+[React Migration Guide](https://ionicframework.com/docs/react/virtual-scroll)<br />
+[Vue Migration Guide](hhttps://ionicframework.com/docs/vue/virtual-scroll)
+
+## Need Help Upgrading?
+
+Be sure to look at the [Ionic 7 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x-accordion-group). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
+
+If you need help upgrading, please post a thread on the [Ionic Forum](https://forum.ionicframework.com/).
+

--- a/docs/updating/4-0.md
+++ b/docs/updating/4-0.md
@@ -1,52 +1,8 @@
 ---
-title: Migration Guide
-sidebar_label: Migration
+title: Updating to 4.0
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-<head>
-  <title>App Migration Guide: Documentation to Migrate Ionic 4.x to 5.x</title>
-  <meta
-    name="description"
-    content="The Ionic Migration Guide provides documentation for how to migrate an app from 4.x to 5.x. Read to learn more about what updates this process requires."
-  />
-</head>
-
-## Migrating from Ionic 5.x to Ionic 6.x
-
-Please see the [Ionic 6 Migration Guide](../intro/upgrading-to-ionic-6).
-
-## Migrating from Ionic 4.x to Ionic 5.x
-
-Migrating an app from 4.x to 5.x requires a few updates to the API properties, CSS utilities, and the installed package dependencies.
-
-### API and CSS Updates
-
-For a complete list of breaking changes from 4.x to 5.x, please refer to [the breaking changes document](https://github.com/ionic-team/ionic/blob/master/BREAKING.md#version-5x) in the Ionic core repo.
-
-### Packages and Dependencies
-
-For Angular based projects, you can simply run:
-
-```shell
-npm install @ionic/angular@latest @ionic/angular-toolkit@latest --save
-```
-
-For React projects, you can run:
-
-```shell
-npm install @ionic/react@latest @ionic/react-router@latest ionicons@latest
-```
-
-For Stencil / vanilla JS projects, you can run:
-
-```shell
-npm i @ionic/core@latest --save
-```
-
-If you would like a fresh project starter, a new project base can be created from the CLI and an existing app can be migrated over manually.
+# Updating from Ionic 1-3 to Ionic 4
 
 ## Migrating from Ionic 3.0 to Ionic 4.0
 

--- a/docs/updating/5-0.md
+++ b/docs/updating/5-0.md
@@ -1,0 +1,37 @@
+---
+title: Updating to 5.0
+---
+
+# Updating from Ionic 4 to Ionic 5
+
+Migrating an app from 4.x to 5.x requires a few updates to the API properties, CSS utilities, and the installed package dependencies.
+
+:::note
+This guide assumes that you have already updated your app to the latest version of Ionic 4. Make sure you have followed the [Upgrading to Ionic 4 Guide](./4-0) before starting this guide.
+:::
+
+### API and CSS Updates
+
+For a complete list of breaking changes from 4.x to 5.x, please refer to [the breaking changes document](https://github.com/ionic-team/ionic/blob/master/BREAKING.md#version-5x) in the Ionic core repo.
+
+### Packages and Dependencies
+
+For Angular based projects, you can simply run:
+
+```shell
+npm install @ionic/angular@latest @ionic/angular-toolkit@latest --save
+```
+
+For React projects, you can run:
+
+```shell
+npm install @ionic/react@latest @ionic/react-router@latest ionicons@latest
+```
+
+For Stencil / vanilla JS projects, you can run:
+
+```shell
+npm i @ionic/core@latest --save
+```
+
+If you would like a fresh project starter, a new project base can be created from the CLI and an existing app can be migrated over manually.

--- a/docs/updating/6-0.md
+++ b/docs/updating/6-0.md
@@ -1,6 +1,12 @@
-# Upgrading to Ionic 6
+---
+title: Updating to 6.0
+---
 
-Follow this guide to upgrade your Ionic 5 apps to Ionic 6.
+# Updating from Ionic 5 to Ionic 6
+
+:::note
+This guide assumes that you have already updated your app to the latest version of Ionic 5. Make sure you have followed the [Upgrading to Ionic 5 Guide](./5-0) before starting this guide.
+:::
 
 ## Getting Started
 

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -1,16 +1,18 @@
-# Upgrading to Ionic 7
+---
+title: Updating to 7.0
+---
 
-Follow this guide to upgrade your Ionic 6 apps to Ionic 7.
+# Updating from Ionic 6 to Ionic 7
 
 :::note
 Ionic 7 is in beta. Please report any issues on [the Ionic Framework GitHub Repo](https://github.com/ionic-team/ionic-framework).
 :::
 
-## Getting Started
-
 :::note
-This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Upgrading to Ionic 6 Guide](./upgrading-to-ionic-6) before starting this guide.
+This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Upgrading to Ionic 6 Guide](./6-0) before starting this guide.
 :::
+
+## Getting Started
 
 ### Angular
 

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -116,7 +116,7 @@ npm install @ionic/core@next
 
 ## Need Help Upgrading?
 
-Be sure to look at the [Ionic 7 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x-accordion-group). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
+Be sure to look at the [Ionic 7 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
 
 If you need help upgrading, please post a thread on the [Ionic Forum](https://forum.ionicframework.com/).
 

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -112,7 +112,7 @@ npm install @ionic/core@next
 
 [Angular Migration Guide](https://ionicframework.com/docs/angular/virtual-scroll)<br />
 [React Migration Guide](https://ionicframework.com/docs/react/virtual-scroll)<br />
-[Vue Migration Guide](hhttps://ionicframework.com/docs/vue/virtual-scroll)
+[Vue Migration Guide](https://ionicframework.com/docs/vue/virtual-scroll)
 
 ## Need Help Upgrading?
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -4,7 +4,18 @@ module.exports = {
       type: 'category',
       label: 'Getting Started',
       collapsed: false,
-      items: ['index', 'intro/upgrading-to-ionic-6', 'intro/environment', 'intro/cli', 'intro/cdn', 'intro/vscode-extension', 'intro/next'],
+      items: ['index', 'intro/environment', 'intro/cli', 'intro/cdn', 'intro/vscode-extension', 'intro/next'],
+    },
+    {
+      type: 'category',
+      label: 'Upgrade Guides',
+      collapsed: false,
+      items: [
+        'updating/7-0',
+        'updating/6-0',
+        'updating/5-0',
+        'updating/4-0'
+      ]
     },
     {
       type: 'category',
@@ -219,8 +230,7 @@ module.exports = {
           href: 'https://github.com/ionic-team/ionic/blob/master/CHANGELOG.md',
         },
         'reference/support',
-        'reference/browser-support',
-        'reference/migration',
+        'reference/browser-support'
       ],
     },
   ],


### PR DESCRIPTION
This PR does a few things:

1. Remove the "Upgrading to Ionic 6" and "Migration" links in favor of a dedicated "Upgrade Guides" section on the sidebar. This improves the visibility of the migration guides. It also scales better than the previous approach as we can add an `8-0.md` file to the `updating` directory when it comes time to write the Ionic 8 migration guide.
2. Creates the Ionic 7 migration. I only included the changes that are required in order for an app to compile. (This is what we did with the Ionic 6 migration guide too)
3. Adds a note to the v5, v6, and v7 upgrade guides reminding users to update to the latest version of the previous major release before proceeding with upgrading.

~Note: I still need to create 301 redirects so the old migration guide links do not break. This needs to happen in https://github.com/ionic-team/ionic-nginx/blob/main/config/redirects.conf.~

Added 301 redirects: https://github.com/ionic-team/ionic-nginx/pull/22

v7 guide: https://ionic-docs-git-v7-migration-ionic1.vercel.app/docs/updating/7-0

You can also access other guides in the "Upgrade Guides" sidebar.