### PR TITLE
docs(fab): add label notes for fab

### DIFF
--- a/docs/api/fab.md
+++ b/docs/api/fab.md
@@ -74,7 +74,7 @@ import CSSShadowParts from '@site/static/usage/fab/theming/css-shadow-parts/inde
 
 ### Labels
 
-Since FABs are allowed to only contain icons, developers must provide an `aria-label` on each `ion-fab-button` instance. Without this label, assistive technologies will not be able to announce the purpose of the button.
+Since FABs are allowed to contain only icons, developers must provide an `aria-label` on each `ion-fab-button` instance. Without this label, assistive technologies will not be able to announce the purpose of the button.
 
 ## Properties
 <Props />

--- a/docs/api/fab.md
+++ b/docs/api/fab.md
@@ -74,7 +74,7 @@ import CSSShadowParts from '@site/static/usage/fab/theming/css-shadow-parts/inde
 
 ### Labels
 
-Since FABs are allowed to contain only icons, developers must provide an `aria-label` on each `ion-fab-button` instance. Without this label, assistive technologies will not be able to announce the purpose of the button.
+Since FABs are allowed to contain only icons, developers must provide an `aria-label` on each `ion-fab-button` instance. Without this label, assistive technologies will not be able to announce the purpose of each button.
 
 ## Properties
 <Props />

--- a/docs/api/fab.md
+++ b/docs/api/fab.md
@@ -68,6 +68,13 @@ import CSSCustomProperties from '@site/static/usage/fab/theming/css-custom-prope
 import CSSShadowParts from '@site/static/usage/fab/theming/css-shadow-parts/index.md';
 
 <CSSShadowParts />
+ 
+
+## Accessibility
+
+### Labels
+
+Since FABs are allowed to only contain icons, developers must provide an `aria-label` on each `ion-fab-button` instance. Without this label, assistive technologies will not be able to announce the purpose of the button.
 
 ## Properties
 <Props />


### PR DESCRIPTION
Part of https://github.com/ionic-team/ionic-framework/pull/26619

This PR notes that developers must add a label to each fab button.