### PR TITLE
docs(migration): add browserslist step

### DIFF
--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -67,6 +67,20 @@ npm install @ionic/core@next
 
 ## Updating Your Code
 
+### Browser Support
+
+The list of browsers that Ionic supports has changed. Review the [Browser Support Guide](../reference/browser-support) to ensure you are deploying apps to supported browsers.
+
+If you have a `browserslist` or `.browserslistrc` file, update it with the following content:
+
+```
+Chrome >=79
+Firefox >=70
+Edge >=79
+Safari >=14
+iOS >=14
+```
+
 ### Types
 
 1. `ActionSheetAttributes`, `AlertAttributes`, `AlertTextareaAttributes`, `AlertInputAttributes`, `LoadingAttributes`, `ModalAttributes`, `PickerAttributes`, `PopoverAttributes`, and `ToastAttributes` have been removed. Developers should use `{ [key: string]: any }` instead.


### PR DESCRIPTION
I forgot to add a note about how to migrate the browserslist file when updating to v7. This is important so framework compilers (such as the Angular CLI) correctly transpile code during the build process.