### PR TITLE
docs(icon): add dedicated component page and playground

### DIFF
--- a/docs/api/icon.md
+++ b/docs/api/icon.md
@@ -1,0 +1,21 @@
+---
+title: 'ion-icon'
+---
+
+<head>
+  <title>ion-icon: Icon Component for Ionic Framework Apps</title>
+  <meta
+    name="description"
+    content="Ion-icon is a component for displaying premium designed icons with support for SVG and web font."
+  />
+</head>
+
+Icon is a simple component made available through the <a href="https://ionic.io/ionicons">Ionicons</a> library, which comes pre-packaged by default with all Ionic Framework applications. It can be used to display any icon from the Ionicons set, or a custom SVG. It also has support for styling such as size and color.
+
+For more information, including styling and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
+
+## Basic Usage
+
+import Basic from '@site/static/usage/v7/icon/basic/index.md';
+
+<Basic />

--- a/docs/components.md
+++ b/docs/components.md
@@ -66,7 +66,7 @@ Ionic apps are made of high-level building blocks called Components, which allow
   <p>Floating action buttons are circular buttons that perform a primary action on a screen.</p>
 </DocsCard>
 
-<DocsCard header="Icons" href="https://ionic.io/ionicons" img="/icons/feature-component-icons-icon.png">
+<DocsCard header="Icons" href="api/icon" img="/icons/feature-component-icons-icon.png">
   <p>Beautifully designed icons for use in web, iOS, Android, and desktop apps.</p>
 </DocsCard>
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -330,13 +330,7 @@ module.exports = {
       type: 'category',
       label: 'Icons',
       collapsed: false,
-      items: [
-        {
-          type: 'link',
-          label: 'ion-icon',
-          href: 'https://ionicons.com',
-        },
-      ],
+      items: ['api/icon'],
     },
     {
       type: 'category',
@@ -371,11 +365,7 @@ module.exports = {
       collapsed: false,
       items: [
         'api/avatar',
-        {
-          type: 'link',
-          label: 'ion-icon',
-          href: 'https://ionicons.com',
-        },
+        'api/icon',
         'api/img',
         'api/thumbnail',
       ],

--- a/static/usage/v6/icon/basic/angular.md
+++ b/static/usage/v6/icon/basic/angular.md
@@ -1,0 +1,6 @@
+```html
+<ion-icon name="logo-ionic"></ion-icon>
+<ion-icon name="logo-ionic" size="large"></ion-icon>
+<ion-icon name="logo-ionic" color="primary"></ion-icon>
+<ion-icon name="logo-ionic" size="large" color="primary"></ion-icon>
+```

--- a/static/usage/v6/icon/basic/demo.html
+++ b/static/usage/v6/icon/basic/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Icon</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-icon name="logo-ionic"></ion-icon>
+        <ion-icon name="logo-ionic" size="large"></ion-icon>
+        <ion-icon name="logo-ionic" color="primary"></ion-icon>
+        <ion-icon name="logo-ionic" size="large" color="primary"></ion-icon>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v6/icon/basic/index.md
+++ b/static/usage/v6/icon/basic/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v6/icon/basic/demo.html" />

--- a/static/usage/v6/icon/basic/javascript.md
+++ b/static/usage/v6/icon/basic/javascript.md
@@ -1,0 +1,6 @@
+```html
+<ion-icon name="logo-ionic"></ion-icon>
+<ion-icon name="logo-ionic" size="large"></ion-icon>
+<ion-icon name="logo-ionic" color="primary"></ion-icon>
+<ion-icon name="logo-ionic" size="large" color="primary"></ion-icon>
+```

--- a/static/usage/v6/icon/basic/react.md
+++ b/static/usage/v6/icon/basic/react.md
@@ -1,0 +1,17 @@
+```tsx
+import React from 'react';
+import { IonIcon } from '@ionic/react';
+import { logoIonic } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <>
+      <IonIcon icon={logoIonic}></IonIcon>
+      <IonIcon icon={logoIonic} size="large"></IonIcon>
+      <IonIcon icon={logoIonic} color="primary"></IonIcon>
+      <IonIcon icon={logoIonic} size="large" color="primary"></IonIcon>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v6/icon/basic/vue.md
+++ b/static/usage/v6/icon/basic/vue.md
@@ -1,0 +1,21 @@
+```html
+<template>
+  <ion-icon :icon="logoIonic"></ion-icon>
+  <ion-icon :icon="logoIonic" size="large"></ion-icon>
+  <ion-icon :icon="logoIonic" color="primary"></ion-icon>
+  <ion-icon :icon="logoIonic" size="large" color="primary"></ion-icon>
+</template>
+
+<script lang="ts">
+  import { IonIcon } from '@ionic/vue';
+  import { logoIonic } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonIcon },
+    setup() {
+      return { logoIonic };
+    },
+  });
+</script>
+```

--- a/static/usage/v7/icon/basic/angular.md
+++ b/static/usage/v7/icon/basic/angular.md
@@ -1,0 +1,6 @@
+```html
+<ion-icon name="logo-ionic"></ion-icon>
+<ion-icon name="logo-ionic" size="large"></ion-icon>
+<ion-icon name="logo-ionic" color="primary"></ion-icon>
+<ion-icon name="logo-ionic" size="large" color="primary"></ion-icon>
+```

--- a/static/usage/v7/icon/basic/demo.html
+++ b/static/usage/v7/icon/basic/demo.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Icon</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-icon name="logo-ionic"></ion-icon>
+        <ion-icon name="logo-ionic" size="large"></ion-icon>
+        <ion-icon name="logo-ionic" color="primary"></ion-icon>
+        <ion-icon name="logo-ionic" size="large" color="primary"></ion-icon>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v7/icon/basic/index.md
+++ b/static/usage/v7/icon/basic/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v7/icon/basic/demo.html" />

--- a/static/usage/v7/icon/basic/javascript.md
+++ b/static/usage/v7/icon/basic/javascript.md
@@ -1,0 +1,6 @@
+```html
+<ion-icon name="logo-ionic"></ion-icon>
+<ion-icon name="logo-ionic" size="large"></ion-icon>
+<ion-icon name="logo-ionic" color="primary"></ion-icon>
+<ion-icon name="logo-ionic" size="large" color="primary"></ion-icon>
+```

--- a/static/usage/v7/icon/basic/react.md
+++ b/static/usage/v7/icon/basic/react.md
@@ -1,0 +1,17 @@
+```tsx
+import React from 'react';
+import { IonIcon } from '@ionic/react';
+import { logoIonic } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <>
+      <IonIcon icon={logoIonic}></IonIcon>
+      <IonIcon icon={logoIonic} size="large"></IonIcon>
+      <IonIcon icon={logoIonic} color="primary"></IonIcon>
+      <IonIcon icon={logoIonic} size="large" color="primary"></IonIcon>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/icon/basic/vue.md
+++ b/static/usage/v7/icon/basic/vue.md
@@ -1,0 +1,21 @@
+```html
+<template>
+  <ion-icon :icon="logoIonic"></ion-icon>
+  <ion-icon :icon="logoIonic" size="large"></ion-icon>
+  <ion-icon :icon="logoIonic" color="primary"></ion-icon>
+  <ion-icon :icon="logoIonic" size="large" color="primary"></ion-icon>
+</template>
+
+<script lang="ts">
+  import { IonIcon } from '@ionic/vue';
+  import { logoIonic } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonIcon },
+    setup() {
+      return { logoIonic };
+    },
+  });
+</script>
+```

--- a/versioned_docs/version-v6/api/icon.md
+++ b/versioned_docs/version-v6/api/icon.md
@@ -1,0 +1,21 @@
+---
+title: 'ion-icon'
+---
+
+<head>
+  <title>ion-icon: Icon Component for Ionic Framework Apps</title>
+  <meta
+    name="description"
+    content="Ion-icon is a component for displaying premium designed icons with support for SVG and web font."
+  />
+</head>
+
+Icon is a simple component made available through the <a href="https://ionic.io/ionicons">Ionicons</a> library, which comes pre-packaged by default with all Ionic Framework applications. It can be used to display any icon from the Ionicons set, or a custom SVG. It also has support for styling such as size and color.
+
+For more information, including styling and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
+
+## Basic Usage
+
+import Basic from '@site/static/usage/v6/icon/basic/index.md';
+
+<Basic />

--- a/versioned_docs/version-v6/components.md
+++ b/versioned_docs/version-v6/components.md
@@ -66,7 +66,7 @@ Ionic apps are made of high-level building blocks called Components, which allow
   <p>Floating action buttons are circular buttons that perform a primary action on a screen.</p>
 </DocsCard>
 
-<DocsCard header="Icons" href="https://ionic.io/ionicons" img="/icons/feature-component-icons-icon.png">
+<DocsCard header="Icons" href="api/icon" img="/icons/feature-component-icons-icon.png">
   <p>Beautifully designed icons for use in web, iOS, Android, and desktop apps.</p>
 </DocsCard>
 

--- a/versioned_sidebars/version-v6-sidebars.json
+++ b/versioned_sidebars/version-v6-sidebars.json
@@ -846,9 +846,8 @@
       "collapsed": false,
       "items": [
         {
-          "type": "link",
-          "label": "ion-icon",
-          "href": "https://ionicons.com"
+          "type": "doc",
+          "id": "version-v6/api/icon"
         }
       ],
       "collapsible": true
@@ -935,9 +934,8 @@
           "id": "version-v6/api/avatar"
         },
         {
-          "type": "link",
-          "label": "ion-icon",
-          "href": "https://ionicons.com"
+          "type": "doc",
+          "id": "version-v6/api/icon"
         },
         {
           "type": "doc",


### PR DESCRIPTION
Currently, our docs just link to https://ionic.io/ionicons for info on `ion-icon`. This PR adds a dedicated page for the component, so that we can include a playground in an easy-to-find spot showing how to import and use the icon names with each framework. It also edits the links in the sidebar and main components index page to point to this new dedicated page instead of the Ionicons site.

Some things to note:
- While this PR includes docs for both v6 and v7, it's off the v7 branch so no extra work is needed given the structural changes to the docs repo. There is a separate PR at https://github.com/ionic-team/ionic-docs/pull/2710 which backports the updates to `main`.
- I left off the autogenerated props, methods, etc. because the docs site pulls this info from a file auto-generated by Stencil over on the framework repo, and we're trying to keep the framework and ionicons repos decoupled as much as possible. I figure a link to the dedicated Ionicons site covers our bases there since it already has that info.
- I also didn't include more than a basic usage playground since all the props and such seemed self-explanatory to me, and I didn't want to duplicate too much info between this and the Ionicons site, but LMK if you'd like an additional playground on any particular feature.