### PR TITLE
fix(docs): update upgrade guide cta

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,8 +98,8 @@ module.exports = {
         {
           type: 'cta',
           position: 'left',
-          text: 'Ionic v6.0.0 Upgrade Guide',
-          href: `/intro/upgrading-to-ionic-6`,
+          text: 'Ionic v7.0.0 Upgrade Guide',
+          href: `/updating/7-0`,
         },
         {
           type: 'docsVersionDropdown',


### PR DESCRIPTION
Updates the primary call to action for the upgrade guide to reference Ionic v7.0.0 and to link to the new upgrade guide. 