### PR TITLE
docs(scaffolding): add support note to ionic generate docs

### DIFF
--- a/docs/developing/scaffolding.md
+++ b/docs/developing/scaffolding.md
@@ -44,6 +44,10 @@ The `src/app/` directory contains the root app component and module as well as a
 
 ## Generating New Features
 
+:::note
+This command is only supported in Ionic Angular.
+:::
+
 The Ionic CLI can generate new app features with the [`ionic generate`](../cli/commands/generate.md) command. By running `ionic generate` in the command line, a selection prompt is displayed which lists the available features that can be generated.
 
 ```shell-session


### PR DESCRIPTION
The `ionic generate` command is only supported in Ionic Angular. While this is mentioned in the dedicated docs for the command (https://ionicframework.com/docs/cli/commands/generate), the Scaffolding docs are more misleading: https://ionicframework.com/docs/developing/scaffolding#generating-new-features This PR adds a note to this section to clarify the support situation.

Resolves https://github.com/ionic-team/ionic-docs/issues/1799