### PR TITLE
docs(select): update for Ionic 7

### DIFF
--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -57,7 +57,7 @@ import Clear from '@site/static/usage/v7/input/clear/index.md';
 
 ## Filled Inputs
 
-Material Design offers filled styles for an input. The `fill` property on the item can be set to either `"solid"` or `"outline"`.
+Material Design offers filled styles for an input. The `fill` property on the input can be set to either `"solid"` or `"outline"`.
 
 Since the `fill` styles visually defines the input container, inputs that use `fill` should not be used in `ion-item`.
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -87,6 +87,8 @@ import ObjectValuesAndMultipleSelectionExample from '@site/static/usage/v7/selec
 
 ## Label Positioning
 
+Labels will take up the width of their content by default. This positioning can be changed to be a fixed width, stacked, or floating label.
+
 import LabelExample from '@site/static/usage/v7/select/labels/index.md';
 
 <LabelExample />

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -92,6 +92,15 @@ Labels will take up the width of their content by default. This positioning can 
 import LabelExample from '@site/static/usage/v7/select/labels/index.md';
 
 <LabelExample />
+  
+
+## Justification
+  
+Developers can use the `justify` property to control how the label and control are packed on a line.
+
+import JustifyExample from '@site/static/usage/v7/select/justify/index.md';
+
+<JustifyExample />
 
 ## Filled Selects
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -188,7 +188,7 @@ While developers can continue using the legacy syntax, we recommend migrating as
 
 ### Using the Modern Syntax
 
-Using the modern syntax involves three steps:
+Using the modern syntax involves two steps:
 
 1. Remove `ion-label` and use the `label` property on `ion-select` instead. The placement of the label can be configured using the `labelPlacement` property on `ion-select`.
 2. Move any usage of `fill` and `shape` from `ion-item` on to `ion-select`.

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -83,6 +83,17 @@ import UsingCompareWithExample from '@site/static/usage/v7/select/objects-as-val
 import ObjectValuesAndMultipleSelectionExample from '@site/static/usage/v7/select/objects-as-values/multiple-selection/index.md';
 
 <ObjectValuesAndMultipleSelectionExample />
+  
+
+## Label Positioning
+
+import LabelExample from '@site/static/usage/v7/select/labels/index.md';
+
+<LabelExample />
+
+## Filled Selects
+
+TODO
 
 ## Select Buttons
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -93,7 +93,9 @@ import LabelExample from '@site/static/usage/v7/select/labels/index.md';
 
 ## Filled Selects
 
-TODO
+import FillExample from '@site/static/usage/v7/select/fill/index.md';
+
+<FillExample />
 
 ## Select Buttons
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -93,6 +93,10 @@ import LabelExample from '@site/static/usage/v7/select/labels/index.md';
 
 ## Filled Selects
 
+Material Design offers filled styles for a select. The `fill` property on the select can be set to either `"solid"` or `"outline"`.
+
+Since the `fill` styles visually defines the select container, selects that use `fill` should not be used in `ion-item`.
+
 import FillExample from '@site/static/usage/v7/select/fill/index.md';
 
 <FillExample />

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -179,6 +179,28 @@ interface SelectCustomEvent<T = any> extends CustomEvent {
 }
 ```
 
+## Migrating from Legacy Select Syntax
+
+A simpler select syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an select, resolves accessibility issues, and improves the developer experience.
+
+While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
+
+
+### Using the Modern Syntax
+
+Using the modern syntax involves three steps:
+
+1. Remove `ion-label` and use the `label` property on `ion-select` instead. The placement of the label can be configured using the `labelPlacement` property on `ion-select`.
+2. Move any usage of `fill` and `shape` from `ion-item` on to `ion-select`.
+
+import Migration from '@site/static/usage/v7/select/migration/index.md';
+
+<Migration />
+
+### Using the Legacy Syntax
+
+Ionic uses heuristics to detect if an app is using the modern select syntax. In some instances, it may be preferable to continue using the legacy syntax. Developers can set the `legacy` property on `ion-select` to `true` to force that instance of the input to use the legacy syntax.
+
 ## Properties
 <Props />
 

--- a/static/usage/v7/select/basic/multiple-selection/angular.md
+++ b/static/usage/v7/select/basic/multiple-selection/angular.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select all fruits that apply" [multiple]="true">
+    <ion-select aria-label="Fruit" placeholder="Select all fruits that apply" [multiple]="true">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/multiple-selection/demo.html
+++ b/static/usage/v7/select/basic/multiple-selection/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Multiple Selection</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 </head>
 
 <body>
@@ -17,7 +17,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-select placeholder="Select all fruits that apply" multiple="true">
+            <ion-select aria-label="Fruit" placeholder="Select all fruits that apply" multiple="true">
               <ion-select-option value="apples">Apples</ion-select-option>
               <ion-select-option value="oranges">Oranges</ion-select-option>
               <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/multiple-selection/javascript.md
+++ b/static/usage/v7/select/basic/multiple-selection/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select all fruits that apply" multiple="true">
+    <ion-select aria-label="Fruit" placeholder="Select all fruits that apply" multiple="true">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/multiple-selection/react.md
+++ b/static/usage/v7/select/basic/multiple-selection/react.md
@@ -5,7 +5,7 @@ function Example() {
   return (
     <IonList>
       <IonItem>
-        <IonSelect placeholder="Select all fruits that apply" multiple={true}>
+        <IonSelect aria-label="Fruit" placeholder="Select all fruits that apply" multiple={true}>
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/basic/multiple-selection/vue.md
+++ b/static/usage/v7/select/basic/multiple-selection/vue.md
@@ -2,7 +2,7 @@
 <template>
   <ion-list>
     <ion-item>
-      <ion-select placeholder="Select all fruits that apply" :multiple="true">
+      <ion-select aria-label="Fruit" placeholder="Select all fruits that apply" :multiple="true">
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/responding-to-interaction/angular/example_component_html.md
+++ b/static/usage/v7/select/basic/responding-to-interaction/angular/example_component_html.md
@@ -2,6 +2,7 @@
 <ion-list>
   <ion-item>
     <ion-select
+      aria-label="Fruit"
       placeholder="Select fruit"
       (ionChange)="handleChange($event)"
       (ionCancel)="pushLog('ionCancel fired')"

--- a/static/usage/v7/select/basic/responding-to-interaction/demo.html
+++ b/static/usage/v7/select/basic/responding-to-interaction/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Responding to Interaction</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 
   <style>
     #log {
@@ -27,7 +27,7 @@
         <div>
           <ion-list>
             <ion-item>
-              <ion-select placeholder="Select fruit">
+              <ion-select aria-label="Fruit" placeholder="Select fruit">
                 <ion-select-option value="apples">Apples</ion-select-option>
                 <ion-select-option value="oranges">Oranges</ion-select-option>
                 <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/responding-to-interaction/javascript.md
+++ b/static/usage/v7/select/basic/responding-to-interaction/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select fruit">
+    <ion-select aria-label="Fruit" placeholder="Select fruit">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/responding-to-interaction/react.md
+++ b/static/usage/v7/select/basic/responding-to-interaction/react.md
@@ -14,6 +14,7 @@ function Example() {
       <IonList>
         <IonItem>
           <IonSelect
+            aria-label="Fruit"
             placeholder="Select fruit"
             onIonChange={(e) => pushLog(`ionChange fired with value: ${e.detail.value}`)}
             onIonCancel={() => pushLog('ionCancel fired')}

--- a/static/usage/v7/select/basic/responding-to-interaction/vue.md
+++ b/static/usage/v7/select/basic/responding-to-interaction/vue.md
@@ -3,6 +3,7 @@
   <ion-list>
     <ion-item>
       <ion-select
+        aria-label="Fruit"
         placeholder="Select fruit"
         @ionChange="pushLog('ionChange fired with value: ' + $event.detail.value)"
         @ionCancel="pushLog('ionCancel fired')"

--- a/static/usage/v7/select/basic/single-selection/angular.md
+++ b/static/usage/v7/select/basic/single-selection/angular.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select fruit">
+    <ion-select aria-label="fruit" placeholder="Select fruit">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/single-selection/demo.html
+++ b/static/usage/v7/select/basic/single-selection/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Single Selection</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 </head>
 
 <body>
@@ -17,7 +17,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-select placeholder="Select fruit">
+            <ion-select aria-label="fruit" placeholder="Select fruit">
               <ion-select-option value="apples">Apples</ion-select-option>
               <ion-select-option value="oranges">Oranges</ion-select-option>
               <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/single-selection/javascript.md
+++ b/static/usage/v7/select/basic/single-selection/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select fruit">
+    <ion-select aria-label="fruit" placeholder="Select fruit">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/basic/single-selection/react.md
+++ b/static/usage/v7/select/basic/single-selection/react.md
@@ -5,7 +5,7 @@ function Example() {
   return (
     <IonList>
       <IonItem>
-        <IonSelect placeholder="Select fruit">
+        <IonSelect aria-label="fruit" placeholder="Select fruit">
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/basic/single-selection/vue.md
+++ b/static/usage/v7/select/basic/single-selection/vue.md
@@ -2,7 +2,7 @@
 <template>
   <ion-list>
     <ion-item>
-      <ion-select placeholder="Select fruit">
+      <ion-select aria-label="fruit" placeholder="Select fruit">
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/button-text/angular.md
+++ b/static/usage/v7/select/customization/button-text/angular.md
@@ -1,16 +1,14 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-label>Alert Interface</ion-label>
-    <ion-select placeholder="Select fruit" okText="Choose Fruit" cancelText="Cancel Choice">
+    <ion-select label="Alert Interface" placeholder="Select fruit" okText="Choose Fruit" cancelText="Cancel Choice">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>
     </ion-select>
   </ion-item>
   <ion-item>
-    <ion-label>Action Sheet Interface</ion-label>
-    <ion-select interface="action-sheet" placeholder="Select fruit" cancelText="Cancel Choice">
+    <ion-select label="Action Sheet Interface" interface="action-sheet" placeholder="Select fruit" cancelText="Cancel Choice">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/button-text/demo.html
+++ b/static/usage/v7/select/customization/button-text/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Button Text</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 </head>
 
 <body>
@@ -17,16 +17,14 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-label>Alert Interface</ion-label>
-            <ion-select placeholder="Select fruit" ok-text="Choose Fruit" cancel-text="Cancel Choice">
+            <ion-select label="Alert Interface" placeholder="Select fruit" ok-text="Choose Fruit" cancel-text="Cancel Choice">
               <ion-select-option value="apples">Apples</ion-select-option>
               <ion-select-option value="oranges">Oranges</ion-select-option>
               <ion-select-option value="bananas">Bananas</ion-select-option>
             </ion-select>
           </ion-item>
           <ion-item>
-            <ion-label>Action Sheet Interface</ion-label>
-            <ion-select interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
+            <ion-select label="Action Sheet Interface" interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
               <ion-select-option value="apples">Apples</ion-select-option>
               <ion-select-option value="oranges">Oranges</ion-select-option>
               <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/button-text/javascript.md
+++ b/static/usage/v7/select/customization/button-text/javascript.md
@@ -8,7 +8,7 @@
     </ion-select>
   </ion-item>
   <ion-item>
-=    <ion-select label="Action Sheet Interface" interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
+    <ion-select label="Action Sheet Interface" interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/button-text/javascript.md
+++ b/static/usage/v7/select/customization/button-text/javascript.md
@@ -1,16 +1,14 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-label>Alert Interface</ion-label>
-    <ion-select placeholder="Select fruit" ok-text="Choose Fruit" cancel-text="Cancel Choice">
+    <ion-select label="Alert Interface" placeholder="Select fruit" ok-text="Choose Fruit" cancel-text="Cancel Choice">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>
     </ion-select>
   </ion-item>
   <ion-item>
-    <ion-label>Action Sheet Interface</ion-label>
-    <ion-select interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
+=    <ion-select label="Action Sheet Interface" interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/button-text/react.md
+++ b/static/usage/v7/select/customization/button-text/react.md
@@ -5,16 +5,14 @@ function Example() {
   return (
     <IonList>
       <IonItem>
-        <IonLabel>Alert Interface</IonLabel>
-        <IonSelect placeholder="Select fruit" okText="Choose Fruit" cancelText="Cancel Choice">
+        <IonSelect label="Alert Interface" placeholder="Select fruit" okText="Choose Fruit" cancelText="Cancel Choice">
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>
         </IonSelect>
       </IonItem>
       <IonItem>
-        <IonLabel>Action Sheet Interface</IonLabel>
-        <IonSelect interface="action-sheet" placeholder="Select fruit" cancelText="Cancel Choice">
+        <IonSelect label="Action Sheet Interface" interface="action-sheet" placeholder="Select fruit" cancelText="Cancel Choice">
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/customization/button-text/vue.md
+++ b/static/usage/v7/select/customization/button-text/vue.md
@@ -2,16 +2,14 @@
 <template>
   <ion-list>
     <ion-item>
-      <ion-label>Alert Interface</ion-label>
-      <ion-select placeholder="Select fruit" ok-text="Choose Fruit" cancel-text="Cancel Choice">
+      <ion-select label="Alert Interface" placeholder="Select fruit" ok-text="Choose Fruit" cancel-text="Cancel Choice">
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>
       </ion-select>
     </ion-item>
     <ion-item>
-      <ion-label>Action Sheet Interface</ion-label>
-      <ion-select interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
+      <ion-select label="Action Sheet Interface" interface="action-sheet" placeholder="Select fruit" cancel-text="Cancel Choice">
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/interface-options/angular/example_component_html.md
+++ b/static/usage/v7/select/customization/interface-options/angular/example_component_html.md
@@ -1,8 +1,7 @@
 ```html
 <ion-list>        
   <ion-item>
-    <ion-label>Alert</ion-label>
-    <ion-select [interfaceOptions]="customAlertOptions" interface="alert" placeholder="Select One">
+    <ion-select label="Alert" [interfaceOptions]="customAlertOptions" interface="alert" placeholder="Select One">
       <ion-select-option value="bacon">Bacon</ion-select-option>
       <ion-select-option value="onions">Onions</ion-select-option>
       <ion-select-option value="pepperoni">Pepperoni</ion-select-option>
@@ -10,8 +9,7 @@
   </ion-item>
         
   <ion-item>
-    <ion-label>Popover</ion-label>
-    <ion-select [interfaceOptions]="customPopoverOptions" interface="popover" placeholder="Select One">
+    <ion-select label="Popover" [interfaceOptions]="customPopoverOptions" interface="popover" placeholder="Select One">
       <ion-select-option value="brown">Brown</ion-select-option>
       <ion-select-option value="blonde">Blonde</ion-select-option>
       <ion-select-option value="red">Red</ion-select-option>
@@ -19,8 +17,7 @@
   </ion-item>
         
   <ion-item>
-    <ion-label>Action Sheet</ion-label>
-    <ion-select [interfaceOptions]="customActionSheetOptions" interface="action-sheet" placeholder="Select One">
+    <ion-select label="Action Sheet" [interfaceOptions]="customActionSheetOptions" interface="action-sheet" placeholder="Select One">
       <ion-select-option value="red">Red</ion-select-option>
       <ion-select-option value="green">Green</ion-select-option>
       <ion-select-option value="blue">Blue</ion-select-option>

--- a/static/usage/v7/select/customization/interface-options/demo.html
+++ b/static/usage/v7/select/customization/interface-options/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Interface Options</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 
   <style>
     .container>ion-list {
@@ -23,8 +23,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-label>Alert</ion-label>
-            <ion-select id="customAlertSelect" interface="alert" placeholder="Select One">
+            <ion-select label="Alert" id="customAlertSelect" interface="alert" placeholder="Select One">
               <ion-select-option value="bacon">Bacon</ion-select-option>
               <ion-select-option value="onions">Onions</ion-select-option>
               <ion-select-option value="pepperoni">Pepperoni</ion-select-option>
@@ -32,8 +31,7 @@
           </ion-item>
 
           <ion-item>
-            <ion-label>Popover</ion-label>
-            <ion-select id="customPopoverSelect" interface="popover" placeholder="Select One">
+            <ion-select label="Popover" id="customPopoverSelect" interface="popover" placeholder="Select One">
               <ion-select-option value="brown">Brown</ion-select-option>
               <ion-select-option value="blonde">Blonde</ion-select-option>
               <ion-select-option value="red">Red</ion-select-option>
@@ -41,8 +39,7 @@
           </ion-item>
 
           <ion-item>
-            <ion-label>Action Sheet</ion-label>
-            <ion-select id="customActionSheetSelect" interface="action-sheet" placeholder="Select One">
+            <ion-select label="Action Sheet" id="customActionSheetSelect" interface="action-sheet" placeholder="Select One">
               <ion-select-option value="red">Red</ion-select-option>
               <ion-select-option value="green">Green</ion-select-option>
               <ion-select-option value="blue">Blue</ion-select-option>

--- a/static/usage/v7/select/customization/interface-options/javascript.md
+++ b/static/usage/v7/select/customization/interface-options/javascript.md
@@ -1,8 +1,7 @@
 ```html
 <ion-list>        
   <ion-item>
-    <ion-label>Alert</ion-label>
-    <ion-select id="customAlertSelect" interface="alert" placeholder="Select One">
+    <ion-select label="Alert" id="customAlertSelect" interface="alert" placeholder="Select One">
       <ion-select-option value="bacon">Bacon</ion-select-option>
       <ion-select-option value="onions">Onions</ion-select-option>
       <ion-select-option value="pepperoni">Pepperoni</ion-select-option>
@@ -10,8 +9,7 @@
   </ion-item>
         
   <ion-item>
-    <ion-label>Popover</ion-label>
-    <ion-select id="customPopoverSelect" interface="popover" placeholder="Select One">
+    <ion-select label="Popover" id="customPopoverSelect" interface="popover" placeholder="Select One">
       <ion-select-option value="brown">Brown</ion-select-option>
       <ion-select-option value="blonde">Blonde</ion-select-option>
       <ion-select-option value="red">Red</ion-select-option>
@@ -19,8 +17,7 @@
   </ion-item>
         
   <ion-item>
-    <ion-label>Action Sheet</ion-label>
-    <ion-select id="customActionSheetSelect" interface="action-sheet" placeholder="Select One">
+    <ion-select label="Action Sheet" id="customActionSheetSelect" interface="action-sheet" placeholder="Select One">
       <ion-select-option value="red">Red</ion-select-option>
       <ion-select-option value="green">Green</ion-select-option>
       <ion-select-option value="blue">Blue</ion-select-option>

--- a/static/usage/v7/select/customization/interface-options/react.md
+++ b/static/usage/v7/select/customization/interface-options/react.md
@@ -23,8 +23,7 @@ function Example() {
   return (
     <IonList>        
       <IonItem>
-        <IonLabel>Alert</IonLabel>
-        <IonSelect interfaceOptions={customAlertOptions} interface="alert" placeholder="Select One">
+        <IonSelect label="Alert" interfaceOptions={customAlertOptions} interface="alert" placeholder="Select One">
           <IonSelectOption value="bacon">Bacon</IonSelectOption>
           <IonSelectOption value="onions">Onions</IonSelectOption>
           <IonSelectOption value="pepperoni">Pepperoni</IonSelectOption>
@@ -32,8 +31,7 @@ function Example() {
       </IonItem>
           
       <IonItem>
-        <IonLabel>Popover</IonLabel>
-        <IonSelect interfaceOptions={customPopoverOptions} interface="popover" placeholder="Select One">
+        <IonSelect label="Popover" interfaceOptions={customPopoverOptions} interface="popover" placeholder="Select One">
           <IonSelectOption value="brown">Brown</IonSelectOption>
           <IonSelectOption value="blonde">Blonde</IonSelectOption>
           <IonSelectOption value="red">Red</IonSelectOption>
@@ -41,8 +39,7 @@ function Example() {
       </IonItem>
           
       <IonItem>
-        <IonLabel>Action Sheet</IonLabel>
-        <IonSelect interfaceOptions={customActionSheetOptions} interface="action-sheet" placeholder="Select One">
+        <IonSelect label="Action Sheet" interfaceOptions={customActionSheetOptions} interface="action-sheet" placeholder="Select One">
           <IonSelectOption value="red">Red</IonSelectOption>
           <IonSelectOption value="green">Green</IonSelectOption>
           <IonSelectOption value="blue">Blue</IonSelectOption>

--- a/static/usage/v7/select/customization/interface-options/vue.md
+++ b/static/usage/v7/select/customization/interface-options/vue.md
@@ -2,8 +2,7 @@
 <template>
   <ion-list>        
     <ion-item>
-      <ion-label>Alert</ion-label>
-      <ion-select :interface-options="customAlertOptions" interface="alert" placeholder="Select One">
+      <ion-select label="Alert" :interface-options="customAlertOptions" interface="alert" placeholder="Select One">
         <ion-select-option value="bacon">Bacon</ion-select-option>
         <ion-select-option value="onions">Onions</ion-select-option>
         <ion-select-option value="pepperoni">Pepperoni</ion-select-option>
@@ -11,8 +10,7 @@
     </ion-item>
         
     <ion-item>
-      <ion-label>Popover</ion-label>
-      <ion-select :interface-options="customPopoverOptions" interface="popover" placeholder="Select One">
+      <ion-select label="Popover" :interface-options="customPopoverOptions" interface="popover" placeholder="Select One">
         <ion-select-option value="brown">Brown</ion-select-option>
         <ion-select-option value="blonde">Blonde</ion-select-option>
         <ion-select-option value="red">Red</ion-select-option>
@@ -20,8 +18,7 @@
     </ion-item>
         
     <ion-item>
-      <ion-label>Action Sheet</ion-label>
-      <ion-select :interface-options="customActionSheetOptions" interface="action-sheet" placeholder="Select One">
+      <ion-select label="Action Sheet" :interface-options="customActionSheetOptions" interface="action-sheet" placeholder="Select One">
         <ion-select-option value="red">Red</ion-select-option>
         <ion-select-option value="green">Green</ion-select-option>
         <ion-select-option value="blue">Blue</ion-select-option>

--- a/static/usage/v7/select/customization/styling-select/angular/example_component_html.md
+++ b/static/usage/v7/select/customization/styling-select/angular/example_component_html.md
@@ -1,5 +1,5 @@
 ```html
-<ion-select placeholder="Select fruit">
+<ion-select aria-label="Fruit" placeholder="Select fruit">
   <ion-select-option value="apples">Apples</ion-select-option>
   <ion-select-option value="oranges">Oranges</ion-select-option>
   <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/styling-select/demo.html
+++ b/static/usage/v7/select/customization/styling-select/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Styling the Select</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 
   <style>
     ion-select {
@@ -45,7 +45,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-select placeholder="Select fruit">
+            <ion-select aria-label="Fruit" placeholder="Select fruit">
               <ion-select-option value="apples">Apples</ion-select-option>
               <ion-select-option value="oranges">Oranges</ion-select-option>
               <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/styling-select/javascript.md
+++ b/static/usage/v7/select/customization/styling-select/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-select placeholder="Select fruit">
+<ion-select aria-label="Fruit" placeholder="Select fruit">
   <ion-select-option value="apples">Apples</ion-select-option>
   <ion-select-option value="oranges">Oranges</ion-select-option>
   <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/styling-select/react/main_tsx.md
+++ b/static/usage/v7/select/customization/styling-select/react/main_tsx.md
@@ -6,7 +6,7 @@ import './main.css';
 
 function Example() {
   return (
-    <IonSelect placeholder="Select fruit">
+    <IonSelect aria-label="Fruit" placeholder="Select fruit">
       <IonSelectOption value="apples">Apples</IonSelectOption>
       <IonSelectOption value="oranges">Oranges</IonSelectOption>
       <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/customization/styling-select/vue.md
+++ b/static/usage/v7/select/customization/styling-select/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-select placeholder="Select fruit">
+  <ion-select aria-label="Fruit" placeholder="Select fruit">
     <ion-select-option value="apples">Apples</ion-select-option>
     <ion-select-option value="oranges">Oranges</ion-select-option>
     <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/fill/angular.md
+++ b/static/usage/v7/select/fill/angular.md
@@ -1,0 +1,15 @@
+```html
+<ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+  <ion-select-option value="apple">Apple</ion-select-option>
+  <ion-select-option value="banana">Banana</ion-select-option>
+  <ion-select-option value="orange">Orange</ion-select-option>
+</ion-select>
+
+<br />
+
+<ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+  <ion-select-option value="apple">Apple</ion-select-option>
+  <ion-select-option value="banana">Banana</ion-select-option>
+  <ion-select-option value="orange">Orange</ion-select-option>
+</ion-select>
+```

--- a/static/usage/v7/select/fill/demo.html
+++ b/static/usage/v7/select/fill/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Input</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.1-dev.11674584015.19545cf0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.1-dev.11674584015.19545cf0/css/ionic.bundle.css" />
+
+  <style>
+    .container {
+      flex-flow: column;
+      justify-content: space-evenly;
+
+      width: 300px;
+      margin: 0 auto;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+          <ion-select-option value="apple">Apple</ion-select-option>
+          <ion-select-option value="banana">Banana</ion-select-option>
+          <ion-select-option value="orange">Orange</ion-select-option>
+        </ion-select>
+
+        <ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+          <ion-select-option value="apple">Apple</ion-select-option>
+          <ion-select-option value="banana">Banana</ion-select-option>
+          <ion-select-option value="orange">Orange</ion-select-option>
+        </ion-select>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v7/select/fill/index.md
+++ b/static/usage/v7/select/fill/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/select/fill/demo.html" size="300px" />

--- a/static/usage/v7/select/fill/javascript.md
+++ b/static/usage/v7/select/fill/javascript.md
@@ -1,0 +1,15 @@
+```html
+<ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+  <ion-select-option value="apple">Apple</ion-select-option>
+  <ion-select-option value="banana">Banana</ion-select-option>
+  <ion-select-option value="orange">Orange</ion-select-option>
+</ion-select>
+
+<br />
+
+<ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+  <ion-select-option value="apple">Apple</ion-select-option>
+  <ion-select-option value="banana">Banana</ion-select-option>
+  <ion-select-option value="orange">Orange</ion-select-option>
+</ion-select>
+```

--- a/static/usage/v7/select/fill/react.md
+++ b/static/usage/v7/select/fill/react.md
@@ -1,0 +1,25 @@
+```tsx
+import React from 'react';
+import { IonSelect, IonSelectOption } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonSelect mode="md" label="Solid select" labelPlacement="floating" fill="solid">
+        <IonSelectOption value="apple">Apple</IonSelectOption>
+        <IonSelectOption value="banana">Banana</IonSelectOption>
+        <IonSelectOption value="orange">Orange</IonSelectOption>
+      </IonSelect>
+      
+      <br />
+      
+      <IonSelect mode="md" label="Outline select" labelPlacement="floating" fill="outline">
+        <IonSelectOption value="apple">Apple</IonSelectOption>
+        <IonSelectOption value="banana">Banana</IonSelectOption>
+        <IonSelectOption value="orange">Orange</IonSelectOption>
+      </IonSelect>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/select/fill/vue.md
+++ b/static/usage/v7/select/fill/vue.md
@@ -16,11 +16,11 @@
 </template>
 
 <script lang="ts">
-  import { IonSelect } from '@ionic/vue';
+  import { IonSelect, IonSelectOption } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonSelect },
+    components: { IonSelect, IonSelectOption },
   });
 </script>
 ```

--- a/static/usage/v7/select/fill/vue.md
+++ b/static/usage/v7/select/fill/vue.md
@@ -1,0 +1,26 @@
+```html
+<template>
+  <ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+  
+  <br />
+  
+  <ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+</template>
+
+<script lang="ts">
+  import { IonSelect } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonSelect },
+  });
+</script>
+```

--- a/static/usage/v7/select/interfaces/action-sheet/angular.md
+++ b/static/usage/v7/select/interfaces/action-sheet/angular.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select interface="action-sheet" placeholder="Select fruit">
+    <ion-select aria-label="Fruit" interface="action-sheet" placeholder="Select fruit">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/interfaces/action-sheet/demo.html
+++ b/static/usage/v7/select/interfaces/action-sheet/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Action Sheet</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 </head>
 
 <body>
@@ -17,7 +17,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-select interface="action-sheet" placeholder="Select fruit">
+            <ion-select aria-label="Fruit" interface="action-sheet" placeholder="Select fruit">
               <ion-select-option value="apples">Apples</ion-select-option>
               <ion-select-option value="oranges">Oranges</ion-select-option>
               <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/interfaces/action-sheet/javascript.md
+++ b/static/usage/v7/select/interfaces/action-sheet/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select interface="action-sheet" placeholder="Select fruit">
+    <ion-select aria-label="Fruit" interface="action-sheet" placeholder="Select fruit">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/interfaces/action-sheet/react.md
+++ b/static/usage/v7/select/interfaces/action-sheet/react.md
@@ -5,7 +5,7 @@ function Example() {
   return (
     <IonList>
       <IonItem>
-        <IonSelect interface="action-sheet" placeholder="Select fruit">
+        <IonSelect aria-label="Fruit" interface="action-sheet" placeholder="Select fruit">
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/interfaces/action-sheet/vue.md
+++ b/static/usage/v7/select/interfaces/action-sheet/vue.md
@@ -2,7 +2,7 @@
 <template>
   <ion-list>
     <ion-item>
-      <ion-select interface="action-sheet" placeholder="Select fruit">
+      <ion-select aria-label="Fruit" interface="action-sheet" placeholder="Select fruit">
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/interfaces/popover/angular.md
+++ b/static/usage/v7/select/interfaces/popover/angular.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select interface="popover" placeholder="Select fruit">
+    <ion-select aria-label="Fruit" interface="popover" placeholder="Select fruit">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/interfaces/popover/demo.html
+++ b/static/usage/v7/select/interfaces/popover/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Popover</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 </head>
 
 <body>
@@ -17,7 +17,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-select interface="popover" placeholder="Select fruit">
+            <ion-select aria-label="Fruit" interface="popover" placeholder="Select fruit">
               <ion-select-option value="apples">Apples</ion-select-option>
               <ion-select-option value="oranges">Oranges</ion-select-option>
               <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/interfaces/popover/javascript.md
+++ b/static/usage/v7/select/interfaces/popover/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select interface="popover" placeholder="Select fruit">
+    <ion-select aria-label="Fruit" interface="popover" placeholder="Select fruit">
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/interfaces/popover/react.md
+++ b/static/usage/v7/select/interfaces/popover/react.md
@@ -5,7 +5,7 @@ function Example() {
   return (
     <IonList>
       <IonItem>
-        <IonSelect interface="popover" placeholder="Select fruit">
+        <IonSelect aria-label="Fruit" interface="popover" placeholder="Select fruit">
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/interfaces/popover/vue.md
+++ b/static/usage/v7/select/interfaces/popover/vue.md
@@ -3,9 +3,9 @@
   <ion-list>
     <ion-item>
       <ion-select aria-label="Fruit" interface="popover" placeholder="Select fruit">
-        <IonSelectOption value="apples">Apples</IonSelectOption>
-        <IonSelectOption value="oranges">Oranges</IonSelectOption>
-        <IonSelectOption value="bananas">Bananas</IonSelectOption>
+        <ion-select-option value="apples">Apples</ion-select-option>
+        <ion-select-option value="oranges">Oranges</ion-select-option>
+        <ion-select-option value="bananas">Bananas</ion-select-option>
       </ion-select>
     </ion-item>
   </ion-list>

--- a/static/usage/v7/select/interfaces/popover/vue.md
+++ b/static/usage/v7/select/interfaces/popover/vue.md
@@ -2,7 +2,7 @@
 <template>
   <ion-list>
     <ion-item>
-      <ion-select interface="popover" placeholder="Select fruit">
+      <ion-select aria-label="Fruit" interface="popover" placeholder="Select fruit">
         <IonSelectOption value="apples">Apples</IonSelectOption>
         <IonSelectOption value="oranges">Oranges</IonSelectOption>
         <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/justify/angular.md
+++ b/static/usage/v7/select/justify/angular.md
@@ -1,0 +1,23 @@
+```html
+<ion-item>
+  <ion-select justify="start" label="Start" placeholder="Favorite fruit">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+</ion-item>
+<ion-item>
+  <ion-select justify="end" label="End" placeholder="Favorite fruit">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+</ion-item>
+<ion-item>
+  <ion-select justify="space-between" label="Space Between" placeholder="Favorite fruit">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+</ion-item>
+```

--- a/static/usage/v7/select/justify/demo.html
+++ b/static/usage/v7/select/justify/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>select</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
+
+  <style>
+    ion-list {
+      width: 100%;
+    }
+  </style>
+</head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-select justify="start" label="Start" placeholder="Favorite fruit">
+                <ion-select-option value="apple">Apple</ion-select-option>
+                <ion-select-option value="banana">Banana</ion-select-option>
+                <ion-select-option value="orange">Orange</ion-select-option>
+              </ion-select>
+            </ion-item>
+            <ion-item>
+              <ion-select justify="end" label="End" placeholder="Favorite fruit">
+                <ion-select-option value="apple">Apple</ion-select-option>
+                <ion-select-option value="banana">Banana</ion-select-option>
+                <ion-select-option value="orange">Orange</ion-select-option>
+              </ion-select>
+            </ion-item>
+            <ion-item>
+              <ion-select justify="space-between" label="Space Between" placeholder="Favorite fruit">
+                <ion-select-option value="apple">Apple</ion-select-option>
+                <ion-select-option value="banana">Banana</ion-select-option>
+                <ion-select-option value="orange">Orange</ion-select-option>
+              </ion-select>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/select/justify/index.md
+++ b/static/usage/v7/select/justify/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/select/justify/demo.html" size="300px" />

--- a/static/usage/v7/select/justify/javascript.md
+++ b/static/usage/v7/select/justify/javascript.md
@@ -1,0 +1,23 @@
+```html
+<ion-item>
+  <ion-select justify="start" label="Start" placeholder="Favorite fruit">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+</ion-item>
+<ion-item>
+  <ion-select justify="end" label="End" placeholder="Favorite fruit">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+</ion-item>
+<ion-item>
+  <ion-select justify="space-between" label="Space Between" placeholder="Favorite fruit">
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+</ion-item>
+```

--- a/static/usage/v7/select/justify/react.md
+++ b/static/usage/v7/select/justify/react.md
@@ -1,0 +1,33 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonSelect justify="start" label="Start" placeholder="Favorite fruit">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+      <IonItem>
+        <IonSelect justify="end" label="End" placeholder="Favorite fruit">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+      <IonItem>
+        <IonSelect justify="space-between" label="Space Between" placeholder="Favorite fruit">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/select/justify/vue.md
+++ b/static/usage/v7/select/justify/vue.md
@@ -1,0 +1,36 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-select justify="start" label="Start" placeholder="Favorite fruit">
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item>
+      <ion-select justify="end" label="End" placeholder="Favorite fruit">
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item>
+      <ion-select justify="space-between" label="Space Between" placeholder="Favorite fruit">
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonSelect, IonSelectOption },
+  });
+</script>
+```

--- a/static/usage/v7/select/labels/angular.md
+++ b/static/usage/v7/select/labels/angular.md
@@ -1,0 +1,35 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select label="Default label" placeholder="Favorite Fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-item>
+    <ion-select label="Fixed label" label-placement="fixed" placeholder="Favorite fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-item>
+    <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-item>
+    <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/labels/angular.md
+++ b/static/usage/v7/select/labels/angular.md
@@ -17,7 +17,7 @@
   </ion-item>
 
   <ion-item>
-    <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+    <ion-select label="Stacked label" label-placement="stacked">
       <ion-select-option value="apple">Apple</ion-select-option>
       <ion-select-option value="banana">Banana</ion-select-option>
       <ion-select-option value="orange">Orange</ion-select-option>
@@ -25,7 +25,7 @@
   </ion-item>
 
   <ion-item>
-    <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+    <ion-select label="Floating label" label-placement="floating">
       <ion-select-option value="apple">Apple</ion-select-option>
       <ion-select-option value="banana">Banana</ion-select-option>
       <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/labels/demo.html
+++ b/static/usage/v7/select/labels/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>select</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
+
+  <style>
+    ion-list {
+      width: 100%;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-list>
+          <ion-item>
+            <ion-select label="Default label" placeholder="Favorite Fruit">
+              <ion-select-option value="apple">Apple</ion-select-option>
+              <ion-select-option value="banana">Banana</ion-select-option>
+              <ion-select-option value="orange">Orange</ion-select-option>
+            </ion-select>
+          </ion-item>
+
+          <ion-item>
+            <ion-select label="Fixed label" label-placement="fixed" placeholder="Favorite fruit">
+              <ion-select-option value="apple">Apple</ion-select-option>
+              <ion-select-option value="banana">Banana</ion-select-option>
+              <ion-select-option value="orange">Orange</ion-select-option>
+            </ion-select>
+          </ion-item>
+
+          <ion-item>
+            <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+              <ion-select-option value="apple">Apple</ion-select-option>
+              <ion-select-option value="banana">Banana</ion-select-option>
+              <ion-select-option value="orange">Orange</ion-select-option>
+            </ion-select>
+          </ion-item>
+
+          <ion-item>
+            <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+              <ion-select-option value="apple">Apple</ion-select-option>
+              <ion-select-option value="banana">Banana</ion-select-option>
+              <ion-select-option value="orange">Orange</ion-select-option>
+            </ion-select>
+          </ion-item>
+        </ion-list>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v7/select/labels/demo.html
+++ b/static/usage/v7/select/labels/demo.html
@@ -39,7 +39,7 @@
           </ion-item>
 
           <ion-item>
-            <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+            <ion-select label="Stacked label" label-placement="stacked">
               <ion-select-option value="apple">Apple</ion-select-option>
               <ion-select-option value="banana">Banana</ion-select-option>
               <ion-select-option value="orange">Orange</ion-select-option>
@@ -47,7 +47,7 @@
           </ion-item>
 
           <ion-item>
-            <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+            <ion-select label="Floating label" label-placement="floating">
               <ion-select-option value="apple">Apple</ion-select-option>
               <ion-select-option value="banana">Banana</ion-select-option>
               <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/labels/index.md
+++ b/static/usage/v7/select/labels/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/select/labels/demo.html" size="300px" />

--- a/static/usage/v7/select/labels/javascript.md
+++ b/static/usage/v7/select/labels/javascript.md
@@ -1,0 +1,35 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select label="Default label" placeholder="Favorite Fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-item>
+    <ion-select label="Fixed label" label-placement="fixed" placeholder="Favorite fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-item>
+    <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-item>
+    <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/labels/javascript.md
+++ b/static/usage/v7/select/labels/javascript.md
@@ -17,7 +17,7 @@
   </ion-item>
 
   <ion-item>
-    <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+    <ion-select label="Stacked label" label-placement="stacked">
       <ion-select-option value="apple">Apple</ion-select-option>
       <ion-select-option value="banana">Banana</ion-select-option>
       <ion-select-option value="orange">Orange</ion-select-option>
@@ -25,7 +25,7 @@
   </ion-item>
 
   <ion-item>
-    <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+    <ion-select label="Floating label" label-placement="floating">
       <ion-select-option value="apple">Apple</ion-select-option>
       <ion-select-option value="banana">Banana</ion-select-option>
       <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/labels/react.md
+++ b/static/usage/v7/select/labels/react.md
@@ -1,6 +1,6 @@
 ```tsx
 import React from 'react';
-import { IonItem, IonList, IonSelect } from '@ionic/react';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/react';
 
 function Example() {
   return (

--- a/static/usage/v7/select/labels/react.md
+++ b/static/usage/v7/select/labels/react.md
@@ -22,7 +22,7 @@ function Example() {
       </IonItem>
     
       <IonItem>
-        <IonSelect label="Stacked label" labelPlacement="stacked" placeholder="Favorite fruit">
+        <IonSelect label="Stacked label" labelPlacement="stacked">
           <IonSelectOption value="apple">Apple</IonSelectOption>
           <IonSelectOption value="banana">Banana</IonSelectOption>
           <IonSelectOption value="orange">Orange</IonSelectOption>
@@ -30,7 +30,7 @@ function Example() {
       </IonItem>
     
       <IonItem>
-        <IonSelect label="Floating label" labelPlacement="floating" placeholder="Favorite fruit">
+        <IonSelect label="Floating label" labelPlacement="floating">
           <IonSelectOption value="apple">Apple</IonSelectOption>
           <IonSelectOption value="banana">Banana</IonSelectOption>
           <IonSelectOption value="orange">Orange</IonSelectOption>

--- a/static/usage/v7/select/labels/react.md
+++ b/static/usage/v7/select/labels/react.md
@@ -1,0 +1,43 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonSelect } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonSelect label="Default label" placeholder="Favorite Fruit">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    
+      <IonItem>
+        <IonSelect label="Fixed label" labelPlacement="fixed" placeholder="Favorite fruit">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    
+      <IonItem>
+        <IonSelect label="Stacked label" labelPlacement="stacked" placeholder="Favorite fruit">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    
+      <IonItem>
+        <IonSelect label="Floating label" labelPlacement="floating" placeholder="Favorite fruit">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/select/labels/vue.md
+++ b/static/usage/v7/select/labels/vue.md
@@ -1,0 +1,46 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-select label="Default label" placeholder="Favorite Fruit">
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+      </ion-select>
+    </ion-item>
+  
+    <ion-item>
+      <ion-select label="Fixed label" label-placement="fixed" placeholder="Favorite fruit">
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+      </ion-select>
+    </ion-item>
+  
+    <ion-item>
+      <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+      </ion-select>
+    </ion-item>
+  
+    <ion-item>
+      <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonItem, IonList, IonSelect } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonSelect },
+  });
+</script>
+```

--- a/static/usage/v7/select/labels/vue.md
+++ b/static/usage/v7/select/labels/vue.md
@@ -36,11 +36,11 @@
 </template>
 
 <script lang="ts">
-  import { IonItem, IonList, IonSelect } from '@ionic/vue';
+  import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonItem, IonList, IonSelect },
+    components: { IonItem, IonList, IonSelect, IonSelectOption },
   });
 </script>
 ```

--- a/static/usage/v7/select/labels/vue.md
+++ b/static/usage/v7/select/labels/vue.md
@@ -18,7 +18,7 @@
     </ion-item>
   
     <ion-item>
-      <ion-select label="Stacked label" label-placement="stacked" placeholder="Favorite fruit">
+      <ion-select label="Stacked label" label-placement="stacked">
         <ion-select-option value="apple">Apple</ion-select-option>
         <ion-select-option value="banana">Banana</ion-select-option>
         <ion-select-option value="orange">Orange</ion-select-option>
@@ -26,7 +26,7 @@
     </ion-item>
   
     <ion-item>
-      <ion-select label="Floating label" label-placement="floating" placeholder="Favorite fruit">
+      <ion-select label="Floating label" label-placement="floating">
         <ion-select-option value="apple">Apple</ion-select-option>
         <ion-select-option value="banana">Banana</ion-select-option>
         <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/migration/index.md
+++ b/static/usage/v7/select/migration/index.md
@@ -1,0 +1,140 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+````mdx-code-block
+<Tabs
+  groupId="framework"
+  defaultValue="javascript"
+  values={[
+    { value: 'javascript', label: 'JavaScript' },
+    { value: 'angular', label: 'Angular' },
+    { value: 'react', label: 'React' },
+    { value: 'vue', label: 'Vue' },
+  ]
+}>
+<TabItem value="javascript">
+
+```html
+<!-- Label and Label Position -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="floating">Favorite Fruit:</ion-label>
+  <ion-select>...</ion-select>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-select label="Favorite Fruit:" label-placement="floating">...</ion-select>
+</ion-item>
+
+
+<!-- Fill -->
+
+<!-- Before -->
+<ion-item fill="outline" shape="round">
+  <ion-label position="floating">Favorite Fruit:</ion-label>
+  <ion-select>...</ion-select>
+</ion-item>
+
+<!-- After -->
+
+<!-- Inputs using `fill` should not be placed in ion-item -->
+<ion-select fill="outline" shape="round" label="Favorite Fruit:" label-placement="floating">...</ion-select>
+```
+</TabItem>
+<TabItem value="angular">
+
+```html
+<!-- Label and Label Position -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="floating">Favorite Fruit:</ion-label>
+  <ion-select>...</ion-select>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-select label="Favorite Fruit:" labelPlacement="floating">...</ion-select>
+</ion-item>
+
+
+<!-- Fill -->
+
+<!-- Before -->
+<ion-item fill="outline" shape="round">
+  <ion-label position="floating">Favorite Fruit:</ion-label>
+  <ion-select>...</ion-select>
+</ion-item>
+
+<!-- After -->
+
+<!-- Inputs using `fill` should not be placed in ion-item -->
+<ion-select fill="outline" shape="round" label="Favorite Fruit:" labelPlacement="floating">...</ion-select>
+```
+</TabItem>
+<TabItem value="react">
+
+```tsx
+{/* Label and Label Position */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel position="floating">Favorite Fruit:</IonLabel>
+  <IonSelect>...</IonSelect>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonSelect label="Favorite Fruit:" labelPlacement="floating">...</IonSelect>
+</IonItem>
+
+
+{/* Fill */}
+
+{/* Before */}
+<IonItem fill="outline" shape="round">
+  <IonLabel position="floating">Favorite Fruit:</IonLabel>
+  <IonSelect>...</IonSelect>
+</IonItem>
+
+{/* After */}
+
+{/* Inputs using `fill` should not be placed in IonItem */}
+<IonSelect fill="outline" shape="round" label="Favorite Fruit:" labelPlacement="floating">...</IonSelect>
+```
+</TabItem>
+<TabItem value="vue">
+
+```html
+<!-- Label and Label Position -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="floating">Favorite Fruit:</ion-label>
+  <ion-select>...</ion-select>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-select label="Favorite Fruit:" label-placement="floating">...</ion-select>
+</ion-item>
+
+
+<!-- Fill -->
+
+<!-- Before -->
+<ion-item fill="outline" shape="round">
+  <ion-label position="floating">Favorite Fruit:</ion-label>
+  <ion-select>...</ion-select>
+</ion-item>
+
+<!-- After -->
+
+<!-- Inputs using `fill` should not be placed in ion-item -->
+<ion-select fill="outline" shape="round" label="Favorite Fruit:" label-placement="floating">...</ion-select>
+```
+</TabItem>
+</Tabs>
+````

--- a/static/usage/v7/select/objects-as-values/multiple-selection/angular/example_component_html.md
+++ b/static/usage/v7/select/objects-as-values/multiple-selection/angular/example_component_html.md
@@ -2,6 +2,7 @@
 <ion-list>
   <ion-item>
     <ion-select
+      aria-label="Food"
       [compareWith]="compareWith"
       placeholder="Select food"
       (ionChange)="handleChange($event)"

--- a/static/usage/v7/select/objects-as-values/multiple-selection/demo.html
+++ b/static/usage/v7/select/objects-as-values/multiple-selection/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Object Values and Multiple Selection</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 
   <style>
     .container>ion-list {
@@ -27,7 +27,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-select placeholder="Select food" multiple="true"></ion-select>
+            <ion-select aria-label="Food" placeholder="Select food" multiple="true"></ion-select>
           </ion-item>
           <ion-item lines="none">
             <ion-label>

--- a/static/usage/v7/select/objects-as-values/multiple-selection/javascript.md
+++ b/static/usage/v7/select/objects-as-values/multiple-selection/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select  aria-label="Food" placeholder="Select food" multiple="true"></ion-select>
+    <ion-select aria-label="Food" placeholder="Select food" multiple="true"></ion-select>
   </ion-item>
   <ion-item lines="none">
     <ion-label>

--- a/static/usage/v7/select/objects-as-values/multiple-selection/javascript.md
+++ b/static/usage/v7/select/objects-as-values/multiple-selection/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select food" multiple="true"></ion-select>
+    <ion-select  aria-label="Food" placeholder="Select food" multiple="true"></ion-select>
   </ion-item>
   <ion-item lines="none">
     <ion-label>

--- a/static/usage/v7/select/objects-as-values/multiple-selection/react.md
+++ b/static/usage/v7/select/objects-as-values/multiple-selection/react.md
@@ -45,6 +45,7 @@ function Example() {
     <IonList>
       <IonItem>
         <IonSelect
+          aria-label="Food"
           placeholder="Select food"
           compareWith={compareWith}
           onIonChange={(ev) => setCurrentFood(JSON.stringify(ev.detail.value))}

--- a/static/usage/v7/select/objects-as-values/multiple-selection/vue.md
+++ b/static/usage/v7/select/objects-as-values/multiple-selection/vue.md
@@ -3,6 +3,7 @@
   <ion-list>
     <ion-item>
       <ion-select
+        aria-label="Food"
         placeholder="Select food"
         :compareWith="compareWith"
         @ionChange="currentFood = JSON.stringify($event.detail.value)"

--- a/static/usage/v7/select/objects-as-values/using-comparewith/angular/example_component_html.md
+++ b/static/usage/v7/select/objects-as-values/using-comparewith/angular/example_component_html.md
@@ -2,6 +2,7 @@
 <ion-list>
   <ion-item>
     <ion-select
+      aria-label="Food"
       [compareWith]="compareWith"
       placeholder="Select food"
       (ionChange)="handleChange($event)"

--- a/static/usage/v7/select/objects-as-values/using-comparewith/demo.html
+++ b/static/usage/v7/select/objects-as-values/using-comparewith/demo.html
@@ -7,8 +7,8 @@
   <title>Select - Using compareWith</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.4.2-dev.11673981545.1e612253/css/ionic.bundle.css" />
 
   <style>
     .container>ion-list {
@@ -23,7 +23,7 @@
       <div class="container">
         <ion-list>
           <ion-item>
-            <ion-select placeholder="Select food"></ion-select>
+            <ion-select aria-label="Food" placeholder="Select food"></ion-select>
           </ion-item>
           <ion-item lines="none">
             <ion-label>

--- a/static/usage/v7/select/objects-as-values/using-comparewith/javascript.md
+++ b/static/usage/v7/select/objects-as-values/using-comparewith/javascript.md
@@ -1,7 +1,7 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select food"></ion-select>
+    <ion-select aria-label="Food" placeholder="Select food"></ion-select>
   </ion-item>
   <ion-item lines="none">
     <ion-label>

--- a/static/usage/v7/select/objects-as-values/using-comparewith/react.md
+++ b/static/usage/v7/select/objects-as-values/using-comparewith/react.md
@@ -37,6 +37,7 @@ function Example() {
     <IonList>
       <IonItem>
         <IonSelect
+          aria-label="Food"
           placeholder="Select food"
           compareWith={compareWith}
           onIonChange={(ev) => setCurrentFood(JSON.stringify(ev.detail.value))}

--- a/static/usage/v7/select/objects-as-values/using-comparewith/vue.md
+++ b/static/usage/v7/select/objects-as-values/using-comparewith/vue.md
@@ -3,6 +3,7 @@
   <ion-list>
     <ion-item>
       <ion-select
+        aria-label="Food"
         placeholder="Select fruit"
         :compareWith="compareWith"
         @ionChange="currentFood = JSON.stringify($event.detail.value)"


### PR DESCRIPTION
- Migrates the existing select playgrounds to use the new select syntax for Ionic 7
- Adds label-placement, justify, and filled select playgrounds
- Add migration guide to modern select syntax
Preview https://ionic-docs-git-select-docs-7-ionic1.vercel.app/docs/api/select