### PR TITLE
docs(upgrade-pill): link to v7 upgrade guide

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,8 +98,8 @@ module.exports = {
         {
           type: 'cta',
           position: 'left',
-          text: 'Ionic v6.0.0 Upgrade Guide',
-          href: `/intro/upgrading-to-ionic-6`,
+          text: 'Ionic v7.0.0 Upgrade Guide',
+          href: `/updating/7-0`,
         },
         {
           type: 'docsVersionDropdown',


### PR DESCRIPTION
Migrates the upgrade guide CTA to the v7 migration gude.

Do not merge until v7 is the default version on the Ionic docs site. 