### PR TITLE
docs(alert): add inline usage examples

### DIFF
--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -20,84 +20,33 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="scoped" />
 
-
-
 An Alert is a dialog that presents users with information or collects information from the user using inputs. An alert appears on top of the app's content, and must be manually dismissed by the user before they can resume interaction with the app. It can also optionally have a `header`, `subHeader` and `message`.
 
-## Presenting
+## Inline Alerts (Recommended)
 
-### Controller
+`ion-alert` can be used by writing the component directly in your template. This reduces the number of handlers you need to wire up in order to present the Alert.
+
+import Trigger from '@site/static/usage/v7/alert/presenting/trigger/index.md';
+
+<Trigger />
+
+### Using `isOpen`
+
+The `isOpen` property on `ion-alert` allows developers to control the presentation state of the Alert from their application state. This means when `isOpen` is set to `true` the Alert will be presented, and when `isOpen` is set to `false` the Alert will be dismissed.
+
+`isOpen` uses a one-way data binding, meaning it will not automatically be set to `false` when the Alert is dismissed. Developers should listen for the `ionAlertDidDismiss` or `didDismiss` event and set `isOpen` to `false`. The reason for this is it prevents the internals of `ion-alert` from being tightly coupled with the state of the application. With a one way data binding, the Alert only needs to concern itself with the boolean value that the reactive variable provides. With a two way data binding, the Alert needs to concern itself with both the boolean value as well as the existence of the reactive variable itself. This can lead to non-deterministic behaviors and make applications harder to debug.
+
+import IsOpen from '@site/static/usage/v7/alert/presenting/isOpen/index.md';
+
+<IsOpen />
+
+## Controller Alerts
+
+The `alertController` can be used in situations where more control is needed over when the Alert is presented and dismissed.
 
 import Controller from '@site/static/usage/v7/alert/presenting/controller/index.md';
 
 <Controller />
-
-### Inline
-
-When using Ionic with React or Vue, `ion-alert` can also be placed directly in the template through use of the `isOpen` property. Note that `isOpen` must be set to `false` manually when the alert is dismissed; it will not be updated automatically.
-
-<Tabs defaultValue="react" values={[{ value: 'react', label: 'React' }, { value: 'vue', label: 'Vue' }]}>
-<TabItem value="react">
-
-```tsx
-import React, { useState } from 'react';
-import { IonAlert, IonButton, IonContent } from '@ionic/react';
-
-function Example() {
-  const [showAlert, setShowAlert] = useState(false);
-
-  return (
-    <IonContent>
-      <IonButton onClick={() => setShowAlert(true)}>Click Me</IonButton>
-      <IonAlert
-        isOpen={showAlert}
-        onDidDismiss={() => setShowAlert(false)}
-        header="Alert"
-        subHeader="Important message"
-        message="This is an alert!"
-        buttons={['OK']}
-      />
-    </IonContent>
-  );
-}
-```
-
-</TabItem>
-<TabItem value="vue">
-
-```html
-<template>
-  <ion-content>
-    <ion-button @click="setOpen(true)">Show Alert</ion-button>
-    <ion-alert
-      :is-open="isOpenRef"
-      header="Alert"
-      sub-header="Important message"
-      message="This is an alert!"
-      :buttons="['OK']"
-      @didDismiss="setOpen(false)"
-    ></ion-alert>
-  </ion-content>
-</template>
-
-<script lang="ts">
-import { IonAlert, IonButton, IonContent } from '@ionic/vue';
-import { defineComponent, ref } from 'vue';
-
-export default defineComponent({
-  components: { IonAlert, IonButton },
-  setup() {
-    const isOpenRef = ref(false);
-    const setOpen = (state: boolean) => isOpenRef.value = state;
-    
-    return { isOpenRef, setOpen }
-  }
-});
-</script>
-```
-
-</TabItem>
-</Tabs>
 
 ## Buttons
 

--- a/static/usage/v7/alert/buttons/angular/example_component_html.md
+++ b/static/usage/v7/alert/buttons/angular/example_component_html.md
@@ -1,5 +1,11 @@
 ```html
-<ion-button (click)="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert
+  trigger="present-alert"
+  header="Alert!"
+  [buttons]="alertButtons"
+  (didDismiss)="setResult($event)"
+></ion-alert>
 <p>{{ handlerMessage }}</p>
 <p>{{ roleMessage }}</p>
 ```

--- a/static/usage/v7/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v7/alert/buttons/angular/example_component_ts.md
@@ -1,6 +1,5 @@
 ```ts
 import { Component } from '@angular/core';
-import { AlertController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
@@ -10,33 +9,21 @@ export class ExampleComponent {
   handlerMessage = '';
   roleMessage = '';
 
-  constructor(private alertController: AlertController) {}
+  public alertButtons = [
+    {
+      text: 'Cancel',
+      role: 'cancel',
+      handler: () => { this.handlerMessage = 'Alert canceled'; }
+    },
+    {
+      text: 'OK',
+      role: 'confirm',
+      handler: () => { this.handlerMessage = 'Alert confirmed'; }
+    }
+  ];
 
-  async presentAlert() {
-    const alert = await this.alertController.create({
-      header: 'Alert!',
-      buttons: [
-        {
-          text: 'Cancel',
-          role: 'cancel',
-          handler: () => {
-            this.handlerMessage = 'Alert canceled';
-          },
-        },
-        {
-          text: 'OK',
-          role: 'confirm',
-          handler: () => {
-            this.handlerMessage = 'Alert confirmed';
-          },
-        },
-      ],
-    });
-
-    await alert.present();
-
-    const { role } = await alert.onDidDismiss();
-    this.roleMessage = `Dismissed with role: ${role}`;
+  setResult(ev) {
+    this.roleMessage = `Dismissed with role: ${ev.detail.role}`;
   }
 }
 ```

--- a/static/usage/v7/alert/buttons/demo.html
+++ b/static/usage/v7/alert/buttons/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
 
   <style>
     .container {
@@ -25,7 +25,8 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-button onclick="presentAlert()">Click Me</ion-button>
+        <ion-button id="present-alert">Click Me</ion-button>
+        <ion-alert trigger="present-alert" header="Alert!"></ion-alert>
         <p id="handlerResult"></p>
         <p id="roleResult"></p>
       </div>
@@ -35,29 +36,24 @@
   <script>
     const handlerOutput = document.querySelector('#handlerResult');
     const roleOutput = document.querySelector('#roleResult');
+    const alert = document.querySelector('ion-alert');
 
-    async function presentAlert() {
-      const alert = document.createElement('ion-alert');
-      alert.header = 'Alert!';
-      alert.buttons = [
-        {
-          text: 'Cancel',
-          role: 'cancel',
-          handler: () => { handlerOutput.innerText = 'Alert canceled'; }
-        },
-        {
-          text: 'OK',
-          role: 'confirm',
-          handler: () => { handlerOutput.innerText = 'Alert confirmed'; }
-        }
-      ];
+    alert.buttons = [
+      {
+        text: 'Cancel',
+        role: 'cancel',
+        handler: () => { handlerOutput.innerText = 'Alert canceled'; }
+      },
+      {
+        text: 'OK',
+        role: 'confirm',
+        handler: () => { handlerOutput.innerText = 'Alert confirmed'; }
+      }
+    ];
 
-      document.body.appendChild(alert);
-      await alert.present();
-
-      const { role } = await alert.onDidDismiss();
-      roleOutput.innerText = `Dismissed with role: ${role}`;
-    }
+    alert.addEventListener('ionAlertDidDismiss', (ev) => {
+      roleOutput.innerText = `Dismissed with role: ${ev.detail.role}`;
+    });
   </script>
 </body>
 

--- a/static/usage/v7/alert/buttons/demo.html
+++ b/static/usage/v7/alert/buttons/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 
   <style>
     .container {

--- a/static/usage/v7/alert/buttons/javascript.md
+++ b/static/usage/v7/alert/buttons/javascript.md
@@ -1,33 +1,29 @@
 ```html
-<ion-button onclick="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert trigger="present-alert" header="Alert!"></ion-alert>
 <p id="handlerResult"></p>
 <p id="roleResult"></p>
 
 <script>
   const handlerOutput = document.querySelector('#handlerResult');
   const roleOutput = document.querySelector('#roleResult');
+  const alert = document.querySelector('ion-alert');
 
-  async function presentAlert() {
-    const alert = document.createElement('ion-alert');
-    alert.header = 'Alert!';
-    alert.buttons = [
-      {
-        text: 'Cancel',
-        role: 'cancel',
-        handler: () => { handlerOutput.innerText = 'Alert canceled'; }
-      },
-      {
-        text: 'OK',
-        role: 'confirm',
-        handler: () => { handlerOutput.innerText = 'Alert confirmed'; }
-      }
-    ];
+  alert.buttons = [
+    {
+      text: 'Cancel',
+      role: 'cancel',
+      handler: () => { handlerOutput.innerText = 'Alert canceled'; }
+    },
+    {
+      text: 'OK',
+      role: 'confirm',
+      handler: () => { handlerOutput.innerText = 'Alert confirmed'; }
+    }
+  ];
 
-    document.body.appendChild(alert);
-    await alert.present();
-
-    const { role } = await alert.onDidDismiss();
-    roleOutput.innerText = `Dismissed with role: ${role}`;
-  }
+  alert.addEventListener('ionAlertDidDismiss', (ev) => {
+    roleOutput.innerText = `Dismissed with role: ${ev.detail.role}`;
+  });
 </script>
 ```

--- a/static/usage/v7/alert/buttons/react.md
+++ b/static/usage/v7/alert/buttons/react.md
@@ -1,40 +1,35 @@
 ```tsx
 import React, { useState } from 'react';
-import { IonButton, useIonAlert } from '@ionic/react';
+import { IonAlert, IonButton } from '@ionic/react';
 
 function Example() {
-  const [presentAlert] = useIonAlert();
   const [handlerMessage, setHandlerMessage] = useState('');
   const [roleMessage, setRoleMessage] = useState('');
 
   return (
     <>
-      <IonButton
-        onClick={() =>
-          presentAlert({
-            header: 'Alert!',
-            buttons: [
-              {
-                text: 'Cancel',
-                role: 'cancel',
-                handler: () => {
-                  setHandlerMessage('Alert canceled');
-                },
-              },
-              {
-                text: 'OK',
-                role: 'confirm',
-                handler: () => {
-                  setHandlerMessage('Alert confirmed');
-                },
-              },
-            ],
-            onDidDismiss: (e: CustomEvent) => setRoleMessage(`Dismissed with role: ${e.detail.role}`),
-          })
-        }
-      >
-        Click Me
-      </IonButton>
+      <IonButton id="present-alert">Click Me</IonButton>
+      <IonAlert
+        header="Alert!"
+        trigger="present-alert"
+        buttons={[
+          {
+            text: 'Cancel',
+            role: 'cancel',
+            handler: () => {
+              setHandlerMessage('Alert canceled');
+            },
+          },
+          {
+            text: 'OK',
+            role: 'confirm',
+            handler: () => {
+              setHandlerMessage('Alert confirmed');
+            },
+          },
+        ]}
+        onDidDismiss={({ detail }) => setRoleMessage(`Dismissed with role: ${detail.role}`)}
+      ></IonAlert>
       <p>{handlerMessage}</p>
       <p>{roleMessage}</p>
     </>

--- a/static/usage/v7/alert/buttons/vue.md
+++ b/static/usage/v7/alert/buttons/vue.md
@@ -1,51 +1,52 @@
 ```html
 <template>
-  <ion-button @click="presentAlert">Click Me</ion-button>
+  <ion-button id="present-alert">Click Me</ion-button>
+  <ion-alert
+    trigger="present-alert"
+    header="Alert!"
+    :buttons="alertButtons"
+    @didDismiss="setResult($event)"
+  ></ion-alert>
   <p>{{ handlerMessage }}</p>
   <p>{{ roleMessage }}</p>
 </template>
 
 <script lang="ts">
   import { ref } from 'vue';
-  import { IonButton, alertController } from '@ionic/vue';
+  import { IonAlert, IonButton } from '@ionic/vue';
 
   export default {
-    components: { IonButton },
+    components: { IonAlert, IonButton },
     setup() {
       const handlerMessage = ref('');
       const roleMessage = ref('');
 
-      const presentAlert = async () => {
-        const alert = await alertController.create({
-          header: 'Alert!',
-          buttons: [
-            {
-              text: 'Cancel',
-              role: 'cancel',
-              handler: () => {
-                handlerMessage.value = 'Alert canceled';
-              },
-            },
-            {
-              text: 'OK',
-              role: 'confirm',
-              handler: () => {
-                handlerMessage.value = 'Alert confirmed';
-              },
-            },
-          ],
-        });
+      const alertButtons = [
+        {
+          text: 'Cancel',
+          role: 'cancel',
+          handler: () => {
+            handlerMessage.value = 'Alert canceled';
+          },
+        },
+        {
+          text: 'OK',
+          role: 'confirm',
+          handler: () => {
+            handlerMessage.value = 'Alert confirmed';
+          },
+        },
+      ];
 
-        await alert.present();
-
-        const { role } = await alert.onDidDismiss();
-        roleMessage.value = `Dismissed with role: ${role}`;
-      };
+      const setResult = (ev: CustomEvent) => {
+        roleMessage.value = `Dismissed with role: ${ev.detail.role}`;
+      }
 
       return {
         handlerMessage,
         roleMessage,
-        presentAlert,
+        alertButtons,
+        setResult
       };
     },
   };

--- a/static/usage/v7/alert/customization/angular/example_component_html.md
+++ b/static/usage/v7/alert/customization/angular/example_component_html.md
@@ -1,3 +1,9 @@
 ```html
-<ion-button (click)="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert
+  trigger="present-alert"
+  class="custom-alert"
+  header="Are you sure?"
+  [buttons]="alertButtons"
+></ion-alert>
 ```

--- a/static/usage/v7/alert/customization/angular/example_component_ts.md
+++ b/static/usage/v7/alert/customization/angular/example_component_ts.md
@@ -1,31 +1,20 @@
 ```ts
 import { Component } from '@angular/core';
-import { AlertController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  constructor(private alertController: AlertController) {}
-
-  async presentAlert() {
-    const alert = await this.alertController.create({
-      header: 'Are you sure?',
-      cssClass: 'custom-alert',
-      buttons: [
-        {
-          text: 'No',
-          cssClass: 'alert-button-cancel',
-        },
-        {
-          text: 'Yes',
-          cssClass: 'alert-button-confirm',
-        },
-      ],
-    });
-
-    await alert.present();
-  }
+  public alertButtons = [
+    {
+      text: 'No',
+      cssClass: 'alert-button-cancel',
+    },
+    {
+      text: 'Yes',
+      cssClass: 'alert-button-confirm',
+    },
+  ];
 }
 ```

--- a/static/usage/v7/alert/customization/demo.html
+++ b/static/usage/v7/alert/customization/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
 
   <style>
     ion-alert.custom-alert {
@@ -49,30 +49,25 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-button onclick="presentAlert()">Click Me</ion-button>
+        <ion-button id="present-alert">Click Me</ion-button>
+        <ion-alert trigger="present-alert" class="custom-alert" header="Are you sure?"></ion-alert>
       </div>
     </ion-content>
   </ion-app>
 
   <script>
-    async function presentAlert() {
-      const alert = document.createElement('ion-alert');
-      alert.header = 'Are you sure?';
-      alert.cssClass = 'custom-alert';
-      alert.buttons = [
-        {
-          text: 'No',
-          cssClass: 'alert-button-cancel'
-        },
-        {
-          text: 'Yes',
-          cssClass: 'alert-button-confirm'
-        }
-      ];
+    const alert = document.querySelector('ion-alert');
 
-      document.body.appendChild(alert);
-      await alert.present();
-    }
+    alert.buttons = [
+      {
+        text: 'No',
+        cssClass: 'alert-button-cancel'
+      },
+      {
+        text: 'Yes',
+        cssClass: 'alert-button-confirm'
+      }
+    ];
   </script>
 </body>
 

--- a/static/usage/v7/alert/customization/demo.html
+++ b/static/usage/v7/alert/customization/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 
   <style>
     ion-alert.custom-alert {

--- a/static/usage/v7/alert/customization/javascript.md
+++ b/static/usage/v7/alert/customization/javascript.md
@@ -1,25 +1,20 @@
 ```html
-<ion-button onclick="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert trigger="present-alert" class="custom-alert" header="Are you sure?"></ion-alert>
 
 <script>
-  async function presentAlert() {
-    const alert = document.createElement('ion-alert');
-    alert.header = 'Are you sure?';
-    alert.cssClass = 'custom-alert';
-    alert.buttons = [
-      {
-        text: 'No',
-        cssClass: 'alert-button-cancel'
-      },
-      {
-        text: 'Yes',
-        cssClass: 'alert-button-confirm'
-      }
-    ];
+  const alert = document.querySelector('ion-alert');
 
-    document.body.appendChild(alert);
-    await alert.present();
-  }
+  alert.buttons = [
+    {
+      text: 'No',
+      cssClass: 'alert-button-cancel'
+    },
+    {
+      text: 'Yes',
+      cssClass: 'alert-button-confirm'
+    }
+  ];
 </script>
 
 <style>

--- a/static/usage/v7/alert/customization/react/main_tsx.md
+++ b/static/usage/v7/alert/customization/react/main_tsx.md
@@ -1,33 +1,29 @@
 ```tsx
 import React from 'react';
-import { IonButton, useIonAlert } from '@ionic/react';
+import { IonAlert, IonButton } from '@ionic/react';
 
 import './main.css';
 
 function Example() {
-  const [presentAlert] = useIonAlert();
-
   return (
-    <IonButton
-      onClick={() =>
-        presentAlert({
-          header: 'Are you sure?',
-          cssClass: 'custom-alert',
-          buttons: [
-            {
-              text: 'No',
-              cssClass: 'alert-button-cancel',
-            },
-            {
-              text: 'Yes',
-              cssClass: 'alert-button-confirm',
-            },
-          ],
-        })
-      }
-    >
-      Click Me
-    </IonButton>
+    <>
+      <IonButton id="present-alert">Click Me</IonButton>
+      <IonAlert
+        trigger="present-alert"
+        header="Are you sure?"
+        className="custom-alert"
+        buttons={[
+          {
+            text: 'No',
+            cssClass: 'alert-button-cancel',
+          },
+          {
+            text: 'Yes',
+            cssClass: 'alert-button-confirm',
+          },
+        ]}
+      ></IonAlert>
+    </>
   );
 }
 export default Example;

--- a/static/usage/v7/alert/customization/vue.md
+++ b/static/usage/v7/alert/customization/vue.md
@@ -1,34 +1,32 @@
 ```html
 <template>
-  <ion-button @click="presentAlert">Click Me</ion-button>
+  <ion-button id="present-alert">Click Me</ion-button>
+  <ion-alert
+    trigger="present-alert"
+    class="custom-alert"
+    header="Are you sure?"
+    :buttons="alertButtons"
+  ></ion-alert>
 </template>
 
 <script lang="ts">
-  import { IonButton, alertController } from '@ionic/vue';
+  import { IonAlert, IonButton } from '@ionic/vue';
 
   export default {
-    components: { IonButton },
+    components: { IonAlert, IonButton },
     setup() {
-      const presentAlert = async () => {
-        const alert = await alertController.create({
-          header: 'Are you sure?',
-          cssClass: 'custom-alert',
-          buttons: [
-            {
-              text: 'No',
-              cssClass: 'alert-button-cancel',
-            },
-            {
-              text: 'Yes',
-              cssClass: 'alert-button-confirm',
-            },
-          ],
-        });
+      const alertButtons = [
+        {
+          text: 'No',
+          cssClass: 'alert-button-cancel',
+        },
+        {
+          text: 'Yes',
+          cssClass: 'alert-button-confirm',
+        },
+      ];
 
-        await alert.present();
-      };
-
-      return { presentAlert };
+      return { alertButtons };
     },
   };
 </script>

--- a/static/usage/v7/alert/inputs/radios/angular/example_component_html.md
+++ b/static/usage/v7/alert/inputs/radios/angular/example_component_html.md
@@ -1,3 +1,9 @@
 ```html
-<ion-button (click)="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert
+  trigger="present-alert"
+  header="Select your favorite color"
+  [buttons]="alertButtons"
+  [inputs]="alertInputs"
+></ion-alert>
 ```

--- a/static/usage/v7/alert/inputs/radios/angular/example_component_ts.md
+++ b/static/usage/v7/alert/inputs/radios/angular/example_component_ts.md
@@ -1,38 +1,28 @@
 ```ts
 import { Component } from '@angular/core';
-import { AlertController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  constructor(private alertController: AlertController) {}
-
-  async presentAlert() {
-    const alert = await this.alertController.create({
-      header: 'Select your favorite color',
-      buttons: ['OK'],
-      inputs: [
-        {
-          label: 'Red',
-          type: 'radio',
-          value: 'red',
-        },
-        {
-          label: 'Blue',
-          type: 'radio',
-          value: 'blue',
-        },
-        {
-          label: 'Green',
-          type: 'radio',
-          value: 'green',
-        },
-      ],
-    });
-
-    await alert.present();
-  }
+  public alertButtons = ['OK'];
+  public alertInputs = [
+    {
+      label: 'Red',
+      type: 'radio',
+      value: 'red',
+    },
+    {
+      label: 'Blue',
+      type: 'radio',
+      value: 'blue',
+    },
+    {
+      label: 'Green',
+      type: 'radio',
+      value: 'green',
+    },
+  ];
 }
 ```

--- a/static/usage/v7/alert/inputs/radios/demo.html
+++ b/static/usage/v7/alert/inputs/radios/demo.html
@@ -7,45 +7,41 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
 </head>
 
 <body>
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-button onclick="presentAlert()">Click Me</ion-button>
+        <ion-button id="present-alert">Click Me</ion-button>
+        <ion-alert trigger="present-alert" header="Select your favorite color"></ion-alert>
       </div>
     </ion-content>
   </ion-app>
 
   <script>
-    async function presentAlert() {
-      const alert = document.createElement('ion-alert');
-      alert.header = 'Select your favorite color';
-      alert.buttons = ['OK'];
-      alert.inputs = [
-        {
-          label: 'Red',
-          type: 'radio',
-          value: 'red'
-        },
-        {
-          label: 'Blue',
-          type: 'radio',
-          value: 'blue'
-        },
-        {
-          label: 'Green',
-          type: 'radio',
-          value: 'green'
-        }
-      ];
+    const alert = document.querySelector('ion-alert');
 
-      document.body.appendChild(alert);
-      await alert.present();
-    }
+    alert.buttons = ['OK'];
+    alert.inputs = [
+      {
+        label: 'Red',
+        type: 'radio',
+        value: 'red'
+      },
+      {
+        label: 'Blue',
+        type: 'radio',
+        value: 'blue'
+      },
+      {
+        label: 'Green',
+        type: 'radio',
+        value: 'green'
+      }
+    ];
   </script>
 </body>
 

--- a/static/usage/v7/alert/inputs/radios/demo.html
+++ b/static/usage/v7/alert/inputs/radios/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 </head>
 
 <body>

--- a/static/usage/v7/alert/inputs/radios/javascript.md
+++ b/static/usage/v7/alert/inputs/radios/javascript.md
@@ -1,31 +1,27 @@
 ```html
-<ion-button onclick="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert trigger="present-alert" header="Select your favorite color"></ion-alert>
 
 <script>
-  async function presentAlert() {
-    const alert = document.createElement('ion-alert');
-    alert.header = 'Select your favorite color';
-    alert.buttons = ['OK'];
-    alert.inputs = [
-      {
-        label: 'Red',
-        type: 'radio',
-        value: 'red'
-      },
-      {
-        label: 'Blue',
-        type: 'radio',
-        value: 'blue'
-      },
-      {
-        label: 'Green',
-        type: 'radio',
-        value: 'green'
-      }
-    ];
+  const alert = document.querySelector('ion-alert');
 
-    document.body.appendChild(alert);
-    await alert.present();
-  }
+  alert.buttons = ['OK'];
+  alert.inputs = [
+    {
+      label: 'Red',
+      type: 'radio',
+      value: 'red'
+    },
+    {
+      label: 'Blue',
+      type: 'radio',
+      value: 'blue'
+    },
+    {
+      label: 'Green',
+      type: 'radio',
+      value: 'green'
+    }
+  ];
 </script>
 ```

--- a/static/usage/v7/alert/inputs/radios/react.md
+++ b/static/usage/v7/alert/inputs/radios/react.md
@@ -1,38 +1,34 @@
 ```tsx
 import React from 'react';
-import { IonButton, useIonAlert } from '@ionic/react';
+import { IonAlert, IonButton } from '@ionic/react';
 
 function Example() {
-  const [presentAlert] = useIonAlert();
-
   return (
-    <IonButton
-      onClick={() =>
-        presentAlert({
-          header: 'Select your favorite color',
-          buttons: ['OK'],
-          inputs: [
-            {
-              label: 'Red',
-              type: 'radio',
-              value: 'red',
-            },
-            {
-              label: 'Blue',
-              type: 'radio',
-              value: 'blue',
-            },
-            {
-              label: 'Green',
-              type: 'radio',
-              value: 'green',
-            },
-          ],
-        })
-      }
-    >
-      Click Me
-    </IonButton>
+    <>
+      <IonButton id="present-alert">Click Me</IonButton>
+      <IonAlert
+        trigger="present-alert"
+        header="Select your favorite color"
+        buttons={['OK']}
+        inputs={[
+          {
+            label: 'Red',
+            type: 'radio',
+            value: 'red',
+          },
+          {
+            label: 'Blue',
+            type: 'radio',
+            value: 'blue',
+          },
+          {
+            label: 'Green',
+            type: 'radio',
+            value: 'green',
+          },
+        ]}
+      ></IonAlert>
+    </>
   );
 }
 export default Example;

--- a/static/usage/v7/alert/inputs/radios/vue.md
+++ b/static/usage/v7/alert/inputs/radios/vue.md
@@ -1,41 +1,40 @@
 ```html
 <template>
-  <ion-button @click="presentAlert">Click Me</ion-button>
+  <ion-button id="present-alert">Click Me</ion-button>
+  <ion-alert
+    trigger="present-alert"
+    header="Select your favorite color"
+    :buttons="alertButtons"
+    :inputs="alertInputs"
+  ></ion-alert>
 </template>
 
 <script lang="ts">
-  import { IonButton, alertController } from '@ionic/vue';
+  import { IonAlert, IonButton } from '@ionic/vue';
 
   export default {
-    components: { IonButton },
+    components: { IonAlert, IonButton },
     setup() {
-      const presentAlert = async () => {
-        const alert = await alertController.create({
-          header: 'Select your favorite color',
-          buttons: ['OK'],
-          inputs: [
-            {
-              label: 'Red',
-              type: 'radio',
-              value: 'red',
-            },
-            {
-              label: 'Blue',
-              type: 'radio',
-              value: 'blue',
-            },
-            {
-              label: 'Green',
-              type: 'radio',
-              value: 'green',
-            },
-          ],
-        });
+      const alertButtons = ['OK'];
+      const alertInputs = [
+        {
+          label: 'Red',
+          type: 'radio',
+          value: 'red',
+        },
+        {
+          label: 'Blue',
+          type: 'radio',
+          value: 'blue',
+        },
+        {
+          label: 'Green',
+          type: 'radio',
+          value: 'green',
+        },
+      ];
 
-        await alert.present();
-      };
-
-      return { presentAlert };
+      return { alertButtons, alertInputs };
     },
   };
 </script>

--- a/static/usage/v7/alert/inputs/text-inputs/angular/example_component_html.md
+++ b/static/usage/v7/alert/inputs/text-inputs/angular/example_component_html.md
@@ -1,3 +1,9 @@
 ```html
-<ion-button (click)="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert
+  trigger="present-alert"
+  header="Please enter your info"
+  [buttons]="alertButtons"
+  [inputs]="alertInputs"
+></ion-alert>
 ```

--- a/static/usage/v7/alert/inputs/text-inputs/angular/example_component_ts.md
+++ b/static/usage/v7/alert/inputs/text-inputs/angular/example_component_ts.md
@@ -1,42 +1,32 @@
 ```ts
 import { Component } from '@angular/core';
-import { AlertController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  constructor(private alertController: AlertController) {}
-
-  async presentAlert() {
-    const alert = await this.alertController.create({
-      header: 'Please enter your info',
-      buttons: ['OK'],
-      inputs: [
-        {
-          placeholder: 'Name',
-        },
-        {
-          placeholder: 'Nickname (max 8 characters)',
-          attributes: {
-            maxlength: 8,
-          },
-        },
-        {
-          type: 'number',
-          placeholder: 'Age',
-          min: 1,
-          max: 100,
-        },
-        {
-          type: 'textarea',
-          placeholder: 'A little about yourself',
-        },
-      ],
-    });
-
-    await alert.present();
-  }
+  public alertButtons = ['OK'];
+  public alertInputs = [
+    {
+      placeholder: 'Name',
+    },
+    {
+      placeholder: 'Nickname (max 8 characters)',
+      attributes: {
+        maxlength: 8,
+      },
+    },
+    {
+      type: 'number',
+      placeholder: 'Age',
+      min: 1,
+      max: 100,
+    },
+    {
+      type: 'textarea',
+      placeholder: 'A little about yourself',
+    },
+  ];
 }
 ```

--- a/static/usage/v7/alert/inputs/text-inputs/demo.html
+++ b/static/usage/v7/alert/inputs/text-inputs/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 </head>
 
 <body>

--- a/static/usage/v7/alert/inputs/text-inputs/demo.html
+++ b/static/usage/v7/alert/inputs/text-inputs/demo.html
@@ -7,49 +7,45 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
 </head>
 
 <body>
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-button onclick="presentAlert()">Click Me</ion-button>
+        <ion-button id="present-alert">Click Me</ion-button>
+        <ion-alert trigger="present-alert" header="Please enter your info"></ion-alert>
       </div>
     </ion-content>
   </ion-app>
 
   <script>
-    async function presentAlert() {
-      const alert = document.createElement('ion-alert');
-      alert.header = 'Please enter your info';
-      alert.buttons = ['OK'];
-      alert.inputs = [
-        {
-          placeholder: 'Name'
-        },
-        {
-          placeholder: 'Nickname (max 8 characters)',
-          attributes: {
-            maxlength: 8
-          }
-        },
-        {
-          type: 'number',
-          placeholder: 'Age',
-          min: 1,
-          max: 100
-        },
-        {
-          type: 'textarea',
-          placeholder: 'A little about yourself'
-        }
-      ];
+    const alert = document.querySelector('ion-alert');
 
-      document.body.appendChild(alert);
-      await alert.present();
-    }
+    alert.buttons = ['OK'];
+    alert.inputs = [
+      {
+        placeholder: 'Name'
+      },
+      {
+        placeholder: 'Nickname (max 8 characters)',
+        attributes: {
+          maxlength: 8
+        }
+      },
+      {
+        type: 'number',
+        placeholder: 'Age',
+        min: 1,
+        max: 100
+      },
+      {
+        type: 'textarea',
+        placeholder: 'A little about yourself'
+      }
+    ];
   </script>
 </body>
 

--- a/static/usage/v7/alert/inputs/text-inputs/javascript.md
+++ b/static/usage/v7/alert/inputs/text-inputs/javascript.md
@@ -1,35 +1,31 @@
 ```html
-<ion-button onclick="presentAlert()">Click Me</ion-button>
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert trigger="present-alert" header="Please enter your info"></ion-alert>
 
 <script>
-  async function presentAlert() {
-    const alert = document.createElement('ion-alert');
-    alert.header = 'Please enter your info';
-    alert.buttons = ['OK'];
-    alert.inputs = [
-      {
-        placeholder: 'Name'
-      },
-      {
-        placeholder: 'Nickname (max 8 characters)',
-        attributes: {
-          maxlength: 8
-        }
-      },
-      {
-        type: 'number',
-        placeholder: 'Age',
-        min: 1,
-        max: 100
-      },
-      {
-        type: 'textarea',
-        placeholder: 'A little about yourself'
-      }
-    ];
+  const alert = document.querySelector('ion-alert');
 
-    document.body.appendChild(alert);
-    await alert.present();
-  }
+  alert.buttons = ['OK'];
+  alert.inputs = [
+    {
+      placeholder: 'Name'
+    },
+    {
+      placeholder: 'Nickname (max 8 characters)',
+      attributes: {
+        maxlength: 8
+      }
+    },
+    {
+      type: 'number',
+      placeholder: 'Age',
+      min: 1,
+      max: 100
+    },
+    {
+      type: 'textarea',
+      placeholder: 'A little about yourself'
+    }
+  ];
 </script>
 ```

--- a/static/usage/v7/alert/inputs/text-inputs/react.md
+++ b/static/usage/v7/alert/inputs/text-inputs/react.md
@@ -1,42 +1,38 @@
 ```tsx
 import React from 'react';
-import { IonButton, useIonAlert } from '@ionic/react';
+import { IonAlert, IonButton } from '@ionic/react';
 
 function Example() {
-  const [presentAlert] = useIonAlert();
-
   return (
-    <IonButton
-      onClick={() =>
-        presentAlert({
-          header: 'Please enter your info',
-          buttons: ['OK'],
-          inputs: [
-            {
-              placeholder: 'Name',
+    <>
+      <IonButton id="present-alert">Click Me</IonButton>
+      <IonAlert
+        trigger="present-alert"
+        header="Please enter your info"
+        buttons={['OK']}
+        inputs={[
+          {
+            placeholder: 'Name',
+          },
+          {
+            placeholder: 'Nickname (max 8 characters)',
+            attributes: {
+              maxlength: 8,
             },
-            {
-              placeholder: 'Nickname (max 8 characters)',
-              attributes: {
-                maxlength: 8,
-              },
-            },
-            {
-              type: 'number',
-              placeholder: 'Age',
-              min: 1,
-              max: 100,
-            },
-            {
-              type: 'textarea',
-              placeholder: 'A little about yourself',
-            },
-          ],
-        })
-      }
-    >
-      Click Me
-    </IonButton>
+          },
+          {
+            type: 'number',
+            placeholder: 'Age',
+            min: 1,
+            max: 100,
+          },
+          {
+            type: 'textarea',
+            placeholder: 'A little about yourself',
+          },
+        ]}
+      ></IonAlert>
+    </>
   );
 }
 export default Example;

--- a/static/usage/v7/alert/inputs/text-inputs/vue.md
+++ b/static/usage/v7/alert/inputs/text-inputs/vue.md
@@ -1,45 +1,44 @@
 ```html
 <template>
-  <ion-button @click="presentAlert">Click Me</ion-button>
+  <ion-button id="present-alert">Click Me</ion-button>
+  <ion-alert
+    trigger="present-alert"
+    header="Please enter your info"
+    :buttons="alertButtons"
+    :inputs="alertInputs"
+  ></ion-alert>
 </template>
 
 <script lang="ts">
-  import { IonButton, alertController } from '@ionic/vue';
+  import { IonAlert, IonButton } from '@ionic/vue';
 
   export default {
-    components: { IonButton },
+    components: { IonAlert, IonButton },
     setup() {
-      const presentAlert = async () => {
-        const alert = await alertController.create({
-          header: 'Please enter your info',
-          buttons: ['OK'],
-          inputs: [
-            {
-              placeholder: 'Name',
-            },
-            {
-              placeholder: 'Nickname (max 8 characters)',
-              attributes: {
-                maxlength: 8,
-              },
-            },
-            {
-              type: 'number',
-              placeholder: 'Age',
-              min: 1,
-              max: 100,
-            },
-            {
-              type: 'textarea',
-              placeholder: 'A little about yourself',
-            },
-          ],
-        });
+      const alertButtons = ['OK'];
+      const alertInputs = [
+        {
+          placeholder: 'Name',
+        },
+        {
+          placeholder: 'Nickname (max 8 characters)',
+          attributes: {
+            maxlength: 8,
+          },
+        },
+        {
+          type: 'number',
+          placeholder: 'Age',
+          min: 1,
+          max: 100,
+        },
+        {
+          type: 'textarea',
+          placeholder: 'A little about yourself',
+        },
+      ];
 
-        await alert.present();
-      };
-
-      return { presentAlert };
+      return { alertButtons, alertInputs };
     },
   };
 </script>

--- a/static/usage/v7/alert/presenting/isOpen/angular/example_component_html.md
+++ b/static/usage/v7/alert/presenting/isOpen/angular/example_component_html.md
@@ -3,7 +3,7 @@
 <ion-alert
   [isOpen]="isAlertOpen"
   header="Alert"
-  sub-header="Important message"
+  subHeader="Important message"
   message="This is an alert!"
   [buttons]="alertButtons"
   (didDismiss)="setOpen(false)"

--- a/static/usage/v7/alert/presenting/isOpen/angular/example_component_html.md
+++ b/static/usage/v7/alert/presenting/isOpen/angular/example_component_html.md
@@ -1,0 +1,11 @@
+```html
+<ion-button (click)="setOpen(true)">Click Me</ion-button>
+<ion-alert
+  [isOpen]="isAlertOpen"
+  header="Alert"
+  sub-header="Important message"
+  message="This is an alert!"
+  [buttons]="alertButtons"
+  (didDismiss)="setOpen(false)"
+></ion-alert>
+```

--- a/static/usage/v7/alert/presenting/isOpen/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/isOpen/angular/example_component_ts.md
@@ -1,0 +1,16 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  isAlertOpen = false;
+  public alertButtons = ['OK'];
+
+  setOpen(isOpen: boolean) {
+    this.isAlertOpen = isOpen;
+  }
+}
+```

--- a/static/usage/v7/alert/presenting/isOpen/demo.html
+++ b/static/usage/v7/alert/presenting/isOpen/demo.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button onclick="alert.isOpen = true">Click Me</ion-button>
+        <ion-alert
+          header="Alert"
+          sub-header="Important message"
+          message="This is an alert!"
+        ></ion-alert>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const alert = document.querySelector('ion-alert');
+
+    alert.buttons = ['OK'];
+    alert.addEventListener('ionAlertDidDismiss', () => {
+      alert.isOpen = false;
+    });
+  </script>
+</body>
+
+</html>

--- a/static/usage/v7/alert/presenting/isOpen/demo.html
+++ b/static/usage/v7/alert/presenting/isOpen/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 </head>
 
 <body>

--- a/static/usage/v7/alert/presenting/isOpen/index.md
+++ b/static/usage/v7/alert/presenting/isOpen/index.md
@@ -1,0 +1,25 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="7"
+  size="300px"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/alert/presenting/isOpen/demo.html"
+/>

--- a/static/usage/v7/alert/presenting/isOpen/javascript.md
+++ b/static/usage/v7/alert/presenting/isOpen/javascript.md
@@ -1,0 +1,17 @@
+```html
+<ion-button onclick="alert.isOpen = true">Click Me</ion-button>
+<ion-alert
+  header="Alert"
+  sub-header="Important message"
+  message="This is an alert!"
+></ion-alert>
+
+<script>
+  const alert = document.querySelector('ion-alert');
+
+  alert.buttons = ['OK'];
+  alert.addEventListener('ionAlertDidDismiss', () => {
+    alert.isOpen = false;
+  });
+</script>
+```

--- a/static/usage/v7/alert/presenting/isOpen/react.md
+++ b/static/usage/v7/alert/presenting/isOpen/react.md
@@ -1,0 +1,23 @@
+```tsx
+import React, { useState } from 'react';
+import { IonAlert, IonButton } from '@ionic/react';
+
+function Example() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <IonButton onClick={() => setIsOpen(true)}>Click Me</IonButton>
+      <IonAlert
+        isOpen={isOpen}
+        header="Alert"
+        subHeader="Important message"
+        message="This is an alert!"
+        buttons={['OK']}
+        onDidDismiss={() => setIsOpen(false)}
+      ></IonAlert>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/alert/presenting/isOpen/vue.md
+++ b/static/usage/v7/alert/presenting/isOpen/vue.md
@@ -1,0 +1,32 @@
+```html
+<template>
+  <ion-button @click="setOpen(true)">Click Me</ion-button>
+  <ion-alert
+    :is-open="isOpen"
+    header="Alert"
+    sub-header="Important message"
+    message="This is an alert!"
+    :buttons="alertButtons"
+    @didDismiss="setOpen(false)"
+  ></ion-alert>
+</template>
+
+<script lang="ts">
+  import { ref } from 'vue';
+  import { IonAlert, IonButton } from '@ionic/vue';
+
+  export default {
+    components: { IonAlert, IonButton },
+    setup() {
+      const isOpen = ref(false);
+      const alertButtons = ['OK'];
+
+      const setOpen = (state: boolean) => {
+        isOpen.value = state;
+      };
+
+      return { isOpen, alertButtons, setOpen };
+    },
+  };
+</script>
+```

--- a/static/usage/v7/alert/presenting/trigger/angular/example_component_html.md
+++ b/static/usage/v7/alert/presenting/trigger/angular/example_component_html.md
@@ -1,0 +1,10 @@
+```html
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert
+  trigger="present-alert"
+  header="Alert"
+  sub-header="Important message"
+  message="This is an alert!"
+  [buttons]="alertButtons"
+></ion-alert>
+```

--- a/static/usage/v7/alert/presenting/trigger/angular/example_component_html.md
+++ b/static/usage/v7/alert/presenting/trigger/angular/example_component_html.md
@@ -3,7 +3,7 @@
 <ion-alert
   trigger="present-alert"
   header="Alert"
-  sub-header="Important message"
+  subHeader="Important message"
   message="This is an alert!"
   [buttons]="alertButtons"
 ></ion-alert>

--- a/static/usage/v7/alert/presenting/trigger/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/trigger/angular/example_component_ts.md
@@ -1,0 +1,11 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  public alertButtons = ['OK'];
+}
+```

--- a/static/usage/v7/alert/presenting/trigger/demo.html
+++ b/static/usage/v7/alert/presenting/trigger/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-button id="present-alert">Click Me</ion-button>
+        <ion-alert
+          trigger="present-alert"
+          header="Alert"
+          sub-header="Important message"
+          message="This is an alert!"
+        ></ion-alert>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const alert = document.querySelector('ion-alert');
+    alert.buttons = ['OK'];
+  </script>
+</body>
+
+</html>

--- a/static/usage/v7/alert/presenting/trigger/demo.html
+++ b/static/usage/v7/alert/presenting/trigger/demo.html
@@ -7,8 +7,8 @@
   <title>Alert</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.0/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 </head>
 
 <body>

--- a/static/usage/v7/alert/presenting/trigger/index.md
+++ b/static/usage/v7/alert/presenting/trigger/index.md
@@ -1,0 +1,25 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="7"
+  size="300px"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/alert/presenting/trigger/demo.html"
+/>

--- a/static/usage/v7/alert/presenting/trigger/javascript.md
+++ b/static/usage/v7/alert/presenting/trigger/javascript.md
@@ -1,0 +1,14 @@
+```html
+<ion-button id="present-alert">Click Me</ion-button>
+<ion-alert
+  trigger="present-alert"
+  header="Alert"
+  sub-header="Important message"
+  message="This is an alert!"
+></ion-alert>
+
+<script>
+  const alert = document.querySelector('ion-alert');
+  alert.buttons = ['OK'];
+</script>
+```

--- a/static/usage/v7/alert/presenting/trigger/react.md
+++ b/static/usage/v7/alert/presenting/trigger/react.md
@@ -1,0 +1,20 @@
+```tsx
+import React from 'react';
+import { IonAlert, IonButton } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonButton id="present-alert">Click Me</IonButton>
+      <IonAlert
+        trigger="present-alert"
+        header="Alert"
+        subHeader="Important message"
+        message="This is an alert!"
+        buttons={['OK']}
+      ></IonAlert>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/alert/presenting/trigger/vue.md
+++ b/static/usage/v7/alert/presenting/trigger/vue.md
@@ -1,0 +1,25 @@
+```html
+<template>
+  <ion-button id="present-alert">Click Me</ion-button>
+  <ion-alert
+    trigger="present-alert"
+    header="Alert"
+    sub-header="Important message"
+    message="This is an alert!"
+    :buttons="alertButtons"
+  ></ion-alert>
+</template>
+
+<script lang="ts">
+  import { IonAlert, IonButton } from '@ionic/vue';
+
+  export default {
+    components: { IonAlert, IonButton },
+    setup() {
+      const alertButtons = ['OK'];
+
+      return { alertButtons };
+    },
+  };
+</script>
+```


### PR DESCRIPTION
- Converts existing non-controller playgrounds to use the new inline syntax.
- Adds playgrounds for `trigger` and `isOpen`.