### PR TITLE
docs(many): restore slides and virtual scroll docs

### DIFF
--- a/versioned_docs/version-v6/angular/slides.md
+++ b/versioned_docs/version-v6/angular/slides.md
@@ -10,13 +10,9 @@ title: Slides
   />
 </head>
 
-:::caution Looking for `ion-slides`?
+We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `ion-slides` component, but we now recommend that developers use Swiper for Angular directly.
 
-`ion-slides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
-
-:::
-
-We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for Angular set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Angular integration.
+This guide will go over how to get Swiper for Angular set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Angular integration.
 
 ## Getting Started
 

--- a/versioned_docs/version-v6/angular/virtual-scroll.md
+++ b/versioned_docs/version-v6/angular/virtual-scroll.md
@@ -1,12 +1,8 @@
 # Virtual Scroll
 
-:::caution Looking for `ion-virtual-scroll`?
+In the past, we have provided an `ion-virtual-scroll` component in Ionic Framework to help with list virtualization. At the time this was not available in Angular, but recently Angular has provided its own solution via the `@angular/cdk` package.
 
-`ion-virtual-scroll` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the `@angular/cdk` package detailed below.
-
-:::
-
-## Installation
+## Setup
 
 To setup the CDK Scroller, first install `@angular/cdk`:
 

--- a/versioned_docs/version-v6/api/slide.md
+++ b/versioned_docs/version-v6/api/slide.md
@@ -1,0 +1,60 @@
+---
+title: "ion-slide"
+hide_table_of_contents: true
+---
+import TOCInline from '@theme/TOCInline';
+
+import Props from '@site/static/auto-generated/slide/props.md';
+import Events from '@site/static/auto-generated/slide/events.md';
+import Methods from '@site/static/auto-generated/slide/methods.md';
+import Parts from '@site/static/auto-generated/slide/parts.md';
+import CustomProps from '@site/static/auto-generated/slide/custom-props.md';
+import Slots from '@site/static/auto-generated/slide/slots.md';
+
+<head>
+  <title>ion-slide | Slide API Component for Ionic Framework Apps</title>
+  <meta name="description" content="Slide is a child API component of Slides—written as ion-slide. Any slide content should be written in this component and used in conjunction with Slides." />
+</head>
+
+import EncapsulationPill from '@components/page/api/EncapsulationPill';
+
+
+
+<h2 className="table-of-contents__title">Contents</h2>
+
+<TOCInline
+  toc={toc}
+  maxHeadingLevel={2}
+/>
+
+:::note
+This component has been deprecated in favor of using Swiper.js directly. Please see the [Slides Documentation](./slides#migration) for a migration guide.
+:::
+
+
+The Slide component is a child component of [Slides](./slides). The template
+should be written as `ion-slide`. Any slide content should be written
+in this component and it should be used in conjunction with [Slides](./slides).
+
+See the [Slides API Docs](./slides) for more usage information.
+
+
+
+
+## Properties
+<Props />
+
+## Events
+<Events />
+
+## Methods
+<Methods />
+
+## CSS Shadow Parts
+<Parts />
+
+## CSS Custom Properties
+<CustomProps />
+
+## Slots
+<Slots />

--- a/versioned_docs/version-v6/api/slides.md
+++ b/versioned_docs/version-v6/api/slides.md
@@ -1,0 +1,745 @@
+---
+title: "ion-slides"
+hide_table_of_contents: true
+demoUrl: "/docs/demos/api/slides/index.html"
+demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/slides/index.html"
+---
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import TOCInline from '@theme/TOCInline';
+
+import Props from '@site/static/auto-generated/slides/props.md';
+import Events from '@site/static/auto-generated/slides/events.md';
+import Methods from '@site/static/auto-generated/slides/methods.md';
+import Parts from '@site/static/auto-generated/slides/parts.md';
+import CustomProps from '@site/static/auto-generated/slides/custom-props.md';
+import Slots from '@site/static/auto-generated/slides/slots.md';
+
+<head>
+  <title>Ion-Slides: Mobile Touch Slider with Built-In & Custom Animation</title>
+  <meta name="description" content="Ion-Slides is a multi-section container which offers custom and built-in mobile touch slider animation effects. See how Ion-Slides works with iOS and Android." />
+</head>
+
+import EncapsulationPill from '@components/page/api/EncapsulationPill';
+
+
+<h2 className="table-of-contents__title">Contents</h2>
+
+<TOCInline
+  toc={toc}
+  maxHeadingLevel={2}
+/>
+
+:::note
+This component has been deprecated in favor of using Swiper.js directly. Please see the [migration guide](#migration) below.
+:::
+
+
+The Slides component is a multi-section container. Each section can be swiped
+or dragged between. It contains any number of [Slide](slide.md) components.
+
+This guide will cover migration from the deprecated `ion-slides` component to the framework-specific solutions that Swiper.js provides as well as the existing `ion-slides` API for developers who are still using that component.
+
+Adopted from Swiper.js:
+The most modern mobile touch slider and framework with hardware accelerated transitions.
+
+http://www.idangero.us/swiper/
+
+Copyright 2016, Vladimir Kharlampidi
+The iDangero.us
+http://www.idangero.us/
+
+Licensed under MIT
+
+## Migration
+
+With the release of Ionic Framework v6, the Ionic Team has deprecated the `ion-slides` and `ion-slide` components in favor of using the official framework integrations provided by Swiper. Fear not! You will still be able to use slides components in your application. Additionally, because you are still using Swiper, the functionality of your slides component should remain exactly the same.
+
+### What is Swiper.js?
+
+Swiper.js is the carousel/slider library that powers `ion-slides`. The library is bundled automatically with all versions of Ionic Framework. When Ionic Framework v4. was first released, Swiper did not have framework specific integrations of its library, so `ion-slides` was created as a way of bridging the gap between the core Swiper library and frameworks such as Angular, React, and Vue.
+
+Since then, the Swiper team has released framework specific integrations of Swiper.js for Angular, React, Vue, and more!
+
+### What are the benefits of this change?
+
+There are several benefits for members of the Ionic Framework community. By using the official Swiper.js framework integrations:
+
+- Developers can now be in control of the exact version of Swiper.js they want to use. Previously, developers would need to rely on the Ionic Team to update the version internally and release a new version of Ionic Framework.
+- The Ionic Team can spend more time triaging and fixing other non-slides issues, speeding up our development process so we can make the framework work better for our community.
+- Developers should experience fewer bugs.
+- Application bundle sizes can shrink in some cases. By installing Swiper.js as a 3rd party dependency in your application, bundlers such as Webpack or Rollup should be able to treeshake your code better.
+- Developers have access to new features that they previously did not have when using `ion-slides`.
+
+### How long do I have to migrate?
+
+We plan to remove `ion-slides` and `ion-slide` in Ionic Framework v7. `ion-slides` and `ion-slide` will continue to be available for the entire Ionic Framework v6 lifecycle but will only receive critical bug fixes.
+
+### How do I migrate?
+
+Since the underlying technology that powers your slides is the same, the migration process is easy! Follow the guides below for your specific framework.
+
+[Migration for Ionic Angular users](../angular/slides)
+
+[Migration for Ionic React users](../react/slides)
+
+[Migration for Ionic Vue users](../vue/slides)
+
+------
+
+The following documentation applies to the `ion-slides` component.
+
+## Custom Animations
+
+By default, Ionic slides use the built-in `slide` animation effect. Custom animations can be provided via the `options` property. Examples of other animations can be found below.
+
+
+### Coverflow
+
+```typescript
+const slideOpts = {
+  slidesPerView: 3,
+  coverflowEffect: {
+    rotate: 50,
+    stretch: 0,
+    depth: 100,
+    modifier: 1,
+    slideShadows: true,
+  },
+  on: {
+    beforeInit() {
+      const swiper = this;
+
+      swiper.classNames.push(`${swiper.params.containerModifierClass}coverflow`);
+      swiper.classNames.push(`${swiper.params.containerModifierClass}3d`);
+
+      swiper.params.watchSlidesProgress = true;
+      swiper.originalParams.watchSlidesProgress = true;
+    },
+    setTranslate() {
+      const swiper = this;
+      const {
+        width: swiperWidth, height: swiperHeight, slides, $wrapperEl, slidesSizesGrid, $
+      } = swiper;
+      const params = swiper.params.coverflowEffect;
+      const isHorizontal = swiper.isHorizontal();
+      const transform$$1 = swiper.translate;
+      const center = isHorizontal ? -transform$$1 + (swiperWidth / 2) : -transform$$1 + (swiperHeight / 2);
+      const rotate = isHorizontal ? params.rotate : -params.rotate;
+      const translate = params.depth;
+      // Each slide offset from center
+      for (let i = 0, length = slides.length; i < length; i += 1) {
+        const $slideEl = slides.eq(i);
+        const slideSize = slidesSizesGrid[i];
+        const slideOffset = $slideEl[0].swiperSlideOffset;
+        const offsetMultiplier = ((center - slideOffset - (slideSize / 2)) / slideSize) * params.modifier;
+
+         let rotateY = isHorizontal ? rotate * offsetMultiplier : 0;
+        let rotateX = isHorizontal ? 0 : rotate * offsetMultiplier;
+        // var rotateZ = 0
+        let translateZ = -translate * Math.abs(offsetMultiplier);
+
+         let translateY = isHorizontal ? 0 : params.stretch * (offsetMultiplier);
+        let translateX = isHorizontal ? params.stretch * (offsetMultiplier) : 0;
+
+         // Fix for ultra small values
+        if (Math.abs(translateX) < 0.001) translateX = 0;
+        if (Math.abs(translateY) < 0.001) translateY = 0;
+        if (Math.abs(translateZ) < 0.001) translateZ = 0;
+        if (Math.abs(rotateY) < 0.001) rotateY = 0;
+        if (Math.abs(rotateX) < 0.001) rotateX = 0;
+
+         const slideTransform = `translate3d(${translateX}px,${translateY}px,${translateZ}px)  rotateX(${rotateX}deg) rotateY(${rotateY}deg)`;
+
+         $slideEl.transform(slideTransform);
+        $slideEl[0].style.zIndex = -Math.abs(Math.round(offsetMultiplier)) + 1;
+        if (params.slideShadows) {
+          // Set shadows
+          let $shadowBeforeEl = isHorizontal ? $slideEl.find('.swiper-slide-shadow-left') : $slideEl.find('.swiper-slide-shadow-top');
+          let $shadowAfterEl = isHorizontal ? $slideEl.find('.swiper-slide-shadow-right') : $slideEl.find('.swiper-slide-shadow-bottom');
+          if ($shadowBeforeEl.length === 0) {
+            $shadowBeforeEl = swiper.$(`<div class="swiper-slide-shadow-${isHorizontal ? 'left' : 'top'}"></div>`);
+            $slideEl.append($shadowBeforeEl);
+          }
+          if ($shadowAfterEl.length === 0) {
+            $shadowAfterEl = swiper.$(`<div class="swiper-slide-shadow-${isHorizontal ? 'right' : 'bottom'}"></div>`);
+            $slideEl.append($shadowAfterEl);
+          }
+          if ($shadowBeforeEl.length) $shadowBeforeEl[0].style.opacity = offsetMultiplier > 0 ? offsetMultiplier : 0;
+          if ($shadowAfterEl.length) $shadowAfterEl[0].style.opacity = (-offsetMultiplier) > 0 ? -offsetMultiplier : 0;
+        }
+      }
+
+       // Set correct perspective for IE10
+      if (swiper.support.pointerEvents || swiper.support.prefixedPointerEvents) {
+        const ws = $wrapperEl[0].style;
+        ws.perspectiveOrigin = `${center}px 50%`;
+      }
+    },
+    setTransition(duration) {
+      const swiper = this;
+      swiper.slides
+        .transition(duration)
+        .find('.swiper-slide-shadow-top, .swiper-slide-shadow-right, .swiper-slide-shadow-bottom, .swiper-slide-shadow-left')
+        .transition(duration);
+    }
+  }
+}
+```
+
+### Cube
+
+```typescript
+const slideOpts = {
+  grabCursor: true,
+  cubeEffect: {
+    shadow: true,
+    slideShadows: true,
+    shadowOffset: 20,
+    shadowScale: 0.94,
+  },
+  on: {
+    beforeInit: function() {
+      const swiper = this;
+      swiper.classNames.push(`${swiper.params.containerModifierClass}cube`);
+      swiper.classNames.push(`${swiper.params.containerModifierClass}3d`);
+
+      const overwriteParams = {
+        slidesPerView: 1,
+        slidesPerColumn: 1,
+        slidesPerGroup: 1,
+        watchSlidesProgress: true,
+        resistanceRatio: 0,
+        spaceBetween: 0,
+        centeredSlides: false,
+        virtualTranslate: true,
+      };
+
+      this.params = Object.assign(this.params, overwriteParams);
+      this.originalParams = Object.assign(this.originalParams, overwriteParams);
+    },
+    setTranslate: function() {
+      const swiper = this;
+      const {
+        $el, $wrapperEl, slides, width: swiperWidth, height: swiperHeight, rtlTranslate: rtl, size: swiperSize,
+      } = swiper;
+      const params = swiper.params.cubeEffect;
+      const isHorizontal = swiper.isHorizontal();
+      const isVirtual = swiper.virtual && swiper.params.virtual.enabled;
+      let wrapperRotate = 0;
+      let $cubeShadowEl;
+      if (params.shadow) {
+        if (isHorizontal) {
+          $cubeShadowEl = $wrapperEl.find('.swiper-cube-shadow');
+          if ($cubeShadowEl.length === 0) {
+            $cubeShadowEl = swiper.$('<div class="swiper-cube-shadow"></div>');
+            $wrapperEl.append($cubeShadowEl);
+          }
+          $cubeShadowEl.css({ height: `${swiperWidth}px` });
+        } else {
+          $cubeShadowEl = $el.find('.swiper-cube-shadow');
+          if ($cubeShadowEl.length === 0) {
+            $cubeShadowEl = swiper.$('<div class="swiper-cube-shadow"></div>');
+            $el.append($cubeShadowEl);
+          }
+        }
+      }
+
+      for (let i = 0; i < slides.length; i += 1) {
+        const $slideEl = slides.eq(i);
+        let slideIndex = i;
+        if (isVirtual) {
+          slideIndex = parseInt($slideEl.attr('data-swiper-slide-index'), 10);
+        }
+        let slideAngle = slideIndex * 90;
+        let round = Math.floor(slideAngle / 360);
+        if (rtl) {
+          slideAngle = -slideAngle;
+          round = Math.floor(-slideAngle / 360);
+        }
+        const progress = Math.max(Math.min($slideEl[0].progress, 1), -1);
+        let tx = 0;
+        let ty = 0;
+        let tz = 0;
+        if (slideIndex % 4 === 0) {
+          tx = -round * 4 * swiperSize;
+          tz = 0;
+        } else if ((slideIndex - 1) % 4 === 0) {
+          tx = 0;
+          tz = -round * 4 * swiperSize;
+        } else if ((slideIndex - 2) % 4 === 0) {
+          tx = swiperSize + (round * 4 * swiperSize);
+          tz = swiperSize;
+        } else if ((slideIndex - 3) % 4 === 0) {
+          tx = -swiperSize;
+          tz = (3 * swiperSize) + (swiperSize * 4 * round);
+        }
+        if (rtl) {
+          tx = -tx;
+        }
+
+         if (!isHorizontal) {
+          ty = tx;
+          tx = 0;
+        }
+
+         const transform$$1 = `rotateX(${isHorizontal ? 0 : -slideAngle}deg) rotateY(${isHorizontal ? slideAngle : 0}deg) translate3d(${tx}px, ${ty}px, ${tz}px)`;
+        if (progress <= 1 && progress > -1) {
+          wrapperRotate = (slideIndex * 90) + (progress * 90);
+          if (rtl) wrapperRotate = (-slideIndex * 90) - (progress * 90);
+        }
+        $slideEl.transform(transform$$1);
+        if (params.slideShadows) {
+          // Set shadows
+          let shadowBefore = isHorizontal ? $slideEl.find('.swiper-slide-shadow-left') : $slideEl.find('.swiper-slide-shadow-top');
+          let shadowAfter = isHorizontal ? $slideEl.find('.swiper-slide-shadow-right') : $slideEl.find('.swiper-slide-shadow-bottom');
+          if (shadowBefore.length === 0) {
+            shadowBefore = swiper.$(`<div class="swiper-slide-shadow-${isHorizontal ? 'left' : 'top'}"></div>`);
+            $slideEl.append(shadowBefore);
+          }
+          if (shadowAfter.length === 0) {
+            shadowAfter = swiper.$(`<div class="swiper-slide-shadow-${isHorizontal ? 'right' : 'bottom'}"></div>`);
+            $slideEl.append(shadowAfter);
+          }
+          if (shadowBefore.length) shadowBefore[0].style.opacity = Math.max(-progress, 0);
+          if (shadowAfter.length) shadowAfter[0].style.opacity = Math.max(progress, 0);
+        }
+      }
+      $wrapperEl.css({
+        '-webkit-transform-origin': `50% 50% -${swiperSize / 2}px`,
+        '-moz-transform-origin': `50% 50% -${swiperSize / 2}px`,
+        '-ms-transform-origin': `50% 50% -${swiperSize / 2}px`,
+        'transform-origin': `50% 50% -${swiperSize / 2}px`,
+      });
+
+       if (params.shadow) {
+        if (isHorizontal) {
+          $cubeShadowEl.transform(`translate3d(0px, ${(swiperWidth / 2) + params.shadowOffset}px, ${-swiperWidth / 2}px) rotateX(90deg) rotateZ(0deg) scale(${params.shadowScale})`);
+        } else {
+          const shadowAngle = Math.abs(wrapperRotate) - (Math.floor(Math.abs(wrapperRotate) / 90) * 90);
+          const multiplier = 1.5 - (
+            (Math.sin((shadowAngle * 2 * Math.PI) / 360) / 2)
+            + (Math.cos((shadowAngle * 2 * Math.PI) / 360) / 2)
+          );
+          const scale1 = params.shadowScale;
+          const scale2 = params.shadowScale / multiplier;
+          const offset$$1 = params.shadowOffset;
+          $cubeShadowEl.transform(`scale3d(${scale1}, 1, ${scale2}) translate3d(0px, ${(swiperHeight / 2) + offset$$1}px, ${-swiperHeight / 2 / scale2}px) rotateX(-90deg)`);
+        }
+      }
+
+      const zFactor = (swiper.browser.isSafari || swiper.browser.isUiWebView) ? (-swiperSize / 2) : 0;
+      $wrapperEl
+        .transform(`translate3d(0px,0,${zFactor}px) rotateX(${swiper.isHorizontal() ? 0 : wrapperRotate}deg) rotateY(${swiper.isHorizontal() ? -wrapperRotate : 0}deg)`);
+    },
+    setTransition: function(duration) {
+      const swiper = this;
+      const { $el, slides } = swiper;
+      slides
+        .transition(duration)
+        .find('.swiper-slide-shadow-top, .swiper-slide-shadow-right, .swiper-slide-shadow-bottom, .swiper-slide-shadow-left')
+        .transition(duration);
+      if (swiper.params.cubeEffect.shadow && !swiper.isHorizontal()) {
+        $el.find('.swiper-cube-shadow').transition(duration);
+      }
+    },
+  }
+}
+```
+
+### Fade
+
+```typescript
+const slideOpts = {
+  on: {
+    beforeInit() {
+      const swiper = this;
+      swiper.classNames.push(`${swiper.params.containerModifierClass}fade`);
+      const overwriteParams = {
+        slidesPerView: 1,
+        slidesPerColumn: 1,
+        slidesPerGroup: 1,
+        watchSlidesProgress: true,
+        spaceBetween: 0,
+        virtualTranslate: true,
+      };
+      swiper.params = Object.assign(swiper.params, overwriteParams);
+      swiper.params = Object.assign(swiper.originalParams, overwriteParams);
+    },
+    setTranslate() {
+      const swiper = this;
+      const { slides } = swiper;
+      for (let i = 0; i < slides.length; i += 1) {
+        const $slideEl = swiper.slides.eq(i);
+        const offset$$1 = $slideEl[0].swiperSlideOffset;
+        let tx = -offset$$1;
+        if (!swiper.params.virtualTranslate) tx -= swiper.translate;
+        let ty = 0;
+        if (!swiper.isHorizontal()) {
+          ty = tx;
+          tx = 0;
+        }
+        const slideOpacity = swiper.params.fadeEffect.crossFade
+          ? Math.max(1 - Math.abs($slideEl[0].progress), 0)
+          : 1 + Math.min(Math.max($slideEl[0].progress, -1), 0);
+        $slideEl
+          .css({
+            opacity: slideOpacity,
+          })
+          .transform(`translate3d(${tx}px, ${ty}px, 0px)`);
+      }
+    },
+    setTransition(duration) {
+      const swiper = this;
+      const { slides, $wrapperEl } = swiper;
+      slides.transition(duration);
+      if (swiper.params.virtualTranslate && duration !== 0) {
+        let eventTriggered = false;
+        slides.transitionEnd(() => {
+          if (eventTriggered) return;
+          if (!swiper || swiper.destroyed) return;
+          eventTriggered = true;
+          swiper.animating = false;
+          const triggerEvents = ['webkitTransitionEnd', 'transitionend'];
+          for (let i = 0; i < triggerEvents.length; i += 1) {
+            $wrapperEl.trigger(triggerEvents[i]);
+          }
+        });
+      }
+    },
+  }
+}
+```
+
+### Flip
+
+```typescript
+const slideOpts = {
+  on: {
+    beforeInit() {
+      const swiper = this;
+      swiper.classNames.push(`${swiper.params.containerModifierClass}flip`);
+      swiper.classNames.push(`${swiper.params.containerModifierClass}3d`);
+      const overwriteParams = {
+        slidesPerView: 1,
+        slidesPerColumn: 1,
+        slidesPerGroup: 1,
+        watchSlidesProgress: true,
+        spaceBetween: 0,
+        virtualTranslate: true,
+      };
+      swiper.params = Object.assign(swiper.params, overwriteParams);
+      swiper.originalParams = Object.assign(swiper.originalParams, overwriteParams);
+    },
+    setTranslate() {
+      const swiper = this;
+      const { $, slides, rtlTranslate: rtl } = swiper;
+      for (let i = 0; i < slides.length; i += 1) {
+        const $slideEl = slides.eq(i);
+        let progress = $slideEl[0].progress;
+        if (swiper.params.flipEffect.limitRotation) {
+          progress = Math.max(Math.min($slideEl[0].progress, 1), -1);
+        }
+        const offset$$1 = $slideEl[0].swiperSlideOffset;
+        const rotate = -180 * progress;
+        let rotateY = rotate;
+        let rotateX = 0;
+        let tx = -offset$$1;
+        let ty = 0;
+        if (!swiper.isHorizontal()) {
+          ty = tx;
+          tx = 0;
+          rotateX = -rotateY;
+          rotateY = 0;
+        } else if (rtl) {
+          rotateY = -rotateY;
+        }
+
+         $slideEl[0].style.zIndex = -Math.abs(Math.round(progress)) + slides.length;
+
+         if (swiper.params.flipEffect.slideShadows) {
+          // Set shadows
+          let shadowBefore = swiper.isHorizontal() ? $slideEl.find('.swiper-slide-shadow-left') : $slideEl.find('.swiper-slide-shadow-top');
+          let shadowAfter = swiper.isHorizontal() ? $slideEl.find('.swiper-slide-shadow-right') : $slideEl.find('.swiper-slide-shadow-bottom');
+          if (shadowBefore.length === 0) {
+            shadowBefore = swiper.$(`<div class="swiper-slide-shadow-${swiper.isHorizontal() ? 'left' : 'top'}"></div>`);
+            $slideEl.append(shadowBefore);
+          }
+          if (shadowAfter.length === 0) {
+            shadowAfter = swiper.$(`<div class="swiper-slide-shadow-${swiper.isHorizontal() ? 'right' : 'bottom'}"></div>`);
+            $slideEl.append(shadowAfter);
+          }
+          if (shadowBefore.length) shadowBefore[0].style.opacity = Math.max(-progress, 0);
+          if (shadowAfter.length) shadowAfter[0].style.opacity = Math.max(progress, 0);
+        }
+        $slideEl
+          .transform(`translate3d(${tx}px, ${ty}px, 0px) rotateX(${rotateX}deg) rotateY(${rotateY}deg)`);
+      }
+    },
+    setTransition(duration) {
+      const swiper = this;
+      const { slides, activeIndex, $wrapperEl } = swiper;
+      slides
+        .transition(duration)
+        .find('.swiper-slide-shadow-top, .swiper-slide-shadow-right, .swiper-slide-shadow-bottom, .swiper-slide-shadow-left')
+        .transition(duration);
+      if (swiper.params.virtualTranslate && duration !== 0) {
+        let eventTriggered = false;
+        // eslint-disable-next-line
+        slides.eq(activeIndex).transitionEnd(function onTransitionEnd() {
+          if (eventTriggered) return;
+          if (!swiper || swiper.destroyed) return;
+
+          eventTriggered = true;
+          swiper.animating = false;
+          const triggerEvents = ['webkitTransitionEnd', 'transitionend'];
+          for (let i = 0; i < triggerEvents.length; i += 1) {
+            $wrapperEl.trigger(triggerEvents[i]);
+          }
+        });
+      }
+    }
+  }
+};
+```
+
+
+
+## Usage
+
+<Tabs groupId="framework" defaultValue="angular" values={[{ value: 'angular', label: 'Angular' }, { value: 'javascript', label: 'Javascript' }, { value: 'react', label: 'React' }, { value: 'stencil', label: 'Stencil' }, { value: 'vue', label: 'Vue' }]}>
+
+<TabItem value="angular">
+
+```typescript
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'slides-example',
+  template: `
+    <ion-content>
+      <ion-slides pager="true" [options]="slideOpts">
+        <ion-slide>
+          <h1>Slide 1</h1>
+        </ion-slide>
+        <ion-slide>
+          <h1>Slide 2</h1>
+        </ion-slide>
+        <ion-slide>
+          <h1>Slide 3</h1>
+        </ion-slide>
+      </ion-slides>
+    </ion-content>
+  `
+})
+export class SlideExample {
+  // Optional parameters to pass to the swiper instance.
+  // See https://swiperjs.com/swiper-api for valid options.
+  slideOpts = {
+    initialSlide: 1,
+    speed: 400
+  };
+  constructor() {}
+}
+```
+
+```css
+/* Without setting height the slides will take up the height of the slide's content */
+ion-slides {
+  height: 100%;
+}
+```
+
+
+</TabItem>
+
+
+<TabItem value="javascript">
+
+```html
+<ion-content>
+  <ion-slides pager="true">
+    <ion-slide>
+      <h1>Slide 1</h1>
+    </ion-slide>
+
+    <ion-slide>
+      <h1>Slide 2</h1>
+    </ion-slide>
+
+    <ion-slide>
+      <h1>Slide 3</h1>
+    </ion-slide>
+  </ion-slides>
+</ion-content>
+```
+
+```javascript
+var slides = document.querySelector('ion-slides');
+
+// Optional parameters to pass to the swiper instance.
+// See https://swiperjs.com/swiper-api for valid options.
+slides.options = {
+  initialSlide: 1,
+  speed: 400
+}
+```
+
+```css
+/* Without setting height the slides will take up the height of the slide's content */
+ion-slides {
+  height: 100%;
+}
+```
+
+
+</TabItem>
+
+
+<TabItem value="react">
+
+```tsx
+import React from 'react';
+import { IonSlides, IonSlide, IonContent } from '@ionic/react';
+
+// Optional parameters to pass to the swiper instance.
+// See https://swiperjs.com/swiper-api for valid options.
+const slideOpts = {
+  initialSlide: 1,
+  speed: 400
+};
+
+export const SlidesExample: React.FC = () => (
+  <IonContent>
+    <IonSlides pager={true} options={slideOpts}>
+      <IonSlide>
+        <h1>Slide 1</h1>
+      </IonSlide>
+      <IonSlide>
+        <h1>Slide 2</h1>
+      </IonSlide>
+      <IonSlide>
+        <h1>Slide 3</h1>
+      </IonSlide>
+    </IonSlides>
+  </IonContent>
+);
+```
+
+```css
+/* Without setting height the slides will take up the height of the slide's content */
+ion-slides {
+  height: 100%;
+}
+```
+
+</TabItem>
+
+
+<TabItem value="stencil">
+
+```tsx
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'slides-example',
+  styleUrl: 'slides-example.css'
+})
+export class SlidesExample {
+  // Optional parameters to pass to the swiper instance.
+  // See https://swiperjs.com/swiper-api for valid options.
+  private slideOpts = {
+    initialSlide: 1,
+    speed: 400
+  };
+
+  render() {
+    return [
+      <ion-content>
+        <ion-slides pager={true} options={this.slideOpts}>
+          <ion-slide>
+            <h1>Slide 1</h1>
+          </ion-slide>
+
+          <ion-slide>
+            <h1>Slide 2</h1>
+          </ion-slide>
+
+          <ion-slide>
+            <h1>Slide 3</h1>
+          </ion-slide>
+        </ion-slides>
+      </ion-content>
+    ];
+  }
+}
+```
+
+```css
+/* Without setting height the slides will take up the height of the slide's content */
+ion-slides {
+  height: 100%;
+}
+```
+
+</TabItem>
+
+
+<TabItem value="vue">
+
+```html
+<template>
+  <ion-slides pager="true" :options="slideOpts">
+    <ion-slide>
+      <h1>Slide 1</h1>
+    </ion-slide>
+    <ion-slide>
+      <h1>Slide 2</h1>
+    </ion-slide>
+    <ion-slide>
+      <h1>Slide 3</h1>
+    </ion-slide>
+  </ion-slides>
+</template>
+
+
+<script>
+import { IonSlides, IonSlide } from '@ionic/vue';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  components: { IonSlides, IonSlide },
+  setup() {
+    // Optional parameters to pass to the swiper instance. See https://swiperjs.com/swiper-api for valid options.
+    const slideOpts = {
+      initialSlide: 1,
+      speed: 400
+    };
+    return { slideOpts }
+  }
+});
+</script>
+```
+
+
+</TabItem>
+
+</Tabs>
+
+## Properties
+<Props />
+
+## Events
+<Events />
+
+## Methods
+<Methods />
+
+## CSS Shadow Parts
+<Parts />
+
+## CSS Custom Properties
+<CustomProps />
+
+## Slots
+<Slots />

--- a/versioned_docs/version-v6/api/virtual-scroll.md
+++ b/versioned_docs/version-v6/api/virtual-scroll.md
@@ -1,0 +1,303 @@
+---
+title: "ion-virtual-scroll"
+hide_table_of_contents: true
+---
+import TOCInline from '@theme/TOCInline';
+
+import Props from '@site/static/auto-generated/virtual-scroll/props.md';
+import Events from '@site/static/auto-generated/virtual-scroll/events.md';
+import Methods from '@site/static/auto-generated/virtual-scroll/methods.md';
+import Parts from '@site/static/auto-generated/virtual-scroll/parts.md';
+import CustomProps from '@site/static/auto-generated/virtual-scroll/custom-props.md';
+import Slots from '@site/static/auto-generated/virtual-scroll/slots.md';
+
+<head>
+  <title>ion-virtual-scroll | Angular Virtual Scroll List for Ionic Apps</title>
+  <meta name="description" content="ion-virtual-scroll, supported in Angular, displays a virtual, infinite list. Records are passed to the virtual scroll containing the data to create templates." />
+</head>
+
+import EncapsulationPill from '@components/page/api/EncapsulationPill';
+
+
+<h2 className="table-of-contents__title">Contents</h2>
+
+<TOCInline
+  toc={toc}
+  maxHeadingLevel={2}
+/>
+
+
+:::note
+This component has been deprecated in favor of using virtual scrolling libraries provided by each JavaScript Framework. See below for alternatives.
+:::
+
+
+Virtual Scroll displays a virtual, "infinite" list. An array of records
+is passed to the virtual scroll containing the data to create templates
+for. The template created for each record, referred to as a cell, can
+consist of items, headers, and footers. For performance reasons, not every record
+in the list is rendered at once; instead a small subset of records (enough to fill the viewport)
+are rendered and reused as the user scrolls.
+
+This guide will go over the recommended virtual scrolling packages for each framework integration as well as documentation for the deprecated `ion-virtual-scroll` component for Ionic Angular. We recommend using the framework-specific solutions listed below, but the `ion-virtual-scroll` documentation is available below for developers who are still using that component.
+
+## Angular
+
+For virtual scrolling options in Ionic Angular, please see [Angular Virtual Scroll Guide](../angular/virtual-scroll.md).
+
+## React
+
+For virtual scrolling options in Ionic React, please see [React Virtual Scroll Guide](../react/virtual-scroll.md).
+
+## Vue
+
+For virtual scrolling options in Ionic Vue, please see [Vue Virtual Scroll Guide](../vue/virtual-scroll.md).
+
+------
+
+The following documentation applies to the `ion-virtual-scroll` component.
+
+## Approximate Widths and Heights
+
+If the height of items in the virtual scroll are not close to the
+default size of `40px`, it is extremely important to provide a value for
+the `approxItemHeight` property. An exact pixel-perfect size is not necessary,
+but without an estimate the virtual scroll will not render correctly.
+
+The approximate width and height of each template is used to help
+determine how many cells should be created, and to help calculate
+the height of the scrollable area. Note that the actual rendered size
+of each cell comes from the app's CSS, whereas this approximation
+is only used to help calculate initial dimensions.
+
+It's also important to know that Ionic's default item sizes have
+slightly different heights between platforms, which is perfectly fine.
+
+## Images Within Virtual Scroll
+
+HTTP requests, image decoding, and image rendering can cause jank while
+scrolling. In order to better control images, Ionic provides `<ion-img>`
+to manage HTTP requests and image rendering. While scrolling through items
+quickly, `<ion-img>` knows when and when not to make requests, when and
+when not to render images, and only loads the images that are viewable
+after scrolling. [Read more about `ion-img`.](img.md)
+
+It's also important for app developers to ensure image sizes are locked in,
+and after images have fully loaded they do not change size and affect any
+other element sizes. Simply put, to ensure rendering bugs are not introduced,
+it's vital that elements within a virtual item does not dynamically change.
+
+For virtual scrolling, the natural effects of the `<img>` are not desirable
+features. We recommend using the `<ion-img>` component over the native
+`<img>` element because when an `<img>` element is added to the DOM, it
+immediately makes a HTTP request for the image file. Additionally, `<img>`
+renders whenever it wants which could be while the user is scrolling. However,
+`<ion-img>` is governed by the containing `ion-content` and does not render
+images while scrolling quickly.
+
+
+## Virtual Scroll Performance Tips
+
+### iOS Cordova WKWebView
+
+When deploying to iOS with Cordova, it's highly recommended to use the
+[WKWebView plugin](https://blog.ionicframework.com/cordova-ios-performance-improvements-drop-in-speed-with-wkwebview/)
+in order to take advantage of iOS's higher performing webview. Additionally,
+WKWebView is superior at scrolling efficiently in comparison to the older
+UIWebView.
+
+### Lock in element dimensions and locations
+
+In order for virtual scroll to efficiently size and locate every item, it's
+very important every element within each virtual item does not dynamically
+change its dimensions or location. The best way to ensure size and location
+does not change, it's recommended each virtual item has locked in its size
+via CSS.
+
+### Use `ion-img` for images
+
+When including images within Virtual Scroll, be sure to use
+[`ion-img`](img.md) rather than the standard `<img>` HTML element.
+With `ion-img`, images are lazy loaded so only the viewable ones are
+rendered, and HTTP requests are efficiently controlled while scrolling.
+
+### Set Approximate Widths and Heights
+
+As mentioned above, all elements should lock in their dimensions. However,
+virtual scroll isn't aware of the dimensions until after they have been
+rendered. For the initial render, virtual scroll still needs to set
+how many items should be built. With "approx" property inputs, such as
+`approxItemHeight`, we're able to give virtual scroll an approximate size,
+therefore allowing virtual scroll to decide how many items should be
+created.
+
+### Changing dataset should use `trackBy`
+
+It is possible for the identities of elements in the iterator to change
+while the data does not. This can happen, for example, if the iterator
+produced from an RPC to the server, and that RPC is re-run. Even if the
+"data" hasn't changed, the second response will produce objects with
+different identities, and Ionic will tear down the entire DOM and rebuild
+it. This is an expensive operation and should be avoided if possible.
+
+### Efficient headers and footer functions
+Each virtual item must stay extremely efficient, but one way to really
+kill its performance is to perform any DOM operations within section header
+and footer functions. These functions are called for every record in the
+dataset, so please make sure they're performant.
+
+
+
+## Usage
+
+```html
+<ion-content>
+  <ion-virtual-scroll [items]="items" approxItemHeight="320px">
+    <ion-card *virtualItem="let item; let itemBounds = bounds;">
+      <div>
+        <ion-img [src]="item.imgSrc" [height]="item.imgHeight" [alt]="item.name"></ion-img>
+      </div>
+    <ion-card-header>
+      <ion-card-title>{{ item.name }}</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>{{ item.content }}</ion-card-content>
+    </ion-card>
+  </ion-virtual-scroll>
+</ion-content>
+```
+
+```typescript
+export class VirtualScrollPageComponent {
+  items: any[] = [];
+
+  constructor() {
+    for (let i = 0; i < 1000; i++) {
+      this.items.push({
+        name: i + ' - ' + images[rotateImg],
+        imgSrc: getImgSrc(),
+        avatarSrc: getImgSrc(),
+        imgHeight: Math.floor(Math.random() * 50 + 150),
+        content: lorem.substring(0, Math.random() * (lorem.length - 100) + 100)
+      });
+
+      rotateImg++;
+      if (rotateImg === images.length) {
+        rotateImg = 0;
+      }
+    }
+  }
+}
+
+const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, seddo eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+const images = [
+  'bandit',
+  'batmobile',
+  'blues-brothers',
+  'bueller',
+  'delorean',
+  'eleanor',
+  'general-lee',
+  'ghostbusters',
+  'knight-rider',
+  'mirth-mobile'
+];
+
+function getImgSrc() {
+  const src = 'https://dummyimage.com/600x400/${Math.round( Math.random() * 99999)}/fff.png';
+  rotateImg++;
+  if (rotateImg === images.length) {
+    rotateImg = 0;
+  }
+  return src;
+}
+
+let rotateImg = 0;
+```
+
+### Basic
+
+The array of records should be passed to the `items` property on the `ion-virtual-scroll` element.
+The data given to the `items` property must be an array. An item template with the `*virtualItem` property is required in the `ion-virtual-scroll`. The `*virtualItem` property can be added to any element.
+
+```html
+<ion-virtual-scroll [items]="items">
+  <ion-item *virtualItem="let item">
+    {{ item }}
+  </ion-item>
+</ion-virtual-scroll>
+```
+
+### Section Headers and Footers
+
+Section headers and footers are optional. They can be dynamically created
+from developer-defined functions. For example, a large list of contacts
+usually has a divider for each letter in the alphabet. Developers provide
+their own custom function to be called on each record. The logic in the
+custom function should determine whether to create the section template
+and what data to provide to the template. The custom function should
+return `null` if a template shouldn't be created.
+
+```html
+<ion-virtual-scroll [items]="items" [headerFn]="myHeaderFn">
+  <ion-item-divider *virtualHeader="let header">
+    {{ header }}
+  </ion-item-divider>
+  <ion-item *virtualItem="let item">
+    Item: {{ item }}
+  </ion-item>
+</ion-virtual-scroll>
+```
+
+Below is an example of a custom function called on every record. It
+gets passed the individual record, the record's index number,
+and the entire array of records. In this example, after every 20
+records a header will be inserted. So between the 19th and 20th records,
+between the 39th and 40th, and so on, a `<ion-item-divider>` will
+be created and the template's data will come from the function's
+returned data.
+
+```ts
+myHeaderFn(record, recordIndex, records) {
+  if (recordIndex % 20 === 0) {
+    return 'Header ' + recordIndex;
+  }
+  return null;
+}
+```
+
+
+### Custom Components
+
+If a custom component is going to be used within Virtual Scroll, it's best
+to wrap it with a `<div>` to ensure the component is rendered correctly. Since
+each custom component's implementation and internals can be quite different, wrapping
+within a `<div>` is a safe way to make sure dimensions are measured correctly.
+
+```html
+<ion-virtual-scroll [items]="items">
+  <div *virtualItem="let item">
+    <my-custom-item [item]="item">
+      {{ item }}
+    </my-custom-item>
+  </div>
+</ion-virtual-scroll>
+```
+
+## Properties
+<Props />
+
+## Events
+<Events />
+
+## Methods
+<Methods />
+
+## CSS Shadow Parts
+<Parts />
+
+## CSS Custom Properties
+<CustomProps />
+
+## Slots
+<Slots />

--- a/versioned_docs/version-v6/react/slides.md
+++ b/versioned_docs/version-v6/react/slides.md
@@ -10,13 +10,9 @@ title: Slides
   />
 </head>
 
-:::caution Looking for `IonSlides`?
+We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `IonSlides` component, but we now recommend that developers use Swiper for React directly.
 
-`IonSlides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
-
-:::
-
-We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
+This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
 ## Getting Started
 

--- a/versioned_docs/version-v6/react/virtual-scroll.md
+++ b/versioned_docs/version-v6/react/virtual-scroll.md
@@ -1,11 +1,5 @@
 # Virtual Scroll
 
-:::caution Looking for `ion-virtual-scroll`?
-
-`ion-virtual-scroll` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Virtuoso package detailed below.
-
-:::
-
 One virtual scrolling solution to consider for your Ionic React app is [Virtuoso](https://virtuoso.dev/). This guide will go over how to install `Virtuoso` into your Ionic React application and use it with other Ionic components.
 
 ## Installation
@@ -57,6 +51,12 @@ From there, we can use the `itemContent` property to pass a function that will b
 
 An important thing to note here is the `div` that wraps our `IonItem` component. When lazy loading Ionic components, there may be a few frames where the component is loaded but the styles have not loaded in. When this happens, the component's dimension will be `0`, and Virtuoso may throw an error. This is because Virtuoso needs distinct positions for each item it renders, and it cannot determine that when a component's dimension is `0`.
 
+## A Note on Ionic Components
+
+Certain Ionic Framework functionality is currently not compatible with virtual scrolling. Features such as collapsible large titles, `ion-infinite-scroll`, and `ion-refresher` rely on being able to scroll on `ion-content` itself, and as a result will not work when using virtual scrolling.
+
+We are working to improve compatibility between these components and virtual scrolling solutions. You can follow progress and give feedback here: https://github.com/ionic-team/ionic-framework/issues/23437.
+
 ## Usage with Ionic Components
 
 Ionic Framework requires that features such as collapsible large titles, `ion-infinite-scroll`, `ion-refresher`, and `ion-reorder-group` be used within an `ion-content`. To use these experiences with virtual scrolling, you must add the `.ion-content-scroll-host` class to the virtual scroll viewport.
@@ -66,7 +66,9 @@ For example:
 ```tsx
 <IonPage>
   <IonContent scrollY={false}>
-    <Virtuoso className="ion-content-scroll-host">{/* Your existing content and configurations */}</Virtuoso>
+    <Virtuoso className="ion-content-scroll-host">
+      {/* Your existing content and configurations */}
+    </Virtuoso>
   </IonContent>
 </IonPage>
 ```

--- a/versioned_docs/version-v6/vue/slides.md
+++ b/versioned_docs/version-v6/vue/slides.md
@@ -10,13 +10,9 @@ title: Slides
   />
 </head>
 
-:::caution Looking for `ion-slides`?
+We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `ion-slides` component, but we now recommend that developers use Swiper for Vue directly.
 
-`ion-slides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
-
-:::
-
-We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
+This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
 
 ## Getting Started
 
@@ -96,7 +92,7 @@ These components are imported from `swiper/vue` and provided to your Vue compone
     <ion-content>
       <swiper>
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>
@@ -136,7 +132,7 @@ To begin, we need to import the modules and their corresponding CSS files from t
     <ion-content>
       <swiper>
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>
@@ -170,7 +166,7 @@ From here, we need to provide these modules to Swiper by using the `modules` pro
     <ion-content>
       <swiper :modules="modules">
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>
@@ -209,7 +205,7 @@ Finally, we can turn these features on by using the appropriate properties:
     <ion-content>
       <swiper :modules="modules" :autoplay="true" :keyboard="true" :pagination="true" :scrollbar="true" :zoom="true">
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>
@@ -256,7 +252,7 @@ We can install the `IonicSlides` module by importing it from `@ionic/vue` and pa
     <ion-content>
       <swiper :modules="modules" :autoplay="true" :keyboard="true" :pagination="true" :scrollbar="true" :zoom="true">
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>
@@ -301,7 +297,7 @@ Let's say in an app with `ion-slides` we had the `slidesPerView` and `loop` opti
 <template>
   <ion-slides :options="{ slidesPerView: true, loop: true }">
     <ion-slide>Slide 1</ion-slide>
-    <ion-slide>Slide 2</ion-slide>
+    <ion-slide>Slide 3</ion-slide>
     <ion-slide>Slide 3</ion-slide>
   </ion-slides>
 </template>
@@ -313,7 +309,7 @@ To migrate, we would move these options out of the `options` object and onto the
 <template>
   <swiper :slides-per-view="3" :loop="true">
     <swiper-slide>Slide 1</swiper-slide>
-    <swiper-slide>Slide 2</swiper-slide>
+    <swiper-slide>Slide 3</swiper-slide>
     <swiper-slide>Slide 3</swiper-slide>
   </swiper>
 </template>
@@ -342,7 +338,7 @@ Let's say in an app with `ion-slides` we used the `ionSlideDidChange` event:
 <template>
   <ion-slides @ionSlideDidChange="onSlideChange">
     <ion-slide>Slide 1</ion-slide>
-    <ion-slide>Slide 2</ion-slide>
+    <ion-slide>Slide 3</ion-slide>
     <ion-slide>Slide 3</ion-slide>
   </ion-slides>
 </template>
@@ -354,7 +350,7 @@ To migrate, we would change the name of the event to `slideChange`:
 <template>
   <swiper @slideChange="onSlideChange">
     <swiper-slide>Slide 1</swiper-slide>
-    <swiper-slide>Slide 2</swiper-slide>
+    <swiper-slide>Slide 3</swiper-slide>
     <swiper-slide>Slide 3</swiper-slide>
   </swiper>
 </template>
@@ -423,7 +419,7 @@ Below is a full list of method changes when going from `ion-slides` to Swiper Vu
 | isBeginning()      | Use the `isBeginning` property instead.                                              |
 | isEnd()            | Use the `isEnd` property instead.                                                    |
 | length()           | Use the `slides` property instead. (i.e swiperRef.slides.length)                     |
-| lockSwipeToNext()  | Use the `allowSlideNext` property instead.                                          |
+| lockSwipeToNext()  | Use the `allowSlidesNext` property instead.                                          |
 | lockSwipeToPrev()  | Use the `allowSlidePrev` property instead.                                           |
 | lockSwipes()       | Use the `allowSlideNext`, `allowSlidePrev`, and `allowTouchMove` properties instead. |
 | startAutoplay()    | Use the `autoplay` property instead.                                                 |
@@ -439,7 +435,7 @@ If you are using effects such as Cube or Fade, you can install them just like we
     <ion-content>
       <swiper :modules="modules">
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>
@@ -473,7 +469,7 @@ Next, we need to import the stylesheet associated with the effect:
     <ion-content>
       <swiper :modules="modules">
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>
@@ -508,7 +504,7 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
     <ion-content>
       <swiper :modules="modules" effect="fade">
         <swiper-slide>Slide 1</swiper-slide>
-        <swiper-slide>Slide 2</swiper-slide>
+        <swiper-slide>Slide 3</swiper-slide>
         <swiper-slide>Slide 3</swiper-slide>
       </swiper>
     </ion-content>

--- a/versioned_docs/version-v6/vue/virtual-scroll.md
+++ b/versioned_docs/version-v6/vue/virtual-scroll.md
@@ -1,10 +1,6 @@
 # Virtual Scroll
 
-:::caution Looking for `ion-virtual-scroll`?
-
-`ion-virtual-scroll` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using a Vue library to accomplish this. We outline one approach using `vue-virtual-scroller` below.
-
-:::
+One virtual scrolling solution to consider for your Ionic Vue app is [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller/blob/next/packages/vue-virtual-scroller/README.md). This guide will go over how to install `vue-virtual-scroller` into your Ionic Vue application and use it with other Ionic components.
 
 ## Installation
 

--- a/versioned_sidebars/version-v6-sidebars.json
+++ b/versioned_sidebars/version-v6-sidebars.json
@@ -920,6 +920,10 @@
         {
           "type": "doc",
           "id": "version-v6/api/list-header"
+        },
+        {
+          "type": "doc",
+          "id": "version-v6/api/virtual-scroll"
         }
       ],
       "collapsible": true
@@ -1168,6 +1172,22 @@
         {
           "type": "doc",
           "id": "version-v6/api/select-option"
+        }
+      ],
+      "collapsible": true
+    },
+    {
+      "type": "category",
+      "label": "Slides",
+      "collapsed": false,
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-v6/api/slides"
+        },
+        {
+          "type": "doc",
+          "id": "version-v6/api/slide"
         }
       ],
       "collapsible": true


### PR DESCRIPTION
The slides and virtual scroll docs got removed from the v6 docs during versioning.

1. Adds the slides, slide, and virtual scroll docs back into the v6 docs.
2. Adds deprecation messages at the top of each component page.
3. Adds each page back to their original locations in the sidebar.