### PR TITLE
docs(support): update support policy for v6

### DIFF
--- a/versioned_docs/version-v6/reference/support.md
+++ b/versioned_docs/version-v6/reference/support.md
@@ -22,13 +22,12 @@ The current status of each Ionic Framework version is:
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
-| V7      | **Active**            | TBD          | TBD              | TBD               |
-| V6      | Maintenance           | Dec 8, 2021  | TBD              | TBD               |
-| V5      | Extended Support Only | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
-| V4      | End of Support        | Jan 23, 2019 | Aug 11, 2020     | Sept 30, 2022     |
-| V3      | End of Support        | Apr 5, 2017  | Oct 30, 2019     | Aug 11, 2020      |
-| V2      | End of Support        | Jan 25, 2017 | Apr 5, 2017      | Apr 5, 2017       |
-| V1      | End of Support        | May 12, 2015 | Jan 25, 2017     | Jan 25, 2017      |
+|   V6    |      **Active**       | Dec 8, 2021  |       TBD        |        TBD        |
+|   V5    | Extended Support Only | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
+|   V4    |    End of Support     | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
+|   V3    |    End of Support     | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
+|   V2    |    End of Support     | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
+|   V1    |    End of Support     | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
 - **Extended Support**: For teams and organizations that require additional long term support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).
@@ -43,36 +42,27 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-| v7        | v13                     | v15.x^                   | 4.4+       |   
-| v6        | v12                     | v15.x^                  | 4.0+       |
-| v5        | v8.2                    | v12.x                   | 3.5+       |
-| v4        | v8.2                    | v11.x                   | 3.5+       |
-| v3        | v5.2.11                 | v5.2.11                 | 2.6.2      |
+|    v6     |           v12           |         v15.x^          |    4.0+    |
+|    v5     |          v8.2           |          v12.x          |    3.5+    |
+|    v4     |          v8.2           |          v11.x          |    3.5+    |
+|    v3     |         v5.2.11         |         v5.2.11         |   2.6.2    |
 
 > ^ Angular 14.x supported starting in Ionic v6.1.9. Angular 15.x supported starting in Ionic v6.3.6.
-
-**Angular 13+ Support On Older Versions of iOS**
-
-Angular's support policy for iOS is the two most recent major versions. This means that changes to your Angular project may be necessary to use Ionic Angular v4-v6 on iOS 13. To support iOS 13, change the project `target` specified in `compilerOptions` in the tsconfig.json to `es5`. Without this change an error of `Unexpected token '.' in promiseReactionJob` will occur on app startup in iOS 13.
-
-Note that later versions of Ionic do not support iOS 13; see [mobile support table here](./browser-support#mobile-browsers).
 
 #### Ionic React
 
 | Framework | Required React Version | TypeScript |
 | :-------: | :--------------------: | :--------: |
-| v7        | v17+                   | 3.7+       |
-| v6        | v17+                   | 3.7+       |
-| v5        | v16.8+                 | 3.7+       |
-| v4        | v16.8+                 | 3.7+       |
+|    v6     |          v17+          |    3.7+    |
+|    v5     |         v16.8+         |    3.7+    |
+|    v4     |         v16.8+         |    3.7+    |
 
 #### Ionic Vue
 
 | Framework | Required Vue Version | TypeScript |
 | :-------: | :------------------: | :--------: |
-| v7        | v3.0.6+              | 3.9+       |
-| v6        | v3.0.6+              | 3.9+       |
-| v5        | v3.0+                | 3.9+       |
+|    v6     |       v3.0.6+        |    3.9+    |
+|    v5     |        v3.0+         |    3.9+    |
 
 ### Native Bridges
 


### PR DESCRIPTION
Some changes were lost during the Docusaurus versioning for v7. This PR restores the changes made to the support policy page for v6.