### PR TITLE
docs(range): update for new syntax, add migration guide

### DIFF
--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -1,3 +1,4 @@
+test
 ---
 title: "ion-range"
 ---

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -108,6 +108,30 @@ import CSSParts from '@site/static/usage/v7/range/theming/css-shadow-parts/index
 
 <CSSParts />
 
+## Migrating from Legacy Range Syntax
+
+A simpler range syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an range, resolves accessibility issues, and improves the developer experience.
+
+While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
+
+### Using the Modern Syntax
+
+Using the modern syntax involves removing the `ion-label` and passing the label directly inside of `ion-range`. The placement of the label can be configured using the `labelPlacement` property on `ion-range`.
+
+import Migration from '@site/static/usage/v7/range/migration/index.md';
+
+<Migration />
+
+
+:::note
+In past versions of Ionic, `ion-item` was required for `ion-range` to function properly. Starting in Ionic 7.0, `ion-range` should only be used in an `ion-item` when the item is placed in an `ion-list`. Additionally, `ion-item` is no longer required for `ion-range` to function properly.
+:::
+
+### Using the Legacy Syntax
+
+Ionic uses heuristics to detect if an app is using the modern range syntax. In some instances, it may be preferable to continue using the legacy syntax. Developers can set the `legacy` property on `ion-range` to `true` to force that instance of the range to use the legacy syntax.
+
+
 ## Interfaces
 
 ### RangeChangeEventDetail

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -116,7 +116,7 @@ Developers can perform this migration one range at a time. While developers can 
 
 ### Using the Modern Syntax
 
-Using the modern syntax involves removing the `ion-label` and passing the label directly inside of `ion-range`. The placement of the label can be configured using the `labelPlacement` property on `ion-range`.
+Using the modern syntax involves removing the `ion-label` and passing the label directly inside of `ion-range` using `slot="label"`. The placement of the label can be configured using the `labelPlacement` property on `ion-range`.
 
 import Migration from '@site/static/usage/v7/range/migration/index.md';
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -38,7 +38,7 @@ import LabelsPlayground from '@site/static/usage/v7/range/labels/index.md';
 
 Decorative elements can be passed into the `start` or `end` slots of the range. This is useful for adding icons such as low volume or high volume icons. Since these elements are decorative, they should not be announced by assistive technology such as screen readers.
 
-If the directionality of the document is set to left to right, the contents slotted to the `start` position will display to the left of the range, where as contents slotted to the `end` position will display to the right of the range. In right to left (rtl) directionality, the contents slotted to the `start` position will display to the right of the range, where as contents slotted to the `end` position` will display to the left of the range.
+If the directionality of the document is set to left to right, the contents slotted to the `start` position will display to the left of the range, where as contents slotted to the `end` position will display to the right of the range. In right to left (rtl) directionality, the contents slotted to the `start` position will display to the right of the range, where as contents slotted to the `end` position will display to the left of the range.
 
 import DecorationsPlayground from '@site/static/usage/v7/range/slots/index.md';
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -112,7 +112,7 @@ import CSSParts from '@site/static/usage/v7/range/theming/css-shadow-parts/index
 
 A simpler range syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an range, resolves accessibility issues, and improves the developer experience.
 
-While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
+Developers can perform this migration one range at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
 
 ### Using the Modern Syntax
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -27,10 +27,12 @@ By default the Range slider has a minimum value of `0` and a maximum value of `1
 import Basic from '@site/static/usage/v7/range/basic/index.md';
 
 <Basic />
-  
+
 ## Label Placement
 
-TODO
+import LabelsPlayground from '@site/static/usage/v7/range/labels/index.md';
+
+<LabelsPlayground />
 
 ## Decorations
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -27,14 +27,20 @@ By default the Range slider has a minimum value of `0` and a maximum value of `1
 import Basic from '@site/static/usage/v7/range/basic/index.md';
 
 <Basic />
+  
+## Label Placement
 
-## Range Labels
+TODO
 
-Labels and custom UI elements can be slotted on either side of the range by adding `slot="start"` or `slot="end"` to the element. The element can be any element, such as an `ion-label`, `ion-icon` or a `div`. If the directionality of the document is set to left to right, the contents slotted to the `start` position will display to the left of the range, where as contents slotted to the `end` position will display to the right of the range. In right to left (rtl) directionality, the contents slotted to the `start` position will display to the right of the range, where as contents slotted to the `end` position` will display to the left of the range.
+## Decorations
 
-import SlotsPlayground from '@site/static/usage/v7/range/slots/index.md';
+Decorative elements can be passed into the `start` or `end` slots of the range. This is useful for adding icons such as low volume or high volume icons. Since these elements are decorative, they should not be announced by assistive technology such as screen readers.
 
-<SlotsPlayground />
+If the directionality of the document is set to left to right, the contents slotted to the `start` position will display to the left of the range, where as contents slotted to the `end` position will display to the right of the range. In right to left (rtl) directionality, the contents slotted to the `start` position will display to the right of the range, where as contents slotted to the `end` position` will display to the left of the range.
+
+import DecorationsPlayground from '@site/static/usage/v7/range/slots/index.md';
+
+<DecorationsPlayground />
 
 ## Dual Knobs
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -1,4 +1,3 @@
-test
 ---
 title: "ion-range"
 ---

--- a/static/usage/v7/range/basic/angular.md
+++ b/static/usage/v7/range/basic/angular.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range></ion-range>
+<ion-range aria-label="Volume"></ion-range>
 ```

--- a/static/usage/v7/range/basic/demo.html
+++ b/static/usage/v7/range/basic/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     ion-range {
       max-width: 320px;
@@ -20,7 +20,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-range></ion-range>
+        <ion-range aria-label="Volume"></ion-range>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/range/basic/javascript.md
+++ b/static/usage/v7/range/basic/javascript.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range></ion-range>
+<ion-range aria-label="Volume"></ion-range>
 ```

--- a/static/usage/v7/range/basic/react.md
+++ b/static/usage/v7/range/basic/react.md
@@ -2,7 +2,7 @@
 import React from 'react';
 import { IonRange } from '@ionic/react';
 function Example() {
-  return <IonRange></IonRange>;
+  return <IonRange aria-label="Volume"></IonRange>;
 }
 export default Example;
 ```

--- a/static/usage/v7/range/basic/vue.md
+++ b/static/usage/v7/range/basic/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range></ion-range>
+  <ion-range aria-label="Volume"></ion-range>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/range/dual-knobs/angular.md
+++ b/static/usage/v7/range/dual-knobs/angular.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range [dualKnobs]="true" [value]="{ lower: 20, upper: 80 }"></ion-range>
+<ion-range aria-label="Dual Knobs Range" [dualKnobs]="true" [value]="{ lower: 20, upper: 80 }"></ion-range>
 ```

--- a/static/usage/v7/range/dual-knobs/demo.html
+++ b/static/usage/v7/range/dual-knobs/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     ion-range {
       max-width: 320px;
@@ -20,7 +20,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-range dual-knobs="true"></ion-range>
+        <ion-range aria-label="Dual Knobs Range" dual-knobs="true"></ion-range>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/range/dual-knobs/javascript.md
+++ b/static/usage/v7/range/dual-knobs/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range dual-knobs="true"></ion-range>
+<ion-range aria-label="Dual Knobs Range" dual-knobs="true"></ion-range>
 
 <script>
   const range = document.querySelector('ion-range');

--- a/static/usage/v7/range/dual-knobs/react.md
+++ b/static/usage/v7/range/dual-knobs/react.md
@@ -4,6 +4,7 @@ import { IonRange } from '@ionic/react';
 function Example() {
   return (
     <IonRange
+      aria-label="Dual Knobs Range"
       dualKnobs={true}
       value={{
         lower: 20,

--- a/static/usage/v7/range/dual-knobs/vue.md
+++ b/static/usage/v7/range/dual-knobs/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range :dual-knobs="true" :value="{ lower: 20, upper: 80 }"></ion-range>
+  <ion-range aria-label="Dual Knobs Range" :dual-knobs="true" :value="{ lower: 20, upper: 80 }"></ion-range>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/range/ion-change-event/angular/example_component_html.md
+++ b/static/usage/v7/range/ion-change-event/angular/example_component_html.md
@@ -1,4 +1,4 @@
 ```html
-<ion-range (ionChange)="onIonChange($event)"></ion-range>
+<ion-range aria-label="Range with ionChange" (ionChange)="onIonChange($event)"></ion-range>
 <ion-label>ionChange emitted value: {{ lastEmittedValue }}</ion-label>
 ```

--- a/static/usage/v7/range/ion-change-event/demo.html
+++ b/static/usage/v7/range/ion-change-event/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     .demo {
       max-width: 320px;
@@ -22,7 +22,7 @@
     <ion-content>
       <div class="container">
         <div class="demo">
-          <ion-range></ion-range>
+          <ion-range aria-label="Range with ionChange"></ion-range>
           <ion-label>ionChange emitted value: <span id="lastValue"></span></ion-label>
         </div>
     </ion-content>

--- a/static/usage/v7/range/ion-change-event/javascript.md
+++ b/static/usage/v7/range/ion-change-event/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range></ion-range>
+<ion-range aria-label="Range with ionChange"></ion-range>
 <ion-label>ionChange emitted value: <span id="lastValue"></span></ion-label>
 
 <script>

--- a/static/usage/v7/range/ion-change-event/react.md
+++ b/static/usage/v7/range/ion-change-event/react.md
@@ -6,7 +6,7 @@ function Example() {
   const [lastEmittedValue, setLastEmittedValue] = useState<RangeValue>();
   return (
     <>
-      <IonRange onIonChange={({ detail }) => setLastEmittedValue(detail.value)}></IonRange>
+      <IonRange aria-label="Range with ionChange" onIonChange={({ detail }) => setLastEmittedValue(detail.value)}></IonRange>
       <IonLabel>ionChange emitted value: {lastEmittedValue as number}</IonLabel>
     </>
   );

--- a/static/usage/v7/range/ion-change-event/vue.md
+++ b/static/usage/v7/range/ion-change-event/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range @ionChange="onIonChange"></ion-range>
+  <ion-range aria-label="Range with ionChange" @ionChange="onIonChange"></ion-range>
   <ion-label>ionChange emitted value: {{lastEmittedValue}}</ion-label>
 </template>
 

--- a/static/usage/v7/range/ion-knob-move-event/angular/example_component_html.md
+++ b/static/usage/v7/range/ion-knob-move-event/angular/example_component_html.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range (ionKnobMoveStart)="onIonKnobMoveStart($event)" (ionKnobMoveEnd)="onIonKnobMoveEnd($event)"></ion-range>
+<ion-range aria-label="Range with knob events" (ionKnobMoveStart)="onIonKnobMoveStart($event)" (ionKnobMoveEnd)="onIonKnobMoveEnd($event)"></ion-range>
 <div>
   <ion-label>ionKnobMoveStart: {{ moveStart }}</ion-label>
 </div>

--- a/static/usage/v7/range/ion-knob-move-event/demo.html
+++ b/static/usage/v7/range/ion-knob-move-event/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     .demo {
       max-width: 320px;
@@ -22,7 +22,7 @@
     <ion-content>
       <div class="container">
         <div class="demo">
-          <ion-range></ion-range>
+          <ion-range aria-label="Range with knob events"></ion-range>
           <div>
             <ion-label>ionKnobMoveStart: <span id="moveStart"></span></ion-label>
           </div>

--- a/static/usage/v7/range/ion-knob-move-event/javascript.md
+++ b/static/usage/v7/range/ion-knob-move-event/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range></ion-range>
+<ion-range aria-label="Range with knob events"></ion-range>
 <div>
   <ion-label>ionKnobMoveStart: <span id="moveStart"></span></ion-label>
 </div>

--- a/static/usage/v7/range/ion-knob-move-event/react.md
+++ b/static/usage/v7/range/ion-knob-move-event/react.md
@@ -8,6 +8,7 @@ function Example() {
   return (
     <>
       <IonRange
+        aria-label="Range with knob events"
         onIonKnobMoveStart={({ detail }) => setMoveStartValue(detail.value)}
         onIonKnobMoveEnd={({ detail }) => setMoveEndValue(detail.value)}
       ></IonRange>

--- a/static/usage/v7/range/ion-knob-move-event/vue.md
+++ b/static/usage/v7/range/ion-knob-move-event/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range @ionKnobMoveStart="onIonKnobMoveStart" @ionKnobMoveEnd="onIonKnobMoveEnd"></ion-range>
+  <ion-range aria-label="Range with knob events" @ionKnobMoveStart="onIonKnobMoveStart" @ionKnobMoveEnd="onIonKnobMoveEnd"></ion-range>
   <div>
     <ion-label>ionKnobMoveStart: {{moveStart}}</ion-label>
   </div>

--- a/static/usage/v7/range/labels/angular.md
+++ b/static/usage/v7/range/labels/angular.md
@@ -1,0 +1,17 @@
+```html
+<ion-range labelPlacement="start">
+  <div slot="label">Label at the Start</div>
+</ion-range>
+
+<br />
+
+<ion-range labelPlacement="end">
+  <div slot="label">Label at the End</div>
+</ion-range>
+
+<br />
+
+<ion-range labelPlacement="fixed">
+  <div slot="label">Fixed Width Label</div>
+</ion-range>
+```

--- a/static/usage/v7/range/labels/demo.html
+++ b/static/usage/v7/range/labels/demo.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Range</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
+  <style>
+    .wrapper {
+      width: calc(100% - 100px);
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div class="wrapper">
+          <ion-range label-placement="start">
+            <div slot="label">Label at the Start</div>
+          </ion-range>
+
+          <br />
+
+          <ion-range label-placement="end">
+            <div slot="label">Label at the End</div>
+          </ion-range>
+
+          <br />
+
+          <ion-range label-placement="fixed">
+            <div slot="label">Fixed Width Label</div>
+          </ion-range>
+        </div>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v7/range/labels/index.md
+++ b/static/usage/v7/range/labels/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/labels/demo.html" size="300px" />

--- a/static/usage/v7/range/labels/javascript.md
+++ b/static/usage/v7/range/labels/javascript.md
@@ -1,0 +1,17 @@
+```html
+<ion-range label-placement="start">
+  <div slot="label">Label at the Start</div>
+</ion-range>
+
+<br />
+
+<ion-range label-placement="end">
+  <div slot="label">Label at the End</div>
+</ion-range>
+
+<br />
+
+<ion-range label-placement="fixed">
+  <div slot="label">Fixed Width Label</div>
+</ion-range>
+```

--- a/static/usage/v7/range/labels/react.md
+++ b/static/usage/v7/range/labels/react.md
@@ -3,21 +3,23 @@ import React from 'react';
 import { IonRange } from '@ionic/react';
 function Example() {
   return (
-    <IonRange labelPlacement="start">
-      <div slot="label">Label at the Start</div>
-    </IonRange>
+    <>
+      <IonRange labelPlacement="start">
+        <div slot="label">Label at the Start</div>
+      </IonRange>
     
-    <br />
+      <br />
     
-    <IonRange labelPlacement="end">
-      <div slot="label">Label at the End</div>
-    </IonRange>
+      <IonRange labelPlacement="end">
+        <div slot="label">Label at the End</div>
+      </IonRange>
     
-    <br />
+      <br />
     
-    <IonRange labelPlacement="fixed">
-      <div slot="label">Fixed Width Label</div>
-    </IonRange>
+      <IonRange labelPlacement="fixed">
+        <div slot="label">Fixed Width Label</div>
+      </IonRange>
+   </>
   );
 }
 export default Example;

--- a/static/usage/v7/range/labels/react.md
+++ b/static/usage/v7/range/labels/react.md
@@ -1,0 +1,24 @@
+```tsx
+import React from 'react';
+import { IonRange } from '@ionic/react';
+function Example() {
+  return (
+    <IonRange labelPlacement="start">
+      <div slot="label">Label at the Start</div>
+    </IonRange>
+    
+    <br />
+    
+    <IonRange labelPlacement="end">
+      <div slot="label">Label at the End</div>
+    </IonRange>
+    
+    <br />
+    
+    <IonRange labelPlacement="fixed">
+      <div slot="label">Fixed Width Label</div>
+    </IonRange>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/range/labels/vue.md
+++ b/static/usage/v7/range/labels/vue.md
@@ -1,0 +1,28 @@
+```html
+<template>
+  <ion-range label-placement="start">
+    <div slot="label">Label at the Start</div>
+  </ion-range>
+  
+  <br />
+  
+  <ion-range label-placement="end">
+    <div slot="label">Label at the End</div>
+  </ion-range>
+  
+  <br />
+  
+  <ion-range label-placement="fixed">
+    <div slot="label">Fixed Width Label</div>
+  </ion-range>
+</template>
+
+<script lang="ts">
+  import { IonRange } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRange },
+  });
+</script>
+```

--- a/static/usage/v7/range/migration/index.md
+++ b/static/usage/v7/range/migration/index.md
@@ -1,0 +1,212 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+````mdx-code-block
+<Tabs
+  groupId="framework"
+  defaultValue="javascript"
+  values={[
+    { value: 'javascript', label: 'JavaScript' },
+    { value: 'angular', label: 'Angular' },
+    { value: 'react', label: 'React' },
+    { value: 'vue', label: 'Vue' },
+  ]
+}>
+<TabItem value="javascript">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range>
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range label-placement="fixed">
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+
+<!-- Range at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range label-placement="end">
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+```
+</TabItem>
+<TabItem value="angular">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range>
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range label-placement="fixed">
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+
+<!-- Range at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range label-placement="end">
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+```
+</TabItem>
+<TabItem value="react">
+
+```tsx
+{/* Basic */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel>Notifications</IonLabel>
+  <IonRange></IonRange>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonRange>
+    <div slot="label">Notifications</div>
+  </IonRange>
+</IonItem>
+
+{/* Fixed Labels */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel position="fixed">Notifications</IonLabel>
+  <IonRange></IonRange>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonRange labelPlacement="fixed">
+    <div slot="label">Notifications</div>
+  </IonRange>
+</IonItem>
+
+{/* Range at the start of line, Label at the end of line */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel slot="end">Notifications</IonLabel>
+  <IonRange></IonRange>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonRange labelPlacement="end">
+    <div slot="label">Notifications</div>
+  </IonRange>
+</IonItem>
+```
+</TabItem>
+<TabItem value="vue">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range>
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range label-placement="fixed">
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+
+<!-- Range at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Notifications</ion-label>
+  <ion-range></ion-range>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-range label-placement="end">
+    <div slot="label">Notifications</div>
+  </ion-range>
+</ion-item>
+```
+</TabItem>
+</Tabs>
+````

--- a/static/usage/v7/range/migration/index.md
+++ b/static/usage/v7/range/migration/index.md
@@ -89,7 +89,7 @@ import TabItem from '@theme/TabItem';
 
 <!-- After -->
 <ion-item>
-  <ion-range label-placement="fixed">
+  <ion-range labelPlacement="fixed">
     <div slot="label">Notifications</div>
   </ion-range>
 </ion-item>

--- a/static/usage/v7/range/migration/index.md
+++ b/static/usage/v7/range/migration/index.md
@@ -104,7 +104,7 @@ import TabItem from '@theme/TabItem';
 
 <!-- After -->
 <ion-item>
-  <ion-range label-placement="end">
+  <ion-range labelPlacement="end">
     <div slot="label">Notifications</div>
   </ion-range>
 </ion-item>

--- a/static/usage/v7/range/pins/angular/example_component_html.md
+++ b/static/usage/v7/range/pins/angular/example_component_html.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range [pin]="true" [pinFormatter]="pinFormatter"></ion-range>
+<ion-range aria-label="Range with pin" [pin]="true" [pinFormatter]="pinFormatter"></ion-range>
 ```

--- a/static/usage/v7/range/pins/demo.html
+++ b/static/usage/v7/range/pins/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     ion-range {
       max-width: 320px;
@@ -20,7 +20,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-range pin="true"></ion-range>
+        <ion-range pin="true" aria-label="Range with pin"></ion-range>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/range/pins/javascript.md
+++ b/static/usage/v7/range/pins/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range pin="true"></ion-range>
+<ion-range aria-label="Range with pin" pin="true"></ion-range>
 
 <script>
   const range = document.querySelector('ion-range');

--- a/static/usage/v7/range/pins/react.md
+++ b/static/usage/v7/range/pins/react.md
@@ -2,7 +2,7 @@
 import React from 'react';
 import { IonRange } from '@ionic/react';
 function Example() {
-  return <IonRange pin={true} pinFormatter={(value: number) => `${value}%`}></IonRange>;
+  return <IonRange aria-label="Range with pin" pin={true} pinFormatter={(value: number) => `${value}%`}></IonRange>;
 }
 export default Example;
 ```

--- a/static/usage/v7/range/pins/vue.md
+++ b/static/usage/v7/range/pins/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range :pin="true" :pin-formatter="pinFormatter"></ion-range>
+  <ion-range aria-label="Range with pin" :pin="true" :pin-formatter="pinFormatter"></ion-range>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/range/slots/angular.md
+++ b/static/usage/v7/range/slots/angular.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range>
+<ion-range aria-label="Temperature">
   <ion-icon slot="start" name="snow-outline"></ion-icon>
   <ion-icon slot="end" name="sunny-outline"></ion-icon>
 </ion-range>

--- a/static/usage/v7/range/slots/demo.html
+++ b/static/usage/v7/range/slots/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     ion-range {
       max-width: 320px;
@@ -20,7 +20,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-range>
+        <ion-range aria-label="Temperature">
           <ion-icon slot="start" name="snow-outline"></ion-icon>
           <ion-icon slot="end" name="sunny-outline"></ion-icon>
         </ion-range>

--- a/static/usage/v7/range/slots/javascript.md
+++ b/static/usage/v7/range/slots/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range>
+<ion-range aria-label="Temperature">
   <ion-icon slot="start" name="snow-outline"></ion-icon>
   <ion-icon slot="end" name="sunny-outline"></ion-icon>
 </ion-range>

--- a/static/usage/v7/range/slots/react.md
+++ b/static/usage/v7/range/slots/react.md
@@ -5,7 +5,7 @@ import { snowOutline, sunnyOutline } from 'ionicons/icons';
 
 function Example() {
   return (
-    <IonRange>
+    <IonRange aria-label="Temperature">
       <IonIcon slot="start" icon={snowOutline}></IonIcon>
       <IonIcon slot="end" icon={sunnyOutline}></IonIcon>
     </IonRange>

--- a/static/usage/v7/range/slots/vue.md
+++ b/static/usage/v7/range/slots/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range>
+  <ion-range aria-label="Temperature">
     <ion-icon slot="start" :icon="snowOutline"></ion-icon>
     <ion-icon slot="end" :icon="sunnyOutline"></ion-icon>
   </ion-range>

--- a/static/usage/v7/range/snapping-ticks/angular.md
+++ b/static/usage/v7/range/snapping-ticks/angular.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range [ticks]="true" [snaps]="true" [min]="0" [max]="10"></ion-range>
+<ion-range aria-label="Range with ticks" [ticks]="true" [snaps]="true" [min]="0" [max]="10"></ion-range>
 ```

--- a/static/usage/v7/range/snapping-ticks/demo.html
+++ b/static/usage/v7/range/snapping-ticks/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     ion-range {
       max-width: 320px;
@@ -20,7 +20,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-range ticks="true" snaps="true" min="0" max="10"></ion-range>
+        <ion-range aria-label="Range with ticks" ticks="true" snaps="true" min="0" max="10"></ion-range>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/range/snapping-ticks/javascript.md
+++ b/static/usage/v7/range/snapping-ticks/javascript.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range ticks="true" snaps="true" min="0" max="10"></ion-range>
+<ion-range aria-label="Range with ticks" ticks="true" snaps="true" min="0" max="10"></ion-range>
 ```

--- a/static/usage/v7/range/snapping-ticks/react.md
+++ b/static/usage/v7/range/snapping-ticks/react.md
@@ -2,7 +2,7 @@
 import React from 'react';
 import { IonRange } from '@ionic/react';
 function Example() {
-  return <IonRange ticks={true} snaps={true} min={0} max={10}></IonRange>;
+  return <IonRange aria-label="Range with ticks" ticks={true} snaps={true} min={0} max={10}></IonRange>;
 }
 export default Example;
 ```

--- a/static/usage/v7/range/snapping-ticks/vue.md
+++ b/static/usage/v7/range/snapping-ticks/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-range :ticks="true" :snaps="true" :min="0" :max="10"></ion-range>
+  <ion-range aria-label="Range with ticks" :ticks="true" :snaps="true" :min="0" :max="10"></ion-range>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/range/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/v7/range/theming/css-properties/angular/example_component_html.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range [value]="50" [pin]="true"></ion-range>
+<ion-range aria-label="Custom range" [value]="50" [pin]="true"></ion-range>
 ```

--- a/static/usage/v7/range/theming/css-properties/demo.html
+++ b/static/usage/v7/range/theming/css-properties/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     ion-range {
       --bar-background: #a2d2ff;
@@ -29,7 +29,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-range value="50" pin="true"></ion-range>
+        <ion-range aria-label="Custom range" value="50" pin="true"></ion-range>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/range/theming/css-properties/javascript.md
+++ b/static/usage/v7/range/theming/css-properties/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range value="50" pin="true"></ion-range>
+<ion-range aria-label="Custom range" value="50" pin="true"></ion-range>
 
 <style>
   ion-range {

--- a/static/usage/v7/range/theming/css-properties/react/main_tsx.md
+++ b/static/usage/v7/range/theming/css-properties/react/main_tsx.md
@@ -5,7 +5,7 @@ import { IonRange } from '@ionic/react';
 import './main.css';
 
 function Example() {
-  return <IonRange value={50} pin={true}></IonRange>;
+  return <IonRange aria-label="Custom range" value={50} pin={true}></IonRange>;
 }
 export default Example;
 ```

--- a/static/usage/v7/range/theming/css-properties/vue.md
+++ b/static/usage/v7/range/theming/css-properties/vue.md
@@ -13,7 +13,7 @@
 </style>
 
 <template>
-  <ion-range :value="50" :pin="true"></ion-range>
+  <ion-range aria-label="Custom range" :value="50" :pin="true"></ion-range>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/range/theming/css-shadow-parts/angular/example_component_html.md
+++ b/static/usage/v7/range/theming/css-shadow-parts/angular/example_component_html.md
@@ -1,3 +1,3 @@
 ```html
-<ion-range [min]="0" [max]="10" [value]="5" [pin]="true" [ticks]="true" [snaps]="true"></ion-range>
+<ion-range aria-label="Custom range" [min]="0" [max]="10" [value]="5" [pin]="true" [ticks]="true" [snaps]="true"></ion-range>
 ```

--- a/static/usage/v7/range/theming/css-shadow-parts/demo.html
+++ b/static/usage/v7/range/theming/css-shadow-parts/demo.html
@@ -7,8 +7,8 @@
   <title>Range</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     ion-range {
       max-width: 320px;
@@ -62,7 +62,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-range min="0" max="10" value="5" pin="true" ticks="true" snaps="true"></ion-range>
+        <ion-range aria-label="Custom range" min="0" max="10" value="5" pin="true" ticks="true" snaps="true"></ion-range>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/range/theming/css-shadow-parts/javascript.md
+++ b/static/usage/v7/range/theming/css-shadow-parts/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-range min="0" max="10" value="5" pin="true" ticks="true" snaps="true"></ion-range>
+<ion-range aria-label="Custom range" min="0" max="10" value="5" pin="true" ticks="true" snaps="true"></ion-range>
 
 <style>
   ion-range::part(tick) {

--- a/static/usage/v7/range/theming/css-shadow-parts/react/main_tsx.md
+++ b/static/usage/v7/range/theming/css-shadow-parts/react/main_tsx.md
@@ -5,7 +5,7 @@ import { IonRange } from '@ionic/react';
 import './main.css';
 
 function Example() {
-  return <IonRange min={0} max={10} value={5} pin={true} ticks={true} snaps={true}></IonRange>;
+  return <IonRange aria-label="Custom range" min={0} max={10} value={5} pin={true} ticks={true} snaps={true}></IonRange>;
 }
 
 export default Example;

--- a/static/usage/v7/range/theming/css-shadow-parts/vue.md
+++ b/static/usage/v7/range/theming/css-shadow-parts/vue.md
@@ -44,7 +44,7 @@
 </style>
 
 <template>
-  <ion-range :min="0" :max="10" :value="5" :pin="true" :ticks="true" :snaps="true"></ion-range>
+  <ion-range aria-label="Custom range" :min="0" :max="10" :value="5" :pin="true" :ticks="true" :snaps="true"></ion-range>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
This PR makes the following changes:

1. Updates existing playgrounds to v7 and uses the new range syntax (most ranges do not have visible labels in these samples, so I added `aria-label` to them)
2. Adds a migration guide for moving to the new syntax.
3. Renames the "Labels" playground to "Decorations" to avoid confusion with the visible label in the `label` slot.
4. Adds a "Label Placement" example. 
Preview: https://ionic-docs-git-fw-2939-ionic1.vercel.app/docs/api/range