### PR TITLE
docs(input, select): add note about migrating

### DIFF
--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -105,8 +105,7 @@ import CSSProps from '@site/static/usage/v7/input/theming/css-properties/index.m
 
 A simpler input syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an input, resolves accessibility issues, and improves the developer experience.
 
-While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
-
+Developers can perform this migration one input at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible..
 
 ### Using the Modern Syntax
 

--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -105,7 +105,7 @@ import CSSProps from '@site/static/usage/v7/input/theming/css-properties/index.m
 
 A simpler input syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an input, resolves accessibility issues, and improves the developer experience.
 
-Developers can perform this migration one input at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible..
+Developers can perform this migration one input at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
 
 ### Using the Modern Syntax
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -183,7 +183,7 @@ interface SelectCustomEvent<T = any> extends CustomEvent {
 
 A simpler select syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an select, resolves accessibility issues, and improves the developer experience.
 
-While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
+Developers can perform this migration one select at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
 
 
 ### Using the Modern Syntax


### PR DESCRIPTION
This PRs clarifies the migration for new form control syntax to state that devs can migrate one by one (i.e. they do not need to do the migration all at once).

Textarea: https://github.com/ionic-team/ionic-docs/pull/2720#discussion_r1092323399
Range: https://github.com/ionic-team/ionic-docs/pull/2742/commits/64c36f981a06fe49997cfa7b9e28d4414bbc45e9
(Checkbox and Radio will have this when the docs are updated)