### PR TITLE
docs(radio): update for new syntax, add migration guide

### DIFF
--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -1,4 +1,3 @@
-test
 ---
 title: "ion-radio"
 ---

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -36,6 +36,19 @@ import LabelPlacement from '@site/static/usage/v7/radio/label-placement/index.md
 
 <LabelPlacement />
 
+## Justification
+
+Developers can use the `justify` property to control how the label and control are packed on a line.
+
+import Justify from '@site/static/usage/v7/radio/justify/index.md';
+
+<Justify />
+
+
+:::note
+`ion-item` is only used in the demos to emphasize how `justify` works. It is not needed in order for `justify` to function correctly.
+:::
+
 ## Deselecting Radios
 
 By default, once a radio is selected it cannot be deselected; pressing it again will keep it selected. This behavior can be modified by using the `allowEmptySelection` property on the parent radio group, which enables the radios to be deselected.

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -78,6 +78,30 @@ import CSSParts from '@site/static/usage/v7/radio/theming/css-shadow-parts/index
 
 <CSSParts />
 
+## Migrating from Legacy Radio Syntax
+
+A simpler radio syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an radio, resolves accessibility issues, and improves the developer experience.
+
+Developers can perform this migration one radio at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
+
+### Using the Modern Syntax
+
+Using the modern syntax involves removing the `ion-label` and passing the label directly inside of `ion-radio`. The placement of the label can be configured using the `labelPlacement` property on `ion-radio`. The way the label and the control are packed on a line can be controlled using the `justify` property on `ion-radio`.
+
+import Migration from '@site/static/usage/v7/radio/migration/index.md';
+
+<Migration />
+  
+
+:::note
+In past versions of Ionic, `ion-item` was required for `ion-radio` to function properly. Starting in Ionic 7.0, `ion-radio` should only be used in an `ion-item` when the item is placed in an `ion-list`. Additionally, `ion-item` is no longer required for `ion-radio` to function properly.
+:::
+
+### Using the Legacy Syntax
+
+Ionic uses heuristics to detect if an app is using the modern radio syntax. In some instances, it may be preferable to continue using the legacy syntax. Developers can set the `legacy` property on `ion-radio` to `true` to force that instance of the radio to use the legacy syntax.
+
+
 
 ## Properties
 <Props />

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -1,3 +1,4 @@
+test
 ---
 title: "ion-radio"
 ---

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -28,6 +28,13 @@ import Basic from '@site/static/usage/v7/radio/basic/index.md';
 
 <Basic />
 
+## Label Placement
+
+Developers can use the `labelPlacement` property to control how the label is placed relative to the control.
+
+import LabelPlacement from '@site/static/usage/v7/radio/label-placement/index.md';
+
+<LabelPlacement />
 
 ## Deselecting Radios
 

--- a/static/usage/v7/radio/basic/angular.md
+++ b/static/usage/v7/radio/basic/angular.md
@@ -1,25 +1,8 @@
 ```html
-<ion-list>
-  <ion-radio-group value="strawberries">
-    <ion-item>
-      <ion-label>Grapes</ion-label>
-      <ion-radio slot="end" value="grapes"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Strawberries</ion-label>
-      <ion-radio slot="end" value="strawberries"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Pineapple</ion-label>
-      <ion-radio slot="end" value="pineapple"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Cherries (Disabled)</ion-label>
-      <ion-radio slot="end" value="cherries" [disabled]="true"></ion-radio>
-    </ion-item>
-  </ion-radio-group>
-</ion-list>
+<ion-radio-group value="strawberries">
+  <ion-radio value="grapes">Grapes</ion-radio><br/>
+  <ion-radio value="strawberries">Strawberries</ion-radio><br />
+  <ion-radio value="pineapple">Pineapple</ion-radio><br />
+  <ion-radio value="cherries">Cherries</ion-radio>
+</ion-radio-group>
 ```

--- a/static/usage/v7/radio/basic/demo.html
+++ b/static/usage/v7/radio/basic/demo.html
@@ -7,8 +7,8 @@
   <title>Radio</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 
   <style>
     ion-list {
@@ -21,29 +21,12 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-list>
-          <ion-radio-group value="strawberries">
-            <ion-item>
-              <ion-label>Grapes</ion-label>
-              <ion-radio slot="end" value="grapes"></ion-radio>
-            </ion-item>
-
-            <ion-item>
-              <ion-label>Strawberries</ion-label>
-              <ion-radio slot="end" value="strawberries"></ion-radio>
-            </ion-item>
-
-            <ion-item>
-              <ion-label>Pineapple</ion-label>
-              <ion-radio slot="end" value="pineapple"></ion-radio>
-            </ion-item>
-
-            <ion-item>
-              <ion-label>Cherries (Disabled)</ion-label>
-              <ion-radio slot="end" value="cherries" disabled="true"></ion-radio>
-            </ion-item>
-          </ion-radio-group>
-        </ion-list>
+        <ion-radio-group value="strawberries">
+          <ion-radio value="grapes">Grapes</ion-radio><br/>
+          <ion-radio value="strawberries">Strawberries</ion-radio><br />
+          <ion-radio value="pineapple">Pineapple</ion-radio><br />
+          <ion-radio value="cherries">Cherries</ion-radio>
+        </ion-radio-group>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/radio/basic/index.md
+++ b/static/usage/v7/radio/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/basic/demo.html" size="250px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/basic/demo.html" />

--- a/static/usage/v7/radio/basic/javascript.md
+++ b/static/usage/v7/radio/basic/javascript.md
@@ -1,25 +1,8 @@
 ```html
-<ion-list>
-  <ion-radio-group value="strawberries">
-    <ion-item>
-      <ion-label>Grapes</ion-label>
-      <ion-radio slot="end" value="grapes"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Strawberries</ion-label>
-      <ion-radio slot="end" value="strawberries"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Pineapple</ion-label>
-      <ion-radio slot="end" value="pineapple"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Cherries (Disabled)</ion-label>
-      <ion-radio slot="end" value="cherries" disabled="true"></ion-radio>
-    </ion-item>
-  </ion-radio-group>
-</ion-list>
+<ion-radio-group value="strawberries">
+  <ion-radio value="grapes">Grapes</ion-radio><br/>
+  <ion-radio value="strawberries">Strawberries</ion-radio><br />
+  <ion-radio value="pineapple">Pineapple</ion-radio><br />
+  <ion-radio value="cherries">Cherries</ion-radio>
+</ion-radio-group>
 ```

--- a/static/usage/v7/radio/basic/react.md
+++ b/static/usage/v7/radio/basic/react.md
@@ -1,32 +1,15 @@
 ```tsx
 import React from 'react';
-import { IonItem, IonLabel, IonList, IonRadio, IonRadioGroup } from '@ionic/react';
+import { IonRadio, IonRadioGroup } from '@ionic/react';
 
 function Example() {
   return (
-    <IonList>
-      <IonRadioGroup value="strawberries">
-        <IonItem>
-          <IonLabel>Grapes</IonLabel>
-          <IonRadio slot="end" value="grapes"></IonRadio>
-        </IonItem>
-
-        <IonItem>
-          <IonLabel>Strawberries</IonLabel>
-          <IonRadio slot="end" value="strawberries"></IonRadio>
-        </IonItem>
-
-        <IonItem>
-          <IonLabel>Pineapple</IonLabel>
-          <IonRadio slot="end" value="pineapple"></IonRadio>
-        </IonItem>
-
-        <IonItem>
-          <IonLabel>Cherries (Disabled)</IonLabel>
-          <IonRadio slot="end" value="cherries" disabled={true}></IonRadio>
-        </IonItem>
-      </IonRadioGroup>
-    </IonList>
+    <IonRadioGroup value="strawberries">
+      <IonRadio value="grapes">Grapes</IonRadio><br/>
+      <IonRadio value="strawberries">Strawberries</IonRadio><br />
+      <IonRadio value="pineapple">Pineapple</IonRadio><br />
+      <IonRadio value="cherries">Cherries</IonRadio>
+    </IonRadioGroup>
   );
 }
 export default Example;

--- a/static/usage/v7/radio/basic/vue.md
+++ b/static/usage/v7/radio/basic/vue.md
@@ -1,36 +1,19 @@
 ```html
 <template>
-  <ion-list>
-    <ion-radio-group value="strawberries">
-      <ion-item>
-        <ion-label>Grapes</ion-label>
-        <ion-radio slot="end" value="grapes"></ion-radio>
-      </ion-item>
-
-      <ion-item>
-        <ion-label>Strawberries</ion-label>
-        <ion-radio slot="end" value="strawberries"></ion-radio>
-      </ion-item>
-
-      <ion-item>
-        <ion-label>Pineapple</ion-label>
-        <ion-radio slot="end" value="pineapple"></ion-radio>
-      </ion-item>
-
-      <ion-item>
-        <ion-label>Cherries (Disabled)</ion-label>
-        <ion-radio slot="end" value="cherries" :disabled="true"></ion-radio>
-      </ion-item>
-    </ion-radio-group>
-  </ion-list>
+  <ion-radio-group value="strawberries">
+    <ion-radio value="grapes">Grapes</ion-radio><br/>
+    <ion-radio value="strawberries">Strawberries</ion-radio><br />
+    <ion-radio value="pineapple">Pineapple</ion-radio><br />
+    <ion-radio value="cherries">Cherries</ion-radio>
+  </ion-radio-group>
 </template>
 
 <script lang="ts">
-  import { IonItem, IonLabel, IonList, IonRadio, IonRadioGroup } from '@ionic/vue';
+  import { IonRadio, IonRadioGroup } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonItem, IonLabel, IonList, IonRadio, IonRadioGroup },
+    components: { IonRadio, IonRadioGroup },
   });
 </script>
 ```

--- a/static/usage/v7/radio/empty-selection/angular.md
+++ b/static/usage/v7/radio/empty-selection/angular.md
@@ -1,25 +1,8 @@
 ```html
-<ion-list>
-  <ion-radio-group [allowEmptySelection]="true" value="turtles">
-    <ion-item>
-      <ion-label>Dogs</ion-label>
-      <ion-radio slot="end" value="dogs"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Cats</ion-label>
-      <ion-radio slot="end" value="cats"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Turtles</ion-label>
-      <ion-radio slot="end" value="turtles"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Fish</ion-label>
-      <ion-radio slot="end" value="fish"></ion-radio>
-    </ion-item>
-  </ion-radio-group>
-</ion-list>
+<ion-radio-group [allowEmptySelection]="true" value="turtles">
+  <ion-radio value="dogs">Dogs</ion-radio><br />
+  <ion-radio value="cats">Cats</ion-radio><br />
+  <ion-radio value="turtles">Turtles</ion-radio><br />
+  <ion-radio value="fish">Fish</ion-radio><br />
+</ion-radio-group>
 ```

--- a/static/usage/v7/radio/empty-selection/demo.html
+++ b/static/usage/v7/radio/empty-selection/demo.html
@@ -7,43 +7,20 @@
   <title>Radio</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
-
-  <style>
-    ion-list {
-      width: 100%;
-    }
-  </style>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 </head>
 
 <body>
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-list>
-          <ion-radio-group allow-empty-selection="true" value="turtles">
-            <ion-item>
-              <ion-label>Dogs</ion-label>
-              <ion-radio slot="end" value="dogs"></ion-radio>
-            </ion-item>
-
-            <ion-item>
-              <ion-label>Cats</ion-label>
-              <ion-radio slot="end" value="cats"></ion-radio>
-            </ion-item>
-
-            <ion-item>
-              <ion-label>Turtles</ion-label>
-              <ion-radio slot="end" value="turtles"></ion-radio>
-            </ion-item>
-
-            <ion-item>
-              <ion-label>Fish</ion-label>
-              <ion-radio slot="end" value="fish"></ion-radio>
-            </ion-item>
-          </ion-radio-group>
-        </ion-list>
+        <ion-radio-group allow-empty-selection="true" value="turtles">
+          <ion-radio value="dogs">Dogs</ion-radio><br />
+          <ion-radio value="cats">Cats</ion-radio><br />
+          <ion-radio value="turtles">Turtles</ion-radio><br />
+          <ion-radio value="fish">Fish</ion-radio><br />
+        </ion-radio-group>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/radio/empty-selection/index.md
+++ b/static/usage/v7/radio/empty-selection/index.md
@@ -9,5 +9,4 @@ import angular from './angular.md';
   version="7"
   code={{ javascript, react, vue, angular }}
   src="usage/v7/radio/empty-selection/demo.html"
-  size="250px"
 />

--- a/static/usage/v7/radio/empty-selection/javascript.md
+++ b/static/usage/v7/radio/empty-selection/javascript.md
@@ -1,25 +1,8 @@
 ```html
-<ion-list>
-  <ion-radio-group allow-empty-selection="true" value="turtles">
-    <ion-item>
-      <ion-label>Dogs</ion-label>
-      <ion-radio slot="end" value="dogs"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Cats</ion-label>
-      <ion-radio slot="end" value="cats"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Turtles</ion-label>
-      <ion-radio slot="end" value="turtles"></ion-radio>
-    </ion-item>
-
-    <ion-item>
-      <ion-label>Fish</ion-label>
-      <ion-radio slot="end" value="fish"></ion-radio>
-    </ion-item>
-  </ion-radio-group>
-</ion-list>
+<ion-radio-group allow-empty-selection="true" value="turtles">
+  <ion-radio value="dogs">Dogs</ion-radio><br />
+  <ion-radio value="cats">Cats</ion-radio><br />
+  <ion-radio value="turtles">Turtles</ion-radio><br />
+  <ion-radio value="fish">Fish</ion-radio><br />
+</ion-radio-group>
 ```

--- a/static/usage/v7/radio/empty-selection/react.md
+++ b/static/usage/v7/radio/empty-selection/react.md
@@ -1,32 +1,15 @@
 ```tsx
 import React from 'react';
-import { IonItem, IonLabel, IonList, IonRadio, IonRadioGroup } from '@ionic/react';
+import { IonRadio, IonRadioGroup } from '@ionic/react';
 
 function Example() {
   return (
-    <IonList>
-      <IonRadioGroup allowEmptySelection={true} value="turtles">
-        <IonItem>
-          <IonLabel>Dogs</IonLabel>
-          <IonRadio slot="end" value="dogs"></IonRadio>
-        </IonItem>
-
-        <IonItem>
-          <IonLabel>Cats</IonLabel>
-          <IonRadio slot="end" value="cats"></IonRadio>
-        </IonItem>
-
-        <IonItem>
-          <IonLabel>Turtles</IonLabel>
-          <IonRadio slot="end" value="turtles"></IonRadio>
-        </IonItem>
-
-        <IonItem>
-          <IonLabel>Fish</IonLabel>
-          <IonRadio slot="end" value="fish"></IonRadio>
-        </IonItem>
-      </IonRadioGroup>
-    </IonList>
+    <IonRadioGroup allowEmptySelection={true} value="turtles">
+      <IonRadio value="dogs">Dogs</IonRadio><br />
+      <IonRadio value="cats">Cats</IonRadio><br />
+      <IonRadio value="turtles">Turtles</IonRadio><br />
+      <IonRadio value="fish">Fish</IonRadio><br />
+    </IonRadioGroup>
   );
 }
 export default Example;

--- a/static/usage/v7/radio/empty-selection/vue.md
+++ b/static/usage/v7/radio/empty-selection/vue.md
@@ -1,36 +1,19 @@
 ```html
 <template>
-  <ion-list>
-    <ion-radio-group :allow-empty-selection="true" value="turtles">
-      <ion-item>
-        <ion-label>Dogs</ion-label>
-        <ion-radio slot="end" value="dogs"></ion-radio>
-      </ion-item>
-
-      <ion-item>
-        <ion-label>Cats</ion-label>
-        <ion-radio slot="end" value="cats"></ion-radio>
-      </ion-item>
-
-      <ion-item>
-        <ion-label>Turtles</ion-label>
-        <ion-radio slot="end" value="turtles"></ion-radio>
-      </ion-item>
-
-      <ion-item>
-        <ion-label>Fish</ion-label>
-        <ion-radio slot="end" value="fish"></ion-radio>
-      </ion-item>
-    </ion-radio-group>
-  </ion-list>
+  <ion-radio-group allow-empty-selection="true" value="turtles">
+    <ion-radio value="dogs">Dogs</ion-radio><br />
+    <ion-radio value="cats">Cats</ion-radio><br />
+    <ion-radio value="turtles">Turtles</ion-radio><br />
+    <ion-radio value="fish">Fish</ion-radio><br />
+  </ion-radio-group>
 </template>
 
 <script lang="ts">
-  import { IonItem, IonLabel, IonList, IonRadio, IonRadioGroup } from '@ionic/vue';
+  import { IonRadio, IonRadioGroup } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonItem, IonLabel, IonList, IonRadio, IonRadioGroup },
+    components: { IonRadio, IonRadioGroup },
   });
 </script>
 ```

--- a/static/usage/v7/radio/justify/angular.md
+++ b/static/usage/v7/radio/justify/angular.md
@@ -1,0 +1,21 @@
+```html
+<ion-list>
+  <ion-radio-group value="start">
+    <ion-item>
+      <ion-radio value="start" justify="start">Packed at the Start of Line</ion-radio>
+    </ion-item>
+  </ion-radio-group>
+
+  <ion-radio-group value="end">
+    <ion-item>
+      <ion-radio value="end" justify="end">Packed at the End of Line</ion-radio>
+    </ion-item>
+  </ion-radio-group>
+
+  <ion-radio-group value="space-between">
+    <ion-item>
+      <ion-radio value="space-between" justify="space-between">Space Between Label and Control</ion-radio>
+    </ion-item>
+  </ion-radio-group>
+</ion-list>
+```

--- a/static/usage/v7/radio/justify/demo.html
+++ b/static/usage/v7/radio/justify/demo.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Radio</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
+
+  <style>
+    ion-list {
+      width: 100%;
+    }
+  </style>
+</head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-radio-group value="start">
+              <ion-item>
+                <ion-radio value="start" justify="start">Packed at the Start of Line</ion-radio>
+              </ion-item>
+            </ion-radio-group>
+
+            <ion-radio-group value="end">
+              <ion-item>
+                <ion-radio value="end" justify="end">Packed at the End of Line</ion-radio>
+              </ion-item>
+            </ion-radio-group>
+
+            <ion-radio-group value="space-between">
+              <ion-item>
+                <ion-radio value="space-between" justify="space-between">Space Between Label and Control</ion-radio>
+              </ion-item>
+            </ion-radio-group>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/radio/justify/index.md
+++ b/static/usage/v7/radio/justify/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/justify/demo.html" />

--- a/static/usage/v7/radio/justify/javascript.md
+++ b/static/usage/v7/radio/justify/javascript.md
@@ -1,0 +1,21 @@
+```html
+<ion-list>
+  <ion-radio-group value="start">
+    <ion-item>
+      <ion-radio value="start" justify="start">Packed at the Start of Line</ion-radio>
+    </ion-item>
+  </ion-radio-group>
+
+  <ion-radio-group value="end">
+    <ion-item>
+      <ion-radio value="end" justify="end">Packed at the End of Line</ion-radio>
+    </ion-item>
+  </ion-radio-group>
+
+  <ion-radio-group value="space-between">
+    <ion-item>
+      <ion-radio value="space-between" justify="space-between">Space Between Label and Control</ion-radio>
+    </ion-item>
+  </ion-radio-group>
+</ion-list>
+```

--- a/static/usage/v7/radio/justify/react.md
+++ b/static/usage/v7/radio/justify/react.md
@@ -1,0 +1,29 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonRadioGroup value="start">
+        <IonItem>
+          <IonRadio value="start" justify="start">Packed at the Start of Line</IonRadio>
+        </IonItem>
+      </IonRadioGroup>
+    
+      <IonRadioGroup value="end">
+        <IonItem>
+          <IonRadio value="end" justify="end">Packed at the End of Line</IonRadio>
+        </IonItem>
+      </IonRadioGroup>
+    
+      <IonRadioGroup value="space-between">
+        <IonItem>
+          <IonRadio value="space-between" justify="space-between">Space Between Label and Control</IonRadio>
+        </IonItem>
+      </IonRadioGroup>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/radio/justify/vue.md
+++ b/static/usage/v7/radio/justify/vue.md
@@ -1,0 +1,32 @@
+```html
+<template>
+  <ion-list>
+    <ion-radio-group value="start">
+      <ion-item>
+        <ion-radio value="start" justify="start">Packed at the Start of Line</ion-radio>
+      </ion-item>
+    </ion-radio-group>
+  
+    <ion-radio-group value="end">
+      <ion-item>
+        <ion-radio value="end" justify="end">Packed at the End of Line</ion-radio>
+      </ion-item>
+    </ion-radio-group>
+  
+    <ion-radio-group value="space-between">
+      <ion-item>
+        <ion-radio value="space-between" justify="space-between">Space Between Label and Control</ion-radio>
+      </ion-item>
+    </ion-radio-group>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonRadio, IonRadioGroup },
+  });
+</script>
+```

--- a/static/usage/v7/radio/label-placement/angular.md
+++ b/static/usage/v7/radio/label-placement/angular.md
@@ -1,0 +1,17 @@
+```html
+<ion-radio-group value="start">
+  <ion-radio value="start" labelPlacement="start">Label at the Start</ion-radio>
+</ion-radio-group>
+
+<br />
+
+<ion-radio-group value="end">
+  <ion-radio value="end" labelPlacement="end">Label at the End</ion-radio>
+</ion-radio-group>
+
+<br />
+
+<ion-radio-group value="fixed">
+  <ion-radio value="fixed" labelPlacement="fixed">Fixed Width Label</ion-radio>
+</ion-radio-group>
+```

--- a/static/usage/v7/radio/label-placement/demo.html
+++ b/static/usage/v7/radio/label-placement/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Radio</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div>
+          <ion-radio-group value="start">
+            <ion-radio value="start" label-placement="start">Label at the Start</ion-radio>
+          </ion-radio-group>
+
+          <br />
+
+          <ion-radio-group value="end">
+            <ion-radio value="end" label-placement="end">Label at the End</ion-radio>
+          </ion-radio-group>
+
+          <br />
+
+          <ion-radio-group value="fixed">
+            <ion-radio value="fixed" label-placement="fixed">Fixed Width Label</ion-radio>
+          </ion-radio-group>
+        </div>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v7/radio/label-placement/index.md
+++ b/static/usage/v7/radio/label-placement/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/label-placement/demo.html" />

--- a/static/usage/v7/radio/label-placement/javascript.md
+++ b/static/usage/v7/radio/label-placement/javascript.md
@@ -1,0 +1,17 @@
+```html
+<ion-radio-group value="start">
+  <ion-radio value="start" label-placement="start">Label at the Start</ion-radio>
+</ion-radio-group>
+
+<br />
+
+<ion-radio-group value="end">
+  <ion-radio value="end" label-placement="end">Label at the End</ion-radio>
+</ion-radio-group>
+
+<br />
+
+<ion-radio-group value="fixed">
+  <ion-radio value="fixed" label-placement="fixed">Fixed Width Label</ion-radio>
+</ion-radio-group>
+```

--- a/static/usage/v7/radio/label-placement/react.md
+++ b/static/usage/v7/radio/label-placement/react.md
@@ -1,0 +1,27 @@
+```tsx
+import React from 'react';
+import { IonRadio, IonRadioGroup } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonRadioGroup value="start">
+        <IonRadio value="start" labelPlacement="start">Label at the Start</IonRadio>
+      </IonRadioGroup>
+      
+      <br />
+      
+      <IonRadioGroup value="end">
+        <IonRadio value="end" labelPlacement="end">Label at the End</IonRadio>
+      </IonRadioGroup>
+      
+      <br />
+      
+      <IonRadioGroup value="fixed">
+        <IonRadio value="fixed" labelPlacement="fixed">Fixed Width Label</IonRadio>
+      </IonRadioGroup>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/radio/label-placement/vue.md
+++ b/static/usage/v7/radio/label-placement/vue.md
@@ -1,0 +1,28 @@
+```html
+<template>
+  <ion-radio-group value="start">
+    <ion-radio value="start" label-placement="start">Label at the Start</ion-radio>
+  </ion-radio-group>
+  
+  <br />
+  
+  <ion-radio-group value="end">
+    <ion-radio value="end" label-placement="end">Label at the End</ion-radio>
+  </ion-radio-group>
+  
+  <br />
+  
+  <ion-radio-group value="fixed">
+    <ion-radio value="fixed" label-placement="fixed">Fixed Width Label</ion-radio>
+  </ion-radio-group>
+</template>
+
+<script lang="ts">
+  import { IonRadio, IonRadioGroup } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonRadio, IonRadioGroup },
+  });
+</script>
+```

--- a/static/usage/v7/radio/migration/index.md
+++ b/static/usage/v7/radio/migration/index.md
@@ -94,7 +94,7 @@ import TabItem from '@theme/TabItem';
 
 <!-- After -->
 <ion-item>
-  <ion-radio label-placement="end">Radio Label</ion-radio>
+  <ion-radio labelPlacement="end">Radio Label</ion-radio>
 </ion-item>
 ```
 </TabItem>

--- a/static/usage/v7/radio/migration/index.md
+++ b/static/usage/v7/radio/migration/index.md
@@ -1,0 +1,188 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+````mdx-code-block
+<Tabs
+  groupId="framework"
+  defaultValue="javascript"
+  values={[
+    { value: 'javascript', label: 'JavaScript' },
+    { value: 'angular', label: 'Angular' },
+    { value: 'react', label: 'React' },
+    { value: 'vue', label: 'Vue' },
+  ]
+}>
+<TabItem value="javascript">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio>Radio Label</ion-radio>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio label-placement="fixed">Radio Label</ion-radio>
+</ion-item>
+
+<!-- Radio at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio label-placement="end">Radio Label</ion-radio>
+</ion-item>
+```
+</TabItem>
+<TabItem value="angular">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio>Radio Label</ion-radio>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio label-placement="fixed">Radio Label</ion-radio>
+</ion-item>
+
+<!-- Radio at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio label-placement="end">Radio Label</ion-radio>
+</ion-item>
+```
+</TabItem>
+<TabItem value="react">
+
+```tsx
+{/* Basic */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel>Radio Label</IonLabel>
+  <IonRadio></IonRadio>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonRadio>Radio Label</IonRadio>
+</IonItem>
+
+{/* Fixed Labels */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel position="fixed">Radio Label</IonLabel>
+  <IonRadio></IonRadio>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonRadio labelPlacement="fixed">Radio Label</IonRadio>
+</IonItem>
+
+{/* Radio at the start of line, Label at the end of line */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel slot="end">Radio Label</IonLabel>
+  <IonRadio></IonRadio>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonRadio labelPlacement="end">Radio Label</IonRadio>
+</IonItem>
+```
+</TabItem>
+<TabItem value="vue">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio>Radio Label</ion-radio>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio label-placement="fixed">Radio Label</ion-radio>
+</ion-item>
+
+<!-- Radio at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Radio Label</ion-label>
+  <ion-radio></ion-radio>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-radio label-placement="end">Radio Label</ion-radio>
+</ion-item>
+```
+</TabItem>
+</Tabs>
+````

--- a/static/usage/v7/radio/migration/index.md
+++ b/static/usage/v7/radio/migration/index.md
@@ -81,7 +81,7 @@ import TabItem from '@theme/TabItem';
 
 <!-- After -->
 <ion-item>
-  <ion-radio label-placement="fixed">Radio Label</ion-radio>
+  <ion-radio labelPlacement="fixed">Radio Label</ion-radio>
 </ion-item>
 
 <!-- Radio at the start of line, Label at the end of line -->

--- a/static/usage/v7/radio/theming/colors/angular.md
+++ b/static/usage/v7/radio/theming/colors/angular.md
@@ -1,29 +1,29 @@
 ```html
 <ion-radio-group value="primary">
-  <ion-radio color="primary" value="primary"></ion-radio>
+  <ion-radio aria-label="Primary" color="primary" value="primary"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="secondary">
-  <ion-radio color="secondary" value="secondary"></ion-radio>
+  <ion-radio aria-label="Secondary" color="secondary" value="secondary"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="tertiary">
-  <ion-radio color="tertiary" value="tertiary"></ion-radio>
+  <ion-radio aria-label="Tertiary" color="tertiary" value="tertiary"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="success">
-  <ion-radio color="success" value="success"></ion-radio>
+  <ion-radio aria-label="Success" color="success" value="success"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="warning">
-  <ion-radio color="warning" value="warning"></ion-radio>
+  <ion-radio aria-label="Warning" color="warning" value="warning"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="danger">
-  <ion-radio color="danger" value="danger"></ion-radio>
+  <ion-radio aria-label="Danger" color="danger" value="danger"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="light">
-  <ion-radio color="light" value="light"></ion-radio>
+  <ion-radio aria-label="Light" color="light" value="light"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="medium">
-  <ion-radio color="medium" value="medium"></ion-radio>
+  <ion-radio aria-label="Medium" color="medium" value="medium"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="dark">
-  <ion-radio color="dark" value="dark"></ion-radio>
+  <ion-radio aria-label="Dark" color="dark" value="dark"></ion-radio>
 </ion-radio-group>
 ```

--- a/static/usage/v7/radio/theming/colors/demo.html
+++ b/static/usage/v7/radio/theming/colors/demo.html
@@ -7,12 +7,8 @@
   <title>Radio</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
-
-  <style>
-
-  </style>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 </head>
 
 <body>
@@ -20,31 +16,31 @@
     <ion-content>
       <div class="container">
         <ion-radio-group value="primary">
-          <ion-radio color="primary" value="primary"></ion-radio>
+          <ion-radio aria-label="Primary" color="primary" value="primary"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="secondary">
-          <ion-radio color="secondary" value="secondary"></ion-radio>
+          <ion-radio aria-label="Secondary" color="secondary" value="secondary"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="tertiary">
-          <ion-radio color="tertiary" value="tertiary"></ion-radio>
+          <ion-radio aria-label="Tertiary" color="tertiary" value="tertiary"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="success">
-          <ion-radio color="success" value="success"></ion-radio>
+          <ion-radio aria-label="Success" color="success" value="success"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="warning">
-          <ion-radio color="warning" value="warning"></ion-radio>
+          <ion-radio aria-label="Warning" color="warning" value="warning"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="danger">
-          <ion-radio color="danger" value="danger"></ion-radio>
+          <ion-radio aria-label="Danger" color="danger" value="danger"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="light">
-          <ion-radio color="light" value="light"></ion-radio>
+          <ion-radio aria-label="Light" color="light" value="light"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="medium">
-          <ion-radio color="medium" value="medium"></ion-radio>
+          <ion-radio aria-label="Medium" color="medium" value="medium"></ion-radio>
         </ion-radio-group>
         <ion-radio-group value="dark">
-          <ion-radio color="dark" value="dark"></ion-radio>
+          <ion-radio aria-label="Dark" color="dark" value="dark"></ion-radio>
         </ion-radio-group>
       </div>
     </ion-content>

--- a/static/usage/v7/radio/theming/colors/javascript.md
+++ b/static/usage/v7/radio/theming/colors/javascript.md
@@ -1,29 +1,29 @@
 ```html
 <ion-radio-group value="primary">
-  <ion-radio color="primary" value="primary"></ion-radio>
+  <ion-radio aria-label="Primary" color="primary" value="primary"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="secondary">
-  <ion-radio color="secondary" value="secondary"></ion-radio>
+  <ion-radio aria-label="Secondary" color="secondary" value="secondary"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="tertiary">
-  <ion-radio color="tertiary" value="tertiary"></ion-radio>
+  <ion-radio aria-label="Tertiary" color="tertiary" value="tertiary"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="success">
-  <ion-radio color="success" value="success"></ion-radio>
+  <ion-radio aria-label="Success" color="success" value="success"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="warning">
-  <ion-radio color="warning" value="warning"></ion-radio>
+  <ion-radio aria-label="Warning" color="warning" value="warning"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="danger">
-  <ion-radio color="danger" value="danger"></ion-radio>
+  <ion-radio aria-label="Danger" color="danger" value="danger"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="light">
-  <ion-radio color="light" value="light"></ion-radio>
+  <ion-radio aria-label="Light" color="light" value="light"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="medium">
-  <ion-radio color="medium" value="medium"></ion-radio>
+  <ion-radio aria-label="Medium" color="medium" value="medium"></ion-radio>
 </ion-radio-group>
 <ion-radio-group value="dark">
-  <ion-radio color="dark" value="dark"></ion-radio>
+  <ion-radio aria-label="Dark" color="dark" value="dark"></ion-radio>
 </ion-radio-group>
 ```

--- a/static/usage/v7/radio/theming/colors/react.md
+++ b/static/usage/v7/radio/theming/colors/react.md
@@ -6,31 +6,31 @@ function Example() {
   return (
     <>
       <IonRadioGroup value="primary">
-        <IonRadio color="primary" value="primary"></IonRadio>
+        <IonRadio aria-label="Primary" color="primary" value="primary"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="secondary">
-        <IonRadio color="secondary" value="secondary"></IonRadio>
+        <IonRadio aria-label="Secondary" color="secondary" value="secondary"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="tertiary">
-        <IonRadio color="tertiary" value="tertiary"></IonRadio>
+        <IonRadio aria-label="Tertiary" color="tertiary" value="tertiary"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="success">
-        <IonRadio color="success" value="success"></IonRadio>
+        <IonRadio aria-label="Success" color="success" value="success"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="warning">
-        <IonRadio color="warning" value="warning"></IonRadio>
+        <IonRadio aria-label="Warning" color="warning" value="warning"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="danger">
-        <IonRadio color="danger" value="danger"></IonRadio>
+        <IonRadio aria-label="Danger" color="danger" value="danger"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="light">
-        <IonRadio color="light" value="light"></IonRadio>
+        <IonRadio aria-label="Light" color="light" value="light"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="medium">
-        <IonRadio color="medium" value="medium"></IonRadio>
+        <IonRadio aria-label="Medium" color="medium" value="medium"></IonRadio>
       </IonRadioGroup>
       <IonRadioGroup value="dark">
-        <IonRadio color="dark" value="dark"></IonRadio>
+        <IonRadio aria-label="Dark" color="dark" value="dark"></IonRadio>
       </IonRadioGroup>
     </>
   );

--- a/static/usage/v7/radio/theming/colors/vue.md
+++ b/static/usage/v7/radio/theming/colors/vue.md
@@ -1,31 +1,31 @@
 ```html
 <template>
   <ion-radio-group value="primary">
-    <ion-radio color="primary" value="primary"></ion-radio>
+    <ion-radio aria-label="Primary" color="primary" value="primary"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="secondary">
-    <ion-radio color="secondary" value="secondary"></ion-radio>
+    <ion-radio aria-label="Secondary" color="secondary" value="secondary"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="tertiary">
-    <ion-radio color="tertiary" value="tertiary"></ion-radio>
+    <ion-radio aria-label="Tertiary" color="tertiary" value="tertiary"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="success">
-    <ion-radio color="success" value="success"></ion-radio>
+    <ion-radio aria-label="Success" color="success" value="success"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="warning">
-    <ion-radio color="warning" value="warning"></ion-radio>
+    <ion-radio aria-label="Warning" color="warning" value="warning"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="danger">
-    <ion-radio color="danger" value="danger"></ion-radio>
+    <ion-radio aria-label="Danger" color="danger" value="danger"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="light">
-    <ion-radio color="light" value="light"></ion-radio>
+    <ion-radio aria-label="Light" color="light" value="light"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="medium">
-    <ion-radio color="medium" value="medium"></ion-radio>
+    <ion-radio aria-label="Medium" color="medium" value="medium"></ion-radio>
   </ion-radio-group>
   <ion-radio-group value="dark">
-    <ion-radio color="dark" value="dark"></ion-radio>
+    <ion-radio aria-label="Dark" color="dark" value="dark"></ion-radio>
   </ion-radio-group>
 </template>
 

--- a/static/usage/v7/radio/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/v7/radio/theming/css-properties/angular/example_component_css.md
@@ -7,7 +7,7 @@ ion-radio {
   --color-checked: #6815ec;
 }
 
-ion-radio.ios {
+ion-radio.ios::part(container) {
   width: 20px;
   height: 20px;
 
@@ -15,7 +15,7 @@ ion-radio.ios {
   border-radius: 4px;
 }
 
-.radio-checked.ios {
+.radio-checked.ios::part(container) {
   border-color: #6815ec;
 }
 ```

--- a/static/usage/v7/radio/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/v7/radio/theming/css-properties/angular/example_component_html.md
@@ -1,6 +1,6 @@
 ```html
 <ion-radio-group value="custom-checked">
-  <ion-radio value="custom"></ion-radio>
-  <ion-radio value="custom-checked"></ion-radio>
+  <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+  <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
 </ion-radio-group>
 ```

--- a/static/usage/v7/radio/theming/css-properties/demo.html
+++ b/static/usage/v7/radio/theming/css-properties/demo.html
@@ -7,8 +7,8 @@
   <title>Radio</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 
   <style>
     ion-radio {
@@ -19,7 +19,7 @@
       --color-checked: #6815ec;
     }
 
-    ion-radio.ios {
+    ion-radio.ios::part(container) {
       width: 20px;
       height: 20px;
 
@@ -27,7 +27,7 @@
       border-radius: 4px;
     }
 
-    .radio-checked.ios {
+    .radio-checked.ios::part(container) {
       border-color: #6815ec;
     }
   </style>
@@ -38,8 +38,8 @@
     <ion-content>
       <div class="container">
         <ion-radio-group value="custom-checked">
-          <ion-radio value="custom"></ion-radio>
-          <ion-radio value="custom-checked"></ion-radio>
+          <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+          <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
         </ion-radio-group>
       </div>
     </ion-content>

--- a/static/usage/v7/radio/theming/css-properties/javascript.md
+++ b/static/usage/v7/radio/theming/css-properties/javascript.md
@@ -1,27 +1,27 @@
 ```html
 <ion-radio-group value="custom-checked">
-  <ion-radio value="custom"></ion-radio>
-  <ion-radio value="custom-checked"></ion-radio>
+  <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+  <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
 </ion-radio-group>
 
 <style>
   ion-radio {
     --border-radius: 4px;
     --inner-border-radius: 4px;
-
+  
     --color: #ddd;
     --color-checked: #6815ec;
   }
-
-  ion-radio.ios {
+  
+  ion-radio.ios::part(container) {
     width: 20px;
     height: 20px;
-
+  
     border: 2px solid #ddd;
     border-radius: 4px;
   }
-
-  .radio-checked.ios {
+  
+  .radio-checked.ios::part(container) {
     border-color: #6815ec;
   }
 </style>

--- a/static/usage/v7/radio/theming/css-properties/react/main_css.md
+++ b/static/usage/v7/radio/theming/css-properties/react/main_css.md
@@ -7,7 +7,7 @@ ion-radio {
   --color-checked: #6815ec;
 }
 
-ion-radio.ios {
+ion-radio.ios::part(container) {
   width: 20px;
   height: 20px;
 
@@ -15,7 +15,7 @@ ion-radio.ios {
   border-radius: 4px;
 }
 
-.radio-checked.ios {
+.radio-checked.ios::part(container) {
   border-color: #6815ec;
 }
 ```

--- a/static/usage/v7/radio/theming/css-properties/react/main_tsx.md
+++ b/static/usage/v7/radio/theming/css-properties/react/main_tsx.md
@@ -7,8 +7,8 @@ import './main.css';
 function Example() {
   return (
     <IonRadioGroup value="custom-checked">
-      <IonRadio value="custom"></IonRadio>
-      <IonRadio value="custom-checked"></IonRadio>
+      <IonRadio value="custom" aria-label="Custom checkbox"></IonRadio>
+      <IonRadio value="custom-checked" aria-label="Custom checkbox that is checked"></IonRadio>
     </IonRadioGroup>
   );
 }

--- a/static/usage/v7/radio/theming/css-properties/vue.md
+++ b/static/usage/v7/radio/theming/css-properties/vue.md
@@ -1,8 +1,8 @@
 ```html
 <template>
   <ion-radio-group value="custom-checked">
-    <ion-radio value="custom"></ion-radio>
-    <ion-radio value="custom-checked"></ion-radio>
+    <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+    <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
   </ion-radio-group>
 </template>
 
@@ -19,20 +19,20 @@
   ion-radio {
     --border-radius: 4px;
     --inner-border-radius: 4px;
-
+  
     --color: #ddd;
     --color-checked: #6815ec;
   }
-
-  ion-radio.ios {
+  
+  ion-radio.ios::part(container) {
     width: 20px;
     height: 20px;
-
+  
     border: 2px solid #ddd;
     border-radius: 4px;
   }
-
-  .radio-checked.ios {
+  
+  .radio-checked.ios::part(container) {
     border-color: #6815ec;
   }
 </style>

--- a/static/usage/v7/radio/theming/css-shadow-parts/angular/example_component_css.md
+++ b/static/usage/v7/radio/theming/css-shadow-parts/angular/example_component_css.md
@@ -1,10 +1,8 @@
 ```css
-ion-radio {
+ion-radio::part(container) {
   width: 30px;
   height: 30px;
-}
-
-ion-radio::part(container) {
+  
   border-radius: 8px;
   border: 2px solid #ddd;
 }

--- a/static/usage/v7/radio/theming/css-shadow-parts/angular/example_component_html.md
+++ b/static/usage/v7/radio/theming/css-shadow-parts/angular/example_component_html.md
@@ -1,6 +1,6 @@
 ```html
 <ion-radio-group value="custom-checked">
-  <ion-radio value="custom"></ion-radio>
-  <ion-radio value="custom-checked"></ion-radio>
+  <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+  <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
 </ion-radio-group>
 ```

--- a/static/usage/v7/radio/theming/css-shadow-parts/demo.html
+++ b/static/usage/v7/radio/theming/css-shadow-parts/demo.html
@@ -7,16 +7,14 @@
   <title>Radio</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
 
   <style>
-    ion-radio {
+    ion-radio::part(container) {
       width: 30px;
       height: 30px;
-    }
 
-    ion-radio::part(container) {
       border-radius: 8px;
       border: 2px solid #ddd;
     }
@@ -51,8 +49,8 @@
     <ion-content>
       <div class="container">
         <ion-radio-group value="custom-checked">
-          <ion-radio value="custom"></ion-radio>
-          <ion-radio value="custom-checked"></ion-radio>
+          <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+          <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
         </ion-radio-group>
       </div>
     </ion-content>

--- a/static/usage/v7/radio/theming/css-shadow-parts/javascript.md
+++ b/static/usage/v7/radio/theming/css-shadow-parts/javascript.md
@@ -1,16 +1,14 @@
 ```html
 <ion-radio-group value="custom-checked">
-  <ion-radio value="custom"></ion-radio>
-  <ion-radio value="custom-checked"></ion-radio>
+  <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+  <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
 </ion-radio-group>
 
 <style>
-  ion-radio {
+  ion-radio::part(container) {
     width: 30px;
     height: 30px;
-  }
-
-  ion-radio::part(container) {
+    
     border-radius: 8px;
     border: 2px solid #ddd;
   }

--- a/static/usage/v7/radio/theming/css-shadow-parts/react/main_css.md
+++ b/static/usage/v7/radio/theming/css-shadow-parts/react/main_css.md
@@ -1,10 +1,8 @@
 ```css
-ion-radio {
+ion-radio::part(container) {
   width: 30px;
   height: 30px;
-}
-
-ion-radio::part(container) {
+  
   border-radius: 8px;
   border: 2px solid #ddd;
 }

--- a/static/usage/v7/radio/theming/css-shadow-parts/react/main_tsx.md
+++ b/static/usage/v7/radio/theming/css-shadow-parts/react/main_tsx.md
@@ -7,8 +7,8 @@ import './main.css';
 function Example() {
   return (
     <IonRadioGroup value="custom-checked">
-      <IonRadio value="custom"></IonRadio>
-      <IonRadio value="custom-checked"></IonRadio>
+      <IonRadio value="custom" aria-label="Custom checkbox"></IonRadio>
+      <IonRadio value="custom-checked" aria-label="Custom checkbox that is checked"></IonRadio>
     </IonRadioGroup>
   );
 }

--- a/static/usage/v7/radio/theming/css-shadow-parts/vue.md
+++ b/static/usage/v7/radio/theming/css-shadow-parts/vue.md
@@ -1,8 +1,8 @@
 ```html
 <template>
   <ion-radio-group value="custom-checked">
-    <ion-radio value="custom"></ion-radio>
-    <ion-radio value="custom-checked"></ion-radio>
+    <ion-radio value="custom" aria-label="Custom checkbox"></ion-radio>
+    <ion-radio value="custom-checked" aria-label="Custom checkbox that is checked"></ion-radio>
   </ion-radio-group>
 </template>
 
@@ -16,12 +16,10 @@
 </script>
 
 <style scoped>
-  ion-radio {
+  ion-radio::part(container) {
     width: 30px;
     height: 30px;
-  }
 
-  ion-radio::part(container) {
     border-radius: 8px;
     border: 2px solid #ddd;
   }


### PR DESCRIPTION
This PR makes the following changes:

1. Updates existing playgrounds to v7 and uses the new radio syntax.
2. Adds a migration guide for moving to the new syntax.
3. Adds "Label Placement" and "Justification" playgrounds.

