### PR TITLE
docs(checkbox): update for new syntax, add migration guide

### DIFF
--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -84,7 +84,28 @@ interface CheckboxCustomEvent<T = any> extends CustomEvent {
 }
 ```
 
+## Migrating from Legacy Checkbox Syntax
 
+A simpler checkbox syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an checkbox, resolves accessibility issues, and improves the developer experience.
+
+Developers can perform this migration one checkbox at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
+
+### Using the Modern Syntax
+
+Using the modern syntax involves removing the `ion-label` and passing the label directly inside of `ion-checkbox`. The placement of the label can be configured using the `labelPlacement` property on `ion-checkbox`. The way the label and the control are packed on a line can be controlled using the `justify` property on `ion-checkbox`.
+
+import Migration from '@site/static/usage/v7/checkbox/migration/index.md';
+
+<Migration />
+  
+
+:::note
+In past versions of Ionic, `ion-item` was required for `ion-checkbox` to function properly. Starting in Ionic 7.0, `ion-checkbox` should only be used in an `ion-item` when the item is placed in an `ion-list`. Additionally, `ion-item` is no longer required for `ion-checkbox` to function properly.
+:::
+
+### Using the Legacy Syntax
+
+Ionic uses heuristics to detect if an app is using the modern checkbox syntax. In some instances, it may be preferable to continue using the legacy syntax. Developers can set the `legacy` property on `ion-checkbox` to `true` to force that instance of the checkbox to use the legacy syntax.
 
 
 ## Properties

--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -86,7 +86,7 @@ interface CheckboxCustomEvent<T = any> extends CustomEvent {
 
 ## Migrating from Legacy Checkbox Syntax
 
-A simpler checkbox syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an checkbox, resolves accessibility issues, and improves the developer experience.
+A simpler checkbox syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup a checkbox, resolves accessibility issues, and improves the developer experience.
 
 Developers can perform this migration one checkbox at a time. While developers can continue using the legacy syntax, we recommend migrating as soon as possible.
 

--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -35,6 +35,19 @@ import LabelPlacement from '@site/static/usage/v7/checkbox/label-placement/index
 
 <LabelPlacement />
 
+## Justification
+
+Developers can use the `justify` property to control how the label and control are packed on a line.
+
+import Justify from '@site/static/usage/v7/checkbox/justify/index.md';
+
+<Justify />
+
+
+:::note
+`ion-item` is only used in the demos to emphasize how `justify` works. It is not needed in order for `justify` to function correctly.
+:::
+
 ## Indeterminate Checkboxes
 
 import Indeterminate from '@site/static/usage/v7/checkbox/indeterminate/index.md';

--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -27,6 +27,14 @@ import Basic from '@site/static/usage/v7/checkbox/basic/index.md';
 
 <Basic />
 
+## Label Placement
+
+Developers can use the `labelPlacement` property to control how the label is placed relative to the control.
+
+import LabelPlacement from '@site/static/usage/v7/checkbox/label-placement/index.md';
+
+<LabelPlacement />
+
 ## Indeterminate Checkboxes
 
 import Indeterminate from '@site/static/usage/v7/checkbox/indeterminate/index.md';

--- a/static/usage/v7/checkbox/basic/angular.md
+++ b/static/usage/v7/checkbox/basic/angular.md
@@ -1,6 +1,3 @@
 ```html
-<ion-item>
-  <ion-checkbox slot="start"></ion-checkbox>
-  <ion-label>I agree to the terms and conditions</ion-label>
-</ion-item>
+<ion-checkbox>I agree to the terms and conditions</ion-checkbox>
 ```

--- a/static/usage/v7/checkbox/basic/demo.html
+++ b/static/usage/v7/checkbox/basic/demo.html
@@ -7,18 +7,15 @@
   <title>Checkbox</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/css/ionic.bundle.css" />
 </head>
 
 <body>
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-item>
-          <ion-checkbox slot="start"></ion-checkbox>
-          <ion-label>I agree to the terms and conditions</ion-label>
-        </ion-item>
+        <ion-checkbox>I agree to the terms and conditions</ion-checkbox>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/checkbox/basic/javascript.md
+++ b/static/usage/v7/checkbox/basic/javascript.md
@@ -1,6 +1,3 @@
 ```html
-<ion-item>
-  <ion-checkbox slot="start"></ion-checkbox>
-  <ion-label>I agree to the terms and conditions</ion-label>
-</ion-item>
+<ion-checkbox>I agree to the terms and conditions</ion-checkbox>
 ```

--- a/static/usage/v7/checkbox/basic/react.md
+++ b/static/usage/v7/checkbox/basic/react.md
@@ -1,8 +1,6 @@
 ```tsx
 import React from 'react';
-import {
-  IonCheckbox,
-} from '@ionic/react';
+import { IonCheckbox } from '@ionic/react';
 
 function Example() {
   return (

--- a/static/usage/v7/checkbox/basic/react.md
+++ b/static/usage/v7/checkbox/basic/react.md
@@ -2,16 +2,11 @@
 import React from 'react';
 import {
   IonCheckbox,
-  IonItem,
-  IonLabel
 } from '@ionic/react';
 
 function Example() {
   return (
-    <IonItem>
-      <IonCheckbox slot="start"></IonCheckbox>
-      <IonLabel>I agree to the terms and conditions</IonLabel>
-    </IonItem>
+    <IonCheckbox>I agree to the terms and conditions</IonCheckbox>
   );
 }
 export default Example;

--- a/static/usage/v7/checkbox/basic/vue.md
+++ b/static/usage/v7/checkbox/basic/vue.md
@@ -4,17 +4,11 @@
 </template>
 
 <script lang="ts">
-  import {
-    IonCheckbox,
-    IonItem,
-    IonLabel
-  } from '@ionic/vue';
+  import { IonCheckbox } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: {
-      IonCheckbox
-    }
+    components: { IonCheckbox }
   });
 </script>
 ```

--- a/static/usage/v7/checkbox/basic/vue.md
+++ b/static/usage/v7/checkbox/basic/vue.md
@@ -1,9 +1,6 @@
 ```html
 <template>
-  <ion-item>
-    <ion-checkbox slot="start"></ion-checkbox>
-    <ion-label>I agree to the terms and conditions</ion-label>
-  </ion-item>
+  <ion-checkbox>I agree to the terms and conditions</ion-checkbox>
 </template>
 
 <script lang="ts">
@@ -16,9 +13,7 @@
 
   export default defineComponent({
     components: {
-      IonCheckbox,
-      IonItem,
-      IonLabel
+      IonCheckbox
     }
   });
 </script>

--- a/static/usage/v7/checkbox/indeterminate/angular.md
+++ b/static/usage/v7/checkbox/indeterminate/angular.md
@@ -1,6 +1,3 @@
 ```html
-<ion-item>
-  <ion-checkbox slot="start" [indeterminate]="true"></ion-checkbox>
-  <ion-label>Indeterminate checkbox</ion-label>
-</ion-item>
+<ion-checkbox [indeterminate]="true">Indeterminate checkbox</ion-checkbox>
 ```

--- a/static/usage/v7/checkbox/indeterminate/demo.html
+++ b/static/usage/v7/checkbox/indeterminate/demo.html
@@ -7,18 +7,15 @@
   <title>Checkbox</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/css/ionic.bundle.css" />
 </head>
 
 <body>
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-item>
-          <ion-checkbox slot="start" indeterminate="true"></ion-checkbox>
-          <ion-label>Indeterminate checkbox</ion-label>
-        </ion-item>
+        <ion-checkbox indeterminate="true">Indeterminate checkbox</ion-checkbox>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/checkbox/indeterminate/javascript.md
+++ b/static/usage/v7/checkbox/indeterminate/javascript.md
@@ -1,6 +1,3 @@
 ```html
-<ion-item>
-  <ion-checkbox slot="start" indeterminate="true"></ion-checkbox>
-  <ion-label>Indeterminate checkbox</ion-label>
-</ion-item>
+<ion-checkbox indeterminate="true">Indeterminate checkbox</ion-checkbox>
 ```

--- a/static/usage/v7/checkbox/indeterminate/react.md
+++ b/static/usage/v7/checkbox/indeterminate/react.md
@@ -1,17 +1,10 @@
 ```tsx
 import React from 'react';
-import {
-  IonCheckbox,
-  IonItem,
-  IonLabel
-} from '@ionic/react';
+import { IonCheckbox } from '@ionic/react';
 
 function Example() {
   return (
-    <IonItem>
-      <IonCheckbox slot="start" indeterminate={true}></IonCheckbox>
-      <IonLabel>Indeterminate checkbox</IonLabel>
-    </IonItem>
+    <IonCheckbox indeterminate={true}>Indeterminate checkbox</IonCheckbox>
   );
 }
 export default Example;

--- a/static/usage/v7/checkbox/indeterminate/vue.md
+++ b/static/usage/v7/checkbox/indeterminate/vue.md
@@ -1,25 +1,14 @@
 ```html
 <template>
-  <ion-item>
-    <ion-checkbox slot="start" :indeterminate="true"></ion-checkbox>
-    <ion-label>Indeterminate checkbox</ion-label>
-  </ion-item>
+  <ion-checkbox :indeterminate="true">Indeterminate checkbox</ion-checkbox>
 </template>
 
 <script lang="ts">
-  import {
-    IonCheckbox,
-    IonItem,
-    IonLabel
-  } from '@ionic/vue';
+  import { IonCheckbox } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: {
-      IonCheckbox,
-      IonItem,
-      IonLabel
-    }
+    components: { IonCheckbox }
   });
 </script>
 ```

--- a/static/usage/v7/checkbox/justify/angular.md
+++ b/static/usage/v7/checkbox/justify/angular.md
@@ -1,0 +1,15 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-checkbox justify="start">Packed at the Start of Line</ion-checkbox>
+  </ion-item>
+  
+  <ion-item>
+    <ion-checkbox justify="end">Packed at the End of Line</ion-checkbox>
+  </ion-item>
+  
+  <ion-item>
+    <ion-checkbox justify="space-between">Space Between Label and Control</ion-checkbox>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/checkbox/justify/demo.html
+++ b/static/usage/v7/checkbox/justify/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Checkbox</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/css/ionic.bundle.css" />
+
+  <style>
+    ion-list {
+      width: 100%;
+    }
+  </style>
+</head>
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-checkbox justify="start">Packed at the Start of Line</ion-checkbox>
+            </ion-item>
+
+            <ion-item>
+              <ion-checkbox justify="end">Packed at the End of Line</ion-checkbox>
+            </ion-item>
+
+            <ion-item>
+              <ion-checkbox justify="space-between">Space Between Label and Control</ion-checkbox>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/checkbox/justify/index.md
+++ b/static/usage/v7/checkbox/justify/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/checkbox/justify/demo.html" />

--- a/static/usage/v7/checkbox/justify/javascript.md
+++ b/static/usage/v7/checkbox/justify/javascript.md
@@ -1,0 +1,15 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-checkbox justify="start">Packed at the Start of Line</ion-checkbox>
+  </ion-item>
+  
+  <ion-item>
+    <ion-checkbox justify="end">Packed at the End of Line</ion-checkbox>
+  </ion-item>
+  
+  <ion-item>
+    <ion-checkbox justify="space-between">Space Between Label and Control</ion-checkbox>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/checkbox/justify/react.md
+++ b/static/usage/v7/checkbox/justify/react.md
@@ -1,0 +1,23 @@
+```tsx
+import React from 'react';
+import { IonCheckbox, IonItem, IonList } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonCheckbox justify="start">Packed at the Start of Line</IonCheckbox>
+      </IonItem>
+      
+      <IonItem>
+        <IonCheckbox justify="end">Packed at the End of Line</IonCheckbox>
+      </IonItem>
+      
+      <IonItem>
+        <IonCheckbox justify="space-between">Space Between Label and Control</IonCheckbox>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/checkbox/justify/vue.md
+++ b/static/usage/v7/checkbox/justify/vue.md
@@ -1,0 +1,26 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-checkbox justify="start">Packed at the Start of Line</ion-checkbox>
+    </ion-item>
+    
+    <ion-item>
+      <ion-checkbox justify="end">Packed at the End of Line</ion-checkbox>
+    </ion-item>
+    
+    <ion-item>
+      <ion-checkbox justify="space-between">Space Between Label and Control</ion-checkbox>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonCheckbox, IonItem, IonList } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonCheckbox, IonItem, IonList },
+  });
+</script>
+```

--- a/static/usage/v7/checkbox/label-placement/angular.md
+++ b/static/usage/v7/checkbox/label-placement/angular.md
@@ -1,0 +1,11 @@
+```html
+<ion-checkbox labelPlacement="start">Label at the Start</ion-checkbox>
+
+<br />
+
+<ion-checkbox labelPlacement="end">Label at the End</ion-checkbox>
+
+<br />
+
+<ion-checkbox labelPlacement="fixed">Fixed Width Label</ion-checkbox>
+```

--- a/static/usage/v7/checkbox/label-placement/demo.html
+++ b/static/usage/v7/checkbox/label-placement/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Checkbox</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <div>
+          <ion-checkbox label-placement="start">Label at the Start</ion-checkbox>
+
+          <br />
+
+          <ion-checkbox label-placement="end">Label at the End</ion-checkbox>
+
+          <br />
+
+          <ion-checkbox label-placement="fixed">Fixed Width Label</ion-checkbox>
+        </div>
+      </div>
+    </ion-content>
+  </ion-app>
+</body>
+
+</html>

--- a/static/usage/v7/checkbox/label-placement/index.md
+++ b/static/usage/v7/checkbox/label-placement/index.md
@@ -1,0 +1,8 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/checkbox/label-placement/demo.html" />

--- a/static/usage/v7/checkbox/label-placement/javascript.md
+++ b/static/usage/v7/checkbox/label-placement/javascript.md
@@ -1,0 +1,11 @@
+```html
+<ion-checkbox label-placement="start">Label at the Start</ion-checkbox>
+
+<br />
+
+<ion-checkbox label-placement="end">Label at the End</ion-checkbox>
+
+<br />
+
+<ion-checkbox label-placement="fixed">Fixed Width Label</ion-checkbox>
+```

--- a/static/usage/v7/checkbox/label-placement/react.md
+++ b/static/usage/v7/checkbox/label-placement/react.md
@@ -1,0 +1,21 @@
+```tsx
+import React from 'react';
+import { IonCheckbox } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonCheckbox labelPlacement="start">Label at the Start</IonCheckbox>
+      
+      <br />
+      
+      <IonCheckbox labelPlacement="end">Label at the End</IonCheckbox>
+      
+      <br />
+      
+      <IonCheckbox labelPlacement="fixed">Fixed Width Label</IonCheckbox>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/checkbox/label-placement/vue.md
+++ b/static/usage/v7/checkbox/label-placement/vue.md
@@ -1,0 +1,22 @@
+```html
+<template>
+  <ion-checkbox label-placement="start">Label at the Start</ion-checkbox>
+  
+  <br />
+  
+  <ion-checkbox label-placement="end">Label at the End</ion-checkbox>
+  
+  <br />
+  
+  <ion-checkbox label-placement="fixed">Fixed Width Label</ion-checkbox>
+</template>
+
+<script lang="ts">
+  import { IonCheckbox } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonCheckbox },
+  });
+</script>
+```

--- a/static/usage/v7/checkbox/migration/index.md
+++ b/static/usage/v7/checkbox/migration/index.md
@@ -1,0 +1,188 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+````mdx-code-block
+<Tabs
+  groupId="framework"
+  defaultValue="javascript"
+  values={[
+    { value: 'javascript', label: 'JavaScript' },
+    { value: 'angular', label: 'Angular' },
+    { value: 'react', label: 'React' },
+    { value: 'vue', label: 'Vue' },
+  ]
+}>
+<TabItem value="javascript">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox>Checkbox Label</ion-checkbox>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox label-placement="fixed">Checkbox Label</ion-checkbox>
+</ion-item>
+
+<!-- Checkbox at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox label-placement="end">Checkbox Label</ion-checkbox>
+</ion-item>
+```
+</TabItem>
+<TabItem value="angular">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox>Checkbox Label</ion-checkbox>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox labelPlacement="fixed">Checkbox Label</ion-checkbox>
+</ion-item>
+
+<!-- Checkbox at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox labelPlacement="end">Checkbox Label</ion-checkbox>
+</ion-item>
+```
+</TabItem>
+<TabItem value="react">
+
+```tsx
+{/* Basic */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel>Checkbox Label</IonLabel>
+  <IonCheckbox></IonCheckbox>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonCheckbox>Checkbox Label</IonCheckbox>
+</IonItem>
+
+{/* Fixed Labels */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel position="fixed">Checkbox Label</IonLabel>
+  <IonCheckbox></IonCheckbox>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonCheckbox labelPlacement="fixed">Checkbox Label</IonCheckbox>
+</IonItem>
+
+{/* Checkbox at the start of line, Label at the end of line */}
+
+{/* Before */}
+<IonItem>
+  <IonLabel slot="end">Checkbox Label</IonLabel>
+  <IonCheckbox></IonCheckbox>
+</IonItem>
+
+{/* After */}
+<IonItem>
+  <IonCheckbox labelPlacement="end">Checkbox Label</IonCheckbox>
+</IonItem>
+```
+</TabItem>
+<TabItem value="vue">
+
+```html
+<!-- Basic -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label>Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox>Checkbox Label</ion-checkbox>
+</ion-item>
+
+<!-- Fixed Labels -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label position="fixed">Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox label-placement="fixed">Checkbox Label</ion-checkbox>
+</ion-item>
+
+<!-- Checkbox at the start of line, Label at the end of line -->
+
+<!-- Before -->
+<ion-item>
+  <ion-label slot="end">Checkbox Label</ion-label>
+  <ion-checkbox></ion-checkbox>
+</ion-item>
+
+<!-- After -->
+<ion-item>
+  <ion-checkbox label-placement="end">Checkbox Label</ion-checkbox>
+</ion-item>
+```
+</TabItem>
+</Tabs>
+````

--- a/static/usage/v7/checkbox/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/v7/checkbox/theming/css-properties/angular/example_component_css.md
@@ -1,7 +1,7 @@
 ```css
 ion-checkbox {
   --size: 32px;
-  --background-checked: #6815ec;
+  --checkbox-background-checked: #6815ec;
 }
 
 ion-checkbox::part(container) {

--- a/static/usage/v7/checkbox/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/v7/checkbox/theming/css-properties/angular/example_component_html.md
@@ -1,6 +1,3 @@
 ```html
-<ion-item>
-  <ion-checkbox slot="start"></ion-checkbox>
-  <ion-label>Themed checkbox</ion-label>
-</ion-item>
+<ion-checkbox>Themed checkbox</ion-checkbox>
 ```

--- a/static/usage/v7/checkbox/theming/css-properties/demo.html
+++ b/static/usage/v7/checkbox/theming/css-properties/demo.html
@@ -7,12 +7,12 @@
   <title>Checkbox</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.0-beta.1/css/ionic.bundle.css" />
   <style>
     ion-checkbox {
       --size: 32px;
-      --background-checked: #6815ec;
+      --checkbox-background-checked: #6815ec;
     }
 
     ion-checkbox::part(container) {
@@ -26,10 +26,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-item>
-          <ion-checkbox slot="start"></ion-checkbox>
-          <ion-label>Themed checkbox</ion-label>
-        </ion-item>
+        <ion-checkbox>Themed checkbox</ion-checkbox>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/checkbox/theming/css-properties/javascript.md
+++ b/static/usage/v7/checkbox/theming/css-properties/javascript.md
@@ -1,13 +1,10 @@
 ```html
-<ion-item>
-  <ion-checkbox slot="start"></ion-checkbox>
-  <ion-label>Themed checkbox</ion-label>
-</ion-item>
+<ion-checkbox>Themed checkbox</ion-checkbox>
 
 <style>
   ion-checkbox {
     --size: 32px;
-    --background-checked: #6815ec;
+    --checkbox-background-checked: #6815ec;
   }
   
   ion-checkbox::part(container) {

--- a/static/usage/v7/checkbox/theming/css-properties/react/main_css.md
+++ b/static/usage/v7/checkbox/theming/css-properties/react/main_css.md
@@ -1,7 +1,7 @@
 ```css
 ion-checkbox {
   --size: 32px;
-  --background-checked: #6815ec;
+  --checkbox-background-checked: #6815ec;
 }
 
 ion-checkbox::part(container) {

--- a/static/usage/v7/checkbox/theming/css-properties/react/main_tsx.md
+++ b/static/usage/v7/checkbox/theming/css-properties/react/main_tsx.md
@@ -1,19 +1,12 @@
 ```tsx
 import React from 'react';
-import {
-  IonCheckbox,
-  IonItem,
-  IonLabel
-} from '@ionic/react';
+import { IonCheckbox } from '@ionic/react';
 
 import './main.css';
 
 function Example() {
   return (
-    <IonItem>
-      <IonCheckbox slot="start"></IonCheckbox>
-      <IonLabel>Themed checkbox</IonLabel>
-    </IonItem>
+    <IonCheckbox>Themed checkbox</IonCheckbox>
   );
 }
 export default Example;

--- a/static/usage/v7/checkbox/theming/css-properties/vue.md
+++ b/static/usage/v7/checkbox/theming/css-properties/vue.md
@@ -1,32 +1,21 @@
 ```html
 <template>
-  <ion-item>
-    <ion-checkbox slot="start"></ion-checkbox>
-    <ion-label>Themed checkbox</ion-label>
-  </ion-item>
+  <ion-checkbox>Themed checkbox</ion-checkbox>
 </template>
 
 <script lang="ts">
-  import {
-    IonCheckbox,
-    IonItem,
-    IonLabel
-  } from '@ionic/vue';
+  import { IonCheckbox } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: {
-      IonCheckbox,
-      IonItem,
-      IonLabel
-    }
+    components: { IonCheckbox }
   });
 </script>
 
 <style>
   ion-checkbox {
     --size: 32px;
-    --background-checked: #6815ec;
+    --checkbox-background-checked: #6815ec;
   }
   
   ion-checkbox::part(container) {


### PR DESCRIPTION
This PR makes the following changes:

1. Updates existing playgrounds to v7 and uses the new checkbox syntax.
2. Adds a migration guide for moving to the new syntax.
3. Adds "Label Placement" and "Justification" playgrounds.


Preview: https://ionic-docs-git-fw-2942-ionic1.vercel.app/docs/v7/api/checkbox

Note: There is a height discrepancy between checkbox and radio that I am currently investigating. As a result, the checkboxes in the "Label Placement" demo may look a bit smushed for now.