### PR TITLE
fix(playground): demo container is visible on small viewports

### DIFF
--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -208,6 +208,10 @@
   width: 0%;
 }
 
+.playground .frame-visible {
+  width: 100%;
+}
+
 /** Tabs **/
 .playground .tabs-container {
   background: var(--playground-code-background);


### PR DESCRIPTION
This PR fixes the sizing of the rendered `iframe` to fill the available space.

When previewing on a Pixel 5 (can be observed with Chrome Dev Tools/Device Emulation): https://ionicframework.com/docs/v7/api/toast the rendered previews are not visible.

Reported on Twitter: https://twitter.com/vberchet/status/1620981423644475396

Quick preview: https://ionic-docs-git-fix-playground-sizing-ionic1.vercel.app/docs/api/toast