### PR TITLE
update swiper/ionic7 Slides migration guide

### DIFF
--- a/versioned_docs/version-v6/react/slides.md
+++ b/versioned_docs/version-v6/react/slides.md
@@ -84,7 +84,10 @@ import React from 'react';
 import { IonContent, IonPage } from '@ionic/react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
+//If using Create-React-App
 import 'swiper/swiper.less';
+//If using Vite
+import 'swiper/less';
 import '@ionic/react/css/ionic-swiper.css';
 
 const Home: React.FC = () => {
@@ -102,7 +105,10 @@ import React from 'react';
 import { IonContent, IonPage } from '@ionic/react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
+//If using Create-React-App
 import 'swiper/swiper.scss';
+//If using Vite
+import 'swiper/scss';
 import '@ionic/react/css/ionic-swiper.css';
 
 const Home: React.FC = () => {


### PR DESCRIPTION
If using Vite or similar build tools (that aren't Create-React-App) then the given import path is unclear and not documented anywhere that I could see so I added those import variations under the Pre-Processors section