### PR TITLE
docs(input, textarea): add bottom content styling example

### DIFF
--- a/static/usage/v7/input/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/v7/input/theming/css-properties/angular/example_component_css.md
@@ -10,4 +10,9 @@ ion-input.custom {
   --padding-start: 10px;
   --padding-top: 10px;
 }
+
+ion-input.custom .helper-text,
+ion-input.custom .counter {
+  color: #373737;
+}
 ```

--- a/static/usage/v7/input/theming/css-properties/angular/example_component_css.md
+++ b/static/usage/v7/input/theming/css-properties/angular/example_component_css.md
@@ -13,6 +13,6 @@ ion-input.custom {
 
 ion-input.custom .helper-text,
 ion-input.custom .counter {
-  color: #373737;
+  color: var(--ion-color-step-700, #373737);
 }
 ```

--- a/static/usage/v7/input/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/v7/input/theming/css-properties/angular/example_component_html.md
@@ -5,6 +5,6 @@
   class="custom" 
   helperText="Helper text"
   [counter]="true"
-  maxlength="20"
+  [maxlength]="20"
 ></ion-input>
 ```

--- a/static/usage/v7/input/theming/css-properties/angular/example_component_html.md
+++ b/static/usage/v7/input/theming/css-properties/angular/example_component_html.md
@@ -1,3 +1,10 @@
 ```html
-<ion-input aria-label="Custom input" placeholder="Custom input" class="custom"></ion-input>
+<ion-input
+  aria-label="Custom input" 
+  placeholder="Custom input" 
+  class="custom" 
+  helperText="Helper text"
+  [counter]="true"
+  maxlength="20"
+></ion-input>
 ```

--- a/static/usage/v7/input/theming/css-properties/demo.html
+++ b/static/usage/v7/input/theming/css-properties/demo.html
@@ -27,6 +27,11 @@
       --padding-start: 10px;
       --padding-top: 10px;
     }
+
+    ion-input.custom .helper-text,
+    ion-input.custom .counter {
+      color: #373737;
+    }
   </style>
 </head>
 
@@ -34,7 +39,14 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-input aria-label="Custom input" placeholder="Custom input" class="custom"></ion-input>
+        <ion-input
+          aria-label="Custom input"
+          placeholder="Custom input"
+          class="custom"
+          helper-text="Helper text"
+          counter="true"
+          maxlength="20"
+        ></ion-input>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/input/theming/css-properties/demo.html
+++ b/static/usage/v7/input/theming/css-properties/demo.html
@@ -30,7 +30,7 @@
 
     ion-input.custom .helper-text,
     ion-input.custom .counter {
-      color: #373737;
+      color: var(--ion-color-step-700, #373737);
     }
   </style>
 </head>

--- a/static/usage/v7/input/theming/css-properties/javascript.md
+++ b/static/usage/v7/input/theming/css-properties/javascript.md
@@ -1,5 +1,12 @@
 ```html
-<ion-input aria-label="Custom input" placeholder="Custom input" class="custom"></ion-input>
+<ion-input
+  aria-label="Custom input" 
+  placeholder="Custom input" 
+  class="custom"
+  helper-text="Helper text"
+  counter="true"
+  maxlength="20"
+></ion-input>
 
 <style>
   ion-input.custom {
@@ -12,6 +19,11 @@
     --padding-end: 10px;
     --padding-start: 10px;
     --padding-top: 10px;
+  }
+  
+  ion-input.custom .helper-text,
+  ion-input.custom .counter {
+    color: #373737;
   }
 </style>
 ```

--- a/static/usage/v7/input/theming/css-properties/javascript.md
+++ b/static/usage/v7/input/theming/css-properties/javascript.md
@@ -23,7 +23,7 @@
   
   ion-input.custom .helper-text,
   ion-input.custom .counter {
-    color: #373737;
+    color: var(--ion-color-step-700, #373737);
   }
 </style>
 ```

--- a/static/usage/v7/input/theming/css-properties/react/main_css.md
+++ b/static/usage/v7/input/theming/css-properties/react/main_css.md
@@ -10,4 +10,9 @@ ion-input.custom {
   --padding-start: 10px;
   --padding-top: 10px;
 }
+
+ion-input.custom .helper-text,
+ion-input.custom .counter {
+  color: #373737;
+}
 ```

--- a/static/usage/v7/input/theming/css-properties/react/main_tsx.md
+++ b/static/usage/v7/input/theming/css-properties/react/main_tsx.md
@@ -6,7 +6,14 @@ import './main.css';
 
 function Example() {
   return (
-    <IonInput aria-label="Custom input" placeholder="Custom input" class="custom"></IonInput>
+    <IonInput
+      aria-label="Custom input" 
+      placeholder="Custom input" 
+      class="custom"
+      helperText="Helper text"
+      counter={true}
+      maxlength="20"
+    ></IonInput>
   );
 }
 export default Example;

--- a/static/usage/v7/input/theming/css-properties/react/main_tsx.md
+++ b/static/usage/v7/input/theming/css-properties/react/main_tsx.md
@@ -12,7 +12,7 @@ function Example() {
       class="custom"
       helperText="Helper text"
       counter={true}
-      maxlength="20"
+      maxlength={20}
     ></IonInput>
   );
 }

--- a/static/usage/v7/input/theming/css-properties/vue.md
+++ b/static/usage/v7/input/theming/css-properties/vue.md
@@ -6,7 +6,7 @@
     class="custom"
     helper-text="Helper text"
     :counter="true"
-    maxlength="20"
+    :maxlength="20"
   ></ion-input>
 </template>
 

--- a/static/usage/v7/input/theming/css-properties/vue.md
+++ b/static/usage/v7/input/theming/css-properties/vue.md
@@ -1,6 +1,13 @@
 ```html
 <template>
-  <ion-input aria-label="Custom input" placeholder="Custom input" class="custom"></ion-input>
+  <ion-input
+    aria-label="Custom input" 
+    placeholder="Custom input" 
+    class="custom"
+    helper-text="Helper text"
+    :counter="true"
+    maxlength="20"
+  ></ion-input>
 </template>
 
 <script lang="ts">
@@ -23,6 +30,11 @@
     --padding-end: 10px;
     --padding-start: 10px;
     --padding-top: 10px;
+  }
+  
+  ion-input.custom .helper-text,
+  ion-input.custom .counter {
+    color: #373737;
   }
 </style>
 ```

--- a/static/usage/v7/input/theming/css-properties/vue.md
+++ b/static/usage/v7/input/theming/css-properties/vue.md
@@ -19,7 +19,7 @@
   });
 </script>
 
-<style scoped>
+<style>
   ion-input.custom {
     --background: #373737;
     --color: #fff;

--- a/static/usage/v7/input/theming/css-properties/vue.md
+++ b/static/usage/v7/input/theming/css-properties/vue.md
@@ -34,7 +34,7 @@
   
   ion-input.custom .helper-text,
   ion-input.custom .counter {
-    color: #373737;
+    color: var(--ion-color-step-700, #373737);
   }
 </style>
 ```

--- a/static/usage/v7/textarea/theming/angular/example_component_css.md
+++ b/static/usage/v7/textarea/theming/angular/example_component_css.md
@@ -1,10 +1,15 @@
 ```css
-ion-textarea.custom-textarea {
+ion-textarea.custom {
   --background: #373737;
   --color: #fff;
   --padding-end: 10px;
   --padding-start: 10px;
   --placeholder-color: #ddd;
   --placeholder-opacity: 0.8;
+}
+
+ion-textarea.custom .helper-text,
+ion-textarea.custom .counter {
+  color: #373737;
 }
 ```

--- a/static/usage/v7/textarea/theming/angular/example_component_html.md
+++ b/static/usage/v7/textarea/theming/angular/example_component_html.md
@@ -1,3 +1,10 @@
 ```html
-<ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+<ion-textarea
+  aria-label="Custom textarea"
+  placeholder="Type something here"
+  class="custom"
+  helperText="Helper text"
+  [counter]="true"
+  maxlength="100"
+></ion-textarea>
 ```

--- a/static/usage/v7/textarea/theming/angular/example_component_html.md
+++ b/static/usage/v7/textarea/theming/angular/example_component_html.md
@@ -5,6 +5,6 @@
   class="custom"
   helperText="Helper text"
   [counter]="true"
-  maxlength="100"
+  [maxlength]="100"
 ></ion-textarea>
 ```

--- a/static/usage/v7/textarea/theming/demo.html
+++ b/static/usage/v7/textarea/theming/demo.html
@@ -7,20 +7,25 @@
   <title>Textarea - Theming</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
   <style>
     .container {
       padding: 0 40px;
     }
 
-    ion-textarea.custom-textarea {
+    ion-textarea.custom {
       --background: #373737;
       --color: #fff;
       --padding-end: 10px;
       --padding-start: 10px;
       --placeholder-color: #ddd;
       --placeholder-opacity: 0.8;
+    }
+
+    ion-textarea.custom .helper-text,
+    ion-textarea.custom .counter {
+      color: #373737;
     }
   </style>
 </head>
@@ -29,7 +34,14 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+        <ion-textarea
+          aria-label="Custom textarea"
+          placeholder="Type something here"
+          class="custom"
+          helper-text="Helper text"
+          counter="true"
+          maxlength="100"
+        ></ion-textarea>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/textarea/theming/javascript.md
+++ b/static/usage/v7/textarea/theming/javascript.md
@@ -1,14 +1,26 @@
 ```html
-<ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+<ion-textarea
+  aria-label="Custom textarea"
+  placeholder="Type something here"
+  class="custom"
+  helper-text="Helper text"
+  counter="true"
+  maxlength="100"
+></ion-textarea>
 
 <style>
-  ion-textarea.custom-textarea {
+  ion-textarea.custom {
     --background: #373737;
     --color: #fff;
     --padding-end: 10px;
     --padding-start: 10px;
     --placeholder-color: #ddd;
     --placeholder-opacity: 0.8;
+  }
+  
+  ion-textarea.custom .helper-text,
+  ion-textarea.custom .counter {
+    color: #373737;
   }
 </style>
 ```

--- a/static/usage/v7/textarea/theming/react/main_css.md
+++ b/static/usage/v7/textarea/theming/react/main_css.md
@@ -1,10 +1,15 @@
 ```css
-ion-textarea.custom-textarea {
+ion-textarea.custom {
   --background: #373737;
   --color: #fff;
   --padding-end: 10px;
   --padding-start: 10px;
   --placeholder-color: #ddd;
   --placeholder-opacity: 0.8;
+}
+
+ion-textarea.custom .helper-text,
+ion-textarea.custom .counter {
+  color: #373737;
 }
 ```

--- a/static/usage/v7/textarea/theming/react/main_tsx.md
+++ b/static/usage/v7/textarea/theming/react/main_tsx.md
@@ -5,7 +5,16 @@ import { IonTextarea } from '@ionic/react';
 import './main.css';
 
 function Example() {
-  return <IonTextarea className="custom-textarea" placeholder="Type something here"></IonTextarea>;
+  return (
+    <IonTextarea
+      aria-label="Custom textarea"
+      placeholder="Type something here"
+      class="custom"
+      helperText="Helper text"
+      counter={true}
+      maxlength="100"
+    ></IonTextarea>
+  );
 }
 export default Example;
 ```

--- a/static/usage/v7/textarea/theming/react/main_tsx.md
+++ b/static/usage/v7/textarea/theming/react/main_tsx.md
@@ -12,7 +12,7 @@ function Example() {
       class="custom"
       helperText="Helper text"
       counter={true}
-      maxlength="100"
+      maxlength={100}
     ></IonTextarea>
   );
 }

--- a/static/usage/v7/textarea/theming/vue.md
+++ b/static/usage/v7/textarea/theming/vue.md
@@ -22,7 +22,7 @@
     class="custom"
     helper-text="Helper text"
     :counter="true"
-    maxlength="100"
+    :maxlength="100"
   ></ion-textarea>
 </template>
 

--- a/static/usage/v7/textarea/theming/vue.md
+++ b/static/usage/v7/textarea/theming/vue.md
@@ -1,6 +1,6 @@
 ```html
 <style>
-  ion-textarea.custom-textarea {
+  ion-textarea.custom {
     --background: #373737;
     --color: #fff;
     --padding-end: 10px;
@@ -8,10 +8,22 @@
     --placeholder-color: #ddd;
     --placeholder-opacity: 0.8;
   }
+  
+  ion-textarea.custom .helper-text,
+  ion-textarea.custom .counter {
+    color: #373737;
+  }
 </style>
 
 <template>
-  <ion-textarea class="custom-textarea" placeholder="Type something here"></ion-textarea>
+  <ion-textarea
+    aria-label="Custom textarea"
+    placeholder="Type something here"
+    class="custom"
+    helper-text="Helper text"
+    :counter="true"
+    maxlength="100"
+  ></ion-textarea>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
See: https://github.com/ionic-team/ionic-framework/issues/26737

This PR makes use of the bottom content on `ion-input` and `ion-textarea` in the theming demos to show how to style this content. I also changed the class on the textarea demo from `custom-textarea` to `custom` for consistency with the input demo (which also uses the `custom` class).