### PR TITLE
docs(many): add mode prop to playgrounds where needed

### DIFF
--- a/static/usage/v6/footer/custom-scroll-target/index.md
+++ b/static/usage/v6/footer/custom-scroll-target/index.md
@@ -30,4 +30,5 @@ import angular_example_component_css from './angular/example_component_css.md';
   src="usage/v6/footer/custom-scroll-target/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v6/footer/fade/index.md
+++ b/static/usage/v6/footer/fade/index.md
@@ -10,4 +10,5 @@ import angular from './angular.md';
   src="usage/v6/footer/fade/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v6/footer/translucent/index.md
+++ b/static/usage/v6/footer/translucent/index.md
@@ -10,4 +10,5 @@ import angular from './angular.md';
   src="usage/v6/footer/translucent/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v6/header/condense/index.md
+++ b/static/usage/v6/header/condense/index.md
@@ -10,4 +10,5 @@ import angular from './angular.md';
   src="usage/v6/header/condense/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v6/header/custom-scroll-target/index.md
+++ b/static/usage/v6/header/custom-scroll-target/index.md
@@ -30,4 +30,5 @@ import angular_example_component_css from './angular/example_component_css.md';
   src="usage/v6/header/custom-scroll-target/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v6/header/fade/index.md
+++ b/static/usage/v6/header/fade/index.md
@@ -10,4 +10,5 @@ import angular from './angular.md';
   src="usage/v6/header/fade/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v6/header/translucent/index.md
+++ b/static/usage/v6/header/translucent/index.md
@@ -10,4 +10,5 @@ import angular from './angular.md';
   src="usage/v6/header/translucent/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v6/input/fill/index.md
+++ b/static/usage/v6/input/fill/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground code={{ javascript, react, vue, angular }} src="usage/v6/input/fill/demo.html" size="250px" />
+<Playground
+  code={{ javascript, react, vue, angular }}
+  src="usage/v6/input/fill/demo.html"
+  size="250px"
+  mode="md"
+/>

--- a/static/usage/v6/modal/card/basic/index.md
+++ b/static/usage/v6/modal/card/basic/index.md
@@ -21,4 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
   }}
   src="usage/v6/modal/card/basic/demo.html"
   devicePreview
+  mode="ios"
 />

--- a/static/usage/v6/title/collapsible-large-title/basic/index.md
+++ b/static/usage/v6/title/collapsible-large-title/basic/index.md
@@ -11,4 +11,5 @@ import angular from './angular.md';
   src="usage/v6/title/collapsible-large-title/basic/demo.html"
   devicePreview={true}
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/footer/custom-scroll-target/index.md
+++ b/static/usage/v7/footer/custom-scroll-target/index.md
@@ -31,4 +31,5 @@ import angular_example_component_css from './angular/example_component_css.md';
   src="usage/v7/footer/custom-scroll-target/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/footer/fade/index.md
+++ b/static/usage/v7/footer/fade/index.md
@@ -11,4 +11,5 @@ import angular from './angular.md';
   src="usage/v7/footer/fade/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/footer/translucent/index.md
+++ b/static/usage/v7/footer/translucent/index.md
@@ -11,4 +11,5 @@ import angular from './angular.md';
   src="usage/v7/footer/translucent/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/header/condense/index.md
+++ b/static/usage/v7/header/condense/index.md
@@ -11,4 +11,5 @@ import angular from './angular.md';
   src="usage/v7/header/condense/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/header/custom-scroll-target/index.md
+++ b/static/usage/v7/header/custom-scroll-target/index.md
@@ -31,4 +31,5 @@ import angular_example_component_css from './angular/example_component_css.md';
   src="usage/v7/header/custom-scroll-target/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/header/fade/index.md
+++ b/static/usage/v7/header/fade/index.md
@@ -11,4 +11,5 @@ import angular from './angular.md';
   src="usage/v7/header/fade/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/header/translucent/index.md
+++ b/static/usage/v7/header/translucent/index.md
@@ -11,4 +11,5 @@ import angular from './angular.md';
   src="usage/v7/header/translucent/demo.html"
   devicePreview
   includeIonContent={false}
+  mode="ios"
 />

--- a/static/usage/v7/input/fill/angular.md
+++ b/static/usage/v7/input/fill/angular.md
@@ -1,7 +1,7 @@
 ```html
-<ion-input mode="md" label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
+<ion-input label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
 
 <br />
 
-<ion-input mode="md" label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
+<ion-input label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
 ```

--- a/static/usage/v7/input/fill/demo.html
+++ b/static/usage/v7/input/fill/demo.html
@@ -25,9 +25,9 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-input mode="md" label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
+        <ion-input label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
 
-        <ion-input mode="md" label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
+        <ion-input label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
       </div>
     </ion-content>
   </ion-app>

--- a/static/usage/v7/input/fill/index.md
+++ b/static/usage/v7/input/fill/index.md
@@ -5,4 +5,10 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/input/fill/demo.html" size="250px" />
+<Playground 
+  version="7"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v7/input/fill/demo.html"
+  size="250px"
+  mode="md"
+/>

--- a/static/usage/v7/input/fill/javascript.md
+++ b/static/usage/v7/input/fill/javascript.md
@@ -1,7 +1,7 @@
 ```html
-<ion-input mode="md" label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
+<ion-input label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
 
 <br />
 
-<ion-input mode="md" label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
+<ion-input label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
 ```

--- a/static/usage/v7/input/fill/react.md
+++ b/static/usage/v7/input/fill/react.md
@@ -5,11 +5,11 @@ import { IonInput } from '@ionic/react';
 function Example() {
   return (
     <>
-      <IonInput mode="md" label="Solid input" labelPlacement="floating" fill="solid" placeholder="Enter text"></IonInput>
+      <IonInput label="Solid input" labelPlacement="floating" fill="solid" placeholder="Enter text"></IonInput>
       
       <br />
       
-      <IonInput mode="md" label="Outline input" labelPlacement="floating" fill="outline" placeholder="Enter text"></IonInput>
+      <IonInput label="Outline input" labelPlacement="floating" fill="outline" placeholder="Enter text"></IonInput>
     </>
   );
 }

--- a/static/usage/v7/input/fill/vue.md
+++ b/static/usage/v7/input/fill/vue.md
@@ -1,10 +1,10 @@
 ```html
 <template>
-  <ion-input mode="md" label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
+  <ion-input label="Solid input" label-placement="floating" fill="solid" placeholder="Enter text"></ion-input>
   
   <br />
   
-  <ion-input mode="md" label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
+  <ion-input label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/modal/card/basic/index.md
+++ b/static/usage/v7/modal/card/basic/index.md
@@ -22,4 +22,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
   }}
   src="usage/v7/modal/card/basic/demo.html"
   devicePreview
+  mode="ios"
 />

--- a/static/usage/v7/select/fill/angular.md
+++ b/static/usage/v7/select/fill/angular.md
@@ -1,5 +1,5 @@
 ```html
-<ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+<ion-select label="Solid select" label-placement="floating" fill="solid">
   <ion-select-option value="apple">Apple</ion-select-option>
   <ion-select-option value="banana">Banana</ion-select-option>
   <ion-select-option value="orange">Orange</ion-select-option>
@@ -7,7 +7,7 @@
 
 <br />
 
-<ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+<ion-select label="Outline select" label-placement="floating" fill="outline">
   <ion-select-option value="apple">Apple</ion-select-option>
   <ion-select-option value="banana">Banana</ion-select-option>
   <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/fill/demo.html
+++ b/static/usage/v7/select/fill/demo.html
@@ -25,13 +25,13 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+        <ion-select label="Solid select" label-placement="floating" fill="solid">
           <ion-select-option value="apple">Apple</ion-select-option>
           <ion-select-option value="banana">Banana</ion-select-option>
           <ion-select-option value="orange">Orange</ion-select-option>
         </ion-select>
 
-        <ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+        <ion-select label="Outline select" label-placement="floating" fill="outline">
           <ion-select-option value="apple">Apple</ion-select-option>
           <ion-select-option value="banana">Banana</ion-select-option>
           <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/fill/index.md
+++ b/static/usage/v7/select/fill/index.md
@@ -5,4 +5,10 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/select/fill/demo.html" size="300px" />
+<Playground
+  version="7"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v7/select/fill/demo.html"
+  size="300px"
+  mode="md"
+/>

--- a/static/usage/v7/select/fill/javascript.md
+++ b/static/usage/v7/select/fill/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+<ion-select label="Solid select" label-placement="floating" fill="solid">
   <ion-select-option value="apple">Apple</ion-select-option>
   <ion-select-option value="banana">Banana</ion-select-option>
   <ion-select-option value="orange">Orange</ion-select-option>
@@ -7,7 +7,7 @@
 
 <br />
 
-<ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+<ion-select label="Outline select" label-placement="floating" fill="outline">
   <ion-select-option value="apple">Apple</ion-select-option>
   <ion-select-option value="banana">Banana</ion-select-option>
   <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/fill/react.md
+++ b/static/usage/v7/select/fill/react.md
@@ -5,7 +5,7 @@ import { IonSelect, IonSelectOption } from '@ionic/react';
 function Example() {
   return (
     <>
-      <IonSelect mode="md" label="Solid select" labelPlacement="floating" fill="solid">
+      <IonSelect label="Solid select" labelPlacement="floating" fill="solid">
         <IonSelectOption value="apple">Apple</IonSelectOption>
         <IonSelectOption value="banana">Banana</IonSelectOption>
         <IonSelectOption value="orange">Orange</IonSelectOption>
@@ -13,7 +13,7 @@ function Example() {
       
       <br />
       
-      <IonSelect mode="md" label="Outline select" labelPlacement="floating" fill="outline">
+      <IonSelect label="Outline select" labelPlacement="floating" fill="outline">
         <IonSelectOption value="apple">Apple</IonSelectOption>
         <IonSelectOption value="banana">Banana</IonSelectOption>
         <IonSelectOption value="orange">Orange</IonSelectOption>

--- a/static/usage/v7/select/fill/vue.md
+++ b/static/usage/v7/select/fill/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-select mode="md" label="Solid select" label-placement="floating" fill="solid">
+  <ion-select label="Solid select" label-placement="floating" fill="solid">
     <ion-select-option value="apple">Apple</ion-select-option>
     <ion-select-option value="banana">Banana</ion-select-option>
     <ion-select-option value="orange">Orange</ion-select-option>
@@ -8,7 +8,7 @@
   
   <br />
   
-  <ion-select mode="md" label="Outline select" label-placement="floating" fill="outline">
+  <ion-select label="Outline select" label-placement="floating" fill="outline">
     <ion-select-option value="apple">Apple</ion-select-option>
     <ion-select-option value="banana">Banana</ion-select-option>
     <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/title/collapsible-large-title/basic/index.md
+++ b/static/usage/v7/title/collapsible-large-title/basic/index.md
@@ -12,4 +12,5 @@ import angular from './angular.md';
   src="usage/v7/title/collapsible-large-title/basic/demo.html"
   devicePreview={true}
   includeIonContent={false}
+  mode="ios"
 />


### PR DESCRIPTION
Adds the `mode` property to any playgrounds where the feature is only available on one mode or the other, and also removes a few usages of the `mode` prop within the demo itself since that's no longer needed.