### PR TITLE
fix(datetime): align basic demo container to the start

### DIFF
--- a/static/usage/v6/datetime/basic/demo.html
+++ b/static/usage/v6/datetime/basic/demo.html
@@ -13,6 +13,10 @@
     ion-datetime {
       width: 350px;
     }
+
+    .container {
+      align-items: flex-start;
+    }
   </style>
 </head>
 

--- a/static/usage/v7/datetime/basic/demo.html
+++ b/static/usage/v7/datetime/basic/demo.html
@@ -13,6 +13,10 @@
     ion-datetime {
       width: 350px;
     }
+
+    .container {
+      align-items: flex-start;
+    }
   </style>
 </head>
 


### PR DESCRIPTION
When viewing the [basic usage](https://ionicframework.com/docs/api/datetime#basic-usage) example for `ion-datetime` in MD mode, toggling the month/year picker results in a UI shift. 

This isn't a behavior of Ionic, but the result of the container styles in the demo. 

Aligning the container to the start removes this layout shift.

Before:

<video src="https://user-images.githubusercontent.com/13732623/217121595-2ec22191-b2a2-4053-8c24-fb604dcd719d.mp4"></video>

After:

<video src="https://user-images.githubusercontent.com/13732623/217121683-c9738564-e661-4c56-a6b3-a3266224ebad.mp4"></video>


