### PR TITLE
docs(toast): add layout demos

### DIFF
--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -55,11 +55,18 @@ The following example demonstrates how to use the `buttons` property to add a bu
 import ButtonsPlayground from '@site/static/usage/v7/toast/buttons/index.md';
 
 <ButtonsPlayground />
-  
 
 ## Positioning
 
 Toasts can be positioned at the top, bottom or middle of the viewport. The position can be passed upon creation. The possible values are `top`, `bottom` and `middle`. If the position is not specified, the toast will be displayed at the bottom of the viewport.
+
+## Layout
+
+Button containers within the toast can be displayed either inline with the message or stacked on separate lines using the `layout` property. The stacked layout should be used with buttons that have long text values. Additionally, buttons in a stacked toast layout can use a `side` value of either `start` or `end`, but not both.
+
+import StackedPlayground from '@site/static/usage/v7/toast/layout/index.md';
+
+<StackedPlayground />
 
 ## Icons
 

--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -62,7 +62,7 @@ Toasts can be positioned at the top, bottom or middle of the viewport. The posit
 
 ## Layout
 
-Button containers within the toast can be displayed either inline with the message or stacked on separate lines using the `layout` property. The stacked layout should be used with buttons that have long text values. Additionally, buttons in a stacked toast layout can use a `side` value of either `start` or `end`, but not both.
+Button containers within the toast can be displayed either on the same line as the message or stacked on separate lines using the `layout` property. The stacked layout should be used with buttons that have long text values. Additionally, buttons in a stacked toast layout can use a `side` value of either `start` or `end`, but not both.
 
 import StackedPlayground from '@site/static/usage/v7/toast/layout/index.md';
 

--- a/static/usage/v6/toast/layout/angular/example_component_html.md
+++ b/static/usage/v6/toast/layout/angular/example_component_html.md
@@ -1,4 +1,4 @@
 ```html
-<ion-button (click)="presentInlineToast()">Open Inline Layout Toast</ion-button>
+<ion-button (click)="presentBaselineToast()">Open Baseline Layout Toast</ion-button>
 <ion-button (click)="presentStackedToast()">Click Stacked Layout Toast</ion-button>
 ```

--- a/static/usage/v6/toast/layout/angular/example_component_html.md
+++ b/static/usage/v6/toast/layout/angular/example_component_html.md
@@ -1,0 +1,4 @@
+```html
+<ion-button (click)="presentInlineToast()">Open Inline Layout Toast</ion-button>
+<ion-button (click)="presentStackedToast()">Click Stacked Layout Toast</ion-button>
+```

--- a/static/usage/v6/toast/layout/angular/example_component_ts.md
+++ b/static/usage/v6/toast/layout/angular/example_component_ts.md
@@ -1,0 +1,40 @@
+```ts
+import { Component } from '@angular/core';
+import { ToastController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+
+  constructor(private toastController: ToastController) {}
+  
+  async presentToast(opts) {
+    const toast = await this.toastController.create(opts);
+  
+    await toast.present();
+  }
+  
+  async presentInlineToast() {
+    await this.presentToast({
+      duration: 3000,
+      message: "This is a toast with a long message and a button that appears on the same line.",
+      buttons: [
+        { text: 'Action With Long Text'}
+      ]
+    });
+  }
+  
+  async presentStackedToast() {
+    await this.presentToast({
+      duration: 3000,
+      message: "This is a toast with a long message and a button that appears on the next line.",
+      buttons: [
+        { text: 'Action With Long Text'}
+      ],
+      layout: "stacked"
+    });
+  }
+}
+```

--- a/static/usage/v6/toast/layout/angular/example_component_ts.md
+++ b/static/usage/v6/toast/layout/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { ToastController } from '@ionic/angular';
+import type { ToastOptions } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
@@ -10,7 +11,7 @@ export class ExampleComponent {
 
   constructor(private toastController: ToastController) {}
   
-  async presentToast(opts) {
+  async presentToast(opts: ToastOptions) {
     const toast = await this.toastController.create(opts);
   
     await toast.present();

--- a/static/usage/v6/toast/layout/angular/example_component_ts.md
+++ b/static/usage/v6/toast/layout/angular/example_component_ts.md
@@ -16,7 +16,7 @@ export class ExampleComponent {
     await toast.present();
   }
   
-  async presentInlineToast() {
+  async presentBaselineToast() {
     await this.presentToast({
       duration: 3000,
       message: "This is a toast with a long message and a button that appears on the same line.",

--- a/static/usage/v6/toast/layout/demo.html
+++ b/static/usage/v6/toast/layout/demo.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toast</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676303024.114a8ff3/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676303024.114a8ff3/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Toast</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button onclick="presentInlineToast()">Open Inline Layout Toast</ion-button>
+      <ion-button onclick="presentStackedToast()">Click Stacked Layout Toast</ion-button>
+    </ion-content>
+  </ion-app>
+
+  <script type="module">
+    import { toastController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676303024.114a8ff3/dist/ionic/index.esm.js';
+    window.toastController = toastController;
+  </script>
+
+  <script>
+    async function presentToast(opts) {
+      const toast = await toastController.create(opts);
+
+      await toast.present();
+    }
+
+    async function presentInlineToast() {
+      await presentToast({
+        duration: 3000,
+        message: "This is a toast with a long message and a button that appears on the same line.",
+        buttons: [
+          { text: 'Action With Long Text'}
+        ]
+      });
+    }
+
+    async function presentStackedToast() {
+      await presentToast({
+        duration: 3000,
+        message: "This is a toast with a long message and a button that appears on the next line.",
+        buttons: [
+          { text: 'Action With Long Text'}
+        ],
+        layout: "stacked"
+      });
+    }
+  </script>
+</body>
+
+</html>

--- a/static/usage/v6/toast/layout/demo.html
+++ b/static/usage/v6/toast/layout/demo.html
@@ -7,8 +7,8 @@
   <title>Toast</title>
   <link rel="stylesheet" href="../../../common.css" />
   <script src="../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676303024.114a8ff3/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676303024.114a8ff3/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6/css/ionic.bundle.css" />
 </head>
 
 <body>

--- a/static/usage/v6/toast/layout/demo.html
+++ b/static/usage/v6/toast/layout/demo.html
@@ -19,7 +19,7 @@
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <ion-button onclick="presentInlineToast()">Open Inline Layout Toast</ion-button>
+      <ion-button onclick="presentBaselineToast()">Open Baseline Layout Toast</ion-button>
       <ion-button onclick="presentStackedToast()">Click Stacked Layout Toast</ion-button>
     </ion-content>
   </ion-app>
@@ -36,7 +36,7 @@
       await toast.present();
     }
 
-    async function presentInlineToast() {
+    async function presentBaselineToast() {
       await presentToast({
         duration: 3000,
         message: "This is a toast with a long message and a button that appears on the same line.",

--- a/static/usage/v6/toast/layout/index.md
+++ b/static/usage/v6/toast/layout/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  devicePreview
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v6/toast/layout/demo.html"
+/>

--- a/static/usage/v6/toast/layout/javascript.md
+++ b/static/usage/v6/toast/layout/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-button onclick="presentInlineToast()">Open Inline Layout Toast</ion-button>
+<ion-button onclick="presentBaselineToast()">Open Baseline Layout Toast</ion-button>
 <ion-button onclick="presentStackedToast()">Click Stacked Layout Toast</ion-button>
 
 <script>
@@ -9,7 +9,7 @@
     await toast.present();
   }
   
-  async function presentInlineToast() {
+  async function presentBaselineToast() {
     await presentToast({
       duration: 3000,
       message: "This is a toast with a long message and a button that appears on the same line.",

--- a/static/usage/v6/toast/layout/javascript.md
+++ b/static/usage/v6/toast/layout/javascript.md
@@ -1,0 +1,33 @@
+```html
+<ion-button onclick="presentInlineToast()">Open Inline Layout Toast</ion-button>
+<ion-button onclick="presentStackedToast()">Click Stacked Layout Toast</ion-button>
+
+<script>
+  async function presentToast(opts) {
+    const toast = await toastController.create(opts);
+  
+    await toast.present();
+  }
+  
+  async function presentInlineToast() {
+    await presentToast({
+      duration: 3000,
+      message: "This is a toast with a long message and a button that appears on the same line.",
+      buttons: [
+        { text: 'Action With Long Text'}
+      ]
+    });
+  }
+  
+  async function presentStackedToast() {
+    await presentToast({
+      duration: 3000,
+      message: "This is a toast with a long message and a button that appears on the next line.",
+      buttons: [
+        { text: 'Action With Long Text'}
+      ],
+      layout: "stacked"
+    });
+  }
+</script>
+```

--- a/static/usage/v6/toast/layout/react.md
+++ b/static/usage/v6/toast/layout/react.md
@@ -18,7 +18,7 @@ function Example() {
           })
         }}
       >
-        Open Inline Layout Toast
+        Open Baseline Layout Toast
       </IonButton>
       <IonButton
         onClick={() => {

--- a/static/usage/v6/toast/layout/react.md
+++ b/static/usage/v6/toast/layout/react.md
@@ -1,0 +1,41 @@
+```tsx
+import React from 'react';
+import { IonButton, useIonToast } from '@ionic/react';
+
+function Example() {
+  const [presentToast] = useIonToast();
+
+  return (
+    <>
+      <IonButton
+        onClick={() => {
+          presentToast({
+            duration: 3000,
+            message: "This is a toast with a long message and a button that appears on the next line.",
+            buttons: [
+              { text: 'Action With Long Text'}
+            ]
+          })
+        }}
+      >
+        Open Inline Layout Toast
+      </IonButton>
+      <IonButton
+        onClick={() => {
+          presentToast({
+            duration: 3000,
+            message: "This is a toast with a long message and a button that appears on the next line.",
+            buttons: [
+              { text: 'Action With Long Text'}
+            ],
+            layout: "stacked"
+          })
+        }}
+      >
+        Open Stacked Layout Toast
+      </IonButton>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v6/toast/layout/vue.md
+++ b/static/usage/v6/toast/layout/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-button @click="presentInlineToast()">Open Inline Layout Toast</ion-button>
+  <ion-button @click="presentBaselineToast()">Open Baseline Layout Toast</ion-button>
   <ion-button @click="presentStackedToast()">Click Stacked Layout Toast</ion-button>
 </template>
 
@@ -17,7 +17,7 @@
         await toast.present();
       }
       
-      const presentInlineToast = async () => {
+      const presentBaselineToast = async () => {
         await presentToast({
           duration: 3000,
           message: "This is a toast with a long message and a button that appears on the same line.",
@@ -38,7 +38,7 @@
         });
       }
       
-      return { presentInlineToast, presentStackedToast }
+      return { presentBaselineToast, presentStackedToast }
     }
   });
 </script>

--- a/static/usage/v6/toast/layout/vue.md
+++ b/static/usage/v6/toast/layout/vue.md
@@ -1,0 +1,45 @@
+```html
+<template>
+  <ion-button @click="presentInlineToast()">Open Inline Layout Toast</ion-button>
+  <ion-button @click="presentStackedToast()">Click Stacked Layout Toast</ion-button>
+</template>
+
+<script lang="ts">
+  import { IonButton, toastController } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton },
+    setup() {
+      const presentToast = async (opts) => {
+        const toast = await toastController.create(opts);
+      
+        await toast.present();
+      }
+      
+      const presentInlineToast = async () => {
+        await presentToast({
+          duration: 3000,
+          message: "This is a toast with a long message and a button that appears on the same line.",
+          buttons: [
+            { text: 'Action With Long Text'}
+          ]
+        });
+      }
+      
+      const presentStackedToast = async () => {
+        await presentToast({
+          duration: 3000,
+          message: "This is a toast with a long message and a button that appears on the next line.",
+          buttons: [
+            { text: 'Action With Long Text'}
+          ],
+          layout: "stacked"
+        });
+      }
+      
+      return { presentInlineToast, presentStackedToast }
+    }
+  });
+</script>
+```

--- a/static/usage/v6/toast/layout/vue.md
+++ b/static/usage/v6/toast/layout/vue.md
@@ -6,12 +6,13 @@
 
 <script lang="ts">
   import { IonButton, toastController } from '@ionic/vue';
+  import type { ToastOptions } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
     components: { IonButton },
     setup() {
-      const presentToast = async (opts) => {
+      const presentToast = async (opts: ToastOptions) => {
         const toast = await toastController.create(opts);
       
         await toast.present();

--- a/static/usage/v7/toast/layout/angular/example_component_html.md
+++ b/static/usage/v7/toast/layout/angular/example_component_html.md
@@ -1,5 +1,5 @@
 ```html
-<ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+<ion-button id="open-inline-toast">Open Baseline Layout Toast</ion-button>
 <ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
 <ion-toast 
   trigger="open-inline-toast" 

--- a/static/usage/v7/toast/layout/angular/example_component_html.md
+++ b/static/usage/v7/toast/layout/angular/example_component_html.md
@@ -1,6 +1,6 @@
 ```html
-<ion-button id="open-inline-toast">Open Inline Toast</ion-button>
-<ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+<ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+<ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
 <ion-toast 
   trigger="open-inline-toast" 
   [duration]="3000"

--- a/static/usage/v7/toast/layout/angular/example_component_html.md
+++ b/static/usage/v7/toast/layout/angular/example_component_html.md
@@ -1,0 +1,17 @@
+```html
+<ion-button id="open-inline-toast">Open Inline Toast</ion-button>
+<ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+<ion-toast 
+  trigger="open-inline-toast" 
+  [duration]="3000"
+  [buttons]="toastButtons"
+  message="This is a toast with a long message and a button that appears on the same line."
+></ion-toast>
+<ion-toast
+  trigger="open-stacked-toast" 
+  [duration]="3000"
+  [buttons]="toastButtons"
+  message="This is a toast with a long message and a button that appears on the next line." 
+  layout="stacked"
+></ion-toast>
+```

--- a/static/usage/v7/toast/layout/angular/example_component_ts.md
+++ b/static/usage/v7/toast/layout/angular/example_component_ts.md
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  public toastButtons = [
+  toastButtons = [
     {
       text: 'Action With Long Text',
     }

--- a/static/usage/v7/toast/layout/angular/example_component_ts.md
+++ b/static/usage/v7/toast/layout/angular/example_component_ts.md
@@ -1,0 +1,15 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  public toastButtons = [
+    {
+      text: 'Action With Long Text',
+    }
+  ];
+}
+```

--- a/static/usage/v7/toast/layout/demo.html
+++ b/static/usage/v7/toast/layout/demo.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Toast</title>
+  <link rel="stylesheet" href="../../../common.css" />
+  <script src="../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
+</head>
+
+<body>
+  <ion-app>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Toast</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-button id="open-inline-toast">Open Inline Toast</ion-button>
+      <ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+      <ion-toast trigger="open-stacked-toast" duration="3000" message="This is a toast with a long message and a button that appears on the next line." layout="stacked"></ion-toast>
+      <ion-toast trigger="open-inline-toast" duration="3000" message="This is a toast with a long message and a button that appears on the same line."></ion-toast>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const toasts = document.querySelectorAll('ion-toast');
+
+    toasts.forEach((toast) => {
+      toast.buttons = [
+        {
+          text: 'Action With Long Text',
+        },
+      ];
+    });
+  </script>
+</body>
+
+</html>

--- a/static/usage/v7/toast/layout/demo.html
+++ b/static/usage/v7/toast/layout/demo.html
@@ -19,7 +19,7 @@
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+      <ion-button id="open-inline-toast">Open Baseline Layout Toast</ion-button>
       <ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
       <ion-toast trigger="open-stacked-toast" duration="3000" message="This is a toast with a long message and a button that appears on the next line." layout="stacked"></ion-toast>
       <ion-toast trigger="open-inline-toast" duration="3000" message="This is a toast with a long message and a button that appears on the same line."></ion-toast>

--- a/static/usage/v7/toast/layout/demo.html
+++ b/static/usage/v7/toast/layout/demo.html
@@ -19,8 +19,8 @@
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <ion-button id="open-inline-toast">Open Inline Toast</ion-button>
-      <ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+      <ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+      <ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
       <ion-toast trigger="open-stacked-toast" duration="3000" message="This is a toast with a long message and a button that appears on the next line." layout="stacked"></ion-toast>
       <ion-toast trigger="open-inline-toast" duration="3000" message="This is a toast with a long message and a button that appears on the same line."></ion-toast>
     </ion-content>

--- a/static/usage/v7/toast/layout/index.md
+++ b/static/usage/v7/toast/layout/index.md
@@ -1,0 +1,25 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="7"
+  devicePreview
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/toast/layout/demo.html"
+/>

--- a/static/usage/v7/toast/layout/javascript.md
+++ b/static/usage/v7/toast/layout/javascript.md
@@ -1,0 +1,18 @@
+```html
+<ion-button id="open-inline-toast">Open Inline Toast</ion-button>
+<ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+<ion-toast trigger="open-inline-toast" duration="3000" message="This is a toast with a long message and a button that appears on the same line."></ion-toast>
+<ion-toast trigger="open-stacked-toast" duration="3000" message="This is a toast with a long message and a button that appears on the next line." layout="stacked"></ion-toast>
+
+<script>
+  const toasts = document.querySelectorAll('ion-toast');
+  
+  toasts.forEach((toast) => {
+    toast.buttons = [
+      {
+        text: 'Action With Long Text',
+      },
+    ];
+  });
+</script>
+```

--- a/static/usage/v7/toast/layout/javascript.md
+++ b/static/usage/v7/toast/layout/javascript.md
@@ -1,5 +1,5 @@
 ```html
-<ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+<ion-button id="open-inline-toast">Open Baseline Layout Toast</ion-button>
 <ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
 <ion-toast trigger="open-inline-toast" duration="3000" message="This is a toast with a long message and a button that appears on the same line."></ion-toast>
 <ion-toast trigger="open-stacked-toast" duration="3000" message="This is a toast with a long message and a button that appears on the next line." layout="stacked"></ion-toast>

--- a/static/usage/v7/toast/layout/javascript.md
+++ b/static/usage/v7/toast/layout/javascript.md
@@ -1,6 +1,6 @@
 ```html
-<ion-button id="open-inline-toast">Open Inline Toast</ion-button>
-<ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+<ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+<ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
 <ion-toast trigger="open-inline-toast" duration="3000" message="This is a toast with a long message and a button that appears on the same line."></ion-toast>
 <ion-toast trigger="open-stacked-toast" duration="3000" message="This is a toast with a long message and a button that appears on the next line." layout="stacked"></ion-toast>
 

--- a/static/usage/v7/toast/layout/react.md
+++ b/static/usage/v7/toast/layout/react.md
@@ -1,0 +1,35 @@
+```tsx
+import React from 'react';
+import { IonButton, IonToast } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonButton id="open-stacked-toast">Open Stacked Toast</IonButton>
+      <IonButton id="open-inline-toast">Open Inline Toast</IonButton>
+      <IonToast
+        trigger="open-inline-toast"
+        message="This is a toast with a long message and a button that appears on the same line."
+        duration={3000}
+        buttons={[
+          {
+            text: 'Action With Long Text',
+          }
+        ]}
+      ></IonToast>
+      <IonToast
+        trigger="open-stacked-toast"
+        message="This is a toast with a long message and a button that appears on the next line."
+        duration={3000}
+        buttons={[
+          {
+            text: 'Action With Long Text',
+          }
+        ]}
+        layout="stacked"
+      ></IonToast>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/toast/layout/react.md
+++ b/static/usage/v7/toast/layout/react.md
@@ -5,8 +5,8 @@ import { IonButton, IonToast } from '@ionic/react';
 function Example() {
   return (
     <>
-      <IonButton id="open-stacked-toast">Open Stacked Toast</IonButton>
-      <IonButton id="open-inline-toast">Open Inline Toast</IonButton>
+      <IonButton id="open-stacked-toast">Open Stacked Layout Toast</IonButton>
+      <IonButton id="open-inline-toast">Open Inline Layout Toast</IonButton>
       <IonToast
         trigger="open-inline-toast"
         message="This is a toast with a long message and a button that appears on the same line."

--- a/static/usage/v7/toast/layout/react.md
+++ b/static/usage/v7/toast/layout/react.md
@@ -6,7 +6,7 @@ function Example() {
   return (
     <>
       <IonButton id="open-stacked-toast">Open Stacked Layout Toast</IonButton>
-      <IonButton id="open-inline-toast">Open Inline Layout Toast</IonButton>
+      <IonButton id="open-inline-toast">Open Baseline Layout Toast</IonButton>
       <IonToast
         trigger="open-inline-toast"
         message="This is a toast with a long message and a button that appears on the same line."

--- a/static/usage/v7/toast/layout/vue.md
+++ b/static/usage/v7/toast/layout/vue.md
@@ -1,0 +1,37 @@
+```html
+<template>
+  <ion-button id="open-inline-toast">Open Inline Toast</ion-button>
+  <ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+  <ion-toast 
+    trigger="open-inline-toast" 
+    :duration="3000"
+    :buttons="toastButtons"
+    message="This is a toast with a long message and a button that appears on the same line."
+  ></ion-toast>
+  <ion-toast
+    trigger="open-stacked-toast" 
+    :duration="3000"
+    :buttons="toastButtons"
+    message="This is a toast with a long message and a button that appears on the next line." 
+    layout="stacked"
+  ></ion-toast>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonToast } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonButton, IonToast },
+    setup() {
+      const toastButtons = [
+        {
+          text: 'Action With Long Text'
+        }
+      ]
+
+      return toastButtons }
+    }
+  });
+</script>
+```

--- a/static/usage/v7/toast/layout/vue.md
+++ b/static/usage/v7/toast/layout/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+  <ion-button id="open-inline-toast">Open Baseline Layout Toast</ion-button>
   <ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
   <ion-toast 
     trigger="open-inline-toast" 

--- a/static/usage/v7/toast/layout/vue.md
+++ b/static/usage/v7/toast/layout/vue.md
@@ -1,7 +1,7 @@
 ```html
 <template>
-  <ion-button id="open-inline-toast">Open Inline Toast</ion-button>
-  <ion-button id="open-stacked-toast">Open Stacked Toast</ion-button>
+  <ion-button id="open-inline-toast">Open Inline Layout Toast</ion-button>
+  <ion-button id="open-stacked-toast">Open Stacked Layout Toast</ion-button>
   <ion-toast 
     trigger="open-inline-toast" 
     :duration="3000"

--- a/versioned_docs/version-v6/api/toast.md
+++ b/versioned_docs/version-v6/api/toast.md
@@ -101,7 +101,7 @@ import ButtonsPlayground from '@site/static/usage/v6/toast/buttons/index.md';
 
 ## Layout
 
-Button containers within the toast can be displayed either inline with the message or stacked on separate lines using the `layout` property. The stacked layout should be used with buttons that have long text values. Additionally, buttons in a stacked toast layout can use a `side` value of either `start` or `end`, but not both.
+Button containers within the toast can be displayed either on the same line as the message or stacked on separate lines using the `layout` property. The stacked layout should be used with buttons that have long text values. Additionally, buttons in a stacked toast layout can use a `side` value of either `start` or `end`, but not both.
 
 import StackedPlayground from '@site/static/usage/v6/toast/layout/index.md';
 

--- a/versioned_docs/version-v6/api/toast.md
+++ b/versioned_docs/version-v6/api/toast.md
@@ -99,6 +99,14 @@ import ButtonsPlayground from '@site/static/usage/v6/toast/buttons/index.md';
 
 <ButtonsPlayground />
 
+## Layout
+
+Button containers within the toast can be displayed either inline with the message or stacked on separate lines using the `layout` property. The stacked layout should be used with buttons that have long text values. Additionally, buttons in a stacked toast layout can use a `side` value of either `start` or `end`, but not both.
+
+import StackedPlayground from '@site/static/usage/v6/toast/layout/index.md';
+
+<StackedPlayground />
+
 ## Icons
 
 An icon can be added next to the content inside of the toast. In general, icons in toasts should be used to add additional style or context, not to grab the user's attention or elevate the priority of the toast. If you wish to convey a higher priority message to the user or guarantee a response, we recommend using an [Alert](alert.md) instead.


### PR DESCRIPTION
⚠️ Remove dev builds from html demo prior to merging.

Part of https://github.com/ionic-team/ionic-framework/pull/26790

This PR adds a playground to both the v7 and v6 docs to show how to use the new layout feature for `ion-toast`.

Note: I made two dev builds, one for v6 and one for v7, to show in the iframe demos. However, the layout feature will not work on StackBlitz since those are pulling the latest versions of Ionic. The toasts in StackBlitz demos _should_ still open/close properly though.

Preview: https://ionic-docs-git-1503-docs-ionic1.vercel.app/docs/api/toast#layout