### PR TITLE
docs(datetime): add highlightedDates playgrounds

### DIFF
--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -290,6 +290,8 @@ Developers can provide their own buttons for advanced custom behavior.
 
 Using the `highlightedDates` property, developers can style particular dates with custom text or background colors. This property can be defined as either an array of dates and their colors, or a callback that receives an ISO string and returns the colors to use.
 
+To maintain a consistent user experience, the style of selected date(s) will always override custom highlights.
+
 :::note
 This property is only supported when `preferWheel="false"`, and using a `presentation` of either `"date"`, `"date-time"`, or `"time-date"`.
 :::

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -298,9 +298,13 @@ This property is only supported when `preferWheel="false"`, and using a `present
 
 ### Using Array
 
+An array is better when the highlights apply to fixed dates, such as due dates.
+
 <HighlightedDatesArray />
 
 ### Using Callback
+
+A callback is better when the highlighted dates are recurring, such as birthdays or recurring meetings.
 
 <HighlightedDatesCallback />
 

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -290,6 +290,8 @@ Developers can provide their own buttons for advanced custom behavior.
 
 Using the `highlightedDates` property, developers can style particular dates with custom text or background colors. This property can be defined as either an array of dates and their colors, or a callback that receives an ISO string and returns the colors to use.
 
+When specifying colors, any valid CSS color format can be used. This includes hex codes, rgba, [color variables](../theming/colors), etc.
+
 To maintain a consistent user experience, the style of selected date(s) will always override custom highlights.
 
 :::note

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -31,6 +31,9 @@ import ShowingConfirmationButtons from '@site/static/usage/v7/datetime/buttons/s
 import CustomizingButtons from '@site/static/usage/v7/datetime/buttons/customizing-buttons/index.md';
 import CustomizingButtonTexts from '@site/static/usage/v7/datetime/buttons/customizing-button-texts/index.md';
 
+import HighlightedDatesArray from '@site/static/usage/v7/datetime/highlightedDates/array/index.md';
+import HighlightedDatesCallback from '@site/static/usage/v7/datetime/highlightedDates/callback/index.md';
+
 import MultipleDateSelection from '@site/static/usage/v7/datetime/multiple/index.md';
 
 import Theming from '@site/static/usage/v7/datetime/theming/index.md';
@@ -282,6 +285,24 @@ Developers can provide their own buttons for advanced custom behavior.
 `ion-datetime` has `confirm`, `cancel`, and `reset` methods that developers can call when clicking on custom buttons. The `reset` method also allows developers to provide a date to reset the datetime to.
 
 <CustomizingButtons />
+
+## Highlighting Specific Dates
+
+Using the `highlightedDates` property, developers can style particular dates with custom text or background colors. This property can be defined as either an array of dates and their colors, or a callback that receives an ISO string and returns the colors to use.
+
+:::note
+This property is only supported when `preferWheel="false"`, and using a `presentation` of either `"date"`, `"date-time"`, or `"time-date"`.
+:::
+
+### Using Array
+
+Note that provided `date` strings should not contain any time information.
+
+<HighlightedDatesArray />
+
+### Using Callback
+
+<HighlightedDatesCallback />
 
 ## Theming
 

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -296,8 +296,6 @@ This property is only supported when `preferWheel="false"`, and using a `present
 
 ### Using Array
 
-Note that provided `date` strings should not contain any time information.
-
 <HighlightedDatesArray />
 
 ### Using Callback

--- a/static/usage/v6/datetime/highlightedDates/array/angular/example_component_html.md
+++ b/static/usage/v6/datetime/highlightedDates/array/angular/example_component_html.md
@@ -1,0 +1,7 @@
+```html
+<ion-datetime
+  presentation="date"
+  value="2023-01-01"
+  [highlightedDates]="highlightedDates"
+></ion-datetime>
+```

--- a/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  public highlightedDates = [
+  highlightedDates = [
     {
       date: '2023-01-05',
       textColor: '#800080',

--- a/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -1,0 +1,32 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  public highlightedDates = [
+    {
+      date: '2023-01-05',
+      color: '#800080',
+      backgroundColor: '#ffc0cb',
+    },
+    {
+      date: '2023-01-10',
+      color: '#09721b',
+      backgroundColor: '#c8e5d0',
+    },
+    {
+      date: '2023-01-20',
+      color: '#0000ff',
+      backgroundColor: '#add8e6',
+    },
+    {
+      date: '2023-01-23',
+      color: '#440ab8',
+      backgroundColor: '#d3c8e5'
+    }
+  ];
+}
+```

--- a/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -9,22 +9,22 @@ export class ExampleComponent {
   public highlightedDates = [
     {
       date: '2023-01-05',
-      color: '#800080',
+      textColor: '#800080',
       backgroundColor: '#ffc0cb',
     },
     {
       date: '2023-01-10',
-      color: '#09721b',
+      textColor: '#09721b',
       backgroundColor: '#c8e5d0',
     },
     {
       date: '2023-01-20',
-      color: '#0000ff',
+      textColor: '#0000ff',
       backgroundColor: '#add8e6',
     },
     {
       date: '2023-01-23',
-      color: '#440ab8',
+      textColor: '#440ab8',
       backgroundColor: '#d3c8e5'
     }
   ];

--- a/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v6/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -19,13 +19,13 @@ export class ExampleComponent {
     },
     {
       date: '2023-01-20',
-      textColor: '#0000ff',
-      backgroundColor: '#add8e6',
+      textColor: 'var(--ion-color-secondary-contrast)',
+      backgroundColor: 'var(--ion-color-secondary)',
     },
     {
       date: '2023-01-23',
-      textColor: '#440ab8',
-      backgroundColor: '#d3c8e5'
+      textColor: 'rgb(68, 10, 184)',
+      backgroundColor: 'rgb(211, 200, 229)'
     }
   ];
 }

--- a/static/usage/v6/datetime/highlightedDates/array/demo.html
+++ b/static/usage/v6/datetime/highlightedDates/array/demo.html
@@ -40,13 +40,13 @@
       },
       {
         date: '2023-01-20',
-        textColor: '#0000ff',
-        backgroundColor: '#add8e6',
+        textColor: 'var(--ion-color-secondary-contrast)',
+        backgroundColor: 'var(--ion-color-secondary)',
       },
       {
         date: '2023-01-23',
-        textColor: '#440ab8',
-        backgroundColor: '#d3c8e5'
+        textColor: 'rgb(68, 10, 184)',
+        backgroundColor: 'rgb(211, 200, 229)'
       }
     ];
   </script>

--- a/static/usage/v6/datetime/highlightedDates/array/demo.html
+++ b/static/usage/v6/datetime/highlightedDates/array/demo.html
@@ -7,8 +7,8 @@
   <title>Datetime</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/css/ionic.bundle.css" />
   <style>
     ion-datetime {
       width: 350px;
@@ -30,22 +30,22 @@
     datetime.highlightedDates = [
       {
         date: '2023-01-05',
-        color: '#800080',
+        textColor: '#800080',
         backgroundColor: '#ffc0cb',
       },
       {
         date: '2023-01-10',
-        color: '#09721b',
+        textColor: '#09721b',
         backgroundColor: '#c8e5d0',
       },
       {
         date: '2023-01-20',
-        color: '#0000ff',
+        textColor: '#0000ff',
         backgroundColor: '#add8e6',
       },
       {
         date: '2023-01-23',
-        color: '#440ab8',
+        textColor: '#440ab8',
         backgroundColor: '#d3c8e5'
       }
     ];

--- a/static/usage/v6/datetime/highlightedDates/array/demo.html
+++ b/static/usage/v6/datetime/highlightedDates/array/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Datetime</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <style>
+    ion-datetime {
+      width: 350px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-datetime presentation="date" value="2023-01-01"></ion-datetime>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const datetime = document.querySelector('ion-datetime');
+    datetime.highlightedDates = [
+      {
+        date: '2023-01-05',
+        color: '#800080',
+        backgroundColor: '#ffc0cb',
+      },
+      {
+        date: '2023-01-10',
+        color: '#09721b',
+        backgroundColor: '#c8e5d0',
+      },
+      {
+        date: '2023-01-20',
+        color: '#0000ff',
+        backgroundColor: '#add8e6',
+      },
+      {
+        date: '2023-01-23',
+        color: '#440ab8',
+        backgroundColor: '#d3c8e5'
+      }
+    ];
+  </script>
+</body>
+
+</html>

--- a/static/usage/v6/datetime/highlightedDates/array/index.md
+++ b/static/usage/v6/datetime/highlightedDates/array/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  size="medium"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v6/datetime/highlightedDates/array/demo.html"
+/>

--- a/static/usage/v6/datetime/highlightedDates/array/index.md
+++ b/static/usage/v6/datetime/highlightedDates/array/index.md
@@ -9,6 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
+  version={6}
   code={{
     javascript,
     react,

--- a/static/usage/v6/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/array/javascript.md
@@ -1,0 +1,29 @@
+```html
+<ion-datetime presentation="date" value="2023-01-01"></ion-datetime>
+
+<script>
+  const datetime = document.querySelector('ion-datetime');
+  datetime.highlightedDates = [
+    {
+      date: '2023-01-05',
+      color: '#800080',
+      backgroundColor: '#ffc0cb',
+    },
+    {
+      date: '2023-01-10',
+      color: '#09721b',
+      backgroundColor: '#c8e5d0',
+    },
+    {
+      date: '2023-01-20',
+      color: '#0000ff',
+      backgroundColor: '#add8e6',
+    },
+    {
+      date: '2023-01-23',
+      color: '#440ab8',
+      backgroundColor: '#d3c8e5'
+    }
+  ];
+</script>
+```

--- a/static/usage/v6/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/array/javascript.md
@@ -16,13 +16,13 @@
     },
     {
       date: '2023-01-20',
-      textColor: '#0000ff',
-      backgroundColor: '#add8e6',
+      textColor: 'var(--ion-color-secondary-contrast)',
+      backgroundColor: 'var(--ion-color-secondary)',
     },
     {
       date: '2023-01-23',
-      textColor: '#440ab8',
-      backgroundColor: '#d3c8e5'
+      textColor: 'rgb(68, 10, 184)',
+      backgroundColor: 'rgb(211, 200, 229)'
     }
   ];
 </script>

--- a/static/usage/v6/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/array/javascript.md
@@ -2,7 +2,7 @@
 <ion-datetime presentation="date" value="2023-01-01"></ion-datetime>
 
 <script>
-  const datetime = document.querySelector('ion-datetime');
+  var datetime = document.querySelector('ion-datetime');
   datetime.highlightedDates = [
     {
       date: '2023-01-05',

--- a/static/usage/v6/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/array/javascript.md
@@ -6,22 +6,22 @@
   datetime.highlightedDates = [
     {
       date: '2023-01-05',
-      color: '#800080',
+      textColor: '#800080',
       backgroundColor: '#ffc0cb',
     },
     {
       date: '2023-01-10',
-      color: '#09721b',
+      textColor: '#09721b',
       backgroundColor: '#c8e5d0',
     },
     {
       date: '2023-01-20',
-      color: '#0000ff',
+      textColor: '#0000ff',
       backgroundColor: '#add8e6',
     },
     {
       date: '2023-01-23',
-      color: '#440ab8',
+      textColor: '#440ab8',
       backgroundColor: '#d3c8e5'
     }
   ];

--- a/static/usage/v6/datetime/highlightedDates/array/react.md
+++ b/static/usage/v6/datetime/highlightedDates/array/react.md
@@ -1,0 +1,35 @@
+```tsx
+import React from 'react';
+import { IonDatetime } from '@ionic/react';
+function Example() {
+  return (
+    <IonDatetime
+      presentation="date"
+      value="2023-01-01"
+      highlightedDates={[
+        {
+          date: '2023-01-05',
+          color: '#800080',
+          backgroundColor: '#ffc0cb',
+        },
+        {
+          date: '2023-01-10',
+          color: '#09721b',
+          backgroundColor: '#c8e5d0',
+        },
+        {
+          date: '2023-01-20',
+          color: '#0000ff',
+          backgroundColor: '#add8e6',
+        },
+        {
+          date: '2023-01-23',
+          color: '#440ab8',
+          backgroundColor: '#d3c8e5'
+        }
+      ]}
+    ></IonDatetime>
+  );
+}
+export default Example;
+```

--- a/static/usage/v6/datetime/highlightedDates/array/react.md
+++ b/static/usage/v6/datetime/highlightedDates/array/react.md
@@ -9,22 +9,22 @@ function Example() {
       highlightedDates={[
         {
           date: '2023-01-05',
-          color: '#800080',
+          textColor: '#800080',
           backgroundColor: '#ffc0cb',
         },
         {
           date: '2023-01-10',
-          color: '#09721b',
+          textColor: '#09721b',
           backgroundColor: '#c8e5d0',
         },
         {
           date: '2023-01-20',
-          color: '#0000ff',
+          textColor: '#0000ff',
           backgroundColor: '#add8e6',
         },
         {
           date: '2023-01-23',
-          color: '#440ab8',
+          textColor: '#440ab8',
           backgroundColor: '#d3c8e5'
         }
       ]}

--- a/static/usage/v6/datetime/highlightedDates/array/react.md
+++ b/static/usage/v6/datetime/highlightedDates/array/react.md
@@ -19,13 +19,13 @@ function Example() {
         },
         {
           date: '2023-01-20',
-          textColor: '#0000ff',
-          backgroundColor: '#add8e6',
+          textColor: 'var(--ion-color-secondary-contrast)',
+          backgroundColor: 'var(--ion-color-secondary)',
         },
         {
           date: '2023-01-23',
-          textColor: '#440ab8',
-          backgroundColor: '#d3c8e5'
+          textColor: 'rgb(68, 10, 184)',
+          backgroundColor: 'rgb(211, 200, 229)'
         }
       ]}
     ></IonDatetime>

--- a/static/usage/v6/datetime/highlightedDates/array/vue.md
+++ b/static/usage/v6/datetime/highlightedDates/array/vue.md
@@ -1,0 +1,44 @@
+```html
+<template>
+  <ion-datetime
+    presentation="date"
+    value="2023-01-01"
+    :highlighted-dates="highlightedDates"
+  ></ion-datetime>
+</template>
+
+<script lang="ts">
+  import { IonDatetime } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonDatetime },
+    setup() {
+      const highlightedDates = [
+        {
+          date: '2023-01-05',
+          color: '#800080',
+          backgroundColor: '#ffc0cb',
+        },
+        {
+          date: '2023-01-10',
+          color: '#09721b',
+          backgroundColor: '#c8e5d0',
+        },
+        {
+          date: '2023-01-20',
+          color: '#0000ff',
+          backgroundColor: '#add8e6',
+        },
+        {
+          date: '2023-01-23',
+          color: '#440ab8',
+          backgroundColor: '#d3c8e5'
+        }
+      ];
+      
+      return { highlightedDates }
+    }
+  });
+</script>
+```

--- a/static/usage/v6/datetime/highlightedDates/array/vue.md
+++ b/static/usage/v6/datetime/highlightedDates/array/vue.md
@@ -27,13 +27,13 @@
         },
         {
           date: '2023-01-20',
-          textColor: '#0000ff',
-          backgroundColor: '#add8e6',
+          textColor: 'var(--ion-color-secondary-contrast)',
+          backgroundColor: 'var(--ion-color-secondary)',
         },
         {
           date: '2023-01-23',
-          textColor: '#440ab8',
-          backgroundColor: '#d3c8e5'
+          textColor: 'rgb(68, 10, 184)',
+          backgroundColor: 'rgb(211, 200, 229)'
         }
       ];
       

--- a/static/usage/v6/datetime/highlightedDates/array/vue.md
+++ b/static/usage/v6/datetime/highlightedDates/array/vue.md
@@ -17,22 +17,22 @@
       const highlightedDates = [
         {
           date: '2023-01-05',
-          color: '#800080',
+          textColor: '#800080',
           backgroundColor: '#ffc0cb',
         },
         {
           date: '2023-01-10',
-          color: '#09721b',
+          textColor: '#09721b',
           backgroundColor: '#c8e5d0',
         },
         {
           date: '2023-01-20',
-          color: '#0000ff',
+          textColor: '#0000ff',
           backgroundColor: '#add8e6',
         },
         {
           date: '2023-01-23',
-          color: '#440ab8',
+          textColor: '#440ab8',
           backgroundColor: '#d3c8e5'
         }
       ];

--- a/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_html.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-datetime presentation="date" [highlightedDates]="highlightedDates"></ion-datetime>
+```

--- a/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_ts.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_ts.md
@@ -19,8 +19,8 @@ export class ExampleComponent {
 
     if(utcDay % 3 === 0) {
       return {
-        textColor: '#0000ff',
-        backgroundColor: '#add8e6',
+        textColor: 'var(--ion-color-secondary-contrast)',
+        backgroundColor: 'var(--ion-color-secondary)',
       };
     }
 

--- a/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_ts.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_ts.md
@@ -1,0 +1,30 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  highlightedDates = (isoString) => {
+    const date = new Date(isoString);
+    const utcDay = date.getUTCDate();
+
+    if(utcDay % 5 === 0) {
+      return {
+        color: '#800080',
+        backgroundColor: '#ffc0cb',
+      };
+    }
+
+    if(utcDay % 3 === 0) {
+      return {
+        color: '#0000ff',
+        backgroundColor: '#add8e6',
+      };
+    }
+
+    return undefined;
+  };
+}
+```

--- a/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_ts.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/angular/example_component_ts.md
@@ -12,14 +12,14 @@ export class ExampleComponent {
 
     if(utcDay % 5 === 0) {
       return {
-        color: '#800080',
+        textColor: '#800080',
         backgroundColor: '#ffc0cb',
       };
     }
 
     if(utcDay % 3 === 0) {
       return {
-        color: '#0000ff',
+        textColor: '#0000ff',
         backgroundColor: '#add8e6',
       };
     }

--- a/static/usage/v6/datetime/highlightedDates/callback/demo.html
+++ b/static/usage/v6/datetime/highlightedDates/callback/demo.html
@@ -7,8 +7,8 @@
   <title>Datetime</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/css/ionic.bundle.css" />
   <style>
     ion-datetime {
       width: 350px;
@@ -33,14 +33,14 @@
 
       if(utcDay % 5 === 0) {
         return {
-          color: '#800080',
+          textColor: '#800080',
           backgroundColor: '#ffc0cb',
         };
       }
 
       if(utcDay % 3 === 0) {
         return {
-          color: '#0000ff',
+          textColor: '#0000ff',
           backgroundColor: '#add8e6',
         };
       }

--- a/static/usage/v6/datetime/highlightedDates/callback/demo.html
+++ b/static/usage/v6/datetime/highlightedDates/callback/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Datetime</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <style>
+    ion-datetime {
+      width: 350px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-datetime presentation="date"></ion-datetime>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const datetime = document.querySelector('ion-datetime');
+    datetime.highlightedDates = (isoString) => {
+      const date = new Date(isoString);
+      const utcDay = date.getUTCDate();
+
+      if(utcDay % 5 === 0) {
+        return {
+          color: '#800080',
+          backgroundColor: '#ffc0cb',
+        };
+      }
+
+      if(utcDay % 3 === 0) {
+        return {
+          color: '#0000ff',
+          backgroundColor: '#add8e6',
+        };
+      }
+
+      return undefined;
+    };
+  </script>
+</body>
+
+</html>

--- a/static/usage/v6/datetime/highlightedDates/callback/demo.html
+++ b/static/usage/v6/datetime/highlightedDates/callback/demo.html
@@ -40,8 +40,8 @@
 
       if(utcDay % 3 === 0) {
         return {
-          textColor: '#0000ff',
-          backgroundColor: '#add8e6',
+          textColor: 'var(--ion-color-secondary-contrast)',
+          backgroundColor: 'var(--ion-color-secondary)',
         };
       }
 

--- a/static/usage/v6/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/index.md
@@ -9,6 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
+  version={6}
   code={{
     javascript,
     react,

--- a/static/usage/v6/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  size="medium"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v6/datetime/highlightedDates/callback/demo.html"
+/>

--- a/static/usage/v6/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/javascript.md
@@ -1,0 +1,27 @@
+```html
+<ion-datetime presentation="date"></ion-datetime>
+
+<script>
+  const datetime = document.querySelector('ion-datetime');
+  datetime.highlightedDates = (isoString) => {
+    const date = new Date(isoString);
+    const utcDay = date.getUTCDate();
+
+    if(utcDay % 5 === 0) {
+      return {
+        color: '#800080',
+        backgroundColor: '#ffc0cb',
+      };
+    }
+
+    if(utcDay % 3 === 0) {
+      return {
+        color: '#0000ff',
+        backgroundColor: '#add8e6',
+      };
+    }
+
+    return undefined;
+  };
+</script>
+```

--- a/static/usage/v6/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/javascript.md
@@ -9,14 +9,14 @@
 
     if(utcDay % 5 === 0) {
       return {
-        color: '#800080',
+        textColor: '#800080',
         backgroundColor: '#ffc0cb',
       };
     }
 
     if(utcDay % 3 === 0) {
       return {
-        color: '#0000ff',
+        textColor: '#0000ff',
         backgroundColor: '#add8e6',
       };
     }

--- a/static/usage/v6/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/javascript.md
@@ -2,7 +2,7 @@
 <ion-datetime presentation="date"></ion-datetime>
 
 <script>
-  const datetime = document.querySelector('ion-datetime');
+  var datetime = document.querySelector('ion-datetime');
   datetime.highlightedDates = (isoString) => {
     const date = new Date(isoString);
     const utcDay = date.getUTCDate();

--- a/static/usage/v6/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/javascript.md
@@ -16,8 +16,8 @@
 
     if(utcDay % 3 === 0) {
       return {
-        textColor: '#0000ff',
-        backgroundColor: '#add8e6',
+        textColor: 'var(--ion-color-secondary-contrast)',
+        backgroundColor: 'var(--ion-color-secondary)',
       };
     }
 

--- a/static/usage/v6/datetime/highlightedDates/callback/react.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/react.md
@@ -11,14 +11,14 @@ function Example() {
 
         if(utcDay % 5 === 0) {
           return {
-            color: '#800080',
+            textColor: '#800080',
             backgroundColor: '#ffc0cb',
           };
         }
 
         if(utcDay % 3 === 0) {
           return {
-            color: '#0000ff',
+            textColor: '#0000ff',
             backgroundColor: '#add8e6',
           };
         }

--- a/static/usage/v6/datetime/highlightedDates/callback/react.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/react.md
@@ -1,0 +1,32 @@
+```tsx
+import React from 'react';
+import { IonDatetime } from '@ionic/react';
+function Example() {
+  return (
+    <IonDatetime
+      presentation="date"
+      highlightedDates={(isoString) => {
+        const date = new Date(isoString);
+        const utcDay = date.getUTCDate();
+
+        if(utcDay % 5 === 0) {
+          return {
+            color: '#800080',
+            backgroundColor: '#ffc0cb',
+          };
+        }
+
+        if(utcDay % 3 === 0) {
+          return {
+            color: '#0000ff',
+            backgroundColor: '#add8e6',
+          };
+        }
+
+        return undefined;
+      }}
+    ></IonDatetime>
+  );
+}
+export default Example;
+```

--- a/static/usage/v6/datetime/highlightedDates/callback/react.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/react.md
@@ -18,8 +18,8 @@ function Example() {
 
         if(utcDay % 3 === 0) {
           return {
-            textColor: '#0000ff',
-            backgroundColor: '#add8e6',
+            textColor: 'var(--ion-color-secondary-contrast)',
+            backgroundColor: 'var(--ion-color-secondary)',
           };
         }
 

--- a/static/usage/v6/datetime/highlightedDates/callback/vue.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/vue.md
@@ -16,14 +16,14 @@
 
         if(utcDay % 5 === 0) {
           return {
-            color: '#800080',
+            textColor: '#800080',
             backgroundColor: '#ffc0cb',
           };
         }
 
         if(utcDay % 3 === 0) {
           return {
-            color: '#0000ff',
+            textColor: '#0000ff',
             backgroundColor: '#add8e6',
           };
         }

--- a/static/usage/v6/datetime/highlightedDates/callback/vue.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/vue.md
@@ -23,8 +23,8 @@
 
         if(utcDay % 3 === 0) {
           return {
-            textColor: '#0000ff',
-            backgroundColor: '#add8e6',
+            textColor: 'var(--ion-color-secondary-contrast)',
+            backgroundColor: 'var(--ion-color-secondary)',
           };
         }
 

--- a/static/usage/v6/datetime/highlightedDates/callback/vue.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/vue.md
@@ -1,0 +1,38 @@
+```html
+<template>
+  <ion-datetime presentation="date" :highlighted-dates="highlightedDates"></ion-datetime>
+</template>
+
+<script lang="ts">
+  import { IonDatetime } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonDatetime },
+    setup() {
+      const highlightedDates = (isoString) => {
+        const date = new Date(isoString);
+        const utcDay = date.getUTCDate();
+
+        if(utcDay % 5 === 0) {
+          return {
+            color: '#800080',
+            backgroundColor: '#ffc0cb',
+          };
+        }
+
+        if(utcDay % 3 === 0) {
+          return {
+            color: '#0000ff',
+            backgroundColor: '#add8e6',
+          };
+        }
+
+        return undefined;
+      };
+
+      return { highlightedDates }
+    }
+  });
+</script>
+```

--- a/static/usage/v7/datetime/highlightedDates/array/angular/example_component_html.md
+++ b/static/usage/v7/datetime/highlightedDates/array/angular/example_component_html.md
@@ -1,0 +1,7 @@
+```html
+<ion-datetime
+  presentation="date"
+  value="2023-01-01"
+  [highlightedDates]="highlightedDates"
+></ion-datetime>
+```

--- a/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  public highlightedDates = [
+  highlightedDates = [
     {
       date: '2023-01-05',
       textColor: '#800080',

--- a/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -1,0 +1,32 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  public highlightedDates = [
+    {
+      date: '2023-01-05',
+      color: '#800080',
+      backgroundColor: '#ffc0cb',
+    },
+    {
+      date: '2023-01-10',
+      color: '#09721b',
+      backgroundColor: '#c8e5d0',
+    },
+    {
+      date: '2023-01-20',
+      color: '#0000ff',
+      backgroundColor: '#add8e6',
+    },
+    {
+      date: '2023-01-23',
+      color: '#440ab8',
+      backgroundColor: '#d3c8e5'
+    }
+  ];
+}
+```

--- a/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -9,22 +9,22 @@ export class ExampleComponent {
   public highlightedDates = [
     {
       date: '2023-01-05',
-      color: '#800080',
+      textColor: '#800080',
       backgroundColor: '#ffc0cb',
     },
     {
       date: '2023-01-10',
-      color: '#09721b',
+      textColor: '#09721b',
       backgroundColor: '#c8e5d0',
     },
     {
       date: '2023-01-20',
-      color: '#0000ff',
+      textColor: '#0000ff',
       backgroundColor: '#add8e6',
     },
     {
       date: '2023-01-23',
-      color: '#440ab8',
+      textColor: '#440ab8',
       backgroundColor: '#d3c8e5'
     }
   ];

--- a/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v7/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -19,13 +19,13 @@ export class ExampleComponent {
     },
     {
       date: '2023-01-20',
-      textColor: '#0000ff',
-      backgroundColor: '#add8e6',
+      textColor: 'var(--ion-color-secondary-contrast)',
+      backgroundColor: 'var(--ion-color-secondary)',
     },
     {
       date: '2023-01-23',
-      textColor: '#440ab8',
-      backgroundColor: '#d3c8e5'
+      textColor: 'rgb(68, 10, 184)',
+      backgroundColor: 'rgb(211, 200, 229)'
     }
   ];
 }

--- a/static/usage/v7/datetime/highlightedDates/array/demo.html
+++ b/static/usage/v7/datetime/highlightedDates/array/demo.html
@@ -40,13 +40,13 @@
       },
       {
         date: '2023-01-20',
-        textColor: '#0000ff',
-        backgroundColor: '#add8e6',
+        textColor: 'var(--ion-color-secondary-contrast)',
+        backgroundColor: 'var(--ion-color-secondary)',
       },
       {
         date: '2023-01-23',
-        textColor: '#440ab8',
-        backgroundColor: '#d3c8e5'
+        textColor: 'rgb(68, 10, 184)',
+        backgroundColor: 'rgb(211, 200, 229)'
       }
     ];
   </script>

--- a/static/usage/v7/datetime/highlightedDates/array/demo.html
+++ b/static/usage/v7/datetime/highlightedDates/array/demo.html
@@ -7,8 +7,8 @@
   <title>Datetime</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/css/ionic.bundle.css" />
   <style>
     ion-datetime {
       width: 350px;
@@ -30,22 +30,22 @@
     datetime.highlightedDates = [
       {
         date: '2023-01-05',
-        color: '#800080',
+        textColor: '#800080',
         backgroundColor: '#ffc0cb',
       },
       {
         date: '2023-01-10',
-        color: '#09721b',
+        textColor: '#09721b',
         backgroundColor: '#c8e5d0',
       },
       {
         date: '2023-01-20',
-        color: '#0000ff',
+        textColor: '#0000ff',
         backgroundColor: '#add8e6',
       },
       {
         date: '2023-01-23',
-        color: '#440ab8',
+        textColor: '#440ab8',
         backgroundColor: '#d3c8e5'
       }
     ];

--- a/static/usage/v7/datetime/highlightedDates/array/demo.html
+++ b/static/usage/v7/datetime/highlightedDates/array/demo.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Datetime</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <style>
+    ion-datetime {
+      width: 350px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-datetime presentation="date" value="2023-01-01"></ion-datetime>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const datetime = document.querySelector('ion-datetime');
+    datetime.highlightedDates = [
+      {
+        date: '2023-01-05',
+        color: '#800080',
+        backgroundColor: '#ffc0cb',
+      },
+      {
+        date: '2023-01-10',
+        color: '#09721b',
+        backgroundColor: '#c8e5d0',
+      },
+      {
+        date: '2023-01-20',
+        color: '#0000ff',
+        backgroundColor: '#add8e6',
+      },
+      {
+        date: '2023-01-23',
+        color: '#440ab8',
+        backgroundColor: '#d3c8e5'
+      }
+    ];
+  </script>
+</body>
+
+</html>

--- a/static/usage/v7/datetime/highlightedDates/array/index.md
+++ b/static/usage/v7/datetime/highlightedDates/array/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  size="medium"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/datetime/highlightedDates/array/demo.html"
+/>

--- a/static/usage/v7/datetime/highlightedDates/array/index.md
+++ b/static/usage/v7/datetime/highlightedDates/array/index.md
@@ -9,6 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
+  version={7}
   code={{
     javascript,
     react,

--- a/static/usage/v7/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/array/javascript.md
@@ -1,0 +1,29 @@
+```html
+<ion-datetime presentation="date" value="2023-01-01"></ion-datetime>
+
+<script>
+  const datetime = document.querySelector('ion-datetime');
+  datetime.highlightedDates = [
+    {
+      date: '2023-01-05',
+      color: '#800080',
+      backgroundColor: '#ffc0cb',
+    },
+    {
+      date: '2023-01-10',
+      color: '#09721b',
+      backgroundColor: '#c8e5d0',
+    },
+    {
+      date: '2023-01-20',
+      color: '#0000ff',
+      backgroundColor: '#add8e6',
+    },
+    {
+      date: '2023-01-23',
+      color: '#440ab8',
+      backgroundColor: '#d3c8e5'
+    }
+  ];
+</script>
+```

--- a/static/usage/v7/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/array/javascript.md
@@ -16,13 +16,13 @@
     },
     {
       date: '2023-01-20',
-      textColor: '#0000ff',
-      backgroundColor: '#add8e6',
+      textColor: 'var(--ion-color-secondary-contrast)',
+      backgroundColor: 'var(--ion-color-secondary)',
     },
     {
       date: '2023-01-23',
-      textColor: '#440ab8',
-      backgroundColor: '#d3c8e5'
+      textColor: 'rgb(68, 10, 184)',
+      backgroundColor: 'rgb(211, 200, 229)'
     }
   ];
 </script>

--- a/static/usage/v7/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/array/javascript.md
@@ -2,7 +2,7 @@
 <ion-datetime presentation="date" value="2023-01-01"></ion-datetime>
 
 <script>
-  const datetime = document.querySelector('ion-datetime');
+  var datetime = document.querySelector('ion-datetime');
   datetime.highlightedDates = [
     {
       date: '2023-01-05',

--- a/static/usage/v7/datetime/highlightedDates/array/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/array/javascript.md
@@ -6,22 +6,22 @@
   datetime.highlightedDates = [
     {
       date: '2023-01-05',
-      color: '#800080',
+      textColor: '#800080',
       backgroundColor: '#ffc0cb',
     },
     {
       date: '2023-01-10',
-      color: '#09721b',
+      textColor: '#09721b',
       backgroundColor: '#c8e5d0',
     },
     {
       date: '2023-01-20',
-      color: '#0000ff',
+      textColor: '#0000ff',
       backgroundColor: '#add8e6',
     },
     {
       date: '2023-01-23',
-      color: '#440ab8',
+      textColor: '#440ab8',
       backgroundColor: '#d3c8e5'
     }
   ];

--- a/static/usage/v7/datetime/highlightedDates/array/react.md
+++ b/static/usage/v7/datetime/highlightedDates/array/react.md
@@ -1,0 +1,35 @@
+```tsx
+import React from 'react';
+import { IonDatetime } from '@ionic/react';
+function Example() {
+  return (
+    <IonDatetime
+      presentation="date"
+      value="2023-01-01"
+      highlightedDates={[
+        {
+          date: '2023-01-05',
+          color: '#800080',
+          backgroundColor: '#ffc0cb',
+        },
+        {
+          date: '2023-01-10',
+          color: '#09721b',
+          backgroundColor: '#c8e5d0',
+        },
+        {
+          date: '2023-01-20',
+          color: '#0000ff',
+          backgroundColor: '#add8e6',
+        },
+        {
+          date: '2023-01-23',
+          color: '#440ab8',
+          backgroundColor: '#d3c8e5'
+        }
+      ]}
+    ></IonDatetime>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/datetime/highlightedDates/array/react.md
+++ b/static/usage/v7/datetime/highlightedDates/array/react.md
@@ -9,22 +9,22 @@ function Example() {
       highlightedDates={[
         {
           date: '2023-01-05',
-          color: '#800080',
+          textColor: '#800080',
           backgroundColor: '#ffc0cb',
         },
         {
           date: '2023-01-10',
-          color: '#09721b',
+          textColor: '#09721b',
           backgroundColor: '#c8e5d0',
         },
         {
           date: '2023-01-20',
-          color: '#0000ff',
+          textColor: '#0000ff',
           backgroundColor: '#add8e6',
         },
         {
           date: '2023-01-23',
-          color: '#440ab8',
+          textColor: '#440ab8',
           backgroundColor: '#d3c8e5'
         }
       ]}

--- a/static/usage/v7/datetime/highlightedDates/array/react.md
+++ b/static/usage/v7/datetime/highlightedDates/array/react.md
@@ -19,13 +19,13 @@ function Example() {
         },
         {
           date: '2023-01-20',
-          textColor: '#0000ff',
-          backgroundColor: '#add8e6',
+          textColor: 'var(--ion-color-secondary-contrast)',
+          backgroundColor: 'var(--ion-color-secondary)',
         },
         {
           date: '2023-01-23',
-          textColor: '#440ab8',
-          backgroundColor: '#d3c8e5'
+          textColor: 'rgb(68, 10, 184)',
+          backgroundColor: 'rgb(211, 200, 229)'
         }
       ]}
     ></IonDatetime>

--- a/static/usage/v7/datetime/highlightedDates/array/vue.md
+++ b/static/usage/v7/datetime/highlightedDates/array/vue.md
@@ -1,0 +1,44 @@
+```html
+<template>
+  <ion-datetime
+    presentation="date"
+    value="2023-01-01"
+    :highlighted-dates="highlightedDates"
+  ></ion-datetime>
+</template>
+
+<script lang="ts">
+  import { IonDatetime } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonDatetime },
+    setup() {
+      const highlightedDates = [
+        {
+          date: '2023-01-05',
+          color: '#800080',
+          backgroundColor: '#ffc0cb',
+        },
+        {
+          date: '2023-01-10',
+          color: '#09721b',
+          backgroundColor: '#c8e5d0',
+        },
+        {
+          date: '2023-01-20',
+          color: '#0000ff',
+          backgroundColor: '#add8e6',
+        },
+        {
+          date: '2023-01-23',
+          color: '#440ab8',
+          backgroundColor: '#d3c8e5'
+        }
+      ];
+      
+      return { highlightedDates }
+    }
+  });
+</script>
+```

--- a/static/usage/v7/datetime/highlightedDates/array/vue.md
+++ b/static/usage/v7/datetime/highlightedDates/array/vue.md
@@ -27,13 +27,13 @@
         },
         {
           date: '2023-01-20',
-          textColor: '#0000ff',
-          backgroundColor: '#add8e6',
+          textColor: 'var(--ion-color-secondary-contrast)',
+          backgroundColor: 'var(--ion-color-secondary)',
         },
         {
           date: '2023-01-23',
-          textColor: '#440ab8',
-          backgroundColor: '#d3c8e5'
+          textColor: 'rgb(68, 10, 184)',
+          backgroundColor: 'rgb(211, 200, 229)'
         }
       ];
       

--- a/static/usage/v7/datetime/highlightedDates/array/vue.md
+++ b/static/usage/v7/datetime/highlightedDates/array/vue.md
@@ -17,22 +17,22 @@
       const highlightedDates = [
         {
           date: '2023-01-05',
-          color: '#800080',
+          textColor: '#800080',
           backgroundColor: '#ffc0cb',
         },
         {
           date: '2023-01-10',
-          color: '#09721b',
+          textColor: '#09721b',
           backgroundColor: '#c8e5d0',
         },
         {
           date: '2023-01-20',
-          color: '#0000ff',
+          textColor: '#0000ff',
           backgroundColor: '#add8e6',
         },
         {
           date: '2023-01-23',
-          color: '#440ab8',
+          textColor: '#440ab8',
           backgroundColor: '#d3c8e5'
         }
       ];

--- a/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_html.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_html.md
@@ -1,0 +1,3 @@
+```html
+<ion-datetime presentation="date" [highlightedDates]="highlightedDates"></ion-datetime>
+```

--- a/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_ts.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_ts.md
@@ -19,8 +19,8 @@ export class ExampleComponent {
 
     if(utcDay % 3 === 0) {
       return {
-        textColor: '#0000ff',
-        backgroundColor: '#add8e6',
+        textColor: 'var(--ion-color-secondary-contrast)',
+        backgroundColor: 'var(--ion-color-secondary)',
       };
     }
 

--- a/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_ts.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_ts.md
@@ -1,0 +1,30 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  highlightedDates = (isoString) => {
+    const date = new Date(isoString);
+    const utcDay = date.getUTCDate();
+
+    if(utcDay % 5 === 0) {
+      return {
+        color: '#800080',
+        backgroundColor: '#ffc0cb',
+      };
+    }
+
+    if(utcDay % 3 === 0) {
+      return {
+        color: '#0000ff',
+        backgroundColor: '#add8e6',
+      };
+    }
+
+    return undefined;
+  };
+}
+```

--- a/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_ts.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/angular/example_component_ts.md
@@ -12,14 +12,14 @@ export class ExampleComponent {
 
     if(utcDay % 5 === 0) {
       return {
-        color: '#800080',
+        textColor: '#800080',
         backgroundColor: '#ffc0cb',
       };
     }
 
     if(utcDay % 3 === 0) {
       return {
-        color: '#0000ff',
+        textColor: '#0000ff',
         backgroundColor: '#add8e6',
       };
     }

--- a/static/usage/v7/datetime/highlightedDates/callback/demo.html
+++ b/static/usage/v7/datetime/highlightedDates/callback/demo.html
@@ -7,8 +7,8 @@
   <title>Datetime</title>
   <link rel="stylesheet" href="../../../../common.css" />
   <script src="../../../../common.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676573595.1564fefe/css/ionic.bundle.css" />
   <style>
     ion-datetime {
       width: 350px;
@@ -33,14 +33,14 @@
 
       if(utcDay % 5 === 0) {
         return {
-          color: '#800080',
+          textColor: '#800080',
           backgroundColor: '#ffc0cb',
         };
       }
 
       if(utcDay % 3 === 0) {
         return {
-          color: '#0000ff',
+          textColor: '#0000ff',
           backgroundColor: '#add8e6',
         };
       }

--- a/static/usage/v7/datetime/highlightedDates/callback/demo.html
+++ b/static/usage/v7/datetime/highlightedDates/callback/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Datetime</title>
+  <link rel="stylesheet" href="../../../../common.css" />
+  <script src="../../../../common.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/dist/ionic/ionic.esm.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@6.5.3-dev.11676304326.136579da/css/ionic.bundle.css" />
+  <style>
+    ion-datetime {
+      width: 350px;
+    }
+  </style>
+</head>
+
+<body>
+  <ion-app>
+    <ion-content>
+      <div class="container">
+        <ion-datetime presentation="date"></ion-datetime>
+      </div>
+    </ion-content>
+  </ion-app>
+
+  <script>
+    const datetime = document.querySelector('ion-datetime');
+    datetime.highlightedDates = (isoString) => {
+      const date = new Date(isoString);
+      const utcDay = date.getUTCDate();
+
+      if(utcDay % 5 === 0) {
+        return {
+          color: '#800080',
+          backgroundColor: '#ffc0cb',
+        };
+      }
+
+      if(utcDay % 3 === 0) {
+        return {
+          color: '#0000ff',
+          backgroundColor: '#add8e6',
+        };
+      }
+
+      return undefined;
+    };
+  </script>
+</body>
+
+</html>

--- a/static/usage/v7/datetime/highlightedDates/callback/demo.html
+++ b/static/usage/v7/datetime/highlightedDates/callback/demo.html
@@ -40,8 +40,8 @@
 
       if(utcDay % 3 === 0) {
         return {
-          textColor: '#0000ff',
-          backgroundColor: '#add8e6',
+          textColor: 'var(--ion-color-secondary-contrast)',
+          backgroundColor: 'var(--ion-color-secondary)',
         };
       }
 

--- a/static/usage/v7/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/index.md
@@ -9,6 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
+  version={7}
   code={{
     javascript,
     react,

--- a/static/usage/v7/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  size="medium"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/datetime/highlightedDates/callback/demo.html"
+/>

--- a/static/usage/v7/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/javascript.md
@@ -1,0 +1,27 @@
+```html
+<ion-datetime presentation="date"></ion-datetime>
+
+<script>
+  const datetime = document.querySelector('ion-datetime');
+  datetime.highlightedDates = (isoString) => {
+    const date = new Date(isoString);
+    const utcDay = date.getUTCDate();
+
+    if(utcDay % 5 === 0) {
+      return {
+        color: '#800080',
+        backgroundColor: '#ffc0cb',
+      };
+    }
+
+    if(utcDay % 3 === 0) {
+      return {
+        color: '#0000ff',
+        backgroundColor: '#add8e6',
+      };
+    }
+
+    return undefined;
+  };
+</script>
+```

--- a/static/usage/v7/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/javascript.md
@@ -9,14 +9,14 @@
 
     if(utcDay % 5 === 0) {
       return {
-        color: '#800080',
+        textColor: '#800080',
         backgroundColor: '#ffc0cb',
       };
     }
 
     if(utcDay % 3 === 0) {
       return {
-        color: '#0000ff',
+        textColor: '#0000ff',
         backgroundColor: '#add8e6',
       };
     }

--- a/static/usage/v7/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/javascript.md
@@ -2,7 +2,7 @@
 <ion-datetime presentation="date"></ion-datetime>
 
 <script>
-  const datetime = document.querySelector('ion-datetime');
+  var datetime = document.querySelector('ion-datetime');
   datetime.highlightedDates = (isoString) => {
     const date = new Date(isoString);
     const utcDay = date.getUTCDate();

--- a/static/usage/v7/datetime/highlightedDates/callback/javascript.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/javascript.md
@@ -16,8 +16,8 @@
 
     if(utcDay % 3 === 0) {
       return {
-        textColor: '#0000ff',
-        backgroundColor: '#add8e6',
+        textColor: 'var(--ion-color-secondary-contrast)',
+        backgroundColor: 'var(--ion-color-secondary)',
       };
     }
 

--- a/static/usage/v7/datetime/highlightedDates/callback/react.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/react.md
@@ -11,14 +11,14 @@ function Example() {
 
         if(utcDay % 5 === 0) {
           return {
-            color: '#800080',
+            textColor: '#800080',
             backgroundColor: '#ffc0cb',
           };
         }
 
         if(utcDay % 3 === 0) {
           return {
-            color: '#0000ff',
+            textColor: '#0000ff',
             backgroundColor: '#add8e6',
           };
         }

--- a/static/usage/v7/datetime/highlightedDates/callback/react.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/react.md
@@ -1,0 +1,32 @@
+```tsx
+import React from 'react';
+import { IonDatetime } from '@ionic/react';
+function Example() {
+  return (
+    <IonDatetime
+      presentation="date"
+      highlightedDates={(isoString) => {
+        const date = new Date(isoString);
+        const utcDay = date.getUTCDate();
+
+        if(utcDay % 5 === 0) {
+          return {
+            color: '#800080',
+            backgroundColor: '#ffc0cb',
+          };
+        }
+
+        if(utcDay % 3 === 0) {
+          return {
+            color: '#0000ff',
+            backgroundColor: '#add8e6',
+          };
+        }
+
+        return undefined;
+      }}
+    ></IonDatetime>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/datetime/highlightedDates/callback/react.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/react.md
@@ -18,8 +18,8 @@ function Example() {
 
         if(utcDay % 3 === 0) {
           return {
-            textColor: '#0000ff',
-            backgroundColor: '#add8e6',
+            textColor: 'var(--ion-color-secondary-contrast)',
+            backgroundColor: 'var(--ion-color-secondary)',
           };
         }
 

--- a/static/usage/v7/datetime/highlightedDates/callback/vue.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/vue.md
@@ -16,14 +16,14 @@
 
         if(utcDay % 5 === 0) {
           return {
-            color: '#800080',
+            textColor: '#800080',
             backgroundColor: '#ffc0cb',
           };
         }
 
         if(utcDay % 3 === 0) {
           return {
-            color: '#0000ff',
+            textColor: '#0000ff',
             backgroundColor: '#add8e6',
           };
         }

--- a/static/usage/v7/datetime/highlightedDates/callback/vue.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/vue.md
@@ -23,8 +23,8 @@
 
         if(utcDay % 3 === 0) {
           return {
-            textColor: '#0000ff',
-            backgroundColor: '#add8e6',
+            textColor: 'var(--ion-color-secondary-contrast)',
+            backgroundColor: 'var(--ion-color-secondary)',
           };
         }
 

--- a/static/usage/v7/datetime/highlightedDates/callback/vue.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/vue.md
@@ -1,0 +1,38 @@
+```html
+<template>
+  <ion-datetime presentation="date" :highlighted-dates="highlightedDates"></ion-datetime>
+</template>
+
+<script lang="ts">
+  import { IonDatetime } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonDatetime },
+    setup() {
+      const highlightedDates = (isoString) => {
+        const date = new Date(isoString);
+        const utcDay = date.getUTCDate();
+
+        if(utcDay % 5 === 0) {
+          return {
+            color: '#800080',
+            backgroundColor: '#ffc0cb',
+          };
+        }
+
+        if(utcDay % 3 === 0) {
+          return {
+            color: '#0000ff',
+            backgroundColor: '#add8e6',
+          };
+        }
+
+        return undefined;
+      };
+
+      return { highlightedDates }
+    }
+  });
+</script>
+```

--- a/versioned_docs/version-v6/api/datetime.md
+++ b/versioned_docs/version-v6/api/datetime.md
@@ -293,6 +293,8 @@ Developers can provide their own buttons for advanced custom behavior.
 
 Using the `highlightedDates` property, developers can style particular dates with custom text or background colors. This property can be defined as either an array of dates and their colors, or a callback that receives an ISO string and returns the colors to use.
 
+To maintain a consistent user experience, the style of selected date(s) will always override custom highlights.
+
 :::note
 This property is only supported when `preferWheel="false"`, and using a `presentation` of either `"date"`, `"date-time"`, or `"time-date"`.
 :::

--- a/versioned_docs/version-v6/api/datetime.md
+++ b/versioned_docs/version-v6/api/datetime.md
@@ -32,6 +32,9 @@ import ShowingConfirmationButtons from '@site/static/usage/v6/datetime/buttons/s
 import CustomizingButtons from '@site/static/usage/v6/datetime/buttons/customizing-buttons/index.md';
 import CustomizingButtonTexts from '@site/static/usage/v6/datetime/buttons/customizing-button-texts/index.md';
 
+import HighlightedDatesArray from '@site/static/usage/v6/datetime/highlightedDates/array/index.md';
+import HighlightedDatesCallback from '@site/static/usage/v6/datetime/highlightedDates/callback/index.md';
+
 import MultipleDateSelection from '@site/static/usage/v6/datetime/multiple/index.md';
 
 import Theming from '@site/static/usage/v6/datetime/theming/index.md';
@@ -285,6 +288,24 @@ Developers can provide their own buttons for advanced custom behavior.
 `ion-datetime` has `confirm`, `cancel`, and `reset` methods that developers can call when clicking on custom buttons. The `reset` method also allows developers to provide a date to reset the datetime to.
 
 <CustomizingButtons />
+
+## Highlighting Specific Dates
+
+Using the `highlightedDates` property, developers can style particular dates with custom text or background colors. This property can be defined as either an array of dates and their colors, or a callback that receives an ISO string and returns the colors to use.
+
+:::note
+This property is only supported when `preferWheel="false"`, and using a `presentation` of either `"date"`, `"date-time"`, or `"time-date"`.
+:::
+
+### Using Array
+
+Note that provided `date` strings should not contain any time information.
+
+<HighlightedDatesArray />
+
+### Using Callback
+
+<HighlightedDatesCallback />
 
 ## Theming
 

--- a/versioned_docs/version-v6/api/datetime.md
+++ b/versioned_docs/version-v6/api/datetime.md
@@ -299,8 +299,6 @@ This property is only supported when `preferWheel="false"`, and using a `present
 
 ### Using Array
 
-Note that provided `date` strings should not contain any time information.
-
 <HighlightedDatesArray />
 
 ### Using Callback

--- a/versioned_docs/version-v6/api/datetime.md
+++ b/versioned_docs/version-v6/api/datetime.md
@@ -293,6 +293,8 @@ Developers can provide their own buttons for advanced custom behavior.
 
 Using the `highlightedDates` property, developers can style particular dates with custom text or background colors. This property can be defined as either an array of dates and their colors, or a callback that receives an ISO string and returns the colors to use.
 
+When specifying colors, any valid CSS color format can be used. This includes hex codes, rgba, [color variables](../theming/colors), etc.
+
 To maintain a consistent user experience, the style of selected date(s) will always override custom highlights.
 
 :::note

--- a/versioned_docs/version-v6/api/datetime.md
+++ b/versioned_docs/version-v6/api/datetime.md
@@ -301,9 +301,13 @@ This property is only supported when `preferWheel="false"`, and using a `present
 
 ### Using Array
 
+An array is better when the highlights apply to fixed dates, such as due dates.
+
 <HighlightedDatesArray />
 
 ### Using Callback
+
+A callback is better when the highlighted dates are recurring, such as birthdays or recurring meetings.
 
 <HighlightedDatesCallback />
 


### PR DESCRIPTION
Adds playgrounds for the new `highlightedDates` property added here: https://github.com/ionic-team/ionic-framework/pull/26775 Demos for using the prop as both an array and a callback are included, as well as versions for both v6 and v7.

Dev build for feature: `6.5.3-dev.11676573595.1564fefe`