### PR TITLE
docs(slides): note migration guide is for swiper 8

### DIFF
--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -16,6 +16,10 @@ title: Slides
 
 :::
 
+:::note
+This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
+:::
+
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for Angular set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Angular integration.
 
 ## Getting Started
@@ -29,7 +33,7 @@ npm install @ionic/angular@latest
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@8
 ```
 
 Once that is done, we need to import the `SwiperModule` module. This should be done in your component's module file:

--- a/docs/react/slides.md
+++ b/docs/react/slides.md
@@ -16,6 +16,11 @@ title: Slides
 
 :::
 
+:::note
+This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
+:::
+
+
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
 ## Getting Started
@@ -29,7 +34,7 @@ npm install @ionic/react@latest @ionic/react-router@latest
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@8
 ```
 
 :::note

--- a/docs/vue/slides.md
+++ b/docs/vue/slides.md
@@ -16,6 +16,11 @@ title: Slides
 
 :::
 
+:::note
+This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
+:::
+
+
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
 
 ## Getting Started
@@ -35,7 +40,7 @@ vue upgrade --next
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@8
 ```
 
 ## Swiping with Style

--- a/versioned_docs/version-v6/angular/slides.md
+++ b/versioned_docs/version-v6/angular/slides.md
@@ -10,6 +10,10 @@ title: Slides
   />
 </head>
 
+:::note
+This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
+:::
+
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `ion-slides` component, but we now recommend that developers use Swiper for Angular directly.
 
 This guide will go over how to get Swiper for Angular set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Angular integration.
@@ -25,7 +29,7 @@ npm install @ionic/angular@latest
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@8
 ```
 
 Once that is done, we need to import the `SwiperModule` module. This should be done in your component's module file:

--- a/versioned_docs/version-v6/react/slides.md
+++ b/versioned_docs/version-v6/react/slides.md
@@ -10,6 +10,10 @@ title: Slides
   />
 </head>
 
+:::note
+This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
+:::
+
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `IonSlides` component, but we now recommend that developers use Swiper for React directly.
 
 This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
@@ -25,7 +29,7 @@ npm install @ionic/react@latest @ionic/react-router@latest
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@8
 ```
 
 :::note

--- a/versioned_docs/version-v6/vue/slides.md
+++ b/versioned_docs/version-v6/vue/slides.md
@@ -10,6 +10,10 @@ title: Slides
   />
 </head>
 
+:::note
+This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
+:::
+
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `ion-slides` component, but we now recommend that developers use Swiper for Vue directly.
 
 This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
@@ -31,7 +35,7 @@ vue upgrade --next
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper
+npm install swiper@8
 ```
 
 ## Swiping with Style


### PR DESCRIPTION
Swiper 9 was recently released and introduced some breaking changes. As a result, our migration guide does not work with Swiper 9. We are working on updating the guide for Swiper 9. Until then, I have added a note stating the guide is only for Swiper 8.