### PR TITLE
docs(select): fix typo in object values and multiple selection React code

### DIFF
--- a/static/usage/v6/select/objects-as-values/multiple-selection/react.md
+++ b/static/usage/v6/select/objects-as-values/multiple-selection/react.md
@@ -58,7 +58,7 @@ function Example() {
         </IonSelect>
       </IonItem>
       <IonItem lines="none">
-        <IonLabel>Current food: {currentFood}</IonLabel>
+        <IonLabel>Current value: {currentFood}</IonLabel>
       </IonItem>
     </IonList>
   );

--- a/static/usage/v7/select/objects-as-values/multiple-selection/react.md
+++ b/static/usage/v7/select/objects-as-values/multiple-selection/react.md
@@ -59,7 +59,7 @@ function Example() {
         </IonSelect>
       </IonItem>
       <IonItem lines="none">
-        <IonLabel>Current food: {currentFood}</IonLabel>
+        <IonLabel>Current value: {currentFood}</IonLabel>
       </IonItem>
     </IonList>
   );


### PR DESCRIPTION
https://ionicframework.com/docs/api/select#object-values-and-multiple-selection

The live demo and other examples say "Current value" for the label, but React currently says "Current food".

Resolves https://github.com/ionic-team/ionic-docs/issues/2770