### PR TITLE
docs(select): use new rendering syntax for typeahead

### DIFF
--- a/static/usage/v7/select/typeahead/angular/modal-example_component_html.md
+++ b/static/usage/v7/select/typeahead/angular/modal-example_component_html.md
@@ -17,12 +17,11 @@
 <ion-content color="light" class="ion-padding">
   <ion-list id="modal-list" [inset]="true">
     <ion-item *ngFor="let item of filteredItems; trackBy: trackItems">
-      <ion-label>{{ item.text }}</ion-label>
       <ion-checkbox
         [value]="item.value" 
         [checked]="isChecked(item.value)"
         (ionChange)="checkboxChange($event)"
-      ></ion-checkbox>
+      >{{ item.text }}</ion-checkbox>
     </ion-item>
   </ion-list>
 </ion-content>

--- a/static/usage/v7/select/typeahead/demo.html
+++ b/static/usage/v7/select/typeahead/demo.html
@@ -13,7 +13,7 @@
   <body>
     <ion-app>
       <ion-content color="light">
-        <div class="container">
+        <div class="container">
           <ion-list inset="true">
             <ion-item button="true" detail="false" id="select-fruits">
               <ion-label>Favorite Fruits</ion-label>
@@ -124,8 +124,7 @@
           const checked = workingSelectedFruits.includes(item.value);
           template += `
             <ion-item>
-              <ion-label>${item.text}</ion-label>
-              <ion-checkbox slot="end" value="${item.value}" checked="${checked}"></ion-checkbox>
+              <ion-checkbox value="${item.value}" checked="${checked}">${item.text}</ion-checkbox>
             </ion-item>
           `
         });

--- a/static/usage/v7/select/typeahead/javascript.md
+++ b/static/usage/v7/select/typeahead/javascript.md
@@ -110,8 +110,7 @@
       const checked = workingSelectedFruits.includes(item.value);
       template += `
         <ion-item>
-          <ion-label>${item.text}</ion-label>
-          <ion-checkbox slot="end" value="${item.value}" checked="${checked}"></ion-checkbox>
+          <ion-checkbox value="${item.value}" checked="${checked}">${item.text}</ion-checkbox>
         </ion-item>
       `
     });

--- a/static/usage/v7/select/typeahead/react/typeahead_component_tsx.md
+++ b/static/usage/v7/select/typeahead/react/typeahead_component_tsx.md
@@ -1,6 +1,6 @@
 ```tsx
 import React, { useState } from 'react';
-import { IonButton, IonButtons, IonCheckbox, IonContent, IonHeader, IonItem, IonLabel, IonList, IonTitle, IonSearchbar, IonToolbar } from '@ionic/react';
+import { IonButton, IonButtons, IonCheckbox, IonContent, IonHeader, IonItem, IonList, IonTitle, IonSearchbar, IonToolbar } from '@ionic/react';
 import type { CheckboxCustomEvent } from '@ionic/react';
 import type { Item } from './types';
 
@@ -95,12 +95,11 @@ function AppTypeahead(props: TypeaheadProps) {
         <IonList id="modal-list" inset={true}>
           {filteredItems.map(item => (
             <IonItem key={item.value}>
-              <IonLabel>{item.text}</IonLabel>
               <IonCheckbox
                 value={item.value}
                 checked={isChecked(item.value)}
                 onIonChange={checkboxChange}
-              ></IonCheckbox>
+              >{item.text}</IonCheckbox>
             </IonItem>
           ))}
         </IonList>

--- a/static/usage/v7/select/typeahead/vue/typeahead_component_vue.md
+++ b/static/usage/v7/select/typeahead/vue/typeahead_component_vue.md
@@ -21,19 +21,18 @@
         v-for="item in filteredItems"
         :key="item.value"
       >
-        <ion-label>{{ item.text }}</ion-label>
         <ion-checkbox
           :value="item.value" 
           :checked="isChecked(item.value)"
           @ionChange="checkboxChange($event)"
-        ></ion-checkbox>
+        >{{ item.text }}</ion-checkbox>
       </ion-item>
     </ion-list>
   </ion-content>
 </template>
 
 <script lang="ts">
-  import { IonButton, IonButtons, IonCheckbox, IonContent, IonHeader, IonItem, IonLabel, IonList, IonTitle, IonSearchbar, IonToolbar } from '@ionic/vue';
+  import { IonButton, IonButtons, IonCheckbox, IonContent, IonHeader, IonItem, IonList, IonTitle, IonSearchbar, IonToolbar } from '@ionic/vue';
   import type { CheckboxCustomEvent, SearchbarCustomEvent } from '@ionic/vue';
   import { defineComponent, ref } from 'vue';
 
@@ -47,7 +46,7 @@
       }
     },
     emits: ['selection-cancel', 'selection-change'],
-    components: { IonButton, IonButtons, IonCheckbox, IonContent, IonHeader, IonItem, IonLabel, IonList, IonTitle, IonSearchbar, IonToolbar },
+    components: { IonButton, IonButtons, IonCheckbox, IonContent, IonHeader, IonItem, IonList, IonTitle, IonSearchbar, IonToolbar },
     setup(props, { emit }) {
       const filteredItems = ref([...props.items]);
       const workingSelectedValues = ref([...props.selectedItems]);


### PR DESCRIPTION
The typeahead demo for v7 was not using the newer checkbox syntax.