### PR TITLE
fix(playground): prevent horizontal scrollbar on ios device frame view

### DIFF
--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -208,8 +208,10 @@
   width: 0%;
 }
 
-.playground .frame-visible {
-  width: 100%;
+@media only screen and (max-width: 600px) {
+  .playground .frame-visible {
+    width: 100%;
+  }
 }
 
 /** Tabs **/


### PR DESCRIPTION
Currently, when viewing a playground with the device frame turned on (e.g. https://ionicframework.com/docs/api/modal#inline-modals-recommended), there is a horizontal scroll bar on iOS mode.

https://github.com/ionic-team/ionic-docs/pull/2623 removed some CSS that was causing this, but it was re-added in https://github.com/ionic-team/ionic-docs/pull/2754 to fix the iframe not filling the space on smaller screen sizes. This PR restricts the CSS to screen sizes where the device frame no longer shows around the iframe (due to [this styling](https://github.com/ionic-team/ionic-docs/blob/ios-scrollbar-fix/src/components/global/Playground/device-preview.js#L124)), since it isn't needed otherwise. This way, no horizontal scroll bar appears, but the iframe is still viewable on smaller screens.