### PR TITLE
docs(migrate): update guide for v7 beta 5

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -43,7 +43,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-| v7        | v13                     | v15.x^                   | 4.4+       |   
+| v7        | v14                     | v15.x^                  | 4.6+       |   
 | v6        | v12                     | v15.x^                  | 4.0+       |
 | v5        | v8.2                    | v12.x                   | 3.5+       |
 | v4        | v8.2                    | v11.x                   | 3.5+       |

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -16,7 +16,7 @@ This guide assumes that you have already updated your app to the latest version 
 
 ### Angular
 
-1. Ionic 7 supports Angular 13+. Update to the latest version of Angular by following the [Angular Update Guide](https://update.angular.io/).
+1. Ionic 7 supports Angular 14+. Update to the latest version of Angular by following the [Angular Update Guide](https://update.angular.io/).
 2. Update to the latest version of Ionic 7:
 
 ```shell

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -96,6 +96,10 @@ iOS >=14
 1. Remove any code that sets the `value` property to the empty string (`''`).
 2. Remove any code that accesses the time zone information on the `value` property. Datetime does not manage time zones, so any time zone information provided is ignored.
 
+### Input
+
+1. Update any code that accesses the `detail` payload for the `ionInput` event from `event.detail` to `event.detail.value` as the detail payload is now an object containing a value and an event.
+
 ### Modal
 
 1. Remove any usage of the `swipeToClose` property. Use the [canDismiss](https://ionicframework.com/docs/api/modal#preventing-a-modal-from-dismissing) property to control when a modal can dismiss.
@@ -104,6 +108,10 @@ iOS >=14
 ### Picker
 
 1. Remove any code that accesses `refresh` on `ion-picker-column`. Developers should use the `columns` property on `ion-picker` to refresh the view instead.
+
+### Searchbar
+
+1. Update any code that accesses the `detail` payload for the `ionInput` event from `event.detail` to `event.detail.value` as the detail payload is now an object containing a value and an event.
 
 ### Segment
 
@@ -116,6 +124,11 @@ iOS >=14
 [Angular Migration Guide](https://ionicframework.com/docs/angular/slides)<br />
 [React Migration Guide](https://ionicframework.com/docs/react/slides)<br />
 [Vue Migration Guide](https://ionicframework.com/docs/vue/slides)
+
+### Textarea
+
+1. Update any code that accesses the `detail` payload for the `ionInput` event from `event.detail` to `event.detail.value` as the detail payload is now an object containing a value and an event.
+
 
 ### Toggle
 


### PR DESCRIPTION
- Updates minimum Angular version to Angular 14
- Adds input, searchbar, and textarea guides to migration guide re: `ionInput` detail payload