### PR TITLE
chore(version): update v5 and v6 docs to use the versioned docs demo deployment

### DIFF
--- a/static/usage/v6/img/basic/angular.md
+++ b/static/usage/v6/img/basic/angular.md
@@ -1,3 +1,3 @@
 ```html
-<ion-img src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
+<ion-img src="https://ionic-docs-demo-v6.vercel.app/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
 ```

--- a/static/usage/v6/img/basic/demo.html
+++ b/static/usage/v6/img/basic/demo.html
@@ -21,7 +21,7 @@
   <ion-app>
     <ion-content>
       <div class="container">
-        <ion-img src="https://docs-demo.ionic.io/assets/madison.jpg"
+        <ion-img src="https://ionic-docs-demo-v6.vercel.app/assets/madison.jpg"
           alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
       </div>
     </ion-content>

--- a/static/usage/v6/img/basic/javascript.md
+++ b/static/usage/v6/img/basic/javascript.md
@@ -1,3 +1,3 @@
 ```html
-<ion-img src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
+<ion-img src="https://ionic-docs-demo-v6.vercel.app/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
 ```

--- a/static/usage/v6/img/basic/react.md
+++ b/static/usage/v6/img/basic/react.md
@@ -4,7 +4,7 @@ import { IonImg } from '@ionic/react';
 
 function Example() {
   return (
-    <IonImg src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></IonImg>
+    <IonImg src="https://ionic-docs-demo-v6.vercel.app/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></IonImg>
   );
 }
 export default Example;

--- a/static/usage/v6/img/basic/vue.md
+++ b/static/usage/v6/img/basic/vue.md
@@ -1,6 +1,6 @@
 ```html
 <template>
-  <ion-img src="https://docs-demo.ionic.io/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
+  <ion-img src="https://ionic-docs-demo-v6.vercel.app/assets/madison.jpg" alt="The Wisconsin State Capitol building in Madison, WI at night"></ion-img>
 </template>
 
 <script lang="ts">

--- a/versioned_docs/version-v5/index.md
+++ b/versioned_docs/version-v5/index.md
@@ -4,8 +4,8 @@ slug: /
 title: Open-Source UI Toolkit to Create Your Own Mobile or Desktop Apps
 description: Ionic Framework is an open-source UI toolkit to create your own mobile and desktop apps using web technologies with integrations for popular frameworks.
 hide_table_of_contents: true
-demoUrl: https://ionic-docs-demo.herokuapp.com/
-demoSourceUrl: https://github.com/ionic-team/docs-demo
+demoUrl: https://ionic-docs-demo-v5.vercel.app/
+demoSourceUrl: https://github.com/ionic-team/docs-demo/tree/5.x
 ---
 
 import DocsCard from '@components/global/DocsCard';

--- a/versioned_docs/version-v6/index.md
+++ b/versioned_docs/version-v6/index.md
@@ -3,8 +3,8 @@ title: Introduction to Ionic
 sidebar_label: Overview
 slug: /
 hide_table_of_contents: true
-demoUrl: https://docs-demo.ionic.io/
-demoSourceUrl: https://github.com/ionic-team/docs-demo
+demoUrl: https://ionic-docs-demo-v6.vercel.app/
+demoSourceUrl: https://github.com/ionic-team/docs-demo/tree/6.x
 ---
 
 import DocsCard from '@components/global/DocsCard';


### PR DESCRIPTION
This PR updates the v5 and v6 docs to use the new versioned deployments of the phone demo app. No changes are necessary for v7 since the latest version of Ionic will always point to `docs-demo.ionic.io`.
However, until the `main` deployment for `docs-demo` is updated the v7 phone demo will still show a v6 app.