### PR TITLE
pin the versions for angular to v5

### DIFF
--- a/versioned_docs/version-v6/reference/migration.md
+++ b/versioned_docs/version-v6/reference/migration.md
@@ -31,7 +31,7 @@ For a complete list of breaking changes from 4.x to 5.x, please refer to [the br
 For Angular based projects, you can simply run:
 
 ```shell
-npm install @ionic/angular@latest @ionic/angular-toolkit@latest --save
+npm install @ionic/angular@5 @ionic/angular-toolkit@5 --save
 ```
 
 For React projects, you can run:


### PR DESCRIPTION
setting `@ionic/angular@5` and `@ionic/angular-toolkit@5` is important, otherwise this will skip the migration to v5 and go straight to v6 or any other, newer packages.