### PR TITLE
docs(layout): update css-utilities to float properly

### DIFF
--- a/docs/layout/css-utilities.md
+++ b/docs/layout/css-utilities.md
@@ -134,17 +134,37 @@ The float CSS property specifies that an element should be placed along the left
 ```html
 <ion-grid>
   <ion-row>
-    <ion-col class="ion-float-left">
-      <div>
-        <h3>float-left</h3>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac vehicula lorem.
-      </div>
+    <ion-col>
+      <h3>no float</h3>
+      <img
+        alt="Silhouette of a person's head"
+        src="https://ionicframework.com/docs/img/demos/avatar.svg"
+        height="50px"
+      />
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac
+      vehicula lorem.
     </ion-col>
-    <ion-col class="ion-float-right">
-      <div>
-        <h3>float-right</h3>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac vehicula lorem.
-      </div>
+    <ion-col>
+      <h3>float-left</h3>
+      <img
+        alt="Silhouette of a person's head"
+        src="https://ionicframework.com/docs/img/demos/avatar.svg"
+        height="50px"
+        class="ion-float-left"
+      />
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac
+      vehicula lorem.
+    </ion-col>
+    <ion-col>
+      <h3>float-right</h3>
+      <img
+        alt="Silhouette of a person's head"
+        src="https://ionicframework.com/docs/img/demos/avatar.svg"
+        height="50px"
+        class="ion-float-right"
+      />
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac
+      vehicula lorem.
     </ion-col>
   </ion-row>
 </ion-grid>


### PR DESCRIPTION
I kept the grid because this saves us from having to clear the floats between examples, but I moved the float css to an image so you can properly see it 

Code preview: https://1vutb4.stackblitz.io

Site preview: https://ionic-docs-git-fw-3055-ionic1.vercel.app/docs/v7/layout/css-utilities#float-elements

closes #265