### PR TITLE
fix(playground): iframe is hidden using display

### DIFF
--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -204,8 +204,7 @@
 }
 
 .playground .frame-hidden {
-  visibility: hidden;
-  width: 0%;
+  display: none;
 }
 
 @media only screen and (max-width: 600px) {


### PR DESCRIPTION
resolves https://github.com/ionic-team/ionic-docs/issues/2778

This issue was introduced in https://github.com/ionic-team/ionic-docs/pull/2623 when switching from `display: none` to visibility/width. The IntersectionObserver in `ion-datetime` does not fire when the width/visibility change. As a result, the datetime was attempting to center its contents with the width was `0px`. When the width was reset when the iframe shows, datetime does not adjust again.

The visibility/width code was added because the fullscreen offset variables were not being set correctly on `ion-content` with `display: none`. However, I fixed an issue in https://github.com/ionic-team/ionic-framework/pull/26782 which causes the content to recalculate the offset variables when the `resize` event is dispatched on the window. When the iframe is un-hidden, the resize event is dispatched so we are able to safely revert to using `display: none` while ensuring that the offset variables are calculated correctly.


https://ionic-docs-git-fw-3500-ionic1.vercel.app/docs/api/datetime