### PR TITLE
docs(alert): alert input label is only for radio/checkbox

### DIFF
--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -142,6 +142,9 @@ interface AlertInput {
   name?: string;
   placeholder?: string;
   value?: any;
+  /**
+   * The label text to display next to the input, if the input type is `radio` or `checkbox`.
+   */
   label?: string;
   checked?: boolean;
   disabled?: boolean;

--- a/versioned_docs/version-v6/api/alert.md
+++ b/versioned_docs/version-v6/api/alert.md
@@ -192,6 +192,9 @@ interface AlertInput {
   name?: string;
   placeholder?: string;
   value?: any;
+  /**
+   * The label text to display next to the input, if the input type is `radio` or `checkbox`.
+   */
   label?: string;
   checked?: boolean;
   disabled?: boolean;


### PR DESCRIPTION
### What is the current behavior?

The `label` property on `AlertInput` does not currently explain that it is only applied to radios and checkboxes. This is confusing when a developer renders an input or textarea and expects the label to display.

Issue: https://github.com/ionic-team/ionic-framework/issues/26915

### What is the new behavior?

Added a description to the documented interface, so explain that the label is only shown when the input type is `radio` or `checkbox`.
