### PR TITLE
chore: clear docs/native directory when generating markdown

### DIFF
--- a/scripts/native.js
+++ b/scripts/native.js
@@ -36,6 +36,14 @@ async function buildPluginApiDocs(pluginId) {
 
   const apiContent = createApiPage(pluginId, readme, pkgJson);
   const fileName = `${pluginId}.md`;
+
+  // Delete all existing generated markdown files in docs/native
+  fs.readdirSync('docs/native').forEach((file) => {
+    if (file.endsWith('.md')) {
+      fs.rmSync(`docs/native/${file}`);
+    }
+  });
+
   fs.writeFileSync(`docs/native/${fileName}`, apiContent);
   fs.writeFileSync(`versioned_docs/version-v6/native/${fileName}`, apiContent);
 }
@@ -85,18 +93,15 @@ function toTitleCase(str) {
 }
 
 if (!String.prototype.replaceAll) {
-	String.prototype.replaceAll = function(str, newStr){
+  String.prototype.replaceAll = function (str, newStr) {
+    // If a regex pattern
+    if (Object.prototype.toString.call(str).toLowerCase() === '[object regexp]') {
+      return this.replace(str, newStr);
+    }
 
-		// If a regex pattern
-		if (Object.prototype.toString.call(str).toLowerCase() === '[object regexp]') {
-			return this.replace(str, newStr);
-		}
-
-		// If a string
-		return this.replace(new RegExp(str, 'g'), newStr);
-
-	};
+    // If a string
+    return this.replace(new RegExp(str, 'g'), newStr);
+  };
 }
 
 main();
-

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -53,7 +53,6 @@ function renderOptions(title, data) {
 ### ${title}
 ${data
   .map((item) => {
-    console.log(item);
     const alias = item.aliases.length > 0 ? '(or ' + item.aliases.map((alias) => `\`-${alias}\``).join(' ') + ')' : '';
     let name = item.type === 'boolean' && item.default === true ? `no-${item.name}` : item.name;
     if (item.type === 'string') name += `=<${item.spec.value}>`;


### PR DESCRIPTION
Delete all markdown files that were previously generated from the `docs/native` directory. This avoids the local dev experience having broken links when versioning docs or changing directory structures. 

Additionally removed a really noisy `console.log` in the CLI script. 