### PR TITLE
docs(segment): wrap text in labels for segments in toolbar playground

### DIFF
--- a/static/usage/v6/toolbar/segments/angular.md
+++ b/static/usage/v6/toolbar/segments/angular.md
@@ -3,10 +3,10 @@
   <ion-toolbar>
     <ion-segment value="all">
       <ion-segment-button value="all">
-        All
+        <ion-label>All</ion-label>
       </ion-segment-button>
       <ion-segment-button value="favorites">
-        Favorites
+        <ion-label>Favorites</ion-label>
       </ion-segment-button>
     </ion-segment>
   </ion-toolbar>

--- a/static/usage/v6/toolbar/segments/demo.html
+++ b/static/usage/v6/toolbar/segments/demo.html
@@ -18,10 +18,10 @@
       <ion-toolbar>
         <ion-segment value="all">
           <ion-segment-button value="all">
-            All
+            <ion-label>All</ion-label>
           </ion-segment-button>
           <ion-segment-button value="favorites">
-            Favorites
+            <ion-label>Favorites</ion-label>
           </ion-segment-button>
         </ion-segment>
       </ion-toolbar>

--- a/static/usage/v6/toolbar/segments/javascript.md
+++ b/static/usage/v6/toolbar/segments/javascript.md
@@ -3,10 +3,10 @@
   <ion-toolbar>
     <ion-segment value="all">
       <ion-segment-button value="all">
-        All
+        <ion-label>All</ion-label>
       </ion-segment-button>
       <ion-segment-button value="favorites">
-        Favorites
+        <ion-label>Favorites</ion-label>
       </ion-segment-button>
     </ion-segment>
   </ion-toolbar>

--- a/static/usage/v6/toolbar/segments/react.md
+++ b/static/usage/v6/toolbar/segments/react.md
@@ -1,6 +1,6 @@
 ```tsx
 import React from 'react';
-import { IonHeader, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/react';
+import { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/react';
 
 function Example() {
   return (
@@ -8,10 +8,10 @@ function Example() {
       <IonToolbar>
         <IonSegment value="all">
           <IonSegmentButton value="all">
-            All
+            <IonLabel>All</IonLabel>
           </IonSegmentButton>
           <IonSegmentButton value="favorites">
-            Favorites
+            <IonLabel>Favorites</IonLabel>
           </IonSegmentButton>
         </IonSegment>
       </IonToolbar>

--- a/static/usage/v6/toolbar/segments/vue.md
+++ b/static/usage/v6/toolbar/segments/vue.md
@@ -4,10 +4,10 @@
     <ion-toolbar>
       <ion-segment value="all">
         <ion-segment-button value="all">
-          All
+          <ion-label>All</ion-label>
         </ion-segment-button>
         <ion-segment-button value="favorites">
-          Favorites
+          <ion-label>Favorites</ion-label>
         </ion-segment-button>
       </ion-segment>
     </ion-toolbar>
@@ -15,11 +15,11 @@
 </template>
 
 <script lang="ts">
-  import { IonHeader, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/vue';
+  import { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonHeader, IonSegment, IonSegmentButton, IonTitle, IonToolbar },
+    components: { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonTitle, IonToolbar },
   });
 </script>
 ```

--- a/static/usage/v7/toolbar/segments/angular.md
+++ b/static/usage/v7/toolbar/segments/angular.md
@@ -3,10 +3,10 @@
   <ion-toolbar>
     <ion-segment value="all">
       <ion-segment-button value="all">
-        All
+        <ion-label>All</ion-label>
       </ion-segment-button>
       <ion-segment-button value="favorites">
-        Favorites
+        <ion-label>Favorites</ion-label>
       </ion-segment-button>
     </ion-segment>
   </ion-toolbar>

--- a/static/usage/v7/toolbar/segments/demo.html
+++ b/static/usage/v7/toolbar/segments/demo.html
@@ -18,10 +18,10 @@
       <ion-toolbar>
         <ion-segment value="all">
           <ion-segment-button value="all">
-            All
+            <ion-label>All</ion-label>
           </ion-segment-button>
           <ion-segment-button value="favorites">
-            Favorites
+            <ion-label>Favorites</ion-label>
           </ion-segment-button>
         </ion-segment>
       </ion-toolbar>

--- a/static/usage/v7/toolbar/segments/javascript.md
+++ b/static/usage/v7/toolbar/segments/javascript.md
@@ -3,10 +3,10 @@
   <ion-toolbar>
     <ion-segment value="all">
       <ion-segment-button value="all">
-        All
+        <ion-label>All</ion-label>
       </ion-segment-button>
       <ion-segment-button value="favorites">
-        Favorites
+        <ion-label>Favorites</ion-label>
       </ion-segment-button>
     </ion-segment>
   </ion-toolbar>

--- a/static/usage/v7/toolbar/segments/react.md
+++ b/static/usage/v7/toolbar/segments/react.md
@@ -1,6 +1,6 @@
 ```tsx
 import React from 'react';
-import { IonHeader, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/react';
+import { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/react';
 
 function Example() {
   return (
@@ -8,10 +8,10 @@ function Example() {
       <IonToolbar>
         <IonSegment value="all">
           <IonSegmentButton value="all">
-            All
+            <IonLabel>All</IonLabel>
           </IonSegmentButton>
           <IonSegmentButton value="favorites">
-            Favorites
+            <IonLabel>Favorites</IonLabel>
           </IonSegmentButton>
         </IonSegment>
       </IonToolbar>

--- a/static/usage/v7/toolbar/segments/vue.md
+++ b/static/usage/v7/toolbar/segments/vue.md
@@ -4,10 +4,10 @@
     <ion-toolbar>
       <ion-segment value="all">
         <ion-segment-button value="all">
-          All
+          <ion-label>All</ion-label>
         </ion-segment-button>
         <ion-segment-button value="favorites">
-          Favorites
+          <ion-label>Favorites</ion-label>
         </ion-segment-button>
       </ion-segment>
     </ion-toolbar>
@@ -15,11 +15,11 @@
 </template>
 
 <script lang="ts">
-  import { IonHeader, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/vue';
+  import { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonTitle, IonToolbar } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonHeader, IonSegment, IonSegmentButton, IonTitle, IonToolbar },
+    components: { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonTitle, IonToolbar },
   });
 </script>
 ```


### PR DESCRIPTION
In [Ionic v4](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v4.md#segment-button) it became a requirement for text inside of a segment button to be wrapped in a label. This PR updates the only Segment playground that doesn't use a label. 