### PR TITLE
docs(icon): indicate where to find custom SVG usage

### DIFF
--- a/docs/api/icon.md
+++ b/docs/api/icon.md
@@ -12,7 +12,7 @@ title: 'ion-icon'
 
 Icon is a simple component made available through the <a href="https://ionic.io/ionicons">Ionicons</a> library, which comes pre-packaged by default with all Ionic Framework applications. It can be used to display any icon from the Ionicons set, or a custom SVG. It also has support for styling such as size and color.
 
-For more information, including styling, custom SVG usage, and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
+For a list of all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>. For more information including styling and custom SVG usage, see <a href="https://ionic.io/ionicons/usage">the Usage page</a>.
 
 ## Basic Usage
 

--- a/docs/api/icon.md
+++ b/docs/api/icon.md
@@ -12,7 +12,7 @@ title: 'ion-icon'
 
 Icon is a simple component made available through the <a href="https://ionic.io/ionicons">Ionicons</a> library, which comes pre-packaged by default with all Ionic Framework applications. It can be used to display any icon from the Ionicons set, or a custom SVG. It also has support for styling such as size and color.
 
-For more information, including styling and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
+For more information, including styling, custom SVG usage, and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
 
 ## Basic Usage
 

--- a/versioned_docs/version-v6/api/icon.md
+++ b/versioned_docs/version-v6/api/icon.md
@@ -12,7 +12,7 @@ title: 'ion-icon'
 
 Icon is a simple component made available through the <a href="https://ionic.io/ionicons">Ionicons</a> library, which comes pre-packaged by default with all Ionic Framework applications. It can be used to display any icon from the Ionicons set, or a custom SVG. It also has support for styling such as size and color.
 
-For more information, including styling, custom SVG usage, and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
+For a list of all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>. For more information including styling and custom SVG usage, see <a href="https://ionic.io/ionicons/usage">the Usage page</a>.
 
 ## Basic Usage
 

--- a/versioned_docs/version-v6/api/icon.md
+++ b/versioned_docs/version-v6/api/icon.md
@@ -12,7 +12,7 @@ title: 'ion-icon'
 
 Icon is a simple component made available through the <a href="https://ionic.io/ionicons">Ionicons</a> library, which comes pre-packaged by default with all Ionic Framework applications. It can be used to display any icon from the Ionicons set, or a custom SVG. It also has support for styling such as size and color.
 
-For more information, including styling and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
+For more information, including styling, custom SVG usage, and all available icons, see <a href="https://ionic.io/ionicons">ionic.io/ionicons</a>.
 
 ## Basic Usage
 


### PR DESCRIPTION
Resolves https://github.com/ionic-team/ionic-docs/issues/2813

The docs page for `ion-icon` mentions that it's possible to use a custom SVG, but doesn't show how to do so. We intentionally avoided including it since it's on the Ionicons site already, but this connection isn't obvious, so I added a note to point people in the right direction.