### PR TITLE
docs(gestures): remove browser support section

### DIFF
--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -45,6 +45,3 @@ Because Ionic is based on web technologies, it works just as well on desktop bro
 | **Firefox** | 70+      | 63+      | ✔        | ✔        |
 |  **IE 11**  | **X**    | **X**    | **X**    | **X**    |
 
-:::note
-Check the docs for [Ionic Animations](../utilities/animations.md#browser-support) and [Ionic Gestures](../utilities/gestures.md#browser-support) for specific browser support related to those utilities.
-:::

--- a/docs/utilities/gestures.md
+++ b/docs/utilities/gestures.md
@@ -448,18 +448,6 @@ In the example above, we want to be able to detect double clicks on an element. 
 
 See our guide on implementing gesture animations: [Gesture Animations with Ionic Animations](animations.md#gesture-animations)
 
-## Browser Support
-
-| Browser/Platform | Supported Versions |
-| ---------------- | ------------------ |
-| **Chrome**       | 22+                |
-| **Safari**       | 9+                 |
-| **Firefox**      | 32+                |
-| **IE/Edge**      | 11+                |
-| **Opera**        | 30+                |
-| **iOS**          | 9+                 |
-| **Android**      | 5+                 |
-
 ## Types
 
 | Name              | Value                                        |

--- a/versioned_docs/version-v5/reference/browser-support.md
+++ b/versioned_docs/version-v5/reference/browser-support.md
@@ -26,7 +26,3 @@ Because Ionic is based on web technologies, it works just as well on desktop bro
 |  **Edge**   |   79+    |    ✔     |
 | **Firefox** |    ✔     |    ✔     |
 |  **IE 11**  |  **X**   |  **X**   |
-
-:::note
-Check the docs for [Ionic Animations](../utilities/animations.md#browser-support) and [Ionic Gestures](../utilities/gestures.md#browser-support) for specific browser support related to those utilities.
-:::

--- a/versioned_docs/version-v5/utilities/gestures.md
+++ b/versioned_docs/version-v5/utilities/gestures.md
@@ -439,18 +439,6 @@ In the example above, we want to be able to detect double clicks on an element. 
 
 See our guide on implementing gesture animations: [Gesture Animations with Ionic Animations](animations.md#gesture-animations)
 
-## Browser Support
-
-| Browser/Platform | Supported Versions |
-| ---------------- | ------------------ |
-| **Chrome**       | 22+                |
-| **Safari**       | 9+                 |
-| **Firefox**      | 32+                |
-| **IE/Edge**      | 11+                |
-| **Opera**        | 30+                |
-| **iOS**          | 9+                 |
-| **Android**      | 5+                 |
-
 ## Types
 
 | Name              | Value                                        |

--- a/versioned_docs/version-v6/reference/browser-support.md
+++ b/versioned_docs/version-v6/reference/browser-support.md
@@ -50,6 +50,3 @@ Because Ionic is based on web technologies, it works just as well on desktop bro
 | **Firefox** |   63+    |    ✔     |    ✔     |
 |  **IE 11**  |  **X**   |  **X**   |  **X**   |
 
-:::note
-Check the docs for [Ionic Animations](../utilities/animations.md#browser-support) and [Ionic Gestures](../utilities/gestures.md#browser-support) for specific browser support related to those utilities.
-:::

--- a/versioned_docs/version-v6/utilities/gestures.md
+++ b/versioned_docs/version-v6/utilities/gestures.md
@@ -448,18 +448,6 @@ In the example above, we want to be able to detect double clicks on an element. 
 
 See our guide on implementing gesture animations: [Gesture Animations with Ionic Animations](animations.md#gesture-animations)
 
-## Browser Support
-
-| Browser/Platform | Supported Versions |
-| ---------------- | ------------------ |
-| **Chrome**       | 22+                |
-| **Safari**       | 9+                 |
-| **Firefox**      | 32+                |
-| **IE/Edge**      | 11+                |
-| **Opera**        | 30+                |
-| **iOS**          | 9+                 |
-| **Android**      | 5+                 |
-
 ## Types
 
 | Name              | Value                                        |


### PR DESCRIPTION
Removes the browser support section from the v6 & v7 docs for the "Gestures" page. 