### PR TITLE
docs(slides): update React and Vue migration guides to be compatible with Swiper 9

### DIFF
--- a/docs/react/slides.md
+++ b/docs/react/slides.md
@@ -1,5 +1,5 @@
 ---
-title: Slides
+title: Migrating From IonSlides to Swiper.js
 ---
 
 <head>
@@ -16,12 +16,13 @@ title: Slides
 
 :::
 
-:::note
-This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
-:::
-
-
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
+
+:::note
+Swiper's React component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for custom elements yet.
+
+Using Swiper's React component is **not** required to use Swiper.js with Ionic Framework.
+:::
 
 ## Getting Started
 
@@ -34,7 +35,7 @@ npm install @ionic/react@latest @ionic/react-router@latest
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper@8
+npm install swiper@latest
 ```
 
 :::note
@@ -43,7 +44,7 @@ Create React App does not support pure ESM packages yet. Developers can still us
 
 ## Swiping with Style
 
-Next, we need to import the base Swiper styles. We are also going to import the styles that Ionic provides which will let us customize the Swiper styles using the same CSS Variables that we used with `ion-slides`.
+Next, we need to import the base Swiper styles. We are also going to import the styles that Ionic provides which will let us customize the Swiper styles using the same CSS Variables that we used with `IonSlides`.
 
 We recommend importing the styles in the component in which Swiper is being used. This ensures that the styles are only loaded when needed:
 
@@ -64,13 +65,11 @@ export default Home;
 ```
 
 :::note
-Importing `@ionic/react/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+Importing `@ionic/react/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
 :::
 
 :::note
-
 Not using Create React App? You can import the Swiper CSS from `swiper/css` instead.
-
 :::
 
 ### Updating Selectors
@@ -153,16 +152,14 @@ export default Home;
 ```
 
 :::note
-
 Not using Create React App? You can import the Swiper components from `swiper/react` instead.
-
 :::
 
 ## Using Modules
 
 By default, Swiper for React does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
 
-`ion-slides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. This part of the guide will show you how to install these modules.
+`IonSlides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. This part of the guide will show you how to install these modules.
 
 To begin, we need to import the modules and their corresponding CSS files from the `swiper` package:
 
@@ -197,9 +194,7 @@ export default Home;
 ```
 
 :::note
-
 Not using Create React App? You can import these modules from `swiper/css/[MODULE NAME]` instead (i.e. `swiper/css/autoplay`).
-
 :::
 
 From here, we need to provide these modules to Swiper by using the `modules` property on the `Swiper` component:
@@ -279,7 +274,7 @@ See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener nor
 
 ## The IonicSlides Module
 
-With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly. However, using this module is **not** required to use Swiper.js in Ionic.
+With `IonSlides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly. However, using this module is **not** required to use Swiper.js in Ionic.
 
 We can install the `IonicSlides` module by importing it from `@ionic/react` and passing it in as the last item in the `modules` array:
 
@@ -428,7 +423,7 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | onIonSlidesDidLoad        | onInit                       |
 
 :::note
-All events available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-events</a>.
+All events available in Swiper can be found at <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#events</a>.
 :::
 
 ## Methods
@@ -460,7 +455,7 @@ From here, if you wanted to access a property on the Swiper instance you would a
 
 Below is a full list of method changes when going from `IonSlides` to Swiper React:
 
-| ion-slides Method  | Notes                                                                                |
+| IonSlides Method   | Notes                                                                                |
 | ------------------ | ------------------------------------------------------------------------------------ |
 | getActiveIndex()   | Use the `activeIndex` property instead.                                              |
 | getPreviousIndex() | Use the `previousIndex` property instead.                                            |
@@ -491,7 +486,7 @@ const Home: React.FC = () => {
   return (
     <IonPage>
       <IonContent>
-        <Swiper modules={[EffectFact, IonicSlides]}>
+        <Swiper modules={[EffectFade, IonicSlides]}>
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
           <SwiperSlide>Slide 3</SwiperSlide>
@@ -519,7 +514,7 @@ const Home: React.FC = () => {
   return (
     <IonPage>
       <IonContent>
-        <Swiper modules={[EffectFact, IonicSlides]}>
+        <Swiper modules={[EffectFade, IonicSlides]}>
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
           <SwiperSlide>Slide 3</SwiperSlide>
@@ -532,9 +527,7 @@ export default Home;
 ```
 
 :::note
-
 Not using Create React App? You can import these effects from `swiper/css/[EFFECT NAME]` instead (i.e. `swiper/css/effect-fade`).
-
 :::
 
 After that, we can activate it by setting the `effect` property on `swiper` to `"fade"`:
@@ -553,7 +546,7 @@ const Home: React.FC = () => {
   return (
     <IonPage>
       <IonContent>
-        <Swiper modules={[EffectFact, IonicSlides]} swiper="fade">
+        <Swiper modules={[EffectFade, IonicSlides]} effect="fade">
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
           <SwiperSlide>Slide 3</SwiperSlide>

--- a/docs/react/slides.md
+++ b/docs/react/slides.md
@@ -65,7 +65,7 @@ export default Home;
 ```
 
 :::note
-Importing `@ionic/react/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+Importing `@ionic/react/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
 :::
 
 :::note

--- a/docs/react/slides.md
+++ b/docs/react/slides.md
@@ -19,7 +19,7 @@ title: Migrating From IonSlides to Swiper.js
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
 :::note
-Swiper's React component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for custom elements yet.
+Swiper's React component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for Web Components yet.
 
 Using Swiper's React component is **not** required to use Swiper.js with Ionic Framework.
 :::

--- a/docs/vue/slides.md
+++ b/docs/vue/slides.md
@@ -52,7 +52,7 @@ We recommend importing the styles in the component in which Swiper is being used
 <script>
   import { defineComponent } from 'vue';
 
-  import 'swiper/swiper.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -81,14 +81,14 @@ For developers using SCSS or Less styles, Swiper also provides imports for those
 For Less styles, replace `css` with `less` in the Swiper import path:
 
 ```js
-import 'swiper/swiper.less';
+import 'swiper/less';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
 For SCSS styles replace `css` with `scss` in the Swiper import path:
 
 ```js
-import 'swiper/swiper.scss';
+import 'swiper/scss';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
@@ -113,10 +113,10 @@ These components are imported from `swiper/vue` and provided to your Vue compone
 
 <script>
   import { defineComponent } from 'vue';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -153,15 +153,15 @@ To begin, we need to import the modules and their corresponding CSS files from t
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -187,15 +187,15 @@ From here, we need to provide these modules to Swiper by using the `modules` pro
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -226,15 +226,15 @@ Finally, we can turn these features on by using the appropriate properties:
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -273,15 +273,15 @@ We can install the `IonicSlides` module by importing it from `@ionic/vue` and pa
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -456,10 +456,10 @@ If you are using effects such as Cube or Fade, you can install them just like we
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -490,11 +490,11 @@ Next, we need to import the stylesheet associated with the effect:
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
-  import 'swiper/modules/effect-fade/effect-fade.min.css';
+  import 'swiper/css';
+  import 'swiper/css/effect-fade';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -525,11 +525,11 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
-  import 'swiper/modules/effect-fade/effect-fade.min.css';
+  import 'swiper/css';
+  import 'swiper/css/effect-fade';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({

--- a/docs/vue/slides.md
+++ b/docs/vue/slides.md
@@ -62,7 +62,7 @@ We recommend importing the styles in the component in which Swiper is being used
 ```
 
 :::note
-Importing `@ionic/vue/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+Importing `@ionic/vue/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
 :::
 
 ### Updating Selectors

--- a/docs/vue/slides.md
+++ b/docs/vue/slides.md
@@ -1,5 +1,5 @@
 ---
-title: Slides
+title: Migrating From ion-slides to Swiper.js
 ---
 
 <head>
@@ -11,17 +11,16 @@ title: Slides
 </head>
 
 :::caution Looking for `ion-slides`?
-
 `ion-slides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
-
 :::
-
-:::note
-This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
-:::
-
 
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
+
+:::note
+Swiper's Vue component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the Vue component because it provides the most stable experience at the time of writing.
+
+Using Swiper's Vue component is **not** required to use Swiper.js with Ionic Framework.
+:::
 
 ## Getting Started
 
@@ -40,7 +39,7 @@ vue upgrade --next
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper@8
+npm install swiper@latest
 ```
 
 ## Swiping with Style
@@ -53,7 +52,7 @@ We recommend importing the styles in the component in which Swiper is being used
 <script>
   import { defineComponent } from 'vue';
 
-  import 'swiper/css';
+  import 'swiper/swiper.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -82,14 +81,14 @@ For developers using SCSS or Less styles, Swiper also provides imports for those
 For Less styles, replace `css` with `less` in the Swiper import path:
 
 ```js
-import 'swiper/less';
+import 'swiper/swiper.less';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
 For SCSS styles replace `css` with `scss` in the Swiper import path:
 
 ```js
-import 'swiper/scss';
+import 'swiper/swiper.scss';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
@@ -114,10 +113,10 @@ These components are imported from `swiper/vue` and provided to your Vue compone
 
 <script>
   import { defineComponent } from 'vue';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
+  import 'swiper/swiper.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -154,15 +153,15 @@ To begin, we need to import the modules and their corresponding CSS files from t
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -188,15 +187,15 @@ From here, we need to provide these modules to Swiper by using the `modules` pro
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -227,15 +226,15 @@ Finally, we can turn these features on by using the appropriate properties:
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -274,15 +273,15 @@ We can install the `IonicSlides` module by importing it from `@ionic/vue` and pa
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -457,10 +456,10 @@ If you are using effects such as Cube or Fade, you can install them just like we
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
+  import 'swiper/swiper.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -491,11 +490,11 @@ Next, we need to import the stylesheet associated with the effect:
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/effect-fade';
+  import 'swiper/swiper.css';
+  import 'swiper/modules/effect-fade/effect-fade.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -526,11 +525,11 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/effect-fade';
+  import 'swiper/swiper.css';
+  import 'swiper/modules/effect-fade/effect-fade.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({

--- a/versioned_docs/version-v6/react/slides.md
+++ b/versioned_docs/version-v6/react/slides.md
@@ -1,5 +1,5 @@
 ---
-title: Slides
+title: Migrating From IonSlides to Swiper.js
 ---
 
 <head>
@@ -10,13 +10,15 @@ title: Slides
   />
 </head>
 
-:::note
-This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
-:::
-
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `IonSlides` component, but we now recommend that developers use Swiper for React directly.
 
 This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
+
+:::note
+Swiper's React component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for custom elements yet.
+
+Using Swiper's React component is **not** required to use Swiper.js with Ionic Framework.
+:::
 
 ## Getting Started
 
@@ -29,7 +31,7 @@ npm install @ionic/react@latest @ionic/react-router@latest
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper@8
+npm install swiper@latest
 ```
 
 :::note
@@ -38,7 +40,7 @@ Create React App does not support pure ESM packages yet. Developers can still us
 
 ## Swiping with Style
 
-Next, we need to import the base Swiper styles. We are also going to import the styles that Ionic provides which will let us customize the Swiper styles using the same CSS Variables that we used with `ion-slides`.
+Next, we need to import the base Swiper styles. We are also going to import the styles that Ionic provides which will let us customize the Swiper styles using the same CSS Variables that we used with `IonSlides`.
 
 We recommend importing the styles in the component in which Swiper is being used. This ensures that the styles are only loaded when needed:
 
@@ -59,13 +61,11 @@ export default Home;
 ```
 
 :::note
-Importing `@ionic/react/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+Importing `@ionic/react/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
 :::
 
 :::note
-
 Not using Create React App? You can import the Swiper CSS from `swiper/css` instead.
-
 :::
 
 ### Updating Selectors
@@ -148,16 +148,14 @@ export default Home;
 ```
 
 :::note
-
 Not using Create React App? You can import the Swiper components from `swiper/react` instead.
-
 :::
 
 ## Using Modules
 
 By default, Swiper for React does not import any additional modules. To use modules such as Navigation or Pagination, you need to import them first.
 
-`ion-slides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. This part of the guide will show you how to install these modules.
+`IonSlides` automatically included the Pagination, Scrollbar, Autoplay, Keyboard, and Zoom modules. This part of the guide will show you how to install these modules.
 
 To begin, we need to import the modules and their corresponding CSS files from the `swiper` package:
 
@@ -192,9 +190,7 @@ export default Home;
 ```
 
 :::note
-
 Not using Create React App? You can import these modules from `swiper/css/[MODULE NAME]` instead (i.e. `swiper/css/autoplay`).
-
 :::
 
 From here, we need to provide these modules to Swiper by using the `modules` property on the `Swiper` component:
@@ -274,7 +270,7 @@ See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener nor
 
 ## The IonicSlides Module
 
-With `ion-slides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly. However, using this module is **not** required to use Swiper.js in Ionic.
+With `IonSlides`, Ionic automatically customized dozens of Swiper properties. This resulted in an experience that felt smooth when swiping on mobile devices. We recommend using the `IonicSlides` module to ensure that these properties are also set when using Swiper directly. However, using this module is **not** required to use Swiper.js in Ionic.
 
 We can install the `IonicSlides` module by importing it from `@ionic/react` and passing it in as the last item in the `modules` array:
 
@@ -423,7 +419,7 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | onIonSlidesDidLoad        | onInit                       |
 
 :::note
-All events available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-events</a>.
+All events available in Swiper can be found at <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#events</a>.
 :::
 
 ## Methods
@@ -455,7 +451,7 @@ From here, if you wanted to access a property on the Swiper instance you would a
 
 Below is a full list of method changes when going from `IonSlides` to Swiper React:
 
-| ion-slides Method  | Notes                                                                                |
+| IonSlides Method   | Notes                                                                                |
 | ------------------ | ------------------------------------------------------------------------------------ |
 | getActiveIndex()   | Use the `activeIndex` property instead.                                              |
 | getPreviousIndex() | Use the `previousIndex` property instead.                                            |
@@ -486,7 +482,7 @@ const Home: React.FC = () => {
   return (
     <IonPage>
       <IonContent>
-        <Swiper modules={[EffectFact, IonicSlides]}>
+        <Swiper modules={[EffectFade, IonicSlides]}>
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
           <SwiperSlide>Slide 3</SwiperSlide>
@@ -514,7 +510,7 @@ const Home: React.FC = () => {
   return (
     <IonPage>
       <IonContent>
-        <Swiper modules={[EffectFact, IonicSlides]}>
+        <Swiper modules={[EffectFade, IonicSlides]}>
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
           <SwiperSlide>Slide 3</SwiperSlide>
@@ -527,9 +523,7 @@ export default Home;
 ```
 
 :::note
-
 Not using Create React App? You can import these effects from `swiper/css/[EFFECT NAME]` instead (i.e. `swiper/css/effect-fade`).
-
 :::
 
 After that, we can activate it by setting the `effect` property on `swiper` to `"fade"`:
@@ -548,7 +542,7 @@ const Home: React.FC = () => {
   return (
     <IonPage>
       <IonContent>
-        <Swiper modules={[EffectFact, IonicSlides]} swiper="fade">
+        <Swiper modules={[EffectFade, IonicSlides]} effect="fade">
           <SwiperSlide>Slide 1</SwiperSlide>
           <SwiperSlide>Slide 2</SwiperSlide>
           <SwiperSlide>Slide 3</SwiperSlide>

--- a/versioned_docs/version-v6/react/slides.md
+++ b/versioned_docs/version-v6/react/slides.md
@@ -61,7 +61,7 @@ export default Home;
 ```
 
 :::note
-Importing `@ionic/react/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+Importing `@ionic/react/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
 :::
 
 :::note

--- a/versioned_docs/version-v6/react/slides.md
+++ b/versioned_docs/version-v6/react/slides.md
@@ -15,7 +15,7 @@ We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener norefe
 This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
 :::note
-Swiper's React component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for custom elements yet.
+Swiper's React component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for Web Components yet.
 
 Using Swiper's React component is **not** required to use Swiper.js with Ionic Framework.
 :::

--- a/versioned_docs/version-v6/vue/slides.md
+++ b/versioned_docs/version-v6/vue/slides.md
@@ -60,7 +60,7 @@ We recommend importing the styles in the component in which Swiper is being used
 ```
 
 :::note
-Importing `@ionic/vue/css/ionic-swiper.css'` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+Importing `@ionic/vue/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
 :::
 
 ### Updating Selectors

--- a/versioned_docs/version-v6/vue/slides.md
+++ b/versioned_docs/version-v6/vue/slides.md
@@ -1,5 +1,5 @@
 ---
-title: Slides
+title: Migrating From ion-slides to Swiper.js
 ---
 
 <head>
@@ -10,13 +10,15 @@ title: Slides
   />
 </head>
 
-:::note
-This migration guide is compatible with Swiper 8. An updated guide for Swiper 9 is coming soon!
-:::
-
 We recommend <a href="http://swiperjs.com/" target="_blank" rel="noopener noreferrer">Swiper.js</a> if you need a modern touch slider component. It powers our `ion-slides` component, but we now recommend that developers use Swiper for Vue directly.
 
 This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
+
+:::note
+Swiper's Vue component is set to be removed in a future release of Swiper, with <a href="https://swiperjs.com/element" target="_blank" rel="noopener noreferrer">Swiper Element</a> as the replacement. However, this guide shows how to migrate to the Vue component because it provides the most stable experience at the time of writing.
+
+Using Swiper's Vue component is **not** required to use Swiper.js with Ionic Framework.
+:::
 
 ## Getting Started
 
@@ -35,7 +37,7 @@ vue upgrade --next
 Once that is done, install the Swiper dependency in your project:
 
 ```shell
-npm install swiper@8
+npm install swiper@latest
 ```
 
 ## Swiping with Style
@@ -48,7 +50,7 @@ We recommend importing the styles in the component in which Swiper is being used
 <script>
   import { defineComponent } from 'vue';
 
-  import 'swiper/css';
+  import 'swiper/swiper.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -77,14 +79,14 @@ For developers using SCSS or Less styles, Swiper also provides imports for those
 For Less styles, replace `css` with `less` in the Swiper import path:
 
 ```js
-import 'swiper/less';
+import 'swiper/swiper.less';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
 For SCSS styles replace `css` with `scss` in the Swiper import path:
 
 ```js
-import 'swiper/scss';
+import 'swiper/swiper.scss';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
@@ -109,10 +111,10 @@ These components are imported from `swiper/vue` and provided to your Vue compone
 
 <script>
   import { defineComponent } from 'vue';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
+  import 'swiper/swiper.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -149,15 +151,15 @@ To begin, we need to import the modules and their corresponding CSS files from t
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -183,15 +185,15 @@ From here, we need to provide these modules to Swiper by using the `modules` pro
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -222,15 +224,15 @@ Finally, we can turn these features on by using the appropriate properties:
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -269,15 +271,15 @@ We can install the `IonicSlides` module by importing it from `@ionic/vue` and pa
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/autoplay';
-  import 'swiper/css/keyboard';
-  import 'swiper/css/pagination';
-  import 'swiper/css/scrollbar';
-  import 'swiper/css/zoom';
+  import 'swiper/swiper.min.css';
+  import 'swiper/modules/autoplay/autoplay.min.css';
+  import 'swiper/modules/keyboard/keyboard.min.css';
+  import 'swiper/modules/pagination/pagination.min.css';
+  import 'swiper/modules/scrollbar/scrollbar.min.css';
+  import 'swiper/modules/zoom/zoom.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -452,10 +454,10 @@ If you are using effects such as Cube or Fade, you can install them just like we
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
+  import 'swiper/swiper.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -486,11 +488,11 @@ Next, we need to import the stylesheet associated with the effect:
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/effect-fade';
+  import 'swiper/swiper.css';
+  import 'swiper/modules/effect-fade/effect-fade.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -521,11 +523,11 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue';
+  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/css';
-  import 'swiper/css/effect-fade';
+  import 'swiper/swiper.css';
+  import 'swiper/modules/effect-fade/effect-fade.min.css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({

--- a/versioned_docs/version-v6/vue/slides.md
+++ b/versioned_docs/version-v6/vue/slides.md
@@ -50,7 +50,7 @@ We recommend importing the styles in the component in which Swiper is being used
 <script>
   import { defineComponent } from 'vue';
 
-  import 'swiper/swiper.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -79,14 +79,14 @@ For developers using SCSS or Less styles, Swiper also provides imports for those
 For Less styles, replace `css` with `less` in the Swiper import path:
 
 ```js
-import 'swiper/swiper.less';
+import 'swiper/less';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
 For SCSS styles replace `css` with `scss` in the Swiper import path:
 
 ```js
-import 'swiper/swiper.scss';
+import 'swiper/scss';
 import '@ionic/vue/css/ionic-swiper.css';
 ```
 
@@ -111,10 +111,10 @@ These components are imported from `swiper/vue` and provided to your Vue compone
 
 <script>
   import { defineComponent } from 'vue';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -151,15 +151,15 @@ To begin, we need to import the modules and their corresponding CSS files from t
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -185,15 +185,15 @@ From here, we need to provide these modules to Swiper by using the `modules` pro
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -224,15 +224,15 @@ Finally, we can turn these features on by using the appropriate properties:
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -271,15 +271,15 @@ We can install the `IonicSlides` module by importing it from `@ionic/vue` and pa
 <script>
   import { defineComponent } from 'vue';
   import { Autoplay, Keyboard, Pagination, Scrollbar, Zoom } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.min.css';
-  import 'swiper/modules/autoplay/autoplay.min.css';
-  import 'swiper/modules/keyboard/keyboard.min.css';
-  import 'swiper/modules/pagination/pagination.min.css';
-  import 'swiper/modules/scrollbar/scrollbar.min.css';
-  import 'swiper/modules/zoom/zoom.min.css';
+  import 'swiper/css';
+  import 'swiper/css/autoplay';
+  import 'swiper/css/keyboard';
+  import 'swiper/css/pagination';
+  import 'swiper/css/scrollbar';
+  import 'swiper/css/zoom';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -454,10 +454,10 @@ If you are using effects such as Cube or Fade, you can install them just like we
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
+  import 'swiper/css';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -488,11 +488,11 @@ Next, we need to import the stylesheet associated with the effect:
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
-  import 'swiper/modules/effect-fade/effect-fade.min.css';
+  import 'swiper/css';
+  import 'swiper/css/effect-fade';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({
@@ -523,11 +523,11 @@ After that, we can activate it by setting the `effect` property on `swiper` to `
 <script>
   import { defineComponent } from 'vue';
   import { EffectFade } from 'swiper';
-  import { Swiper, SwiperSlide } from 'swiper/vue/swiper-vue.js';
+  import { Swiper, SwiperSlide } from 'swiper/vue';
   import { IonContent, IonPage, IonicSlides } from '@ionic/vue';
 
-  import 'swiper/swiper.css';
-  import 'swiper/modules/effect-fade/effect-fade.min.css';
+  import 'swiper/css';
+  import 'swiper/css/effect-fade';
   import '@ionic/vue/css/ionic-swiper.css';
 
   export default defineComponent({


### PR DESCRIPTION
Because we decided to stick with Swiper's React/Vue components instead of Swiper Element for now, updating the guides for these two frameworks is mostly minor cleanup things. I also took the liberty of fixing some typos and adjusting the React docs to use the React-formatted component name.

Angular will be handled in a separate PR, as it will be a more significant overhaul to use Swiper Element instead. Updating the example repo linked at the bottom of the docs will also be done later. These changes should all be merged at the same time.