### PR TITLE
chore(i18n): remove production check for Japanese docs

### DIFF
--- a/scripts/i18n.sh
+++ b/scripts/i18n.sh
@@ -2,9 +2,7 @@
 set -o errexit
 set -o nounset
 
-if [ "${VERCEL_ENV:-preview}" == "production" ]; then
-    mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-v6/
-    curl -fsSL https://github.com/ionic-team/ionic-docs/archive/refs/heads/translation/jp.tar.gz |
-      tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/version-v6/ --strip-components 2 ionic-docs-translation-jp/docs
-    node scripts/api-ja.js
-fi
+mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-v6/
+curl -fsSL https://github.com/ionic-team/ionic-docs/archive/refs/heads/translation/jp.tar.gz |
+  tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/version-v6/ --strip-components 2 ionic-docs-translation-jp/docs
+node scripts/api-ja.js


### PR DESCRIPTION
The Japanese docs failed to deploy after we merged https://github.com/ionic-team/ionic-docs/pull/2797 because they only get built in production. I'd like to remove this production-only check so we can catch build errors before PRs merge.