### PR TITLE
Set webviewPath property to be nullable

### DIFF
--- a/versioned_docs/version-v6/angular/your-first-app/2-taking-photos.md
+++ b/versioned_docs/version-v6/angular/your-first-app/2-taking-photos.md
@@ -108,7 +108,7 @@ Over in the `addNewToGallery` function, add the newly captured photo to the begi
 
   this.photos.unshift({
     filepath: "soon...",
-    webviewPath: capturedPhoto.webPath
+    webviewPath?: capturedPhoto.webPath
   });
 }
 ```


### PR DESCRIPTION
Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.ts(2322)
photo.service.ts(30, 3): The expected type comes from property 'webviewPath' which is declared