### PR TITLE
docs(modal): clarify swipeToClose migration

### DIFF
--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -102,7 +102,7 @@ iOS >=14
 
 ### Modal
 
-1. Remove any usage of the `swipeToClose` property. Use the [canDismiss](https://ionicframework.com/docs/api/modal#preventing-a-modal-from-dismissing) property to control when a modal can dismiss.
+1. Remove any usage of the `swipeToClose` property. Card modals are swipeable by default, so you can remove `swipeToClose` if you want your card modal to remain swipeable. Use the [canDismiss](https://ionicframework.com/docs/api/modal#preventing-a-modal-from-dismissing) property if you want to prevent a modal from dismissing.
 2. Remove any code that sets the `canDismiss` property to `undefined`. The `canDismiss` property now defaults to `true`, so this code is no longer needed.
 
 ### Picker


### PR DESCRIPTION
Brandy noted in https://github.com/ionic-team/docs-demo/pull/29 that it was not clear how to migrate from `swipeToClose` to `canDismiss`. This PR clarifies this on the migration guide.