### PR TITLE
docs(updating): clean up verbiage on updating documents

### DIFF
--- a/docs/updating/4-0.md
+++ b/docs/updating/4-0.md
@@ -10,7 +10,7 @@ title: Updating to v4
 This guide assumes that you have already updated your app to the latest version of Ionic 3. If you are using Ionic 1 or 2, Make sure to follow the [Updating from Ionic 1 to 4 Guide](#updating-from-ionic-1-to-4) instead.
 :::
 
-:::caution Breaking Changes
+:::info Breaking Changes
 For a **complete list of breaking changes** from Ionic 3 to Ionic 4, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v4.md) in the Ionic Framework repository.
 :::
 

--- a/docs/updating/4-0.md
+++ b/docs/updating/4-0.md
@@ -36,7 +36,7 @@ In Ionic 4, the package name is `@ionic/angular`. Uninstall Ionic 3 and install 
 
 ```shell
 $ npm uninstall ionic-angular
-$ npm install @ionic/angular
+$ npm install @ionic/angular@v4-lts
 ```
 
 While migrating an app, update the imports from `ionic-angular` to `@ionic/angular`.

--- a/docs/updating/4-0.md
+++ b/docs/updating/4-0.md
@@ -1,13 +1,17 @@
 ---
-title: Updating to 4.0
+title: Updating to v4
 ---
 
-# Updating from Ionic 1-3 to Ionic 4
+# Updating to Ionic 4
 
-## Migrating from Ionic 3.0 to Ionic 4.0
+## Updating from Ionic 3 to 4
 
 :::note
-For a **complete list of breaking changes** from Ionic 3 to Ionic 4, please refer to [the breaking changes document](https://github.com/ionic-team/ionic/blob/master/angular/BREAKING.md) in the Ionic core repo.
+This guide assumes that you have already updated your app to the latest version of Ionic 3. If you are using Ionic 1 or 2, Make sure to follow the [Updating from Ionic 1 to 4 Guide](#updating-from-ionic-1-to-4) instead.
+:::
+
+:::caution Breaking Changes
+For a **complete list of breaking changes** from Ionic 3 to Ionic 4, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v4.md) in the Ionic Framework repository.
 :::
 
 We suggest the following general process when migrating an existing application from Ionic 3 to 4:
@@ -243,11 +247,11 @@ Since v4 moved to Custom Elements, there's been a significant change to the mark
 
 To help with these markup changes, we've released a TSLint-based <a href="https://github.com/ionic-team/v4-migration-tslint" target="_blank">Migration Tool</a>, which detects issues and can even fix some of them automatically.
 
-## Migrating from Ionic 1.0 to Ionic 4.0
+## Updating from Ionic 1 to 4
 
-### Ionic 1.0 to Ionic 4.0: What’s Involved?
+### Ionic 1 to Ionic 4: What’s Involved?
 
-Migrating from Ionic 1 to Ionic 4.0 involves moving from AngularJS (aka Angular 1) to Angular 7+. There are many architectural differences between these versions, so some of the app code will have to be rewritten. The amount of work involved depends on the complexity and size of your app.
+Migrating from Ionic 1 to Ionic 4 involves moving from AngularJS (aka Angular 1) to Angular 7+. There are many architectural differences between these versions, so some of the app code will have to be rewritten. The amount of work involved depends on the complexity and size of your app.
 
 One upside is that for the most part, the Ionic UI components you know and love from V1 haven’t changed much.
 
@@ -261,9 +265,9 @@ Here are some considerations to review before beginning the upgrade:
 
 Once your development team has identified a good time frame for beginning the migration, Ionic recommends feature-freezing the Ionic 1 application and getting the code in order: Fix any major bugs, eliminate tech debt, and reorganize as you see fit. Then, identify which features to migrate over and which to abandon.
 
-Once the Ionic 1 app is stable, create a new Ionic 4.0 project. The majority of the dev team’s attention should be given to the new project; only bugs should be fixed in the Ionic 1 app to ensure that the transition happens as quickly and smoothly as possible.
+Once the Ionic 1 app is stable, create a new Ionic 4 project. The majority of the dev team’s attention should be given to the new project; only bugs should be fixed in the Ionic 1 app to ensure that the transition happens as quickly and smoothly as possible.
 
-Once the team is comfortable that the Ionic 4.0 app has become stable and has fulfilled a core set of features, you can then shut down the Ionic 1 app.
+Once the team is comfortable that the Ionic 4 app has become stable and has fulfilled a core set of features, you can then shut down the Ionic 1 app.
 
 ### Moving From AngularJS to Angular
 
@@ -271,8 +275,8 @@ Please reference official [Angular upgrade guide](https://angular.io/guide/upgra
 
 ### Ionic Changes
 
-Our Ionic 3.0 to Ionic 4.0 migration sections above may prove to be a useful reference. Generate a new Ionic 4.0 project using the blank starter (see [Starting an App](../developing/starting.md)). Spend time getting familiar with Ionic 4.0 components. Happy building!
+Our Ionic 3 to Ionic 4 migration sections above may prove to be a useful reference. Generate a new Ionic 4 project using the blank starter (see [Starting an App](../developing/starting.md)). Spend time getting familiar with Ionic 4 components. Happy building!
 
 ### Need Assistance?
 
-If your team would like assistance with the migration, please [reach out to us](https://ionicframework.com/enterprise-engine)! Ionic offers Advisory Services, which includes Ionic 4.0 training, architecture reviews, and migration assistance.
+If your team would like assistance with the migration, please [reach out to us](https://ionicframework.com/enterprise-engine)! Ionic offers Advisory Services, which includes Ionic 4 training, architecture reviews, and migration assistance.

--- a/docs/updating/5-0.md
+++ b/docs/updating/5-0.md
@@ -10,7 +10,7 @@ Migrating an app from Ionic 4 to 5 requires a few updates to the API properties,
 This guide assumes that you have already updated your app to the latest version of Ionic 4. Make sure you have followed the [Updating to Ionic 4 Guide](./4-0) before starting this guide.
 :::
 
-:::caution Breaking Changes
+:::info Breaking Changes
 For a **complete list of breaking changes** from Ionic 4 to Ionic 5, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v5.md) in the Ionic Framework repository.
 :::
 

--- a/docs/updating/5-0.md
+++ b/docs/updating/5-0.md
@@ -19,19 +19,19 @@ For a **complete list of breaking changes** from Ionic 4 to Ionic 5, please refe
 For Angular based projects, you can simply run:
 
 ```shell
-npm install @ionic/angular@latest @ionic/angular-toolkit@latest --save
+npm install @ionic/angular@v5-lts @ionic/angular-toolkit@4.0.0 --save
 ```
 
 For React projects, you can run:
 
 ```shell
-npm install @ionic/react@latest @ionic/react-router@latest ionicons@latest
+npm install @ionic/react@v5-lts @ionic/react-router@v5-lts ionicons@5.5.3
 ```
 
 For Stencil / vanilla JS projects, you can run:
 
 ```shell
-npm i @ionic/core@latest --save
+npm i @ionic/core@v5-lts --save
 ```
 
 If you would like a fresh project starter, a new project base can be created from the CLI and an existing app can be migrated over manually.

--- a/docs/updating/5-0.md
+++ b/docs/updating/5-0.md
@@ -1,18 +1,18 @@
 ---
-title: Updating to 5.0
+title: Updating to v5
 ---
 
-# Updating from Ionic 4 to Ionic 5
+# Updating from Ionic 4 to 5
 
-Migrating an app from 4.x to 5.x requires a few updates to the API properties, CSS utilities, and the installed package dependencies.
+Migrating an app from Ionic 4 to 5 requires a few updates to the API properties, CSS utilities, and the installed package dependencies.
 
 :::note
-This guide assumes that you have already updated your app to the latest version of Ionic 4. Make sure you have followed the [Upgrading to Ionic 4 Guide](./4-0) before starting this guide.
+This guide assumes that you have already updated your app to the latest version of Ionic 4. Make sure you have followed the [Updating to Ionic 4 Guide](./4-0) before starting this guide.
 :::
 
-### API and CSS Updates
-
-For a complete list of breaking changes from 4.x to 5.x, please refer to [the breaking changes document](https://github.com/ionic-team/ionic/blob/master/BREAKING.md#version-5x) in the Ionic core repo.
+:::caution Breaking Changes
+For a **complete list of breaking changes** from Ionic 4 to Ionic 5, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v5.md) in the Ionic Framework repository.
+:::
 
 ### Packages and Dependencies
 

--- a/docs/updating/6-0.md
+++ b/docs/updating/6-0.md
@@ -1,11 +1,15 @@
 ---
-title: Updating to 6.0
+title: Updating to v6
 ---
 
-# Updating from Ionic 5 to Ionic 6
+# Updating from Ionic 5 to 6
 
 :::note
-This guide assumes that you have already updated your app to the latest version of Ionic 5. Make sure you have followed the [Upgrading to Ionic 5 Guide](./5-0) before starting this guide.
+This guide assumes that you have already updated your app to the latest version of Ionic 5. Make sure you have followed the [Updating to Ionic 5 Guide](./5-0) before starting this guide.
+:::
+
+:::caution Breaking Changes
+For a **complete list of breaking changes** from Ionic 5 to Ionic 6, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md) in the Ionic Framework repository.
 :::
 
 ## Getting Started
@@ -190,7 +194,7 @@ This applies to `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `io
 <script>
   import { IonTabs, IonTabBar } from '@ionic/vue';
   import { defineComponent } from 'vue';
-  
+
   export default defineComponent({
     components: { IonTabs, IonTabBar }
   });
@@ -209,7 +213,7 @@ This applies to `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `io
 <script>
   import { IonTabs, IonTabBar, IonRouterOutlet } from '@ionic/vue';
   import { defineComponent } from 'vue';
-  
+
   export default defineComponent({
     components: { IonTabs, IonTabBar, IonRouterOutlet }
   });

--- a/docs/updating/6-0.md
+++ b/docs/updating/6-0.md
@@ -8,7 +8,7 @@ title: Updating to v6
 This guide assumes that you have already updated your app to the latest version of Ionic 5. Make sure you have followed the [Updating to Ionic 5 Guide](./5-0) before starting this guide.
 :::
 
-:::caution Breaking Changes
+:::info Breaking Changes
 For a **complete list of breaking changes** from Ionic 5 to Ionic 6, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md) in the Ionic Framework repository.
 :::
 

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -1,15 +1,19 @@
 ---
-title: Updating to 7.0
+title: Updating to v7
 ---
 
-# Updating from Ionic 6 to Ionic 7
+# Updating from Ionic 6 to 7
 
 :::note
 Ionic 7 is in beta. Please report any issues on [the Ionic Framework GitHub Repo](https://github.com/ionic-team/ionic-framework).
 :::
 
 :::note
-This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Upgrading to Ionic 6 Guide](./6-0) before starting this guide.
+This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Updating to Ionic 6 Guide](./6-0) before starting this guide.
+:::
+
+:::caution Breaking Changes
+For a **complete list of breaking changes** from Ionic 6 to Ionic 7, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x) in the Ionic Framework repository.
 :::
 
 ## Getting Started

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -12,7 +12,7 @@ Ionic 7 is in beta. Please report any issues on [the Ionic Framework GitHub Repo
 This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Updating to Ionic 6 Guide](./6-0) before starting this guide.
 :::
 
-:::caution Breaking Changes
+:::info Breaking Changes
 For a **complete list of breaking changes** from Ionic 6 to Ionic 7, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x) in the Ionic Framework repository.
 :::
 


### PR DESCRIPTION
This PR updates the following:

- Removes the second "Ionic" in the upgrade guide titles to avoid wrapping title (`Updating from Ionic 5 to Ionic 6` -> `Updating from Ionic 5 to 6`)
- References in the sidebar change from 4.0 to v4 (`Ionic 4.0` -> `Ionic v4`)
- Breaking Changes callout 
    - Added to the top of every page (already existed on v4 and v5 pages, exists at the bottom for v6 and v7)
    - Becomes a "caution" block instead of a "note" which highlights it red, this could be changed to info instead which would highlight it blue, but I thought it should be highlighted differently
    - Updates broken links to the breaking changes documents
- Renames all mentions of versions as `4.0` to `4`, `3.0` to `3`, etc. 
- Change links to other guides from `Upgrades to` to `Updates to` for consistency with their titles (see the Note block at the top of each page) 
- Removes usage of 4.x, 5.x, etc. and instead just referred to it by major number. This was used very inconsistently, for example one sentence was: `Once the team is comfortable that the Ionic 4.0 app has become stable and has fulfilled a core set of features, you can then shut down the Ionic 1 app.`

Breaking change `caution` vs `info` block:

| caution | info |
| --| --|
| ![Screenshot 2023-03-21 at 3 24 37 PM](https://user-images.githubusercontent.com/6577830/226723007-664c2704-4d35-4690-b835-06ee78ac50f2.png) | ![Screenshot 2023-03-21 at 3 24 24 PM](https://user-images.githubusercontent.com/6577830/226723151-ed150d0a-0723-4eb9-98d4-994e3891be9a.png) |

My goal was to bring some consistency to the update guides, but I am open to feedback if anyone doesn't like any of these changes.

Preview link: https://ionic-docs-git-docs-upgrading-guides-ionic1.vercel.app/docs/v7/