### PR TITLE
docs(live reload): update docs about Capacitor programmatic builds

### DIFF
--- a/versioned_docs/version-v6/cli/livereload.md
+++ b/versioned_docs/version-v6/cli/livereload.md
@@ -14,8 +14,6 @@ As with regular device deploys, you will need a cable to connect your device to 
 
 ### Capacitor
 
-Capacitor does not yet have a programmatic build for development (track [this issue](https://github.com/ionic-team/capacitor/issues/324) for progress), so the Ionic CLI does **not** automatically forward ports for iOS and Android.
-
 To use Live Reload with Capacitor, make sure you're either using a virtual device or a hardware device connected to the same Wi-Fi network as your computer. Then, you'll need to specify that you want to use an external address for the dev server using the `--external` flag.
 
 ```shell


### PR DESCRIPTION
Resolves #2805 

Changes v6 docs to remove text that is no longer accurate regarding Capacitor programmatic builds.

Note: The current docs were [already changed](https://github.com/ionic-team/ionic-docs/pull/2687).