### PR TITLE
docs(badge): content must be passed to be shown

### DIFF
--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -17,7 +17,7 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-Badges are inline block elements that usually appear near another element. Typically they contain a number or other characters. They can be used as a notification that there are additional items associated with an element and indicate how many items there are.
+Badges are inline block elements that usually appear near another element. Typically they contain a number or other characters. They can be used as a notification that there are additional items associated with an element and indicate how many items there are. Badges are hidden if no content is passed in.
 
 ## Basic Usage
 

--- a/versioned_docs/version-v6/api/badge.md
+++ b/versioned_docs/version-v6/api/badge.md
@@ -21,7 +21,7 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-Badges are inline block elements that usually appear near another element. Typically they contain a number or other characters. They can be used as a notification that there are additional items associated with an element and indicate how many items there are.
+Badges are inline block elements that usually appear near another element. Typically they contain a number or other characters. They can be used as a notification that there are additional items associated with an element and indicate how many items there are. Badges are hidden if no content is passed in.
 
 ## Basic Usage
 


### PR DESCRIPTION
resolves #1658 

`<ion-badge>` will be displayed with the style of `none` when no content is provided. This behavior is on v6 and v7 (beta). I added this behavior on the documentation.