### PR TITLE
docs(many): update config links

### DIFF
--- a/docs/api/back-button.md
+++ b/docs/api/back-button.md
@@ -28,7 +28,7 @@ import Basic from '@site/static/usage/v7/back-button/basic/index.md';
 
 ## Custom Back Button
 
-By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the Config docs for [Angular](/docs/angular/config), [React](/docs/react/config), or [Vue](/docs/vue/config) for more information.
+By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the [Config docs](/docs/developing/config) for more information.
 
 import Custom from '@site/static/usage/v7/back-button/custom/index.md';
 

--- a/docs/api/back-button.md
+++ b/docs/api/back-button.md
@@ -28,7 +28,7 @@ import Basic from '@site/static/usage/v7/back-button/basic/index.md';
 
 ## Custom Back Button
 
-By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the [Config docs](/docs/developing/config) for more information.
+By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the [Config docs](../developing/config) for more information.
 
 import Custom from '@site/static/usage/v7/back-button/custom/index.md';
 

--- a/versioned_docs/version-v5/theming/platform-styles.md
+++ b/versioned_docs/version-v5/theming/platform-styles.md
@@ -11,7 +11,7 @@ Ionic provides platform specific styles based on the device the application is r
 
 ## Ionic Modes
 
-Ionic uses **modes** to customize the look of components. Each **platform** has a default **mode**, but this can be overridden through the global [config](../angular/config.md). The following chart displays the default **mode** that is added to each **platform**:
+Ionic uses **modes** to customize the look of components. Each **platform** has a default **mode**, but this can be overridden through the global [config](../developing/config.md). The following chart displays the default **mode** that is added to each **platform**:
 
 | Platform  | Mode  | Description                                                                                                                      |
 | --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -25,7 +25,7 @@ For example, an app being viewed on an Android platform will use the `md` (Mater
 <html class="md"></html>
 ```
 
-_Note: The **platform** and the **mode** are not the same. The platform can be set to use any mode in the [config](../angular/config.md) of an app._
+_Note: The **platform** and the **mode** are not the same. The platform can be set to use any mode in the [config](../developing/config.md) of an app._
 
 ## Overriding Mode Styles
 

--- a/versioned_docs/version-v5/theming/platform-styles.md
+++ b/versioned_docs/version-v5/theming/platform-styles.md
@@ -11,7 +11,7 @@ Ionic provides platform specific styles based on the device the application is r
 
 ## Ionic Modes
 
-Ionic uses **modes** to customize the look of components. Each **platform** has a default **mode**, but this can be overridden through the global [config](../developing/config.md). The following chart displays the default **mode** that is added to each **platform**:
+Ionic uses **modes** to customize the look of components. Each **platform** has a default **mode**, but this can be overridden through the global [config](../angular/config.md). The following chart displays the default **mode** that is added to each **platform**:
 
 | Platform  | Mode  | Description                                                                                                                      |
 | --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -25,7 +25,7 @@ For example, an app being viewed on an Android platform will use the `md` (Mater
 <html class="md"></html>
 ```
 
-_Note: The **platform** and the **mode** are not the same. The platform can be set to use any mode in the [config](../developing/config.md) of an app._
+_Note: The **platform** and the **mode** are not the same. The platform can be set to use any mode in the [config](../angular/config.md) of an app._
 
 ## Overriding Mode Styles
 

--- a/versioned_docs/version-v6/angular/platform.md
+++ b/versioned_docs/version-v6/angular/platform.md
@@ -63,7 +63,7 @@ Below is a table listing all the possible platform values along with correspondi
 
 #### Customizing Platform Detection Functions
 
-The function used to detect a specific platform can be overridden by providing an alternative function in the global [Ionic config](./config). Each function takes `window` as a parameter and returns a boolean.
+The function used to detect a specific platform can be overridden by providing an alternative function in the global [Ionic config](../developing/config). Each function takes `window` as a parameter and returns a boolean.
 
 ```tsx
 import { IonicModule } from '@ionic/angular';

--- a/versioned_docs/version-v6/api/back-button.md
+++ b/versioned_docs/version-v6/api/back-button.md
@@ -28,7 +28,7 @@ import Basic from '@site/static/usage/v6/back-button/basic/index.md';
 
 ## Custom Back Button
 
-By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the [Config docs](/docs/developing/config) for more information.
+By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the [Config docs](../developing/config) for more information.
 
 import Custom from '@site/static/usage/v6/back-button/custom/index.md';
 

--- a/versioned_docs/version-v6/api/back-button.md
+++ b/versioned_docs/version-v6/api/back-button.md
@@ -28,7 +28,7 @@ import Basic from '@site/static/usage/v6/back-button/basic/index.md';
 
 ## Custom Back Button
 
-By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the Config docs for [Angular](/docs/angular/config), [React](/docs/react/config), or [Vue](/docs/vue/config) for more information.
+By default, the back button will display the text `"Back"` with a `"chevron-back"` icon on `ios`, and an `"arrow-back-sharp"` icon on `md`. This can be customized per back button component by setting the `icon` or `text` properties. Alternatively, it can be set globally using the `backButtonIcon` or `backButtonText` properties in the global config. See the [Config docs](/docs/developing/config) for more information.
 
 import Custom from '@site/static/usage/v6/back-button/custom/index.md';
 

--- a/versioned_docs/version-v6/intro/upgrading-to-ionic-6.md
+++ b/versioned_docs/version-v6/intro/upgrading-to-ionic-6.md
@@ -19,7 +19,7 @@ If you are using Ionic Angular Server, be sure to update that as well:
 npm install @ionic/angular@6 @ionic/angular-server@6
 ```
 
-3. Remove any usage of `Config.set()`. Instead, set your config in `IonicModule.forRoot()`. See the [Angular Config Documentation](../angular/config) for more examples.
+3. Remove any usage of `Config.set()`. Instead, set your config in `IonicModule.forRoot()`. See the [Config Documentation](../developing/config) for more examples.
 4. Remove any usage of the `setupConfig` function previously exported from `@ionic/angular`. Set your config in `IonicModule.forRoot()` instead.
 
 ### React
@@ -73,7 +73,7 @@ setupIonicReact({
 Developers must import and call `setupIonicReact` even if they are not setting custom config.
 :::
 
-See the [React Config Documentation](../react/config) for more examples.
+See the [Config Documentation](../developing/config) for more examples.
 
 5. Update all controller imports from `@ionic/core` to `@ionic/core/components`. As an example, here is a migration for `menuController`:
 
@@ -133,7 +133,7 @@ module.exports = {
 
 See the [Testing section below](#testing) for more information.
 
-5. Remove any usage of the `setupConfig` function previously exported from `@ionic/vue`. Set your config when installing the `IonicVue` plugin instead. See the [Vue Config Documentation](../vue/config) for more examples.
+5. Remove any usage of the `setupConfig` function previously exported from `@ionic/vue`. Set your config when installing the `IonicVue` plugin instead. See the [Config Documentation](../developing/config) for more examples.
 
 6. Rename the `IonRouter` type for `useIonRouter` to `UseIonRouterResult`.
 

--- a/versioned_docs/version-v6/react/platform.md
+++ b/versioned_docs/version-v6/react/platform.md
@@ -47,7 +47,7 @@ Below is a table listing all the possible platform values along with correspondi
 
 ## Customizing Platform Detection Functions
 
-The function used to detect a specific platform can be overridden by providing an alternative function in the global [Ionic config](./config). Each function takes `window` as a parameter and returns a boolean.
+The function used to detect a specific platform can be overridden by providing an alternative function in the global [Ionic config](../developing/config). Each function takes `window` as a parameter and returns a boolean.
 
 ```tsx
 setupIonicReact({

--- a/versioned_docs/version-v6/theming/platform-styles.md
+++ b/versioned_docs/version-v6/theming/platform-styles.md
@@ -14,7 +14,7 @@ Ionic provides platform specific styles based on the device the application is r
 
 ## Ionic Modes
 
-Ionic uses **modes** to customize the look of components. Each **platform** has a default **mode**, but this can be overridden through the global [config](../angular/config.md). The following chart displays the default **mode** that is added to each **platform**:
+Ionic uses **modes** to customize the look of components. Each **platform** has a default **mode**, but this can be overridden through the global [config](../developing/config.md). The following chart displays the default **mode** that is added to each **platform**:
 
 | Platform  | Mode  | Description                                                                                                                      |
 | --------- | ----- | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -28,7 +28,7 @@ For example, an app being viewed on an Android platform will use the `md` (Mater
 <html class="md"></html>
 ```
 
-_Note: The **platform** and the **mode** are not the same. The platform can be set to use any mode in the [config](../angular/config.md) of an app._
+_Note: The **platform** and the **mode** are not the same. The platform can be set to use any mode in the [config](../developing/config.md) of an app._
 
 ## Overriding Mode Styles
 

--- a/versioned_docs/version-v6/vue/platform.md
+++ b/versioned_docs/version-v6/vue/platform.md
@@ -47,7 +47,7 @@ Below is a table listing all the possible platform values along with correspondi
 
 ## Customizing Platform Detection Functions
 
-The function used to detect a specific platform can be overridden by providing an alternative function in the global [Ionic config](./config). Each function takes `window` as a parameter and returns a boolean.
+The function used to detect a specific platform can be overridden by providing an alternative function in the global [Ionic config](../developing/config). Each function takes `window` as a parameter and returns a boolean.
 
 ```tsx
 createApp(App).use(IonicVue, {


### PR DESCRIPTION
I missed some links when merging https://github.com/ionic-team/ionic-docs/commit/d28c8314438091c7f8137a223fc9d8671766ebdd. This PR updates affected links to direct to the new `/developing/config` page.