### PR TITLE
docs: rxjs migration guide for v7

### DIFF
--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -21,7 +21,13 @@ For a **complete list of breaking changes** from Ionic 6 to Ionic 7, please refe
 ### Angular
 
 1. Ionic 7 supports Angular 14+. Update to the latest version of Angular by following the [Angular Update Guide](https://update.angular.io/).
-2. Update to the latest version of Ionic 7:
+2. If your project is using rxjs, Ionic 7 requires a minimum rxjs version of 7.5.0:
+
+```shell
+npm install rxjs@7.5.0
+```
+
+3. Update to the latest version of Ionic 7:
 
 ```shell
 npm install @ionic/angular@next
@@ -90,7 +96,6 @@ iOS >=14
 
 1. `ActionSheetAttributes`, `AlertAttributes`, `AlertTextareaAttributes`, `AlertInputAttributes`, `LoadingAttributes`, `ModalAttributes`, `PickerAttributes`, `PopoverAttributes`, and `ToastAttributes` have been removed. Developers should use `{ [key: string]: any }` instead.
 
-
 ### Checkbox
 
 1. Rename any usages of the `--background` and `--background-checked` CSS Variables to `--checkbox-background` and `--checkbox-background-checked`, respectively.
@@ -133,7 +138,6 @@ iOS >=14
 
 1. Update any code that accesses the `detail` payload for the `ionInput` event from `event.detail` to `event.detail.value` as the detail payload is now an object containing a value and an event.
 
-
 ### Toggle
 
 1. Rename any usages of the `--background` and `--background-checked` CSS Variables to `--track-background` and `--track-background-checked`, respectively.
@@ -151,4 +155,3 @@ iOS >=14
 Be sure to look at the [Ionic 7 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
 
 If you need help upgrading, please post a thread on the [Ionic Forum](https://forum.ionicframework.com/).
-


### PR DESCRIPTION
When upgrading a reproduction example to v7, I observed that the `ng update` command does not necessarily update the `rxjs` dependency.

`@ionic/angular` requires at least a minimum version of `7.5.0` of `rxjs`. We do not currently state this in our migration guide. 