### PR TITLE
docs(input, textarea): clarify error text behavior

### DIFF
--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -68,7 +68,9 @@ import Fill from '@site/static/usage/v7/input/fill/index.md';
 
 ## Helper & Error Text
 
-Helper and error text can be used inside of an input with the `helperText` and `errorText` property. The error text will not be displayed unless the `ion-invalid` class is added to the `ion-input`. In Angular, this is done automatically through form validation. In JavaScript, React and Vue, the class needs to be manually added based on your own validation.
+Helper and error text can be used inside of an input with the `helperText` and `errorText` property. The error text will not be displayed unless the `ion-invalid` and `ion-touched` classes are added to the `ion-input`. This ensures errors are not shown before the user has a chance to enter data.
+
+In Angular, this is done automatically through form validation. In JavaScript, React and Vue, the class needs to be manually added based on your own validation.
 
 import HelperError from '@site/static/usage/v7/input/helper-error/index.md';
 

--- a/docs/api/textarea.md
+++ b/docs/api/textarea.md
@@ -49,7 +49,9 @@ import Fill from '@site/static/usage/v7/textarea/fill/index.md';
 
 ## Helper & Error Text
 
-Helper and error text can be used inside of a textarea with the `helperText` and `errorText` property. The error text will not be displayed unless the `ion-invalid` class is added to the `ion-textarea`. In Angular, this is done automatically through form validation. In JavaScript, React and Vue, the class needs to be manually added based on your own validation.
+Helper and error text can be used inside of a textarea with the `helperText` and `errorText` property. The error text will not be displayed unless the `ion-invalid` and `ion-touched` classes are added to the `ion-textarea`. This ensures errors are not shown before the user has a chance to enter data.
+
+In Angular, this is done automatically through form validation. In JavaScript, React and Vue, the class needs to be manually added based on your own validation.
 
 import HelperError from '@site/static/usage/v7/textarea/helper-error/index.md';
 


### PR DESCRIPTION
Someone on the Ionic Discord noted that we do not state `.ion-touched` is needed. This was a bug we fixed in https://github.com/ionic-team/ionic-framework/commit/ef33270b55122574e0fdb32187410d8d8a4fa1ae, but we did not update the docs.