### PR TITLE
docs(toast): remove hardware back button dismissal

### DIFF
--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -48,9 +48,11 @@ import ControllerExample from '@site/static/usage/v7/toast/presenting/controller
 
 ## Dismissing
 
-Toasts are intended to be subtle notifications and are not intended to interrupt the user.
+Toasts are intended to be subtle notifications and should not interrupt the user. As a result, user interaction should not be required to dismiss the toast.
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance. A hardware back button will not dismiss the toast.
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+
+Pressing the hardware back button does not dismiss toasts since they are not supposed to interrupt the user.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -48,7 +48,7 @@ import ControllerExample from '@site/static/usage/v7/toast/presenting/controller
 
 ## Dismissing
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -48,7 +48,7 @@ import ControllerExample from '@site/static/usage/v7/toast/presenting/controller
 
 ## Dismissing
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. To dismiss the toast after creation, call the `dismiss()` method on the instance.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -48,7 +48,9 @@ import ControllerExample from '@site/static/usage/v7/toast/presenting/controller
 
 ## Dismissing
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+Toasts are intended to be subtle notifications and are not intended to interrupt the user.
+
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance. A hardware back button will not dismiss the toast.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/docs/developing/hardware-back-button.md
+++ b/docs/developing/hardware-back-button.md
@@ -340,6 +340,6 @@ The table below lists all of the internal hardware back button event handlers th
 
 | Handler    | Priority | Propagates | Description                                                                                                                              |
 | ---------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Overlays   | 100      | No         | Applies to overlay components `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `ion-popover`, `ion-picker`, and `ion-toast`. |
+| Overlays   | 100      | No         | Applies to overlay components `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `ion-popover`, and `ion-picker`. |
 | Menu       | 99       | No         | Applies to `ion-menu`.                                                                                                                   |
 | Navigation | 0        | Yes        | Applies to routing navigation (i.e. Angular Routing).                                                                                    |

--- a/versioned_docs/version-v6/api/toast.md
+++ b/versioned_docs/version-v6/api/toast.md
@@ -91,7 +91,7 @@ function Example() {
 
 ## Dismissing
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. To dismiss the toast after creation, call the `dismiss()` method on the instance.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/versioned_docs/version-v6/api/toast.md
+++ b/versioned_docs/version-v6/api/toast.md
@@ -91,9 +91,11 @@ function Example() {
 
 ## Dismissing
 
-Toasts are intended to be subtle notifications and are not intended to interrupt the user.
+Toasts are intended to be subtle notifications and should not interrupt the user. As a result, user interaction should not be required to dismiss the toast.
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance. A hardware back button will not dismiss the toast.
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+
+Pressing the hardware back button does not dismiss toasts since they are not supposed to interrupt the user.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/versioned_docs/version-v6/api/toast.md
+++ b/versioned_docs/version-v6/api/toast.md
@@ -91,7 +91,7 @@ function Example() {
 
 ## Dismissing
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/versioned_docs/version-v6/api/toast.md
+++ b/versioned_docs/version-v6/api/toast.md
@@ -91,7 +91,9 @@ function Example() {
 
 ## Dismissing
 
-The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance.
+Toasts are intended to be subtle notifications and are not intended to interrupt the user.
+
+The toast can be dismissed automatically after a specific amount of time by passing the number of milliseconds to display it in the `duration` of the toast options. If a button with a role of `"cancel"` is added, then that button will dismiss the toast. To dismiss the toast after creation, call the `dismiss()` method on the instance. A hardware back button will not dismiss the toast.
 
 The following example demonstrates how to use the `buttons` property to add a button that automatically dismisses the toast when clicked, as well as how to collect the `role` of the dismiss event.
 

--- a/versioned_docs/version-v6/developing/hardware-back-button.md
+++ b/versioned_docs/version-v6/developing/hardware-back-button.md
@@ -340,6 +340,6 @@ The table below lists all of the internal hardware back button event handlers th
 
 | Handler    | Priority | Propagates | Description                                                                                                                              |
 | ---------- | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Overlays   | 100      | No         | Applies to overlay components `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `ion-popover`, `ion-picker`, and `ion-toast`. |
+| Overlays   | 100      | No         | Applies to overlay components `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `ion-popover`, and `ion-picker`. |
 | Menu       | 99       | No         | Applies to `ion-menu`.                                                                                                                   |
 | Navigation | 0        | Yes        | Applies to routing navigation (i.e. Angular Routing).                                                                                    |


### PR DESCRIPTION
Removed any mentions that `ion-toast` can use the hardware back button to dismiss. The change was added to v6 and v7 (beta).