### PR TITLE
docs(lifecycle): clarify when lifecycles are called

### DIFF
--- a/docs/angular/lifecycle.md
+++ b/docs/angular/lifecycle.md
@@ -41,6 +41,8 @@ In addition to the Angular life cycle events, Ionic Angular provides a few addit
 | `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
 | `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
 
+These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
+
 The difference between `ionViewWillEnter` and `ionViewDidEnter` is when they fire. The former fires right after `ngOnInit` but before the page transition begins, and the latter directly after the transition ends.
 
 For `ionViewWillLeave` and `ionViewDidLeave`, `ionViewWillLeave` gets called directly before the transition away from the current page begins, and `ionViewDidLeave` does not get called until after the new page gets successfully transitioned into (after the new pages `ionViewDidEnter` fires).

--- a/docs/react/lifecycle.md
+++ b/docs/react/lifecycle.md
@@ -24,6 +24,8 @@ Ionic provides a few lifecycle methods that you can use in your apps:
 | `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
 | `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
 
+These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
+
 The way you access these methods varies based on if you are using class-based components or functional components. We cover both methods below.
 
 ## Lifecycle Methods in Class-Based Components

--- a/docs/vue/lifecycle.md
+++ b/docs/vue/lifecycle.md
@@ -17,6 +17,8 @@ Ionic Framework provides a few lifecycle methods that you can use in your apps:
 | `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
 | `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
 
+These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
+
 The lifecycles are defined the same way Vue lifecycle methods are - as functions at the root of your Vue component:
 
 ```tsx

--- a/versioned_docs/version-v6/angular/lifecycle.md
+++ b/versioned_docs/version-v6/angular/lifecycle.md
@@ -41,6 +41,8 @@ In addition to the Angular life cycle events, Ionic Angular provides a few addit
 | `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
 | `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
 
+These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
+
 The difference between `ionViewWillEnter` and `ionViewDidEnter` is when they fire. The former fires right after `ngOnInit` but before the page transition begins, and the latter directly after the transition ends.
 
 For `ionViewWillLeave` and `ionViewDidLeave`, `ionViewWillLeave` gets called directly before the transition away from the current page begins, and `ionViewDidLeave` does not get called until after the new page gets successfully transitioned into (after the new pages `ionViewDidEnter` fires).

--- a/versioned_docs/version-v6/react/lifecycle.md
+++ b/versioned_docs/version-v6/react/lifecycle.md
@@ -24,6 +24,8 @@ Ionic provides a few lifecycle methods that you can use in your apps:
 | `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
 | `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
 
+These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
+
 The way you access these methods varies based on if you are using class-based components or functional components. We cover both methods below.
 
 ## Lifecycle Methods in Class-Based Components

--- a/versioned_docs/version-v6/vue/lifecycle.md
+++ b/versioned_docs/version-v6/vue/lifecycle.md
@@ -17,6 +17,8 @@ Ionic Framework provides a few lifecycle methods that you can use in your apps:
 | `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
 | `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
 
+These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
+
 The lifecycles are defined the same way Vue lifecycle methods are - as functions at the root of your Vue component:
 
 ```tsx


### PR DESCRIPTION
There is some confusion over which components can receive Ionic lifecycles: https://github.com/ionic-team/ionic-framework/issues/27026

This PR updates the lifecycles docs to note that Ionic lifecycles are only called on components mapped to by the router.