### PR TITLE
fix(plugin): account for versions with no paths

### DIFF
--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -49,7 +49,12 @@ module.exports = function (context, options) {
         await generateMarkdownForVersion(version, npmTag, false);
       }
 
-      const npmTag = currentVersion.banner === 'unreleased' ? 'next' : currentVersion.path.slice(1);
+      let npmTag = 'latest';
+      if (currentVersion.banner === 'unreleased') {
+        npmTag = 'next';
+      } else if (currentVersion.path !== undefined) {
+        npmTag = currentVersion.path.slice(1);
+      }
       // Latest version
       await generateMarkdownForVersion(currentVersion.path, npmTag, true);
 


### PR DESCRIPTION
When generating the API docs, we do not account for versions that have no path in the config (i.e. the current version). This causes deployments to fail when updating the latest version of Ionic for the docs.