### PR TITLE
docs(support): update support table for v7

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -22,8 +22,8 @@ The current status of each Ionic Framework version is:
 
 | Version |        Status         |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------------: | :----------: | :--------------: | :---------------: |
-| V7      | Beta                  | TBD          | TBD              | TBD               |
-| V6      | **Active**            | Dec 8, 2021  | TBD              | TBD               |
+| V7      | **Active**            | Mar 29, 2023 | TBD              | TBD               |
+| V6      | Maintenance           | Dec 8, 2021  | Sep 29, 2023     | Mar 29, 2024      |
 | V5      | End of Support        | Feb 11, 2020 | June 8, 2022     | Dec 8, 2022       |
 | V4      | End of Support        | Jan 23, 2019 | Aug 11, 2020     | Sept 30, 2022     |
 | V3      | End of Support        | Apr 5, 2017  | Oct 30, 2019     | Aug 11, 2020      |


### PR DESCRIPTION
Updates the Framework version support table to make v7 the active version and add maintenance/extended support dates for v6. I intentionally didn't update the v6 version of this page because the v5 page didn't get updated when v6 was released either (and also having to update all past versions every time we release a new one sounds annoying 😆), but let me know if I should update all three tables.

Resolves https://github.com/ionic-team/ionic-docs/issues/2867