### PR TITLE
docs(v7): update breaking changes link

### DIFF
--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -9,7 +9,7 @@ This guide assumes that you have already updated your app to the latest version 
 :::
 
 :::info Breaking Changes
-For a **complete list of breaking changes** from Ionic 6 to Ionic 7, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x) in the Ionic Framework repository.
+For a **complete list of breaking changes** from Ionic 6 to Ionic 7, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-7x) in the Ionic Framework repository.
 :::
 
 ## Getting Started

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -148,6 +148,6 @@ iOS >=14
 
 ## Need Help Upgrading?
 
-Be sure to look at the [Ionic 7 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/feature-7.0/BREAKING.md#version-7x). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
+Be sure to look at the [Ionic 7 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-7x). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
 
 If you need help upgrading, please post a thread on the [Ionic Forum](https://forum.ionicframework.com/).


### PR DESCRIPTION
Updates the link to the breaking changes guide now that `feature-7.0` has been merged into `main` on https://github.com/ionic-team/ionic-framework