### PR TITLE
docs(v7): update migration guide tags

### DIFF
--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -26,13 +26,13 @@ npm install rxjs@7.5.0
 3. Update to the latest version of Ionic 7:
 
 ```shell
-npm install @ionic/angular@next
+npm install @ionic/angular@7
 ```
 
 If you are using Ionic Angular Server, be sure to update that as well:
 
 ```shell
-npm install @ionic/angular@next @ionic/angular-server@next
+npm install @ionic/angular@7 @ionic/angular-server@7
 ```
 
 ### React
@@ -46,7 +46,7 @@ npm install react@latest react-dom@latest
 2. Update to the latest version of Ionic 7:
 
 ```shell
-npm install @ionic/react@next @ionic/react-router@next
+npm install @ionic/react@7 @ionic/react-router@7
 ```
 
 ### Vue
@@ -60,7 +60,7 @@ npm install vue@latest vue-router@latest
 3. Update to the latest version of Ionic 7:
 
 ```shell
-npm install @ionic/vue@next @ionic/vue-router@next
+npm install @ionic/vue@7 @ionic/vue-router@7
 ```
 
 ### Core
@@ -68,7 +68,7 @@ npm install @ionic/vue@next @ionic/vue-router@next
 1. Update to the latest version of Ionic 7:
 
 ```shell
-npm install @ionic/core@next
+npm install @ionic/core@7
 ```
 
 ## Updating Your Code


### PR DESCRIPTION
The migration guide from Ionic 6 to Ionic 7 will now have devs install the latest stable version of v7 instead of `next`