### PR TITLE
docs(migration): fix header levels in v4 migration guide

### DIFF
--- a/docs/updating/4-0.md
+++ b/docs/updating/4-0.md
@@ -30,7 +30,7 @@ We suggest the following general process when migrating an existing application 
 
 In many cases, using the Ionic CLI to generate a new object and then copying the code also works very well. For example: `ionic g service weather` will create a shell `Weather` service and test. The code can then be copied from the older project with minor modifications as needed. This helps to ensure the proper structure is followed. This also generates shells for unit tests.
 
-## Changes in Package Name
+### Changes in Package Name
 
 In Ionic 4, the package name is `@ionic/angular`. Uninstall Ionic 3 and install Ionic 4 using the new package name:
 
@@ -41,7 +41,7 @@ $ npm install @ionic/angular@v4-lts
 
 While migrating an app, update the imports from `ionic-angular` to `@ionic/angular`.
 
-## Project structure
+### Project structure
 
 One of the major changes between an Ionic 3 app and an Ionic 4 app is the overall project layout and structure. In v3, Ionic apps had a custom convention for how an app should be set up and what that folder structure should look like. In v4, this has been changed to follow the recommended setup of each supported framework.
 
@@ -133,11 +133,11 @@ See the following `ionic.config.json` as an example:
 }
 ```
 
-## RxJS Changes
+### RxJS Changes
 
 Between V3 and V4, RxJS was updated to version 6. This changes many of the import paths of operators and core RxJS functions. Please see the <a href="https://github.com/ReactiveX/rxjs/blob/6.x/docs_app/content/guide/v6/migration.md" target="_blank">RxJS Migration Guide</a> for details.
 
-## Lifecycle Events
+### Lifecycle Events
 
 With V4, we're now able to utilize the typical events provided by [Angular](https://angular.io/guide/lifecycle-hooks). But for certain cases, you might want to have access to the events fired when a component has finished animating during its route change. In this case, the `ionViewWillEnter`, `ionViewDidEnter`, `ionViewWillLeave`, and `ionViewDidLeave` have been ported over from V3. Use these events to coordinate actions with Ionic's own animations system.
 
@@ -145,7 +145,7 @@ Older events like `ionViewDidLoad`, `ionViewCanLeave`, and `ionViewCanEnter` hav
 
 For more details, check out the [router-outlet docs](../api/router-outlet.md)
 
-## Overlay Components
+### Overlay Components
 
 In prior versions of Ionic, overlay components such as Loading, Toast, or Alert were created synchronously. In Ionic v4, these components are all created asynchronously. As a result of this, the API is now promise-based.
 
@@ -183,7 +183,7 @@ async showAlert() {
 }
 ```
 
-## Navigation
+### Navigation
 
 In V4, navigation received the most changes. Now, instead of using Ionic's own `NavController`, we integrate with the official Angular Router. This not only provides a consistent routing experience across apps, but is much more dependable. The Angular team has an <a href="http://angular.io/guide/router" target="_blank">excellent guide</a> on their docs site that covers the Router in great detail.
 
@@ -191,7 +191,7 @@ To provide the platform-specific animations that users are used to, we have crea
 
 For a detailed explanation in navigation works in a V4 project, check out the [Angular navigation guide](../angular/navigation.md).
 
-## Lazy Loading
+### Lazy Loading
 
 Since Navigation has changed, the mechanism for lazy loading has also changed in V4.
 
@@ -241,7 +241,7 @@ export class AppModule {}
 
 For a detailed explanation of lazy loading in V4 project, check out the [Angular navigation guide](../angular/navigation.md#lazy-loading-routes).
 
-## Markup Changes
+### Markup Changes
 
 Since v4 moved to Custom Elements, there's been a significant change to the markup for each component. These changes have all been made to follow the Custom Elements spec, and have been documented in a <a href="https://github.com/ionic-team/ionic/blob/master/angular/BREAKING.md#breaking-changes" target="_blank">dedicated file on GitHub</a>.
 


### PR DESCRIPTION
These headers were on the same level as the "Updating From 3 to 4" header at the top, but they should be one layer deeper.