### PR TITLE
Add optimizeDeps exclusion note for vite config

### DIFF
--- a/docs/vue/your-first-app.md
+++ b/docs/vue/your-first-app.md
@@ -109,6 +109,15 @@ import { defineCustomElements } from '@ionic/pwa-elements/loader';
 defineCustomElements(window);
 ```
 
+Since we're using Vite, you'll need to also add the following code to `vite.config.ts`.
+
+```tsx
+// Within the defineConfig block
+optimizeDeps: {
+  exclude: [`@ionic/pwa-elements/loader`],
+},
+```
+
 That’s it! Now for the fun part - let’s see the app in action.
 
 ## Run the App


### PR DESCRIPTION
The current instructions for building one's first app using Vue + Vite does not work, and results in a `net::ERR_ABORTED 504 (Outdated Optimize Dep)` error.

Based on the discussion in https://github.com/ionic-team/pwa-elements/issues/109 — and confirmed by my own testing — excluding the `pwa-elements` loader from Vite's dependency optimization fixes the issue in development.

It seems there may be lingering issues in production builds even with this fix based on that same open issue, but at the very least, this removes a current blocker in the documentation for users creating their first Ionic app.