### PR TITLE
fix(jp): set the v7 document version to v7

### DIFF
--- a/scripts/i18n.sh
+++ b/scripts/i18n.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o nounset
 
-mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-v6/
+mkdir -p i18n/ja/docusaurus-plugin-content-docs/current/
 curl -fsSL https://github.com/ionic-team/ionic-docs/archive/refs/heads/translation/jp.tar.gz |
-  tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/version-v6/ --strip-components 2 ionic-docs-translation-jp/docs
+  tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/current/ --strip-components 2 ionic-docs-translation-jp/docs
 node scripts/api-ja.js


### PR DESCRIPTION
Currently, v7 documents are tied to v6 at https://ionicframework.com/docs/ja.
The "current" path refers to the commit at https://github.com/ionic-team/ionic-docs/commit/b2e6a101f3d3cffba4b3648aa568df30fe968e67.

And, please tell me if this script is running in the main branch or in the translate/jp branch.