### PR TITLE
fix(styles): add sidebar indentation for nested sections

### DIFF
--- a/src/styles/components/_doc-sidebar.scss
+++ b/src/styles/components/_doc-sidebar.scss
@@ -103,9 +103,8 @@ html[data-theme='dark'] {
     }
   }
 
-  .theme-doc-sidebar-item-category-level-1 + .theme-doc-sidebar-item-category-level-1 {
-    /* adds margin between first level categories */
-    margin-block-start: 1.5rem;
+  .theme-doc-sidebar-item-category-level-1 > .menu__list > .menu__list-item:last-of-type {
+    padding-block-end: 1.5rem;
   }
 
   .theme-doc-sidebar-item-category-level-1:last-of-type {

--- a/src/styles/components/_doc-sidebar.scss
+++ b/src/styles/components/_doc-sidebar.scss
@@ -81,6 +81,10 @@ html[data-theme='dark'] {
     margin-block-start: 1.5rem;
   }
 
+  .theme-doc-sidebar-item-category-level-1:last-of-type {
+    margin-block-end: 1.5rem;
+  }
+
   .menu__list {
     display: block !important;
     transition: height 0.35s cubic-bezier(0.36, 0.66, 0.04, 1) 25ms !important;

--- a/src/styles/components/_doc-sidebar.scss
+++ b/src/styles/components/_doc-sidebar.scss
@@ -76,15 +76,6 @@ html[data-theme='dark'] {
     margin: 0;
   }
 
-  .theme-doc-sidebar-item-category-level-1 + .theme-doc-sidebar-item-category-level-1 {
-    /* adds margin between first level categories */
-    margin-block-start: 1.5rem;
-  }
-
-  .theme-doc-sidebar-item-category-level-1:last-of-type {
-    margin-block-end: 1.5rem;
-  }
-
   .menu__list {
     display: block !important;
     transition: height 0.35s cubic-bezier(0.36, 0.66, 0.04, 1) 25ms !important;
@@ -110,6 +101,15 @@ html[data-theme='dark'] {
         }
       }
     }
+  }
+
+  .theme-doc-sidebar-item-category-level-1 + .theme-doc-sidebar-item-category-level-1 {
+    /* adds margin between first level categories */
+    margin-block-start: 1.5rem;
+  }
+
+  .theme-doc-sidebar-item-category-level-1:last-of-type {
+    margin-block-end: 1.5rem;
   }
 
   .menu__link {

--- a/src/styles/components/_doc-sidebar.scss
+++ b/src/styles/components/_doc-sidebar.scss
@@ -71,16 +71,20 @@ html[data-theme='dark'] {
     display: none !important;
   }
 
+  .theme-doc-sidebar-item-category-level-1 > .menu__list {
+    /* removes indentation from first level categories */
+    margin: 0;
+  }
+
+  .theme-doc-sidebar-item-category-level-1 + .theme-doc-sidebar-item-category-level-1 {
+    /* adds margin between first level categories */
+    margin-block-start: 1.5rem;
+  }
+
   .menu__list {
     display: block !important;
     transition: height 0.35s cubic-bezier(0.36, 0.66, 0.04, 1) 25ms !important;
     will-change: initial !important;
-
-    margin: 0;
-
-    li:last-of-type {
-      padding-block-end: 1.5rem;
-    }
 
     .menu__list {
       .menu__link--sublist {


### PR DESCRIPTION
Updates the indentation for nested categories in the sidebar and the margin spacing between sections. 

You can see an example of a nested sidebar 3 levels deep with these same changes in this PR: https://github.com/ionic-team/ionic-docs/pull/2861 (React > Testing > Unit Testing)

Our goal is to maintain the spacing and indentation for the first-level categories, but allow the nested categories to be indented. 

![CleanShot 2023-04-06 at 11 43 10](https://user-images.githubusercontent.com/13732623/230430006-38e6e664-44bf-4ba5-9555-3d56bbe389dc.png)
