### PR TITLE
docs(select): popover can be used with multiple prop

### DIFF
--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -52,7 +52,7 @@ import PopoverExample from '@site/static/usage/v7/select/interfaces/popover/inde
 
 By adding the `multiple` attribute to select, users are able to select multiple options. When multiple options can be selected, the alert overlay presents users with a checkbox styled list of options. The select component's value receives an array of all of the selected option values.
 
-Note: the `action-sheet` and `popover` interfaces will not work with multiple selection.
+Note: the `action-sheet` interface will not work with multiple selection.
 
 import MultipleSelectionExample from '@site/static/usage/v7/select/basic/multiple-selection/index.md';
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -50,7 +50,7 @@ import PopoverExample from '@site/static/usage/v7/select/interfaces/popover/inde
 
 ## Multiple Selection
 
-By adding the `multiple` attribute to select, users are able to select multiple options. When multiple options can be selected, the alert overlay presents users with a checkbox styled list of options. The select component's value receives an array of all of the selected option values.
+By adding the `multiple` attribute to select, users are able to select multiple options. When multiple options can be selected, the alert or popover overlay presents users with a checkbox styled list of options. The select component's value receives an array of all of the selected option values.
 
 Note: the `action-sheet` interface will not work with multiple selection.
 


### PR DESCRIPTION
Multi-select popovers in `ion-select` were added in https://github.com/ionic-team/ionic-framework/pull/23474, but the docs still say you can't use popovers with `multiple="true"`.