### PR TITLE
docs(modal): controller playground uses bolded action

### DIFF
--- a/static/usage/v6/modal/controller/angular/modal-example_component_html.md
+++ b/static/usage/v6/modal/controller/angular/modal-example_component_html.md
@@ -6,7 +6,7 @@
     </ion-buttons>
     <ion-title>Welcome</ion-title>
     <ion-buttons slot="end">
-      <ion-button (click)="confirm()">Confirm</ion-button>
+      <ion-button (click)="confirm()" [strong]="true">Confirm</ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>

--- a/static/usage/v6/modal/controller/demo.html
+++ b/static/usage/v6/modal/controller/demo.html
@@ -39,7 +39,7 @@
           </ion-buttons>
           <ion-title>Welcome</ion-title>
           <ion-buttons slot="end">
-            <ion-button onclick="confirm()">Confirm</ion-button>
+            <ion-button onclick="confirm()" strong>Confirm</ion-button>
           </ion-buttons>
         </ion-toolbar>
       </ion-header>

--- a/static/usage/v6/modal/controller/javascript.md
+++ b/static/usage/v6/modal/controller/javascript.md
@@ -20,7 +20,7 @@
           </ion-buttons>
           <ion-title>Welcome</ion-title>
           <ion-buttons slot="end">
-            <ion-button onclick="confirm()">Confirm</ion-button>
+            <ion-button onclick="confirm()" strong>Confirm</ion-button>
           </ion-buttons>
         </ion-toolbar>
       </ion-header>

--- a/static/usage/v6/modal/controller/react.md
+++ b/static/usage/v6/modal/controller/react.md
@@ -32,7 +32,9 @@ const ModalExample = ({
           </IonButtons>
           <IonTitle>Welcome</IonTitle>
           <IonButtons slot="end">
-            <IonButton onClick={() => onDismiss(inputRef.current?.value, 'confirm')}>Confirm</IonButton>
+            <IonButton onClick={() => onDismiss(inputRef.current?.value, 'confirm')} strong={true}>
+              Confirm
+            </IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>

--- a/static/usage/v6/modal/controller/vue/modal_vue.md
+++ b/static/usage/v6/modal/controller/vue/modal_vue.md
@@ -7,7 +7,7 @@
       </ion-buttons>
       <ion-title>Modal</ion-title>
       <ion-buttons slot="end">
-        <ion-button @click="confirm">Confirm</ion-button>
+        <ion-button @click="confirm" :strong="true">Confirm</ion-button>
       </ion-buttons>
     </ion-toolbar>
   </ion-header>

--- a/static/usage/v7/modal/controller/angular/modal-example_component_html.md
+++ b/static/usage/v7/modal/controller/angular/modal-example_component_html.md
@@ -6,7 +6,7 @@
     </ion-buttons>
     <ion-title>Welcome</ion-title>
     <ion-buttons slot="end">
-      <ion-button (click)="confirm()">Confirm</ion-button>
+      <ion-button (click)="confirm()" [strong]="true">Confirm</ion-button>
     </ion-buttons>
   </ion-toolbar>
 </ion-header>

--- a/static/usage/v7/modal/controller/demo.html
+++ b/static/usage/v7/modal/controller/demo.html
@@ -39,7 +39,7 @@
           </ion-buttons>
           <ion-title>Welcome</ion-title>
           <ion-buttons slot="end">
-            <ion-button onclick="confirm()">Confirm</ion-button>
+            <ion-button onclick="confirm()" strong>Confirm</ion-button>
           </ion-buttons>
         </ion-toolbar>
       </ion-header>

--- a/static/usage/v7/modal/controller/javascript.md
+++ b/static/usage/v7/modal/controller/javascript.md
@@ -20,7 +20,7 @@
           </ion-buttons>
           <ion-title>Welcome</ion-title>
           <ion-buttons slot="end">
-            <ion-button onclick="confirm()">Confirm</ion-button>
+            <ion-button onclick="confirm()" strong>Confirm</ion-button>
           </ion-buttons>
         </ion-toolbar>
       </ion-header>

--- a/static/usage/v7/modal/controller/react.md
+++ b/static/usage/v7/modal/controller/react.md
@@ -32,7 +32,9 @@ const ModalExample = ({
           </IonButtons>
           <IonTitle>Welcome</IonTitle>
           <IonButtons slot="end">
-            <IonButton onClick={() => onDismiss(inputRef.current?.value, 'confirm')}>Confirm</IonButton>
+            <IonButton onClick={() => onDismiss(inputRef.current?.value, 'confirm')} strong={true}>
+              Confirm
+            </IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>

--- a/static/usage/v7/modal/controller/vue/modal_vue.md
+++ b/static/usage/v7/modal/controller/vue/modal_vue.md
@@ -7,7 +7,7 @@
       </ion-buttons>
       <ion-title>Modal</ion-title>
       <ion-buttons slot="end">
-        <ion-button @click="confirm">Confirm</ion-button>
+        <ion-button @click="confirm" :strong="true">Confirm</ion-button>
       </ion-buttons>
     </ion-toolbar>
   </ion-header>


### PR DESCRIPTION
Updates the component playground example for using the modal controller to include a bolded primary action, since the example renders two actions. 

This aligns the example with the inline modal playground.

Applies to both the v6 and v7 playground examples. 