### PR TITLE
fix(modal): controller playground uses v7 label syntax

### DIFF
--- a/static/usage/v7/modal/controller/angular/modal-example_component_html.md
+++ b/static/usage/v7/modal/controller/angular/modal-example_component_html.md
@@ -12,8 +12,7 @@
 </ion-header>
 <ion-content class="ion-padding">
   <ion-item>
-    <ion-label position="stacked">Your name</ion-label>
-    <ion-input [(ngModel)]="name" placeholder="Your name"></ion-input>
+    <ion-input labelPlacement="stacked" label="Enter your name" [(ngModel)]="name" placeholder="Your name"></ion-input>
   </ion-item>
 </ion-content>
 ```

--- a/static/usage/v7/modal/controller/demo.html
+++ b/static/usage/v7/modal/controller/demo.html
@@ -45,8 +45,7 @@
       </ion-header>
       <ion-content class="ion-padding">
         <ion-item>
-          <ion-label position="stacked">Enter your name</ion-label>
-          <ion-input type="text" placeholder="Your name"></ion-input>
+          <ion-input type="text" label="Enter your name" label-placement="stacked" placeholder="Your name"></ion-input>
         </ion-item>
       </ion-content>
       `;

--- a/static/usage/v7/modal/controller/javascript.md
+++ b/static/usage/v7/modal/controller/javascript.md
@@ -26,8 +26,7 @@
       </ion-header>
       <ion-content class="ion-padding">
         <ion-item>
-          <ion-label position="stacked">Enter your name</ion-label>
-          <ion-input type="text" placeholder="Your name"></ion-input>
+          <ion-input type="text" label-placement="stacked" label="Enter your name" placeholder="Your name"></ion-input>
         </ion-item>
       </ion-content>
       `;

--- a/static/usage/v7/modal/controller/react.md
+++ b/static/usage/v7/modal/controller/react.md
@@ -9,7 +9,6 @@ import {
   IonTitle,
   IonPage,
   IonItem,
-  IonLabel,
   IonInput,
   useIonModal,
 } from '@ionic/react';

--- a/static/usage/v7/modal/controller/react.md
+++ b/static/usage/v7/modal/controller/react.md
@@ -38,8 +38,7 @@ const ModalExample = ({
       </IonHeader>
       <IonContent className="ion-padding">
         <IonItem>
-          <IonLabel position="stacked">Enter your name</IonLabel>
-          <IonInput ref={inputRef} placeholder="Your name" />
+          <IonInput ref={inputRef} labelPlacement="stacked" label="Enter your name" placeholder="Your name" />
         </IonItem>
       </IonContent>
     </IonPage>

--- a/static/usage/v7/modal/controller/vue/modal_vue.md
+++ b/static/usage/v7/modal/controller/vue/modal_vue.md
@@ -27,7 +27,6 @@
     IonButtons,
     IonButton,
     IonItem,
-    IonLabel,
     IonInput,
     modalController,
   } from '@ionic/vue';
@@ -35,7 +34,7 @@
 
   export default defineComponent({
     name: 'Modal',
-    components: { IonContent, IonHeader, IonTitle, IonToolbar, IonButtons, IonButton, IonItem, IonLabel, IonInput },
+    components: { IonContent, IonHeader, IonTitle, IonToolbar, IonButtons, IonButton, IonItem, IonInput },
     methods: {
       cancel() {
         return modalController.dismiss(null, 'cancel');

--- a/static/usage/v7/modal/controller/vue/modal_vue.md
+++ b/static/usage/v7/modal/controller/vue/modal_vue.md
@@ -13,8 +13,7 @@
   </ion-header>
   <ion-content class="ion-padding">
     <ion-item>
-      <ion-label position="stacked">Your name</ion-label>
-      <ion-input v-model="name" placeholder="Your name"></ion-input>
+      <ion-input label-placement="stacked" label="Enter your name" v-model="name" placeholder="Your name"></ion-input>
     </ion-item>
   </ion-content>
 </template>


### PR DESCRIPTION
Updates the v7 controller playground examples to use the modern syntax. Also updates the inconsistencies with the form label across the different frameworks. 