### PR TITLE
docs(router-link): removal of phone demo on v6 and v7

### DIFF
--- a/docs/api/router-link.md
+++ b/docs/api/router-link.md
@@ -1,10 +1,6 @@
 ---
 title: "ion-router-link"
-hide_table_of_contents: true
-demoUrl: "/docs/demos/api/router-link/index.html"
-demoSourceUrl: "https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/router-link/index.html"
 ---
-import TOCInline from '@theme/TOCInline';
 
 import Props from '@ionic-internal/component-api/v7/router-link/props.md';
 import Events from '@ionic-internal/component-api/v7/router-link/events.md';
@@ -22,23 +18,13 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
-<TOCInline
-  toc={toc}
-  maxHeadingLevel={2}
-/>
-
-
-
 The router link component is used for navigating to a specified link. Similar to the browser's anchor tag, it can accept a href for the location, and a direction for the transition animation.
 
 :::note
  Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use an `<a>` and `routerLink` with the Angular router.
 :::
 
-
-
+See the [Router](./router) documentation for more information.
 
 ## Properties
 <Props />

--- a/versioned_docs/version-v6/api/router-link.md
+++ b/versioned_docs/version-v6/api/router-link.md
@@ -1,11 +1,6 @@
 ---
 title: 'ion-router-link'
-hide_table_of_contents: true
-demoUrl: '/docs/demos/api/router-link/index.html'
-demoSourceUrl: 'https://github.com/ionic-team/ionic-docs/tree/main/static/demos/api/router-link/index.html'
 ---
-
-import TOCInline from '@theme/TOCInline';
 
 import Props from '@ionic-internal/component-api/v6/router-link/props.md';
 import Events from '@ionic-internal/component-api/v6/router-link/events.md';
@@ -26,15 +21,13 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />
 
-<h2 className="table-of-contents__title">Contents</h2>
-
-<TOCInline toc={toc} maxHeadingLevel={2} />
-
 The router link component is used for navigating to a specified link. Similar to the browser's anchor tag, it can accept a href for the location, and a direction for the transition animation.
 
 :::note
 Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use an `<a>` and `routerLink` with the Angular router.
 :::
+
+See the [Router](./router) documentation for more information.
 
 ## Properties
 


### PR DESCRIPTION
## What is the current behavior?

The `router-link` is still using the phone demo. This concept was replaced for playgrounds in v6 and v7.


## What is the new behavior?

For v6 and v7:
- `router-link` doesn't have a phone demo
- `router-link` follows the established layout structure (sidebar, content, and contents)
- `router-link` links back to `router` for more information


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A
