### PR TITLE
docs(native): correctly show all the native plugins

### DIFF
--- a/scripts/native.js
+++ b/scripts/native.js
@@ -37,13 +37,6 @@ async function buildPluginApiDocs(pluginId) {
   const apiContent = createApiPage(pluginId, readme, pkgJson);
   const fileName = `${pluginId}.md`;
 
-  // Delete all existing generated markdown files in docs/native
-  fs.readdirSync('docs/native').forEach((file) => {
-    if (file.endsWith('.md')) {
-      fs.rmSync(`docs/native/${file}`);
-    }
-  });
-
   fs.writeFileSync(`docs/native/${fileName}`, apiContent);
   fs.writeFileSync(`versioned_docs/version-v6/native/${fileName}`, apiContent);
 }


### PR DESCRIPTION
The native script is deleting all plugin files which causes only the last generated plugin to show up: https://ionicframework.com/docs/native

Preview: https://ionic-docs-git-liamdebeasi-patch-1-ionic1.vercel.app/docs/native