### PR TITLE
docs(security): clarify IonicSafeString usage with innerHTMLTemplatesEnabled

### DIFF
--- a/docs/techniques/security.md
+++ b/docs/techniques/security.md
@@ -83,7 +83,7 @@ Ionic Framework provides an application config option called `sanitizerEnabled` 
 Developers can also choose to eject from the sanitizer in certain scenarios. Ionic Framework provides the `IonicSafeString` class that allows developers to do just that.
 
 :::note
-In order to bypass the sanitizer and use custom HTML in the relevant Ionic components, `innerHTMLTemplatesEnabled` must be set to `true` in the Ionic config. See [Enabling Custom HTML Parsing](#enabling-custom-html-parsing-via-innerhtml) for more information.
+In order to bypass the sanitizer and use unsanitized custom HTML in the relevant Ionic components, `innerHTMLTemplatesEnabled` must be set to `true` in the Ionic config. See [Enabling Custom HTML Parsing](#enabling-custom-html-parsing-via-innerhtml) for more information.
 :::
 
 #### Usage

--- a/docs/techniques/security.md
+++ b/docs/techniques/security.md
@@ -82,6 +82,10 @@ Ionic Framework provides an application config option called `sanitizerEnabled` 
 
 Developers can also choose to eject from the sanitizer in certain scenarios. Ionic Framework provides the `IonicSafeString` class that allows developers to do just that.
 
+:::note
+In order to bypass the sanitizer and use custom HTML in the relevant Ionic components, `innerHTMLTemplatesEnabled` must be set to `true` in the Ionic config. See [Enabling Custom HTML Parsing](#enabling-custom-html-parsing-via-innerhtml) for more information.
+:::
+
 #### Usage
 
 ````mdx-code-block


### PR DESCRIPTION
There was some confusion around how to use `IonicSafeString` with the new `innerHTMLTemplatesEnabled` default in Ionic 7: https://github.com/ionic-team/ionic-framework/issues/27118

This PR clarifies that developers using `IonicSafeString` must also set `innerHTMLTemplatesEnabled` to `true`.