### PR TITLE
fix(playground): allow automatic mode selection when relevant base file is overwritten

### DIFF
--- a/static/code/stackblitz/v7/angular/app.module.ts
+++ b/static/code/stackblitz/v7/angular/app.module.ts
@@ -9,9 +9,7 @@ import { AppComponent } from './app.component';
 import { ExampleComponent } from './example.component';
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, RouterModule.forRoot([]), IonicModule.forRoot({
-    mode: '{{ MODE }}'
-  })],
+  imports: [BrowserModule, FormsModule, RouterModule.forRoot([]), IonicModule.forRoot({})],
   declarations: [AppComponent, ExampleComponent],
   bootstrap: [AppComponent],
 })


### PR DESCRIPTION
Example playgrounds that exhibit this bug:
- Angular (replaces `src/app/app.module.ts`): https://ionicframework.com/docs/api/nav#using-navlink
- Javascript (replaces `index.html`): https://ionicframework.com/docs/api/modal#animations
- React (replaces `src/app.tsx`): none yet
- Vue (replaces `src/main.ts`): https://ionicframework.com/docs/api/tabs#usage-with-router