### PR TITLE
docs(cli): update Ionic CLI docs for version 7

### DIFF
--- a/scripts/data/cli.json
+++ b/scripts/data/cli.json
@@ -1671,17 +1671,17 @@
       "type": "project"
     },
     {
-      "name": "ionic deploy add",
-      "namespace": ["ionic", "deploy"],
-      "summary": "Adds Appflow Deploy to the project",
-      "description": "This command adds the Appflow Deploy plugin (`cordova-plugin-ionic`) for both Capacitor and Cordova projects.\n\nFor Capacitor projects it runs all the steps necessary to install the plugin, sync with the native projects and add the configuration to the proper iOS and Android configuration files.\n\nFor Cordova projects it just takes care of running the proper Cordova CLI command with the submitted parameters.",
+      "name": "ionic live-update add",
+      "namespace": ["ionic", "live-update"],
+      "summary": "Adds Appflow Live Update plugin to the project",
+      "description": "This command adds the Appflow Live Update plugin (`cordova-plugin-ionic`) for both Capacitor and Cordova projects.\n\nFor Capacitor projects it runs all the steps necessary to install the plugin, sync with the native projects and add the configuration to the proper iOS and Android configuration files.\n\nFor Cordova projects it just takes care of running the proper Cordova CLI command with the submitted parameters.",
       "footnotes": [],
       "groups": ["paid"],
       "exampleCommands": [
-        "ionic deploy add ",
-        "ionic deploy add --app-id=abcd1234 --channel-name=\"Master\" --update-method=background",
-        "ionic deploy add --max-store=2 --min-background-duration=30",
-        "ionic deploy add --app-id=abcd1234 --channel-name=\"Master\" --update-method=background --max-store=2 --min-background-duration=30"
+        "ionic live-update add ",
+        "ionic live-update add --app-id=abcd1234 --channel-name=\"main\" --update-method=background",
+        "ionic live-update add --max-store=2 --min-background-duration=30",
+        "ionic live-update add --app-id=abcd1234 --channel-name=\"main\" --update-method=background --max-store=2 --min-background-duration=30"
       ],
       "aliases": [],
       "inputs": [],
@@ -1742,81 +1742,19 @@
       "type": "project"
     },
     {
-      "name": "ionic deploy build",
-      "namespace": ["ionic", "deploy"],
-      "summary": "Create a deploy build on Appflow",
-      "description": "This command creates a deploy build on Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created web build zip file in the current directory. Downloading build artifacts can be skipped by supplying the flag `skip-download`.\n\nApart from `--commit`, every option can be specified using the full name setup within the Appflow [Dashboard](https://dashboard.ionicframework.com).\n\nCustomizing the build:\n- The `--environment` and `--channel` options can be used to customize the groups of values exposed to the build.",
-      "footnotes": [],
-      "groups": ["paid", "deprecated"],
-      "exampleCommands": [
-        "ionic deploy build ",
-        "ionic deploy build --environment=\"My Custom Environment Name\"",
-        "ionic deploy build --commit=2345cd3305a1cf94de34e93b73a932f25baac77c",
-        "ionic deploy build --channel=\"Master\"",
-        "ionic deploy build --channel=\"Master\" --skip-download",
-        "ionic deploy build --channel=\"Master\" --channel=\"My Custom Channel\""
-      ],
-      "aliases": [],
-      "inputs": [],
-      "options": [
-        {
-          "name": "environment",
-          "type": "string",
-          "summary": "The group of environment variables exposed to your build",
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "channel",
-          "type": "string",
-          "summary": "The channel you want to auto deploy the build to. This can be repeated multiple times if multiple channels need to be specified.",
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "commit",
-          "type": "string",
-          "summary": "Commit (defaults to HEAD)",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "sha1"
-          }
-        },
-        {
-          "name": "skip-download",
-          "type": "boolean",
-          "summary": "Skip downloading build artifacts after command succeeds.",
-          "default": false,
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        }
-      ],
-      "type": "project"
-    },
-    {
-      "name": "ionic deploy configure",
-      "namespace": ["ionic", "deploy"],
-      "summary": "Overrides Appflow Deploy configuration",
-      "description": "This command overrides configuration for the Appflow Deploy plugin (`cordova-plugin-ionic`) in Capacitor projects.\n\nFor Capacitor projects, if the plugin is already installed, it overrides the configuration variables in the native projects.\n\nFor Cordova projects this is not implemented because it is better to reinstall the plugin with the different parameters and let Cordova deal with the changes.",
+      "name": "ionic live-update configure",
+      "namespace": ["ionic", "live-update"],
+      "summary": "Overrides Appflow Live Update configuration",
+      "description": "This command overrides configuration for the Appflow Live Update plugin (`cordova-plugin-ionic`) in Capacitor projects.\n\nFor Capacitor projects, if the plugin is already installed, it overrides the configuration variables in the native projects.\n\nFor Cordova projects this is not implemented because it is better to reinstall the plugin with the different parameters and let Cordova deal with the changes.",
       "footnotes": [],
       "groups": ["paid"],
       "exampleCommands": [
-        "ionic deploy configure ",
-        "ionic deploy configure --app-id=abcd1234 --channel-name=\"Master\" --update-method=background",
-        "ionic deploy configure --max-store=2 --min-background-duration=30",
-        "ionic deploy configure --app-id=abcd1234 --channel-name=\"Master\" --update-method=background --max-store=2 --min-background-duration=30",
-        "ionic deploy configure android",
-        "ionic deploy configure ios"
+        "ionic live-update configure ",
+        "ionic live-update configure --app-id=abcd1234 --channel-name=\"main\" --update-method=background",
+        "ionic live-update configure --max-store=2 --min-background-duration=30",
+        "ionic live-update configure --app-id=abcd1234 --channel-name=\"main\" --update-method=background --max-store=2 --min-background-duration=30",
+        "ionic live-update configure android",
+        "ionic live-update configure ios"
       ],
       "aliases": [],
       "inputs": [
@@ -1881,9 +1819,9 @@
       "type": "project"
     },
     {
-      "name": "ionic deploy manifest",
-      "namespace": ["ionic", "deploy"],
-      "summary": "Generates a manifest file for the deploy service from a built app directory",
+      "name": "ionic live-update manifest",
+      "namespace": ["ionic", "live-update"],
+      "summary": "Generates a manifest file for the Live Update service from a built app directory",
       "description": "",
       "footnotes": [],
       "groups": ["paid"],
@@ -1892,81 +1830,6 @@
       "inputs": [],
       "options": [],
       "type": "global"
-    },
-    {
-      "name": "ionic docs",
-      "namespace": ["ionic"],
-      "summary": "Open the Ionic documentation website",
-      "description": "",
-      "footnotes": [],
-      "groups": [],
-      "exampleCommands": [],
-      "aliases": [],
-      "inputs": [],
-      "options": [
-        {
-          "name": "browser",
-          "type": "string",
-          "summary": "Specifies the browser to use (`safari`, `firefox`, `google chrome`)",
-          "groups": ["advanced"],
-          "aliases": ["w"],
-          "spec": {
-            "value": "browser"
-          }
-        }
-      ],
-      "type": "global"
-    },
-    {
-      "name": "ionic doctor check",
-      "namespace": ["ionic", "doctor"],
-      "summary": "Check the health of your Ionic project",
-      "description": "This command detects and prints common issues and suggested steps to fix them.\n\nSome issues can be fixed automatically. See `ionic doctor treat --help`.\n\nOptionally supply the `id` argument to check a single issue. Use `ionic doctor list` to list all known issues.",
-      "footnotes": [],
-      "groups": ["deprecated"],
-      "exampleCommands": ["ionic doctor check ", "ionic doctor check git-not-used"],
-      "aliases": ["ionic doctor checkup", "ionic doctor validate"],
-      "inputs": [
-        {
-          "name": "id",
-          "summary": "The issue identifier",
-          "required": false
-        }
-      ],
-      "options": [],
-      "type": "project"
-    },
-    {
-      "name": "ionic doctor list",
-      "namespace": ["ionic", "doctor"],
-      "summary": "List all issues and their identifiers",
-      "description": "Issues can have various tags:\n- **treatable**: `ionic doctor treat` can attempt to fix the issue\n- **ignored**: configured not to be detected in `ionic doctor check` or `ionic doctor treat`\n- **explicit-detection**: issue is only detected explicitly with `ionic doctor check <issue-id>`\n\nYou can flip whether an issue is ignored or not by using `ionic config set -g doctor.issues.<issue-id>.ignored true/false`, where `<issue-id>` matches an ID listed with this command.",
-      "footnotes": [],
-      "groups": ["deprecated"],
-      "exampleCommands": [],
-      "aliases": ["ionic doctor ls"],
-      "inputs": [],
-      "options": [],
-      "type": "project"
-    },
-    {
-      "name": "ionic doctor treat",
-      "namespace": ["ionic", "doctor"],
-      "summary": "Attempt to fix issues in your Ionic project",
-      "description": "This command detects and attempts to fix common issues. Before a fix is attempted, the steps are printed and a confirmation prompt is displayed.\n\nOptionally supply the `id` argument to attempt to fix a single issue. Use `ionic doctor list` to list all known issues.",
-      "footnotes": [],
-      "groups": ["deprecated"],
-      "exampleCommands": ["ionic doctor treat ", "ionic doctor treat git-not-used"],
-      "aliases": ["ionic doctor fix"],
-      "inputs": [
-        {
-          "name": "id",
-          "summary": "The issue identifier",
-          "required": false
-        }
-      ],
-      "options": [],
-      "type": "project"
     },
     {
       "name": "ionic enterprise register",
@@ -2293,198 +2156,6 @@
       "type": "global"
     },
     {
-      "name": "ionic package build",
-      "namespace": ["ionic", "package"],
-      "summary": "Create a package build on Appflow",
-      "description": "This command creates a package build on Appflow. While the build is running, it prints the remote build log to the terminal. If the build is successful, it downloads the created app package file in the current directory. Downloading build artifacts can be skipped by supplying the flag `skip-download`.\n\nApart from `--commit`, every option can be specified using the full name setup within the [Dashboard](https://dashboard.ionicframework.com).\n\nThe `--signing-certificate` option is mandatory for any iOS build but not for Android debug builds.\n\nCustomizing the build:\n- The `--environment` and `--native-config` options can be used to customize the groups of values exposed to the build.\n- Override the preferred platform with `--build-stack`. This is useful for building older iOS apps.\n\nDeploying the build to an App Store:\n- The `--destination` option can be used to deliver the app created by the build to the configured App Store. This can be used only together with build type `release` for Android and build types `app-store` or `enterprise` for iOS.\n\nDownloading build artifacts:\n- By default once the build is complete, all artifacts are downloaded for the selected platform. `aab` and `apk` for Android `ipa` and `dsym` for iOS.\n- The `--artifact-type` option can be used to limit artifact downloads to only of that type. For instance, with Android, you can specify `aab` if you do not wish to download `apk`.",
-      "footnotes": [],
-      "groups": ["paid", "deprecated"],
-      "exampleCommands": [
-        "ionic package build android debug",
-        "ionic package build ios development --signing-certificate=\"iOS Signing Certificate Name\"",
-        "ionic package build android debug --environment=\"My Custom Environment Name\"",
-        "ionic package build android debug --native-config=\"My Custom Native Config Name\"",
-        "ionic package build android debug --commit=2345cd3305a1cf94de34e93b73a932f25baac77c",
-        "ionic package build android debug --artifact-type=aab",
-        "ionic package build android debug --skip-download",
-        "ionic package build android debug --aab-name=\"my-app-prod.aab\" --apk-name=\"my-app-prod.apk\"",
-        "ionic package build ios development --signing-certificate=\"iOS Signing Certificate Name\" --build-stack=\"iOS - Xcode 9\"",
-        "ionic package build ios development --signing-certificate=\"iOS Signing Certificate Name\" --ipa-name=my_custom_file_name.ipa",
-        "ionic package build ios app-store --signing-certificate=\"iOS Signing Certificate Name\" --destination=\"Apple App Store Destination\""
-      ],
-      "aliases": [],
-      "inputs": [
-        {
-          "name": "platform",
-          "summary": "The platform to package (`android`, `ios`)",
-          "required": true
-        },
-        {
-          "name": "type",
-          "summary": "The build type (`debug`, `release`, `development`, `ad-hoc`, `app-store`, `enterprise`)",
-          "required": true
-        }
-      ],
-      "options": [
-        {
-          "name": "signing-certificate",
-          "type": "string",
-          "summary": "Signing certificate",
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "environment",
-          "type": "string",
-          "summary": "The group of environment variables exposed to your build",
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "native-config",
-          "type": "string",
-          "summary": "The group of native config variables exposed to your build",
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "destination",
-          "type": "string",
-          "summary": "The configuration to deploy the build artifact to the app store",
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "commit",
-          "type": "string",
-          "summary": "Commit (defaults to HEAD)",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "sha1"
-          }
-        },
-        {
-          "name": "build-stack",
-          "type": "string",
-          "summary": "Target platform (`\"Android\"`, `\"iOS - Xcode 11 (Preferred)\"`, `\"iOS - Xcode 10\"`)",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "build-file-name",
-          "type": "string",
-          "summary": "The name for the downloaded build file",
-          "groups": ["deprecated"],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "ipa-name",
-          "type": "string",
-          "summary": "The name for the downloaded ipa file",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "dsym-name",
-          "type": "string",
-          "summary": "The name for the downloaded dsym file",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "apk-name",
-          "type": "string",
-          "summary": "The name for the downloaded apk file",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "aab-name",
-          "type": "string",
-          "summary": "The name for the downloaded aab file",
-          "groups": ["advanced"],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "artifact-type",
-          "type": "string",
-          "summary": "The artifact type (`aab`, `apk`, `ipa`, `dsym`)",
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        },
-        {
-          "name": "skip-download",
-          "type": "boolean",
-          "summary": "Skip downloading build artifacts after command succeeds.",
-          "default": false,
-          "groups": [],
-          "aliases": [],
-          "spec": {
-            "value": "name"
-          }
-        }
-      ],
-      "type": "project"
-    },
-    {
-      "name": "ionic package deploy",
-      "namespace": ["ionic", "package"],
-      "summary": "Deploys a binary to a destination, such as an app store using Appflow",
-      "description": "This command deploys a binary to a destination using Appflow. While running, the remote log is printed to the terminal.\n\nThe command takes two parameters: the numeric ID of the package build that previously created the binary and the name of the destination where the binary is going to be deployed.\nBoth can be retrieved from the [Dashboard](https://dashboard.ionicframework.com).",
-      "footnotes": [],
-      "groups": ["paid", "deprecated"],
-      "exampleCommands": ["ionic package deploy 123456789 \"My app store destination\""],
-      "aliases": [],
-      "inputs": [
-        {
-          "name": "build-id",
-          "summary": "The build id of the desired successful package build",
-          "required": true
-        },
-        {
-          "name": "destination",
-          "summary": "The destination to deploy the build artifact to the app store",
-          "required": true
-        }
-      ],
-      "options": [],
-      "type": "project"
-    },
-    {
       "name": "ionic repair",
       "namespace": ["ionic"],
       "summary": "Remove and recreate dependencies and generated files",
@@ -2512,7 +2183,7 @@
       "name": "ionic serve",
       "namespace": ["ionic"],
       "summary": "Start a local dev server for app dev/testing",
-      "description": "Easily spin up a development server which launches in your browser. It watches for changes in your source files and automatically reloads with the updated build.\n\nBy default, `ionic serve` boots up a development server on `localhost`. To serve to your LAN, specify the `--external` option, which will use all network interfaces and print the external address(es) on which your app is being served.\n\nTry the `--lab` option to see multiple platforms at once.\n\n`ionic serve` uses the Angular CLI. Use `ng serve --help` to list all Angular CLI options for serving your app. See the `ng serve` [docs](https://angular.io/cli/serve) for explanations. Options not listed below are considered advanced and can be passed to the Angular CLI using the `--` separator after the Ionic CLI arguments. See the examples.\n\nThe dev server can use HTTPS via the `--ssl` option **(experimental)**. There are several known issues with HTTPS. See issue [#3305](https://github.com/ionic-team/ionic-cli/issues/3305).",
+      "description": "Easily spin up a development server which launches in your browser. It watches for changes in your source files and automatically reloads with the updated build.\n\nBy default, `ionic serve` boots up a development server on `localhost`. To serve to your LAN, specify the `--external` option, which will use all network interfaces and print the external address(es) on which your app is being served.\n\n`ionic serve` uses the Angular CLI. Use `ng serve --help` to list all Angular CLI options for serving your app. See the `ng serve` [docs](https://angular.io/cli/serve) for explanations. Options not listed below are considered advanced and can be passed to the Angular CLI using the `--` separator after the Ionic CLI arguments. See the examples.\n\nThe dev server can use HTTPS via the `--ssl` option **(experimental)**. There are several known issues with HTTPS. See issue [#3305](https://github.com/ionic-team/ionic-cli/issues/3305).",
       "footnotes": [],
       "groups": [],
       "exampleCommands": ["ionic serve ", "ionic serve --external", "ionic serve -- --proxy-config proxy.conf.json"],


### PR DESCRIPTION
Update docs for v7 of ionic cli based on breaking changes/changelog:

* **appflow:** The `package` commands and the `deploy build` command have been removed.

The remaining `deploy` commands have been renamed to `live-update`.

| deploy command | live-update command |
| - | - |
| `ionic deploy add` | `ionic live-update add` |
| `ionic deploy configure` | `ionic live-update configure` |
| `ionic deploy manifest` | `ionic live-update manifest` |

See https://ionic.io/docs/appflow/cli/overview for more information on the Ionic Cloud CLI.
* **docs:** The `ionic docs` command has been removed. 
* **doctor:** The `ionic doctor` command has been removed.
* **lab:** The `--lab` option has been removed from `ionic serve`.