### PR TITLE
fix: styles for ion-slides migration

### DIFF
--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -109,6 +109,7 @@ swiper-slide {
   display: flex;
   position: relative;
 
+  flex-direction: column;
   flex-shrink: 0;
   align-items: center;
   justify-content: center;

--- a/versioned_docs/version-v6/angular/slides.md
+++ b/versioned_docs/version-v6/angular/slides.md
@@ -107,6 +107,7 @@ swiper-slide {
   display: flex;
   position: relative;
 
+  flex-direction: column;
   flex-shrink: 0;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
The existing styles for the `ion-slides` migration can lead to unexpected results when migrating to Swiper.js elements:

![image](https://user-images.githubusercontent.com/13732623/234322725-c5f9f3e7-4246-4e0a-9c21-15038ec67e39.png)

Updates the documentation example to use `flex-direction`.