### PR TITLE
refactor(playground): remove unused angularModuleOptions feature

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -85,17 +85,6 @@ interface UsageTargetOptions {
   files: {
     [key: string]: MdxContent;
   };
-  angularModuleOptions?: {
-    /**
-     * The list of import declarations to add to the `AppModule`.
-     * Accepts value formatted as: `'import { FooComponent } from './foo.component';'`.
-     */
-    imports: string[];
-    /**
-     * The list of class name declarations to add to the `AppModule`.
-     */
-    declarations?: string[];
-  };
 }
 
 /**
@@ -331,9 +320,6 @@ export default function Playground({
       // using outerText will preserve line breaks for formatting in Stackblitz editor
       codeBlock = codeRef.current.querySelector('code').outerText;
     } else {
-      const codeUsageTarget = code[usageTarget] as UsageTargetOptions;
-      editorOptions.angularModuleOptions = codeUsageTarget.angularModuleOptions;
-
       editorOptions.files = Object.keys(codeSnippets[usageTarget])
         .map((fileName) => ({
           [fileName]: hostRef.current!.querySelector<HTMLElement>(`#${getCodeSnippetId(usageTarget, fileName)} code`)

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -31,13 +31,7 @@ export interface EditorOptions {
    */
   mode?: string;
 
-  angularModuleOptions?: {
-    imports: string[];
-    declarations?: string[];
-  };
-
   version?: number;
-
 }
 
 const loadSourceFiles = async (files: string[], version: number) => {
@@ -131,15 +125,6 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
   };
 
   const package_json = defaultFiles[11];
-
-  if (options.angularModuleOptions) {
-    if (options.angularModuleOptions.imports) {
-      files[appModule] = `${options.angularModuleOptions.imports.join('\n')}\n${files[appModule]}`;
-    }
-    if (options.angularModuleOptions.declarations) {
-      files[appModule] = files[appModule].replace('/* CUSTOM_DECLARATIONS */', options.angularModuleOptions.declarations.map(d => `\n  ${d}`).join(','));
-    }
-  }
 
   files[appModule] = files[appModule].replace('IonicModule.forRoot({})', `IonicModule.forRoot({ mode: '${options?.mode}' })`);
 


### PR DESCRIPTION
This feature isn't used in any playgrounds. See https://github.com/ionic-team/ionic-docs/pull/2922#discussion_r1172744254 for context.