### PR TITLE
chore(crowdin): api docs are no longer ignored

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,6 +8,5 @@ files:
   - source: /docs/**/*
     translation: /i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
     ignore:
-      - /docs/api/**/*
       - /docs/cli/commands/**/*
       - /docs/native/**/*


### PR DESCRIPTION
This PR allows the API docs to be translated using CrowdIn. Note that this only applies to the manually written API docs. Autogenerated docs such as props, events, methods, will not be added to CrowdIn. We plan to enable this in the future.