### PR TITLE
docs(breadcrumbs): update vue example

### DIFF
--- a/static/usage/v7/breadcrumbs/theming/colors/vue.md
+++ b/static/usage/v7/breadcrumbs/theming/colors/vue.md
@@ -1,10 +1,10 @@
 ```html
 <template>
-  <ion-breadcrumbs>
-    <ion-breadcrumb color="primary" href="#home">Home</ion-breadcrumb>
-    <ion-breadcrumb color="primary" href="#electronics">Electronics</ion-breadcrumb>
-    <ion-breadcrumb color="primary" href="#cameras">Cameras</ion-breadcrumb>
-    <ion-breadcrumb color="primary" href="#film">Film</ion-breadcrumb>
+  <ion-breadcrumbs color="primary">
+    <ion-breadcrumb href="#home">Home</ion-breadcrumb>
+    <ion-breadcrumb href="#electronics">Electronics</ion-breadcrumb>
+    <ion-breadcrumb href="#cameras">Cameras</ion-breadcrumb>
+    <ion-breadcrumb href="#film">Film</ion-breadcrumb>
   </ion-breadcrumbs>
 </template>
 


### PR DESCRIPTION
Because of a bug ([now fixed](https://github.com/ionic-team/ionic-framework/pull/27040)), the Vue example for breadcrumbs was setting the color on the individual `ion-breadcrumb`s. We can now set it on the `ion-breadcrumbs` component.