### PR TITLE
docs(lifecycle): clarify method descriptions

### DIFF
--- a/docs/angular/lifecycle.md
+++ b/docs/angular/lifecycle.md
@@ -37,9 +37,9 @@ In addition to the Angular life cycle events, Ionic Angular provides a few addit
 | Event Name         | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
 | `ionViewWillEnter` | Fired when the component routing to is about to animate into view. |
-| `ionViewDidEnter`  | Fired when the component routing to has finished animating.        |
-| `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
-| `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
+| `ionViewDidEnter`  | Fired when the component routing to has *finished* animating.      |
+| `ionViewWillLeave` | Fired when the component routing *from* is about to animate.       |
+| `ionViewDidLeave`  | Fired when the component routing *from* has *finished* animating.  |
 
 These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
 

--- a/docs/react/lifecycle.md
+++ b/docs/react/lifecycle.md
@@ -20,9 +20,9 @@ Ionic provides a few lifecycle methods that you can use in your apps:
 | Event Name         | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
 | `ionViewWillEnter` | Fired when the component routing to is about to animate into view. |
-| `ionViewDidEnter`  | Fired when the component routing to has finished animating.        |
-| `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
-| `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
+| `ionViewDidEnter`  | Fired when the component routing to has *finished* animating.      |
+| `ionViewWillLeave` | Fired when the component routing *from* is about to animate.       |
+| `ionViewDidLeave`  | Fired when the component routing *from* has *finished* animating.  |
 
 These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
 

--- a/docs/vue/lifecycle.md
+++ b/docs/vue/lifecycle.md
@@ -9,13 +9,12 @@ This guide discusses how to use the Ionic Framework Lifecycle events in an Ionic
 ## Ionic Framework Lifecycle Methods
 
 Ionic Framework provides a few lifecycle methods that you can use in your apps:
-
 | Event Name         | Description                                                        |
 | ------------------ | ------------------------------------------------------------------ |
 | `ionViewWillEnter` | Fired when the component routing to is about to animate into view. |
-| `ionViewDidEnter`  | Fired when the component routing to has finished animating.        |
-| `ionViewWillLeave` | Fired when the component routing from is about to animate.         |
-| `ionViewDidLeave`  | Fired when the component routing to has finished animating.        |
+| `ionViewDidEnter`  | Fired when the component routing to has *finished* animating.      |
+| `ionViewWillLeave` | Fired when the component routing *from* is about to animate.       |
+| `ionViewDidLeave`  | Fired when the component routing *from* has *finished* animating.  |
 
 These lifecycles are only called on components directly mapped by a router. This means if `/pageOne` maps to `PageOneComponent`, then Ionic lifecycles will be called on `PageOneComponent` but will not be called on any child components that `PageOneComponent` may render.
 


### PR DESCRIPTION
On https://github.com/ionic-team/ionic-docs/pull/2178, a developer noted that the lifecycle descriptions are confusing. For example, the `ionViewDidLeave` description  discusses the lifecycle relative to the entering view, even though this lifecycle hook is fired on the leaving view.

This PR is an extension of the above PR to port the changes to all the lifecycle guides.

```
Co-authored-by: BAYiTUPAi <BAYiTUPAi@users.noreply.github.com>
```