### PR TITLE
docs(updating): add angular toolkit upgrade to v7 upgrade guide

### DIFF
--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -29,11 +29,13 @@ npm install rxjs@7.5.0
 npm install @ionic/angular@7
 ```
 
-If you are using Ionic Angular Server, be sure to update that as well:
+If you are using Ionic Angular Server and Ionic Angular Toolkit, be sure to update those as well:
 
 ```shell
-npm install @ionic/angular@7 @ionic/angular-server@7
+npm install @ionic/angular@7 @ionic/angular-server@7 @ionic/angular-toolkit@9
 ```
+
+> Note: `@ionic/angular-toolkit@9` requires a minimum of Angular 15. If you are still on Angular 14, you can skip updating to `@ionic/angular-toolkit@9`.
 
 ### React
 


### PR DESCRIPTION
Marlon mentioned that Ionic Angular Toolkit was missing from the v7 upgrade guide. This PR updates the upgrade guide to show how to update to the latest version of Ionic Angular Toolkit.