### PR TITLE
docs(support): update angular support policy

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -43,7 +43,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v7     |           v14           |         v15.x^          |    4.6+    |
+|    v7     |           v14           |         v16.x^          |    4.6+    |
 |    v6     |           v12           |         v15.x^          |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |
 |    v4     |          v8.2           |          v11.x          |    3.5+    |


### PR DESCRIPTION
This PR updates the support table to note that Angular 16 is supported for Ionic v7