### PR TITLE
fix(tabs): correct router playground src

### DIFF
--- a/static/usage/v7/tabs/router/index.md
+++ b/static/usage/v7/tabs/router/index.md
@@ -88,6 +88,6 @@ import react_search_page_tsx from './react/search_page_tsx.md';
       },
     },
   }}
-  src="usage/v6/tabs/router/demo.html"
+  src="usage/v7/tabs/router/demo.html"
   devicePreview
 />


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

Tabs has a playground for router that was using v6's `demo.hmtl`

## What is the new behavior?

Switched it to v7's `demo.hmtl`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A