### PR TITLE
docs(vue): remove IonContent from tabs example

### DIFF
--- a/docs/vue/navigation.md
+++ b/docs/vue/navigation.md
@@ -393,27 +393,25 @@ Let's start by taking a look at our `Tabs` component:
 ```html
 <template>
   <ion-page>
-    <ion-content>
-      <ion-tabs>
-        <ion-router-outlet></ion-router-outlet>
-        <ion-tab-bar slot="bottom">
-          <ion-tab-button tab="tab1" href="/tabs/tab1">
-            <ion-icon :icon="triangle" />
-            <ion-label>Tab 1</ion-label>
-          </ion-tab-button>
+    <ion-tabs>
+      <ion-router-outlet></ion-router-outlet>
+      <ion-tab-bar slot="bottom">
+        <ion-tab-button tab="tab1" href="/tabs/tab1">
+          <ion-icon :icon="triangle" />
+          <ion-label>Tab 1</ion-label>
+        </ion-tab-button>
 
-          <ion-tab-button tab="tab2" href="/tabs/tab2">
-            <ion-icon :icon="ellipse" />
-            <ion-label>Tab 2</ion-label>
-          </ion-tab-button>
+        <ion-tab-button tab="tab2" href="/tabs/tab2">
+          <ion-icon :icon="ellipse" />
+          <ion-label>Tab 2</ion-label>
+        </ion-tab-button>
 
-          <ion-tab-button tab="tab3" href="/tabs/tab3">
-            <ion-icon :icon="square" />
-            <ion-label>Tab 3</ion-label>
-          </ion-tab-button>
-        </ion-tab-bar>
-      </ion-tabs>
-    </ion-content>
+        <ion-tab-button tab="tab3" href="/tabs/tab3">
+          <ion-icon :icon="square" />
+          <ion-label>Tab 3</ion-label>
+        </ion-tab-button>
+      </ion-tab-bar>
+    </ion-tabs>
   </ion-page>
 </template>
 
@@ -422,7 +420,6 @@ Let's start by taking a look at our `Tabs` component:
     IonTabBar,
     IonTabButton,
     IonTabs,
-    IonContent,
     IonLabel,
     IonIcon,
     IonPage,
@@ -433,7 +430,6 @@ Let's start by taking a look at our `Tabs` component:
   export default {
     name: 'Tabs',
     components: {
-      IonContent,
       IonLabel,
       IonTabs,
       IonTabBar,


### PR DESCRIPTION
Using IonContent in this way makes the entire view scrollable via the rubber band effect on iOS. This is likely a typo as the component is not used in our Tabs starters: https://github.com/ionic-team/starters/blob/main/vue/official/tabs/src/views/TabsPage.vue