### PR TITLE
fix position <ion-router-outlet> on html

### DIFF
--- a/static/usage/v7/tabs/router/angular/example_component_html.md
+++ b/static/usage/v7/tabs/router/angular/example_component_html.md
@@ -1,7 +1,6 @@
 ```html
+<ion-router-outlet></ion-router-outlet>
 <ion-tabs>
-  <ion-router-outlet></ion-router-outlet>
-
   <ion-tab-bar slot="bottom">
     <ion-tab-button tab="home">
       <ion-icon name="play-circle"></ion-icon>


### PR DESCRIPTION
Because the position it's wrong, the position inside <ion-tabs> create duplication <ion-router-outlet> and we don't change tab.