### PR TITLE
docs(tabs): angular usage does not use explicit ion-router-outlet

### DIFF
--- a/static/usage/v6/tabs/router/angular/example_component_html.md
+++ b/static/usage/v6/tabs/router/angular/example_component_html.md
@@ -1,7 +1,5 @@
 ```html
 <ion-tabs>
-  <ion-router-outlet></ion-router-outlet>
-
   <ion-tab-bar slot="bottom">
     <ion-tab-button tab="home">
       <ion-icon name="play-circle"></ion-icon>

--- a/static/usage/v7/tabs/router/angular/example_component_html.md
+++ b/static/usage/v7/tabs/router/angular/example_component_html.md
@@ -1,7 +1,5 @@
 ```html
 <ion-tabs>
-  <ion-router-outlet></ion-router-outlet>
-
   <ion-tab-bar slot="bottom">
     <ion-tab-button tab="home">
       <ion-icon name="play-circle"></ion-icon>


### PR DESCRIPTION
This PR is in favor of: https://github.com/ionic-team/ionic-docs/pull/2960

Co-authored-by credit has been applied to the commit.

The usage for `ion-tabs` in Angular is incorrect. Ionic Framework renders the `ion-router-outlet` inside the container for the developer, they do not need to explicitly render it. 