### PR TITLE
feat(playground): inline dependencies per framework example

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -85,6 +85,20 @@ interface UsageTargetOptions {
   files: {
     [key: string]: MdxContent;
   };
+  /**
+   * The list of dependencies to use in the Stackblitz example.
+   * The key is the package name and the value is the version.
+   * The version must be a valid semver range.
+   *
+   * For example:
+   * ```ts
+   * dependencies: {
+   *  '@maskito/core': '^0.11.0',
+   * }
+   */
+  dependencies?: {
+    [key: string]: string;
+  };
 }
 
 /**
@@ -326,6 +340,7 @@ export default function Playground({
             .outerText,
         }))
         .reduce((acc, curr) => ({ ...acc, ...curr }), {});
+      editorOptions.dependencies = (code[usageTarget] as UsageTargetOptions).dependencies;
     }
 
     switch (usageTarget) {

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -20,6 +20,14 @@ export interface EditorOptions {
   };
 
   /**
+   * List of dependencies to add to the Stackblitz example.
+   * The key is the name of the dependency, the value is the version.
+   */
+  dependencies?: {
+    [key: string]: string;
+  }
+
+  /**
    * `true` if `ion-app` and `ion-content` should automatically be injected into the
    * Stackblitz example.
    */
@@ -79,6 +87,7 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
     dependencies = {
       ...dependencies,
       ...JSON.parse(package_json).dependencies,
+      ...options?.dependencies,
     };
   } catch (e) {
     console.error('Failed to parse package.json contents', e);
@@ -130,6 +139,7 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
     'angular.json': defaultFiles[9],
     'tsconfig.json': defaultFiles[10],
     ...options?.files,
+    ...options?.dependencies,
   };
 
   const package_json = defaultFiles[11];
@@ -144,6 +154,7 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
     dependencies = {
       ...dependencies,
       ...JSON.parse(package_json).dependencies,
+      ...options?.dependencies,
     };
   } catch (e) {
     console.error('Failed to parse package.json contents', e);
@@ -183,6 +194,7 @@ const openReactEditor = async (code: string, options?: EditorOptions) => {
     'package.json': defaultFiles[4],
     'package-lock.json': defaultFiles[5],
     ...options?.files,
+    ...options?.dependencies,
     '.stackblitzrc': `{
   "startCommand": "yarn run start"
 }`,


### PR DESCRIPTION
This PR adds support for inline dependencies for individual framework examples. For example, this allows you to specify required dependencies that your component playground may need, without having to ship that dependency with every single component playground for all Ionic docs examples.

Example usage:
```tsx
<Playground
  version="7"
  code={{
    javascript: {
      files: {
        'index.html': javascript_index_html,
        'index.ts': javascript_index_ts,
      },
      dependencies: {
        '@maskito/core': '^0.11.0',
      },
    },
  }}
  src="usage/v7/input/mask/demo.html"
  size="300px"
/>
```