### PR TITLE
docs(select): add label slot and aria label playgrounds

### DIFF
--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -24,6 +24,38 @@ A select should be used with child `<ion-select-option>` elements. If the child 
 
 If `value` is set on the `<ion-select>`, the selected option will be chosen based on that value.
 
+## Labels
+
+Select has several options for supplying a label for the component:
+
+- `label` property: used for plaintext labels
+- `label` slot: used for custom HTML labels
+- `aria-label`: used for selects with no visible label
+
+### Label Placement
+
+Labels will take up the width of their content by default. Developers can use the `labelPlacement` property to control how the label is placed relative to the control. While the `label` property is used here, `labelPlacement` can also be used with the `label` slot.
+
+import LabelPlacement from '@site/static/usage/v7/select/label-placement/index.md';
+
+<LabelPlacement />
+
+### Label Slot
+
+While plaintext labels should be passed in via the `label` property, if custom HTML is needed, it can be passed through the `label` slot instead.
+
+import LabelSlot from '@site/static/usage/v7/select/label-slot/index.md';
+
+<LabelSlot />
+
+### No Visible Label
+
+If no visible label is needed, devs should still supply an `aria-label` so the select is accessible to screen readers.
+
+import NoVisibleLabel from '@site/static/usage/v7/select/no-visible-label/index.md';
+
+<NoVisibleLabel />
+
 ## Single Selection
 
 By default, the select allows the user to select only one option. The alert interface presents users with a radio button styled list of options. The select component's value receives the value of the selected option's value.
@@ -83,38 +115,6 @@ import UsingCompareWithExample from '@site/static/usage/v7/select/objects-as-val
 import ObjectValuesAndMultipleSelectionExample from '@site/static/usage/v7/select/objects-as-values/multiple-selection/index.md';
 
 <ObjectValuesAndMultipleSelectionExample />
-
-## Labels
-
-Select has several options for supplying a label for the component:
-
-- `label` property: used for plaintext labels
-- `label` slot: used for custom HTML labels
-- `aria-label`: used for selects with no visible label
-
-### Label Placement
-
-Labels will take up the width of their content by default. Developers can use the `labelPlacement` property to control how the label is placed relative to the control. While the `label` property is used here, `labelPlacement` can also be used with the `label` slot.
-
-import LabelPlacement from '@site/static/usage/v7/select/label-placement/index.md';
-
-<LabelPlacement />
-
-### Label Slot
-
-While plaintext labels should be passed in via the `label` property, if custom HTML is needed, it can be passed through the `label` slot instead.
-
-import LabelSlot from '@site/static/usage/v7/select/label-slot/index.md';
-
-<LabelSlot />
-
-### No Visible Label
-
-If no visible label is needed, devs should still supply an `aria-label` so the select is accessible to screen readers.
-
-import NoVisibleLabel from '@site/static/usage/v7/select/no-visible-label/index.md';
-
-<NoVisibleLabel />
 
 ## Justification
   

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -112,7 +112,9 @@ import LabelSlot from '@site/static/usage/v7/select/label-slot/index.md';
 
 If no visible label is needed, devs should still supply an `aria-label` so the select is accessible to screen readers.
 
-TODO Playground
+import NoVisibleLabel from '@site/static/usage/v7/select/no-visible-label/index.md';
+
+<NoVisibleLabel />
 
 ## Justification
   

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -90,7 +90,7 @@ Select has several options for supplying a label for the component:
 
 - `label` property: used for plaintext labels
 - `label` slot: used for custom HTML labels
-- `aria-label`: used for ranges with no visible label
+- `aria-label`: used for selects with no visible label
 
 ### Label Placement
 
@@ -110,7 +110,7 @@ import LabelSlot from '@site/static/usage/v7/select/label-slot/index.md';
 
 ### No Visible Label
 
-If no visible label is needed, devs should still supply an `aria-label` so the range is accessible to screen readers.
+If no visible label is needed, devs should still supply an `aria-label` so the select is accessible to screen readers.
 
 TODO Playground
 

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -83,15 +83,36 @@ import UsingCompareWithExample from '@site/static/usage/v7/select/objects-as-val
 import ObjectValuesAndMultipleSelectionExample from '@site/static/usage/v7/select/objects-as-values/multiple-selection/index.md';
 
 <ObjectValuesAndMultipleSelectionExample />
-  
 
-## Label Placement
+## Labels
 
-Labels will take up the width of their content by default. Developers can use the `labelPlacement` property to control how the label is placed relative to the control.
+Select has several options for supplying a label for the component:
+
+- `label` property: used for plaintext labels
+- `label` slot: used for custom HTML labels
+- `aria-label`: used for ranges with no visible label
+
+### Label Placement
+
+Labels will take up the width of their content by default. Developers can use the `labelPlacement` property to control how the label is placed relative to the control. While the `label` property is used here, `labelPlacement` can also be used with the `label` slot.
 
 import LabelPlacement from '@site/static/usage/v7/select/label-placement/index.md';
 
 <LabelPlacement />
+
+### Label Slot
+
+While plaintext labels should be passed in via the `label` property, if custom HTML is needed, it can be passed through the `label` slot instead.
+
+import LabelSlot from '@site/static/usage/v7/select/label-slot/index.md';
+
+<LabelSlot />
+
+### No Visible Label
+
+If no visible label is needed, devs should still supply an `aria-label` so the range is accessible to screen readers.
+
+TODO Playground
 
 ## Justification
   

--- a/static/usage/v7/select/label-slot/angular.md
+++ b/static/usage/v7/select/label-slot/angular.md
@@ -1,0 +1,15 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select placeholder="Select a fruit">
+      <div slot="label">
+        Favorite Fruit
+        <ion-text color="danger">(Required)</ion-text>
+      </div>
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/label-slot/angular.md
+++ b/static/usage/v7/select/label-slot/angular.md
@@ -1,11 +1,8 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select a fruit">
-      <div slot="label">
-        Favorite Fruit
-        <ion-text color="danger">(Required)</ion-text>
-      </div>
+    <ion-select placeholder="Select a Fruit">
+      <div slot="label">Favorite Fruit <ion-text color="danger">(Required)</ion-text></div>
       <ion-select-option value="apple">Apple</ion-select-option>
       <ion-select-option value="banana">Banana</ion-select-option>
       <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/label-slot/demo.html
+++ b/static/usage/v7/select/label-slot/demo.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>select</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.7-dev.11684935803.1436320b/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.7-dev.11684935803.1436320b/css/ionic.bundle.css" />
+
+    <style>
+      ion-list {
+        width: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-select placeholder="Select a fruit">
+                <div slot="label">
+                  Favorite Fruit
+                  <ion-text color="danger">(Required)</ion-text>
+                </div>
+                <ion-select-option value="apple">Apple</ion-select-option>
+                <ion-select-option value="banana">Banana</ion-select-option>
+                <ion-select-option value="orange">Orange</ion-select-option>
+              </ion-select>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/select/label-slot/demo.html
+++ b/static/usage/v7/select/label-slot/demo.html
@@ -6,8 +6,8 @@
     <title>select</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.7-dev.11684935803.1436320b/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.7-dev.11684935803.1436320b/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v7/select/label-slot/demo.html
+++ b/static/usage/v7/select/label-slot/demo.html
@@ -8,12 +8,6 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.7-dev.11684935803.1436320b/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7.0.7-dev.11684935803.1436320b/css/ionic.bundle.css" />
-
-    <style>
-      ion-list {
-        width: 100%;
-      }
-    </style>
   </head>
 
   <body>

--- a/static/usage/v7/select/label-slot/demo.html
+++ b/static/usage/v7/select/label-slot/demo.html
@@ -16,11 +16,8 @@
         <div class="container">
           <ion-list>
             <ion-item>
-              <ion-select placeholder="Select a fruit">
-                <div slot="label">
-                  Favorite Fruit
-                  <ion-text color="danger">(Required)</ion-text>
-                </div>
+              <ion-select placeholder="Select a Fruit">
+                <div slot="label">Favorite Fruit <ion-text color="danger">(Required)</ion-text></div>
                 <ion-select-option value="apple">Apple</ion-select-option>
                 <ion-select-option value="banana">Banana</ion-select-option>
                 <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/label-slot/index.md
+++ b/static/usage/v7/select/label-slot/index.md
@@ -1,0 +1,13 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v7/select/label-slot/demo.html"
+  size="300px"
+/>

--- a/static/usage/v7/select/label-slot/javascript.md
+++ b/static/usage/v7/select/label-slot/javascript.md
@@ -1,0 +1,15 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select placeholder="Select a fruit">
+      <div slot="label">
+        Favorite Fruit
+        <ion-text color="danger">(Required)</ion-text>
+      </div>
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/label-slot/javascript.md
+++ b/static/usage/v7/select/label-slot/javascript.md
@@ -1,11 +1,8 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select placeholder="Select a fruit">
-      <div slot="label">
-        Favorite Fruit
-        <ion-text color="danger">(Required)</ion-text>
-      </div>
+    <ion-select placeholder="Select a Fruit">
+      <div slot="label">Favorite Fruit <ion-text color="danger">(Required)</ion-text></div>
       <ion-select-option value="apple">Apple</ion-select-option>
       <ion-select-option value="banana">Banana</ion-select-option>
       <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/label-slot/react.md
+++ b/static/usage/v7/select/label-slot/react.md
@@ -7,10 +7,7 @@ function Example() {
     <IonList>
       <IonItem>
         <IonSelect placeholder="Select a Fruit">
-          <div slot="label">
-            Favorite Fruit
-            <IonText color="danger">(Required)</IonText>
-          </div>
+          <div slot="label">Favorite Fruit <IonText color="danger">(Required)</IonText></div>
           <IonSelectOption value="apple">Apple</IonSelectOption>
           <IonSelectOption value="banana">Banana</IonSelectOption>
           <IonSelectOption value="orange">Orange</IonSelectOption>

--- a/static/usage/v7/select/label-slot/react.md
+++ b/static/usage/v7/select/label-slot/react.md
@@ -1,0 +1,23 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonSelect, IonSelectOption, IonText } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonSelect placeholder="Select a Fruit">
+          <div slot="label">
+            Favorite Fruit
+            <IonText color="danger">(Required)</IonText>
+          </div>
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/select/label-slot/vue.md
+++ b/static/usage/v7/select/label-slot/vue.md
@@ -2,11 +2,8 @@
 <template>
   <ion-list>
     <ion-item>
-     <ion-select placeholder="Select a fruit">
-       <div slot="label">
-         Favorite Fruit
-         <ion-text color="danger">(Required)</ion-text>
-       </div>
+     <ion-select placeholder="Select a Fruit">
+       <div slot="label">Favorite Fruit <ion-text color="danger">(Required)</ion-text></div>
        <ion-select-option value="apple">Apple</ion-select-option>
        <ion-select-option value="banana">Banana</ion-select-option>
        <ion-select-option value="orange">Orange</ion-select-option>

--- a/static/usage/v7/select/label-slot/vue.md
+++ b/static/usage/v7/select/label-slot/vue.md
@@ -1,0 +1,26 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+     <ion-select placeholder="Select a fruit">
+       <div slot="label">
+         Favorite Fruit
+         <ion-text color="danger">(Required)</ion-text>
+       </div>
+       <ion-select-option value="apple">Apple</ion-select-option>
+       <ion-select-option value="banana">Banana</ion-select-option>
+       <ion-select-option value="orange">Orange</ion-select-option>
+     </ion-select>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonItem, IonList, IonSelect, IonSelectOption, IonText } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonSelect, IonSelectOption, IonText },
+  });
+</script>
+```

--- a/static/usage/v7/select/no-visible-label/angular.md
+++ b/static/usage/v7/select/no-visible-label/angular.md
@@ -1,0 +1,11 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select aria-label="Favorite Fruit" value="apple">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/no-visible-label/demo.html
+++ b/static/usage/v7/select/no-visible-label/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>select</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-select aria-label="Favorite Fruit" value="apple">
+                <ion-select-option value="apple">Apple</ion-select-option>
+                <ion-select-option value="banana">Banana</ion-select-option>
+                <ion-select-option value="orange">Orange</ion-select-option>
+              </ion-select>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/select/no-visible-label/index.md
+++ b/static/usage/v7/select/no-visible-label/index.md
@@ -1,0 +1,13 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v7/select/no-visible-label/demo.html"
+  size="300px"
+/>

--- a/static/usage/v7/select/no-visible-label/javascript.md
+++ b/static/usage/v7/select/no-visible-label/javascript.md
@@ -1,0 +1,11 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select aria-label="Favorite Fruit" value="apple">
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/no-visible-label/react.md
+++ b/static/usage/v7/select/no-visible-label/react.md
@@ -1,0 +1,19 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonSelect, IonSelectOption, IonText } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonSelect aria-label="Favorite Fruit" value="apple">
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/select/no-visible-label/vue.md
+++ b/static/usage/v7/select/no-visible-label/vue.md
@@ -1,0 +1,22 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+     <ion-select aria-label="Favorite Fruit" value="apple">
+       <ion-select-option value="apple">Apple</ion-select-option>
+       <ion-select-option value="banana">Banana</ion-select-option>
+       <ion-select-option value="orange">Orange</ion-select-option>
+     </ion-select>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonItem, IonList, IonSelect, IonSelectOption, IonText } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonSelect, IonSelectOption, IonText },
+  });
+</script>
+```


### PR DESCRIPTION
Docs for feature https://github.com/ionic-team/ionic-framework/pull/27545

This creates a "Labels" section that covers 3 topics:

1. Label placement (with label prop)
2. Label slot
3. aria-label

Topic 1 already has a playground. I created new playgrounds for Topics 2 and 3 following what was done in https://github.com/ionic-team/ionic-docs/pull/2955

Preview: https://ionic-docs-git-3532-docs-ionic1.vercel.app/docs/api/select#labels

I added a dev build to the label slot playground, so the iframe should work. However, the StackBlitz playgrounds will load latest (though you could manually install the dev build in StackBlitz). Dev build: 7.0.7-dev.11684935803.1436320b