### PR TITLE
chore: update minor release to happen every 4 weeks if needed

### DIFF
--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -12,7 +12,7 @@ A major release will be published when there is a breaking change introduced in 
 
 ### Minor Release
 
-A minor release will be published when a new feature is added or API changes that are non-breaking are introduced. We will heavily test any changes so that we are confident with the release, but with new code comes the potential for new issues. We are scheduled to release a minor version **every 6 weeks**, if any features or API changes were made.
+A minor release will be published when a new feature is added or API changes that are non-breaking are introduced. We will heavily test any changes so that we are confident with the release, but with new code comes the potential for new issues. We are scheduled to release a minor version **every 4 weeks**, if any features or API changes were made.
 
 ### Patch Release
 


### PR DESCRIPTION
As per our team process change: Minor releases are now done every 4 weeks if needed.