### PR TITLE
docs(PWAs): add Vue to list of PWA deployment guides

### DIFF
--- a/docs/deployment/progressive-web-app.md
+++ b/docs/deployment/progressive-web-app.md
@@ -16,7 +16,7 @@ import DocsCards from '@components/global/DocsCards';
 
 Because Ionic Apps are built with web technologies, they can run just as well as a Progressive Web App as they can a native app. Not sure what PWAs are? Check out Ionic's <a href="https://ionicframework.com/pwa" target="_blank">PWA Overview</a> or the [What are Progressive Web Apps](../core-concepts/what-are-progressive-web-apps.md) page for more info.
 
-For the frameworks Ionic supports, we've created dedicated guides that go into more detail. Below are links for Angular and React.
+For the frameworks Ionic supports, we've created dedicated guides that go into more detail. Below are links for Angular, React, and Vue.
 
 <DocsCards>
   <DocsCard header="Angular" href="../angular/pwa" img="/img/frameworks/angular.svg"></DocsCard>


### PR DESCRIPTION
The PWA deployment index [here](https://ionicframework.com/docs/deployment/progressive-web-app) already has links to guides for all three frameworks, but the text only lists Angular and React.

Essentially the same as https://github.com/ionic-team/ionic-docs/pull/1776, but the link and logo asset had already been added at some point; only the text needed updating. Co-author credit has been given.