### PR TITLE
chore(ci): check for diff after running prettier

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,3 +25,9 @@ jobs:
       run: npm ci --legacy-peer-deps
     - name: Lint
       run: npm run lint
+    # Lint changes should be pushed
+    # to the branch before the branch
+    # is merge eligible.
+    - name: Check Diff
+      run: git diff --exit-code
+      shell: bash

--- a/versioned_docs/version-v5/api/item.md
+++ b/versioned_docs/version-v5/api/item.md
@@ -1033,13 +1033,14 @@ export class ItemExample {
         <ion-item>
           <ion-label>Item</ion-label>
         </ion-item>
-        ,<ion-item lines="none">
+        <ion-item lines="none">
           <ion-label>No Lines Item</ion-label>
         </ion-item>,<ion-item>
           <ion-label class="ion-text-wrap">
             Multiline text that should wrap when it is too long to fit on one line in the item.
           </ion-label>
-        </ion-item>,<ion-item>
+        </ion-item>
+        <ion-item>
           <ion-label class="ion-text-wrap">
             <ion-text color="primary">
               <h3>H3 Primary Title</h3>
@@ -1049,7 +1050,7 @@ export class ItemExample {
               <p>Paragraph line 2 secondary</p>
             </ion-text>
           </ion-label>
-        </ion-item>,
+        </ion-item>
         <ion-item lines="full">
           <ion-label>Item with Full Lines</ion-label>
         </ion-item>

--- a/versioned_docs/version-v5/native/background-fetch.md
+++ b/versioned_docs/version-v5/native/background-fetch.md
@@ -6,7 +6,6 @@ import DocsCard from '@components/global/DocsCard';
 import DocsButton from '@components/page/native/DocsButton';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 # Background Fetch
 
@@ -57,16 +56,17 @@ For more detail, please see https://github.com/transistorsoft/cordova-plugin-bac
   ]}
 >
   <TabItem value="Capacitor">
-    <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-background-fetch {'\n'}$ npm install @awesome-cordova-plugins/background-fetch {'\n'}$
-      ionic cap sync
-    </CodeBlock>
+
+    $ npm install cordova-plugin-background-fetch
+    $ npm install @awesome-cordova-plugins/background-fetch
+    $ ionic cap sync
+
   </TabItem>
   <TabItem value="Cordova">
-    <CodeBlock className="language-shell">
-      $ ionic cordova plugin add cordova-plugin-background-fetch {'\n'}$ npm install
-      @awesome-cordova-plugins/background-fetch {'\n'}
-    </CodeBlock>
+
+    $ ionic cordova plugin add cordova-plugin-background-fetch
+    $ npm install @awesome-cordova-plugins/background-fetch
+
   </TabItem>
   <TabItem value="Enterprise">
     <blockquote>

--- a/versioned_docs/version-v5/native/background-fetch.md
+++ b/versioned_docs/version-v5/native/background-fetch.md
@@ -58,8 +58,8 @@ For more detail, please see https://github.com/transistorsoft/cordova-plugin-bac
 >
   <TabItem value="Capacitor">
     <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-background-fetch {'\n'}$ npm install @awesome-cordova-plugins/background-fetch {'\n'}
-      $ ionic cap sync
+      $ npm install cordova-plugin-background-fetch {'\n'}$ npm install @awesome-cordova-plugins/background-fetch {'\n'}$
+      ionic cap sync
     </CodeBlock>
   </TabItem>
   <TabItem value="Cordova">

--- a/versioned_docs/version-v5/native/bluetooth-serial.md
+++ b/versioned_docs/version-v5/native/bluetooth-serial.md
@@ -51,8 +51,8 @@ This plugin enables serial communication over Bluetooth. It was written for comm
 >
   <TabItem value="Capacitor">
     <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-bluetooth-serial {'\n'}$ npm install @awesome-cordova-plugins/bluetooth-serial {'\n'}
-      $ ionic cap sync
+      $ npm install cordova-plugin-bluetooth-serial {'\n'}$ npm install @awesome-cordova-plugins/bluetooth-serial {'\n'}$
+      ionic cap sync
     </CodeBlock>
   </TabItem>
   <TabItem value="Cordova">

--- a/versioned_docs/version-v5/native/bluetooth-serial.md
+++ b/versioned_docs/version-v5/native/bluetooth-serial.md
@@ -6,7 +6,6 @@ import DocsCard from '@components/global/DocsCard';
 import DocsButton from '@components/page/native/DocsButton';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 # Bluetooth Serial
 
@@ -50,16 +49,17 @@ This plugin enables serial communication over Bluetooth. It was written for comm
   ]}
 >
   <TabItem value="Capacitor">
-    <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-bluetooth-serial {'\n'}$ npm install @awesome-cordova-plugins/bluetooth-serial {'\n'}$
-      ionic cap sync
-    </CodeBlock>
+
+    $ npm install cordova-plugin-bluetooth-serial
+    $ npm install @awesome-cordova-plugins/bluetooth-serial
+    $ ionic cap sync
+
   </TabItem>
   <TabItem value="Cordova">
-    <CodeBlock className="language-shell">
-      $ ionic cordova plugin add cordova-plugin-bluetooth-serial {'\n'}$ npm install
-      @awesome-cordova-plugins/bluetooth-serial {'\n'}
-    </CodeBlock>
+
+    $ ionic cordova plugin add cordova-plugin-bluetooth-serial
+    $ npm install @awesome-cordova-plugins/bluetooth-serial
+
   </TabItem>
   <TabItem value="Enterprise">
     <blockquote>

--- a/versioned_docs/version-v5/native/document-scanner.md
+++ b/versioned_docs/version-v5/native/document-scanner.md
@@ -6,7 +6,6 @@ import DocsCard from '@components/global/DocsCard';
 import DocsButton from '@components/page/native/DocsButton';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 # Document Scanner
 
@@ -55,16 +54,17 @@ This plugin processes images of documents, compensating for perspective.
   ]}
 >
   <TabItem value="Capacitor">
-    <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-document-scanner {'\n'}$ npm install @awesome-cordova-plugins/document-scanner {'\n'}$
-      ionic cap sync
-    </CodeBlock>
+
+    $ npm install cordova-plugin-document-scanner
+    $ npm install @awesome-cordova-plugins/document-scanner
+    $ ionic cap sync
+
   </TabItem>
   <TabItem value="Cordova">
-    <CodeBlock className="language-shell">
-      $ ionic cordova plugin add cordova-plugin-document-scanner {'\n'}$ npm install
-      @awesome-cordova-plugins/document-scanner {'\n'}
-    </CodeBlock>
+
+    $ ionic cordova plugin add cordova-plugin-document-scanner
+    $ npm install @awesome-cordova-plugins/document-scanner
+
   </TabItem>
   <TabItem value="Enterprise">
     <blockquote>

--- a/versioned_docs/version-v5/native/document-scanner.md
+++ b/versioned_docs/version-v5/native/document-scanner.md
@@ -56,8 +56,8 @@ This plugin processes images of documents, compensating for perspective.
 >
   <TabItem value="Capacitor">
     <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-document-scanner {'\n'}$ npm install @awesome-cordova-plugins/document-scanner {'\n'}
-      $ ionic cap sync
+      $ npm install cordova-plugin-document-scanner {'\n'}$ npm install @awesome-cordova-plugins/document-scanner {'\n'}$
+      ionic cap sync
     </CodeBlock>
   </TabItem>
   <TabItem value="Cordova">

--- a/versioned_docs/version-v5/native/firebase-vision.md
+++ b/versioned_docs/version-v5/native/firebase-vision.md
@@ -6,7 +6,6 @@ import DocsCard from '@components/global/DocsCard';
 import DocsButton from '@components/page/native/DocsButton';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 # Firebase Vision
 
@@ -55,16 +54,17 @@ Cordova plugin for Firebase MLKit Vision
   ]}
 >
   <TabItem value="Capacitor">
-    <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-firebase-mlvision {'\n'}$ npm install @awesome-cordova-plugins/firebase-vision {'\n'}$
-      ionic cap sync
-    </CodeBlock>
+
+    $ npm install cordova-plugin-firebase-mlvision
+    $ npm install @awesome-cordova-plugins/firebase-vision
+    $ ionic cap sync
+
   </TabItem>
   <TabItem value="Cordova">
-    <CodeBlock className="language-shell">
-      $ ionic cordova plugin add cordova-plugin-firebase-mlvision {'\n'}$ npm install
-      @awesome-cordova-plugins/firebase-vision {'\n'}
-    </CodeBlock>
+
+    $ ionic cordova plugin add cordova-plugin-firebase-mlvision
+    $ npm install @awesome-cordova-plugins/firebase-vision
+
   </TabItem>
   <TabItem value="Enterprise">
     <blockquote>

--- a/versioned_docs/version-v5/native/firebase-vision.md
+++ b/versioned_docs/version-v5/native/firebase-vision.md
@@ -56,8 +56,8 @@ Cordova plugin for Firebase MLKit Vision
 >
   <TabItem value="Capacitor">
     <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-firebase-mlvision {'\n'}$ npm install @awesome-cordova-plugins/firebase-vision {'\n'}
-      $ ionic cap sync
+      $ npm install cordova-plugin-firebase-mlvision {'\n'}$ npm install @awesome-cordova-plugins/firebase-vision {'\n'}$
+      ionic cap sync
     </CodeBlock>
   </TabItem>
   <TabItem value="Cordova">

--- a/versioned_docs/version-v5/native/google-analytics.md
+++ b/versioned_docs/version-v5/native/google-analytics.md
@@ -6,7 +6,6 @@ import DocsCard from '@components/global/DocsCard';
 import DocsButton from '@components/page/native/DocsButton';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import CodeBlock from '@theme/CodeBlock';
 
 # Google Analytics
 
@@ -55,16 +54,17 @@ Prerequisites:
   ]}
 >
   <TabItem value="Capacitor">
-    <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-google-analytics {'\n'}$ npm install @awesome-cordova-plugins/google-analytics {'\n'}$
-      ionic cap sync
-    </CodeBlock>
+
+    $ npm install cordova-plugin-google-analytics
+    $ npm install @awesome-cordova-plugins/google-analytics
+    $ ionic cap sync
+
   </TabItem>
   <TabItem value="Cordova">
-    <CodeBlock className="language-shell">
-      $ ionic cordova plugin add cordova-plugin-google-analytics {'\n'}$ npm install
-      @awesome-cordova-plugins/google-analytics {'\n'}
-    </CodeBlock>
+
+    $ ionic cordova plugin add cordova-plugin-google-analytics
+    $ npm install @awesome-cordova-plugins/google-analytics
+
   </TabItem>
   <TabItem value="Enterprise">
     <blockquote>

--- a/versioned_docs/version-v5/native/google-analytics.md
+++ b/versioned_docs/version-v5/native/google-analytics.md
@@ -56,8 +56,8 @@ Prerequisites:
 >
   <TabItem value="Capacitor">
     <CodeBlock className="language-shell">
-      $ npm install cordova-plugin-google-analytics {'\n'}$ npm install @awesome-cordova-plugins/google-analytics {'\n'}
-      $ ionic cap sync
+      $ npm install cordova-plugin-google-analytics {'\n'}$ npm install @awesome-cordova-plugins/google-analytics {'\n'}$
+      ionic cap sync
     </CodeBlock>
   </TabItem>
   <TabItem value="Cordova">


### PR DESCRIPTION
Enables an additional step in CI that validates there is no diff with the current working branch. This step runs after lint is ran (which includes prettier formatting).

With this step enabled, CI should fail when prettier changes have not been committed. 

This PR has additional diffs due to some weird inconsistencies with every-other-run with prettier. To avoid these issues, I adjusted the code block formatting to get consistent output. 

Example of failing diff: https://github.com/ionic-team/ionic-docs/actions/runs/5127696576/jobs/9223618711