### PR TITLE
docs(angular): update component testing code snippets

### DIFF
--- a/docs/angular/testing.md
+++ b/docs/angular/testing.md
@@ -82,7 +82,7 @@ Since pages and components contain both TypeScript code and HTML template markup
 
 ```tsx
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsPage } from './tabs.page';
 
@@ -91,13 +91,11 @@ describe('TabsPage', () => {
   let fixture: ComponentFixture<TabsPage>;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
       declarations: [TabsPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(TabsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/versioned_docs/version-v6/angular/testing.md
+++ b/versioned_docs/version-v6/angular/testing.md
@@ -82,7 +82,7 @@ Since pages and components contain both TypeScript code and HTML template markup
 
 ```tsx
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsPage } from './tabs.page';
 
@@ -91,13 +91,11 @@ describe('TabsPage', () => {
   let fixture: ComponentFixture<TabsPage>;
 
   beforeEach(async () => {
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
       declarations: [TabsPage],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(TabsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();


### PR DESCRIPTION
Based on feedback when updating the starters: https://github.com/ionic-team/starters/pull/1785#discussion_r1210758452

Updates the code snippets for Ionic v6 and v7 docs to align with our conventions (and Angular's) for component testing. 