### PR TITLE
feat(playground): add support for generating a new playground

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ Ionic's documentation is built using [Docusaurus](https://docusaurus.io/). The c
     - `components/` - styles split out into the components they target
 - `static/`
   - `demos/` - self-contained demos, optionally presented by pages via `demoUrl` YAML frontmatter
+  - `usage/` - playgrounds that can be scaffolded by running `npm run playground:new` [(docs)](_templates/README.md#new-playground-template)
 - `versioned_docs/` - versions of the docs created by the docusaurus versioning command
 - `versioned_sidebars/` - versions of the docs sidebars created by the docusaurus versioning command
 

--- a/_templates/README.md
+++ b/_templates/README.md
@@ -6,3 +6,27 @@ Some helpful docs links for updating/creating templates:
 
 - [enquirer](https://github.com/enquirer/enquirer#toggle-prompt) for building command line prompts
 - [inflection](https://www.hygen.io/docs/templates#helpers-and-inflections) and [change case](https://www.hygen.io/docs/templates#change-case-helpers) for e.g. changing the case of variables submitted via the prompts
+
+# New playground template
+
+## Generation
+
+To create a new playground, run `npm run playground:new`. This will walk you through some prompts to decide what files for the generator to scaffold for the playground, and what their paths should be.
+
+The path defaults to `basic`. If there is already a basic playground, you'll want to input a different path for the playground.
+
+The CSS option will add extra files if you need to include custom CSS in your playground. This is often not needed.
+
+If you need a component for multiple versions of Ionic Framework, you (currently) need to run the generator once for each version.
+
+## Usage
+
+Once you've generated your playground, you need to add it to the main markdown file in the docs (e.g. [docs/api/button.md](../docs/api/button.md)) by doing something similar to the following example:
+
+```
+## Feature
+
+import Feature from '@site/static/usage/v7/button/feature/index.md';
+
+<Feature />
+```

--- a/_templates/README.md
+++ b/_templates/README.md
@@ -1,0 +1,8 @@
+# Hygen templates
+
+The templates in this directory are intended to be used with [hygen](https://www.hygen.io/) to generate boilerplate files. Check out [the root package.json](../package.json) to see if there are any custom commands to use them (e.g. `npm run playground:new`). You can also run e.g. `hygen playground new` to use a generator.
+
+Some helpful docs links for updating/creating templates:
+
+- [enquirer](https://github.com/enquirer/enquirer#toggle-prompt) for building command line prompts
+- [inflection](https://www.hygen.io/docs/templates#helpers-and-inflections) and [change case](https://www.hygen.io/docs/templates#change-case-helpers) for e.g. changing the case of variables submitted via the prompts

--- a/_templates/playground/new/angular.md.ejs.t
+++ b/_templates/playground/new/angular.md.ejs.t
@@ -1,7 +1,7 @@
 ---
 # this file only gets generated if `css` (from the command line prompt) is false
 # otherwise, the `angular` directory is generated
-to: "<%= css ? null : `static/usage/v7/${name.replace('ion-', '')}/${path}/angular.md` %>"
+to: "<%= css ? null : `static/usage/v${version}/${name.replace('ion-', '')}/${path}/angular.md` %>"
 ---
 ```html
 <<%= name %>></<%= name %>>

--- a/_templates/playground/new/angular.md.ejs.t
+++ b/_templates/playground/new/angular.md.ejs.t
@@ -1,0 +1,6 @@
+---
+to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/angular.md
+---
+```html
+<<%= name %>></<%= name %>>
+```

--- a/_templates/playground/new/angular.md.ejs.t
+++ b/_templates/playground/new/angular.md.ejs.t
@@ -1,5 +1,7 @@
 ---
-to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/angular.md
+# this file only gets generated if `css` (from the command line prompt) is false
+# otherwise, the `angular` directory is generated
+to: "<%= css ? null : `static/usage/v7/${name.replace('ion-', '')}/${path}/angular.md` %>"
 ---
 ```html
 <<%= name %>></<%= name %>>

--- a/_templates/playground/new/angular/example_component_css.md.ejs.t
+++ b/_templates/playground/new/angular/example_component_css.md.ejs.t
@@ -1,0 +1,10 @@
+---
+# this file only gets generated if `css` (from the command line prompt) is true
+# otherwise, the `angular.md` file is generated
+to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/angular/example_component_css.md` : null %>"
+---
+```css
+<%= name %> {
+  /* styles go here */
+}
+```

--- a/_templates/playground/new/angular/example_component_css.md.ejs.t
+++ b/_templates/playground/new/angular/example_component_css.md.ejs.t
@@ -1,7 +1,7 @@
 ---
 # this file only gets generated if `css` (from the command line prompt) is true
 # otherwise, the `angular.md` file is generated
-to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/angular/example_component_css.md` : null %>"
+to: "<%= css ? `static/usage/v${version}/${name.replace('ion-', '')}/${path}/angular/example_component_css.md` : null %>"
 ---
 ```css
 <%= name %> {

--- a/_templates/playground/new/angular/example_component_html.md.ejs.t
+++ b/_templates/playground/new/angular/example_component_html.md.ejs.t
@@ -1,7 +1,7 @@
 ---
 # this file only gets generated if `css` (from the command line prompt) is true
 # otherwise, the `angular.md` file is generated
-to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/angular/example_component_html.md` : null %>"
+to: "<%= css ? `static/usage/v${version}/${name.replace('ion-', '')}/${path}/angular/example_component_html.md` : null %>"
 ---
 ```html
 <<%= name %>></<%= name %>>

--- a/_templates/playground/new/angular/example_component_html.md.ejs.t
+++ b/_templates/playground/new/angular/example_component_html.md.ejs.t
@@ -1,0 +1,8 @@
+---
+# this file only gets generated if `css` (from the command line prompt) is true
+# otherwise, the `angular.md` file is generated
+to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/angular/example_component_html.md` : null %>"
+---
+```html
+<<%= name %>></<%= name %>>
+```

--- a/_templates/playground/new/demo.html.ejs.t
+++ b/_templates/playground/new/demo.html.ejs.t
@@ -1,6 +1,6 @@
 ---
 arbitrary: <% nameWithoutIon = name.replace('ion-', '') %>
-to: static/usage/v7/<%= nameWithoutIon %>/<%= path %>/demo.html
+to: static/usage/v<%= version %>/<%= nameWithoutIon %>/<%= path %>/demo.html
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -10,8 +10,8 @@ to: static/usage/v7/<%= nameWithoutIon %>/<%= path %>/demo.html
     <title><%= h.changeCase.titleCase(nameWithoutIon) %></title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@<%= version %>/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@<%= version %>/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/_templates/playground/new/demo.html.ejs.t
+++ b/_templates/playground/new/demo.html.ejs.t
@@ -1,0 +1,26 @@
+---
+# can i make a variable here?
+to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/demo.html
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TODO: <%= name %></title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <<%= name %>></<%= name %>>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/_templates/playground/new/demo.html.ejs.t
+++ b/_templates/playground/new/demo.html.ejs.t
@@ -1,6 +1,6 @@
 ---
 arbitrary: <% nameWithoutIon = name.replace('ion-', '') %>
-to: static/usage/v<%= version %>/<%= nameWithoutIon %>/<%= path %>/demo.html
+to: "<%= `static/usage/v${version}/${nameWithoutIon}/${path}/demo.html` %>"
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/_templates/playground/new/demo.html.ejs.t
+++ b/_templates/playground/new/demo.html.ejs.t
@@ -1,13 +1,13 @@
 ---
-# can i make a variable here?
-to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/demo.html
+arbitrary: <% nameWithoutIon = name.replace('ion-', '') %>
+to: static/usage/v7/<%= nameWithoutIon %>/<%= path %>/demo.html
 ---
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TODO: <%= name %></title>
+    <title><%= h.changeCase.titleCase(nameWithoutIon) %></title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>

--- a/_templates/playground/new/index.md.ejs.t
+++ b/_templates/playground/new/index.md.ejs.t
@@ -1,0 +1,11 @@
+---
+to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/index.md
+---
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/demo.html" />

--- a/_templates/playground/new/index.md.ejs.t
+++ b/_templates/playground/new/index.md.ejs.t
@@ -1,5 +1,6 @@
 ---
-to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/index.md
+arbitrary: <% nameWithoutIon = name.replace('ion-', '') %>
+to: static/usage/v7/<%= nameWithoutIon %>/<%= path %>/index.md
 ---
 import Playground from '@site/src/components/global/Playground';
 
@@ -8,4 +9,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/<%= nameWithoutIon %>/<%= path %>/demo.html" />

--- a/_templates/playground/new/index.md.ejs.t
+++ b/_templates/playground/new/index.md.ejs.t
@@ -1,6 +1,6 @@
 ---
 arbitrary: <% nameWithoutIon = name.replace('ion-', '') %>
-to: static/usage/v<%= version %>/<%= nameWithoutIon %>/<%= path %>/index.md
+to: "<%= `static/usage/v${version}/${nameWithoutIon}/${path}/index.md` %>"
 ---
 import Playground from '@site/src/components/global/Playground';
 
@@ -9,4 +9,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="<%= version %>" code={{ javascript, react, vue, angular }} src="usage/v<%= version %>/<%= nameWithoutIon %>/<%= path %>/demo.html" />
+<Playground version="<%= version %>" code={{ javascript, react, vue, angular }} src="<%= `usage/v${version}/${nameWithoutIon}/${path}/demo.html` %>" />

--- a/_templates/playground/new/index.md.ejs.t
+++ b/_templates/playground/new/index.md.ejs.t
@@ -1,6 +1,6 @@
 ---
 arbitrary: <% nameWithoutIon = name.replace('ion-', '') %>
-to: static/usage/v7/<%= nameWithoutIon %>/<%= path %>/index.md
+to: static/usage/v<%= version %>/<%= nameWithoutIon %>/<%= path %>/index.md
 ---
 import Playground from '@site/src/components/global/Playground';
 
@@ -9,4 +9,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/<%= nameWithoutIon %>/<%= path %>/demo.html" />
+<Playground version="<%= version %>" code={{ javascript, react, vue, angular }} src="usage/v<%= version %>/<%= nameWithoutIon %>/<%= path %>/demo.html" />

--- a/_templates/playground/new/javascript.md.ejs.t
+++ b/_templates/playground/new/javascript.md.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/javascript.md
+to: static/usage/v<%= version %>/<%= name.replace('ion-', '') %>/<%= path %>/javascript.md
 ---
 ```html
 <<%= name %>></<%= name %>>

--- a/_templates/playground/new/javascript.md.ejs.t
+++ b/_templates/playground/new/javascript.md.ejs.t
@@ -1,0 +1,6 @@
+---
+to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/javascript.md
+---
+```html
+<<%= name %>></<%= name %>>
+```

--- a/_templates/playground/new/javascript.md.ejs.t
+++ b/_templates/playground/new/javascript.md.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: static/usage/v<%= version %>/<%= name.replace('ion-', '') %>/<%= path %>/javascript.md
+to: "<%= `static/usage/v${version}/${name.replace('ion-', '')}/${path}/javascript.md` %>"
 ---
 ```html
 <<%= name %>></<%= name %>>

--- a/_templates/playground/new/prompt.js
+++ b/_templates/playground/new/prompt.js
@@ -15,17 +15,13 @@ module.exports = [
     hint: 'e.g. `theming/colors`',
     initial: 'basic',
   },
-  // {
-  //   type: 'multiselect',
-  //   name: 'versions',
-  //   hint: '(Use <space> to select, <return> to submit)',
-  //   message: 'Select versions to generate playgrounds for',
-  //   initial: [1],
-  //   choices: [
-  //     { name: 'v6', value: 'v6' },
-  //     { name: 'v7', value: 'v7' },
-  //   ],
-  // },
+  {
+    type: 'select',
+    name: 'version',
+    message: 'Select the Ionic Framework version for the playground',
+    initial: '7',
+    choices: ['6', '7'],
+  },
   {
     type: 'toggle',
     name: 'css',

--- a/_templates/playground/new/prompt.js
+++ b/_templates/playground/new/prompt.js
@@ -26,11 +26,11 @@ module.exports = [
   //     { name: 'v7', value: 'v7' },
   //   ],
   // },
-  // {
-  //   type: 'toggle',
-  //   name: 'css',
-  //   message: 'Do you want CSS scaffolded?',
-  //   enabled: 'Yes',
-  //   disabled: 'No',
-  // },
+  {
+    type: 'toggle',
+    name: 'css',
+    message: 'Do you want CSS scaffolded?',
+    enabled: 'Yes',
+    disabled: 'No',
+  },
 ];

--- a/_templates/playground/new/prompt.js
+++ b/_templates/playground/new/prompt.js
@@ -1,0 +1,36 @@
+// see types of prompts:
+// https://github.com/enquirer/enquirer/tree/master/examples
+//
+module.exports = [
+  {
+    type: 'input',
+    name: 'name',
+    message: 'Which component is this playground for?',
+    initial: 'ion-button',
+  },
+  {
+    type: 'input',
+    name: 'path',
+    message: 'What should the playground path be?',
+    hint: 'e.g. `theming/colors`',
+    initial: 'basic',
+  },
+  // {
+  //   type: 'multiselect',
+  //   name: 'versions',
+  //   hint: '(Use <space> to select, <return> to submit)',
+  //   message: 'Select versions to generate playgrounds for',
+  //   initial: [1],
+  //   choices: [
+  //     { name: 'v6', value: 'v6' },
+  //     { name: 'v7', value: 'v7' },
+  //   ],
+  // },
+  // {
+  //   type: 'toggle',
+  //   name: 'css',
+  //   message: 'Do you want CSS scaffolded?',
+  //   enabled: 'Yes',
+  //   disabled: 'No',
+  // },
+];

--- a/_templates/playground/new/react.md.ejs.t
+++ b/_templates/playground/new/react.md.ejs.t
@@ -1,0 +1,17 @@
+---
+to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/react.md
+---
+```tsx
+import React from 'react';
+import { <%= h.changeCase.pascal(name) %> } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <<%= h.changeCase.pascal(name) %>></<%= h.changeCase.pascal(name) %>>
+    </>
+  );
+}
+export default Example;
+```
+

--- a/_templates/playground/new/react.md.ejs.t
+++ b/_templates/playground/new/react.md.ejs.t
@@ -2,7 +2,7 @@
 arbitrary: <% pascalName = h.changeCase.pascal(name) %>
 # this file only gets generated if `css` (from the command line prompt) is false
 # otherwise, the `react` directory is generated
-to: "<%= css ? null : `static/usage/v7/${name.replace('ion-', '')}/${path}/react.md` %>"
+to: "<%= css ? null : `static/usage/v${version}/${name.replace('ion-', '')}/${path}/react.md` %>"
 ---
 ```tsx
 import React from 'react';

--- a/_templates/playground/new/react.md.ejs.t
+++ b/_templates/playground/new/react.md.ejs.t
@@ -1,14 +1,15 @@
 ---
+arbitrary: <% pascalName = h.changeCase.pascal(name) %>
 to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/react.md
 ---
 ```tsx
 import React from 'react';
-import { <%= h.changeCase.pascal(name) %> } from '@ionic/react';
+import { <%= pascalName %> } from '@ionic/react';
 
 function Example() {
   return (
     <>
-      <<%= h.changeCase.pascal(name) %>></<%= h.changeCase.pascal(name) %>>
+      <<%= pascalName %>></<%= pascalName %>>
     </>
   );
 }

--- a/_templates/playground/new/react/main_css.md.ejs.t
+++ b/_templates/playground/new/react/main_css.md.ejs.t
@@ -1,7 +1,7 @@
 ---
 # this file only gets generated if `css` (from the command line prompt) is true
 # otherwise, the `react.md` file is generated
-to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/react/main_css.md` : null %>"
+to: "<%= css ? `static/usage/v${version}/${name.replace('ion-', '')}/${path}/react/main_css.md` : null %>"
 ---
 ```css
 <%= name %> {

--- a/_templates/playground/new/react/main_css.md.ejs.t
+++ b/_templates/playground/new/react/main_css.md.ejs.t
@@ -1,0 +1,10 @@
+---
+# this file only gets generated if `css` (from the command line prompt) is true
+# otherwise, the `react.md` file is generated
+to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/react/main_css.md` : null %>"
+---
+```css
+<%= name %> {
+  /* styles go here */
+}
+```

--- a/_templates/playground/new/react/main_tsx.md.ejs.t
+++ b/_templates/playground/new/react/main_tsx.md.ejs.t
@@ -1,12 +1,14 @@
 ---
 arbitrary: <% pascalName = h.changeCase.pascal(name) %>
-# this file only gets generated if `css` (from the command line prompt) is false
-# otherwise, the `react` directory is generated
-to: "<%= css ? null : `static/usage/v7/${name.replace('ion-', '')}/${path}/react.md` %>"
+# this file only gets generated if `css` (from the command line prompt) is true
+# otherwise, the `react.md` file is generated
+to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/react/main_tsx.md` : null %>"
 ---
 ```tsx
 import React from 'react';
 import { <%= pascalName %> } from '@ionic/react';
+
+import './main.css';
 
 function Example() {
   return (
@@ -17,4 +19,3 @@ function Example() {
 }
 export default Example;
 ```
-

--- a/_templates/playground/new/react/main_tsx.md.ejs.t
+++ b/_templates/playground/new/react/main_tsx.md.ejs.t
@@ -2,7 +2,7 @@
 arbitrary: <% pascalName = h.changeCase.pascal(name) %>
 # this file only gets generated if `css` (from the command line prompt) is true
 # otherwise, the `react.md` file is generated
-to: "<%= css ? `static/usage/v7/${name.replace('ion-', '')}/${path}/react/main_tsx.md` : null %>"
+to: "<%= css ? `static/usage/v${version}/${name.replace('ion-', '')}/${path}/react/main_tsx.md` : null %>"
 ---
 ```tsx
 import React from 'react';

--- a/_templates/playground/new/vue.md.ejs.t
+++ b/_templates/playground/new/vue.md.ejs.t
@@ -8,12 +8,12 @@ to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/vue.md
 </template>
 
 <script lang="ts">
-  import { <%= h.inflection.camelize(name.replace(/-/g, '_'), false) %> } from '@ionic/vue';
+  import { <%= h.changeCase.pascal(name) %> } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
     components: {
-      <%= h.inflection.camelize(name.replace(/-/g, '_'), false) %>,
+      <%= h.changeCase.pascal(name) %>,
     },
   });
 </script>

--- a/_templates/playground/new/vue.md.ejs.t
+++ b/_templates/playground/new/vue.md.ejs.t
@@ -1,6 +1,6 @@
 ---
 arbitrary: <% pascalName = h.changeCase.pascal(name) %>
-to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/vue.md
+to: static/usage/v<%= version %>/<%= name.replace('ion-', '') %>/<%= path %>/vue.md
 ---
 ```html
 <template>

--- a/_templates/playground/new/vue.md.ejs.t
+++ b/_templates/playground/new/vue.md.ejs.t
@@ -1,4 +1,5 @@
 ---
+arbitrary: <% pascalName = h.changeCase.pascal(name) %>
 to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/vue.md
 ---
 ```html
@@ -8,12 +9,12 @@ to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/vue.md
 </template>
 
 <script lang="ts">
-  import { <%= h.changeCase.pascal(name) %> } from '@ionic/vue';
+  import { <%= pascalName %> } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
     components: {
-      <%= h.changeCase.pascal(name) %>,
+      <%= pascalName %>,
     },
   });
 </script>

--- a/_templates/playground/new/vue.md.ejs.t
+++ b/_templates/playground/new/vue.md.ejs.t
@@ -1,6 +1,6 @@
 ---
 arbitrary: <% pascalName = h.changeCase.pascal(name) %>
-to: static/usage/v<%= version %>/<%= name.replace('ion-', '') %>/<%= path %>/vue.md
+to: "<%= `static/usage/v${version}/${name.replace('ion-', '')}/${path}/vue.md` %>"
 ---
 ```html
 <template>

--- a/_templates/playground/new/vue.md.ejs.t
+++ b/_templates/playground/new/vue.md.ejs.t
@@ -1,0 +1,20 @@
+---
+to: static/usage/v7/<%= name.replace('ion-', '') %>/<%= path %>/vue.md
+---
+```html
+<template>
+  <<%= name %>>
+  </<%= name %>>
+</template>
+
+<script lang="ts">
+  import { <%= h.inflection.camelize(name.replace(/-/g, '_'), false) %> } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      <%= h.inflection.camelize(name.replace(/-/g, '_'), false) %>,
+    },
+  });
+</script>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@tsconfig/docusaurus": "^1.0.4",
         "@types/react": "^17.0.37",
         "html-loader": "^3.1.0",
+        "hygen": "^6.2.11",
         "prettier": "^2.8.8",
         "typescript": "^4.5.2"
       }
@@ -3621,6 +3622,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "license": "MIT",
@@ -3872,6 +3882,26 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "license": "MIT"
@@ -3888,6 +3918,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bluebird": {
@@ -4094,6 +4135,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -4416,6 +4481,30 @@
     "node_modules/cli-boxes": {
       "version": "2.2.1",
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -5271,8 +5360,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "license": "MIT",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5334,6 +5424,27 @@
         "node": ">= 10"
       }
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "1.1.3",
       "license": "MIT"
@@ -5353,6 +5464,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/degit": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
+      "integrity": "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==",
+      "dev": true,
+      "bin": {
+        "degit": "degit"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/del": {
@@ -5580,6 +5703,21 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dev": true,
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.894",
       "license": "ISC"
@@ -5622,6 +5760,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -6040,6 +6190,36 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/filesize": {
       "version": "6.4.0",
       "license": "BSD-3-Clause",
@@ -6237,6 +6417,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/front-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "dev": true,
+      "dependencies": {
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "node_modules/front-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/front-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/fs-extra": {
@@ -6949,6 +7160,51 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hygen": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/hygen/-/hygen-6.2.11.tgz",
+      "integrity": "sha512-t6/zLI2XozP5gvV74nnl8LZSbwpVNFUkUs/O9DwuOdiiBbws5k4AQNVwKZ9FGzcKjdJ5EBBYkVzlcUHkLyY0FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^17.0.19",
+        "chalk": "^4.1.2",
+        "change-case": "^3.1.0",
+        "debug": "^4.3.3",
+        "degit": "^2.8.4",
+        "ejs": "^3.1.6",
+        "enquirer": "^2.3.6",
+        "execa": "^5.0.0",
+        "front-matter": "^4.0.2",
+        "fs-extra": "^10.0.0",
+        "ignore-walk": "^4.0.1",
+        "inflection": "^1.12.0",
+        "ora": "^5.0.0",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "hygen": "dist/bin.js"
+      }
+    },
+    "node_modules/hygen/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "dev": true
+    },
+    "node_modules/hygen/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "license": "MIT",
@@ -6969,11 +7225,43 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.1.8",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/ignore-walk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-4.0.1.tgz",
+      "integrity": "sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==",
+      "dev": true,
+      "dependencies": {
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/imgix-url-builder": {
@@ -7037,6 +7325,15 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.4.0"
+      ]
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -7320,6 +7617,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-invalid-path": {
       "version": "0.1.0",
       "license": "MIT",
@@ -7512,6 +7818,18 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-upper-case": {
       "version": "1.1.2",
       "license": "MIT",
@@ -7572,6 +7890,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    },
+    "node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/jest-worker": {
@@ -7856,6 +8210,22 @@
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -8472,6 +8842,29 @@
       "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-cancelable": {
@@ -10593,6 +10986,19 @@
         "lowercase-keys": "^1.0.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "license": "MIT",
@@ -12368,6 +12774,15 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "1.1.4",
       "license": "MIT",
@@ -12834,6 +13249,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {
@@ -15161,6 +15585,12 @@
         }
       }
     },
+    "ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "requires": {
@@ -15308,6 +15738,12 @@
     "base16": {
       "version": "1.0.0"
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "batch": {
       "version": "0.6.1"
     },
@@ -15316,6 +15752,17 @@
     },
     "binary-extensions": {
       "version": "2.2.0"
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2"
@@ -15452,6 +15899,16 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -15662,6 +16119,21 @@
     },
     "cli-boxes": {
       "version": "2.2.1"
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "dev": true
     },
     "clone": {
       "version": "2.1.2"
@@ -16184,7 +16656,9 @@
       "version": "2.22.1"
     },
     "debug": {
-      "version": "4.3.1",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -16218,6 +16692,23 @@
         "execa": "^5.0.0"
       }
     },
+    "defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+          "dev": true
+        }
+      }
+    },
     "defer-to-connect": {
       "version": "1.1.3"
     },
@@ -16229,6 +16720,12 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "degit": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
+      "integrity": "sha512-vqYuzmSA5I50J882jd+AbAhQtgK6bdKUJIex1JNfEUPENCgYsxugzKVZlFyMwV4i06MmnV47/Iqi5Io86zf3Ng==",
+      "dev": true
     },
     "del": {
       "version": "6.0.0",
@@ -16387,6 +16884,15 @@
     "ee-first": {
       "version": "1.1.1"
     },
+    "ejs": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "dev": true,
+      "requires": {
+        "jake": "^10.8.5"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.3.894"
     },
@@ -16410,6 +16916,15 @@
       "requires": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
       }
     },
     "entities": {
@@ -16683,6 +17198,35 @@
         }
       }
     },
+    "filelist": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "filesize": {
       "version": "6.4.0"
     },
@@ -16790,6 +17334,36 @@
     },
     "fresh": {
       "version": "0.5.2"
+    },
+    "front-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
     },
     "fs-extra": {
       "version": "9.1.0",
@@ -17251,6 +17825,47 @@
     "human-signals": {
       "version": "2.1.0"
     },
+    "hygen": {
+      "version": "6.2.11",
+      "resolved": "https://registry.npmjs.org/hygen/-/hygen-6.2.11.tgz",
+      "integrity": "sha512-t6/zLI2XozP5gvV74nnl8LZSbwpVNFUkUs/O9DwuOdiiBbws5k4AQNVwKZ9FGzcKjdJ5EBBYkVzlcUHkLyY0FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^17.0.19",
+        "chalk": "^4.1.2",
+        "change-case": "^3.1.0",
+        "debug": "^4.3.3",
+        "degit": "^2.8.4",
+        "ejs": "^3.1.6",
+        "enquirer": "^2.3.6",
+        "execa": "^5.0.0",
+        "front-matter": "^4.0.2",
+        "fs-extra": "^10.0.0",
+        "ignore-walk": "^4.0.1",
+        "inflection": "^1.12.0",
+        "ora": "^5.0.0",
+        "yargs-parser": "^21.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "17.0.45",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "requires": {
@@ -17260,8 +17875,23 @@
     "icss-utils": {
       "version": "5.1.0"
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
+    },
     "ignore": {
       "version": "5.1.8"
+    },
+    "ignore-walk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-4.0.1.tgz",
+      "integrity": "sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
     },
     "imgix-url-builder": {
       "version": "0.0.3",
@@ -17292,6 +17922,12 @@
     },
     "infima": {
       "version": "0.2.0-alpha.34"
+    },
+    "inflection": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -17430,6 +18066,12 @@
         "is-path-inside": "^3.0.2"
       }
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
     "is-invalid-path": {
       "version": "0.1.0",
       "requires": {
@@ -17525,6 +18167,12 @@
     "is-typedarray": {
       "version": "1.0.0"
     },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
     "is-upper-case": {
       "version": "1.1.2",
       "requires": {
@@ -17560,6 +18208,35 @@
     },
     "isobject": {
       "version": "3.0.1"
+    },
+    "jake": {
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.3",
+        "chalk": "^4.0.2",
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
     },
     "jest-worker": {
       "version": "27.0.6",
@@ -17745,6 +18422,16 @@
     },
     "lodash.uniq": {
       "version": "4.5.0"
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -18105,6 +18792,23 @@
     },
     "opener": {
       "version": "1.5.2"
+    },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      }
     },
     "p-cancelable": {
       "version": "1.1.0"
@@ -19370,6 +20074,16 @@
         "lowercase-keys": "^1.0.0"
       }
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "retry": {
       "version": "0.13.1"
     },
@@ -20466,6 +21180,15 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
+    },
     "web-namespaces": {
       "version": "1.1.4"
     },
@@ -20727,6 +21450,12 @@
     },
     "yaml": {
       "version": "1.10.2"
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate-markdown": "node scripts/native && concurrently \"node scripts/cli\" \"node scripts/release-notes\"",
     "lint": "npm run prettier -- --write --cache",
     "serve": "docusaurus serve",
+    "playground:new": "hygen playground new",
     "prestart": "npm run generate-markdown",
     "prettier": "prettier \"./**/*.{html,ts,tsx,js,jsx,md}\"",
     "start": "docusaurus start",
@@ -71,6 +72,7 @@
     "@tsconfig/docusaurus": "^1.0.4",
     "@types/react": "^17.0.37",
     "html-loader": "^3.1.0",
+    "hygen": "^6.2.11",
     "prettier": "^2.8.8",
     "typescript": "^4.5.2"
   },


### PR DESCRIPTION
Uses [hygen](https://www.hygen.io/) to generate all the files needed for a basic new playground. 

Try it out via `npm run playground:new`.

Options available in the prompts:
- name, e.g. `ion-button`
- path, e.g. `basic`
- Ionic Framework version: 6 or 7
- Scaffold out CSS files: yes or no

Stuff we might want to consider adding in the future:
- Generate playgrounds for multiple Framework versions at once
- More options for the prompts, e.g. adding some basic content, props, etc. for the component and having those get added to each Javascript framework file as relevant.