### PR TITLE
docs(infinite-scroll): use the correct custom event

### DIFF
--- a/static/usage/v6/infinite-scroll/basic/vue.md
+++ b/static/usage/v6/infinite-scroll/basic/vue.md
@@ -25,7 +25,7 @@
     IonAvatar,
     IonImg,
     IonLabel,
-    IonInfiniteCustomEvent,
+    InfiniteScrollCustomEvent,
   } from '@ionic/vue';
   import { defineComponent, reactive } from 'vue';
 
@@ -51,7 +51,7 @@
         }
       };
 
-      const ionInfinite = (ev: IonInfiniteCustomEvent) => {
+      const ionInfinite = (ev: InfiniteScrollCustomEvent) => {
         generateItems();
         setTimeout(() => ev.target.complete(), 500);
       };

--- a/static/usage/v6/infinite-scroll/custom-infinite-scroll-content/vue.md
+++ b/static/usage/v6/infinite-scroll/custom-infinite-scroll-content/vue.md
@@ -91,7 +91,7 @@
     IonAvatar,
     IonImg,
     IonLabel,
-    IonInfiniteCustomEvent,
+    InfiniteScrollCustomEvent,
   } from '@ionic/vue';
   import { defineComponent, reactive } from 'vue';
 

--- a/static/usage/v6/infinite-scroll/infinite-scroll-content/vue.md
+++ b/static/usage/v6/infinite-scroll/infinite-scroll-content/vue.md
@@ -28,7 +28,7 @@
     IonAvatar,
     IonImg,
     IonLabel,
-    IonInfiniteCustomEvent,
+    InfiniteScrollCustomEvent,
   } from '@ionic/vue';
   import { defineComponent, reactive } from 'vue';
 

--- a/static/usage/v7/infinite-scroll/basic/vue.md
+++ b/static/usage/v7/infinite-scroll/basic/vue.md
@@ -25,7 +25,7 @@
     IonAvatar,
     IonImg,
     IonLabel,
-    IonInfiniteCustomEvent,
+    InfiniteScrollCustomEvent,
   } from '@ionic/vue';
   import { defineComponent, reactive } from 'vue';
 
@@ -51,7 +51,7 @@
         }
       };
 
-      const ionInfinite = (ev: IonInfiniteCustomEvent) => {
+      const ionInfinite = (ev: InfiniteScrollCustomEvent) => {
         generateItems();
         setTimeout(() => ev.target.complete(), 500);
       };

--- a/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/vue.md
+++ b/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/vue.md
@@ -91,7 +91,7 @@
     IonAvatar,
     IonImg,
     IonLabel,
-    IonInfiniteCustomEvent,
+    InfiniteScrollCustomEvent,
   } from '@ionic/vue';
   import { defineComponent, reactive } from 'vue';
 

--- a/static/usage/v7/infinite-scroll/infinite-scroll-content/vue.md
+++ b/static/usage/v7/infinite-scroll/infinite-scroll-content/vue.md
@@ -28,7 +28,7 @@
     IonAvatar,
     IonImg,
     IonLabel,
-    IonInfiniteCustomEvent,
+    InfiniteScrollCustomEvent,
   } from '@ionic/vue';
   import { defineComponent, reactive } from 'vue';
 


### PR DESCRIPTION
Issue URL: resolves #2978 


## What is the current behavior?

Infinite scroll docs are using the wrong event on Vue: `IonInfiniteCustomEvent`


## What is the new behavior?

Infinite scroll docs are using the wrong event on Vue: `InfiniteScrollCustomEvent`


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A
