### PR TITLE
docs(select): add playgrounds for toggle icon customization

### DIFF
--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -180,6 +180,24 @@ Customizing the interface dialog should be done by following the Customization s
 
 However, the Select Option does set a class for easier styling and allows for the ability to pass a class to the overlay option, see the [Select Options documentation](select-option.md) for usage examples of customizing options.
 
+### Custom Toggle Icons
+
+The icon that displays next to the select text can be set to any [Ionicon](https://ionic.io/ionicons) using the `toggleIcon` and/or `toggleIconWhenOpen` properties.
+
+import CustomToggleIconsExample from '@site/static/usage/v7/select/customization/custom-toggle-icons/index.md';
+
+<CustomToggleIconsExample />
+
+### Icon Flip Behavior
+
+By default, when the select is open, the toggle icon will automatically rotate on `md` mode and remain static on `ios` mode. This behavior can be customized using CSS.
+
+The below example also uses a [custom `toggleIcon`](#custom-toggle-icons) to better demonstrate the flip behavior on `ios`, since the default icon is vertically symmetrical.
+
+import IconFlipBehaviorExample from '@site/static/usage/v7/select/customization/icon-flip-behavior/index.md';
+
+<IconFlipBehaviorExample />
+
 ## Typeahead Component
 
 Typeahead or autocomplete functionality can be built using existing Ionic components. We recommend using an `ion-modal` to make the best use of the available screen space.

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -182,7 +182,7 @@ However, the Select Option does set a class for easier styling and allows for th
 
 ### Custom Toggle Icons
 
-The icon that displays next to the select text can be set to any [Ionicon](https://ionic.io/ionicons) using the `toggleIcon` and/or `toggleIconWhenOpen` properties.
+The icon that displays next to the select text can be set to any [Ionicon](https://ionic.io/ionicons) using the `toggleIcon` and/or `expandedIcon` properties.
 
 import CustomToggleIconsExample from '@site/static/usage/v7/select/customization/custom-toggle-icons/index.md';
 

--- a/static/usage/v7/select/customization/custom-toggle-icons/angular.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/angular.md
@@ -1,7 +1,13 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select interface="popover" toggleIcon="add" toggleIconWhenOpen="remove" aria-label="fruit" placeholder="Select fruit">
+    <ion-select
+      interface="popover"
+      toggleIcon="add"
+      toggleIconWhenOpen="remove"
+      aria-label="fruit"
+      placeholder="Select fruit"
+    >
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/custom-toggle-icons/angular.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/angular.md
@@ -4,7 +4,7 @@
     <ion-select
       interface="popover"
       toggleIcon="add"
-      toggleIconWhenOpen="remove"
+      expandedIcon="remove"
       aria-label="fruit"
       placeholder="Select fruit"
     >

--- a/static/usage/v7/select/customization/custom-toggle-icons/angular.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/angular.md
@@ -1,0 +1,11 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select interface="popover" toggleIcon="add" toggleIconWhenOpen="remove" aria-label="fruit" placeholder="Select fruit">
+      <ion-select-option value="apples">Apples</ion-select-option>
+      <ion-select-option value="oranges">Oranges</ion-select-option>
+      <ion-select-option value="bananas">Bananas</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/customization/custom-toggle-icons/demo.html
+++ b/static/usage/v7/select/customization/custom-toggle-icons/demo.html
@@ -16,7 +16,13 @@
         <div class="container">
           <ion-list>
             <ion-item>
-              <ion-select interface="popover" toggle-icon="add" toggle-icon-when-open="remove" aria-label="fruit" placeholder="Select fruit">
+              <ion-select
+                interface="popover"
+                toggle-icon="add"
+                toggle-icon-when-open="remove"
+                aria-label="fruit"
+                placeholder="Select fruit"
+              >
                 <ion-select-option value="apples">Apples</ion-select-option>
                 <ion-select-option value="oranges">Oranges</ion-select-option>
                 <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/custom-toggle-icons/demo.html
+++ b/static/usage/v7/select/customization/custom-toggle-icons/demo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Select - Custom Toggle Icons</title>
+    <link rel="stylesheet" href="../../../../common.css" />
+    <script src="../../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-select interface="popover" toggle-icon="add" toggle-icon-when-open="remove" aria-label="fruit" placeholder="Select fruit">
+                <ion-select-option value="apples">Apples</ion-select-option>
+                <ion-select-option value="oranges">Oranges</ion-select-option>
+                <ion-select-option value="bananas">Bananas</ion-select-option>
+              </ion-select>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/select/customization/custom-toggle-icons/demo.html
+++ b/static/usage/v7/select/customization/custom-toggle-icons/demo.html
@@ -19,7 +19,7 @@
               <ion-select
                 interface="popover"
                 toggle-icon="add"
-                toggle-icon-when-open="remove"
+                expanded-icon="remove"
                 aria-label="fruit"
                 placeholder="Select fruit"
               >

--- a/static/usage/v7/select/customization/custom-toggle-icons/index.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/index.md
@@ -7,7 +7,7 @@ import angular from './angular.md';
 
 <Playground
   version="7"
-  size="350px"
+  size="400px"
   code={{ javascript, react, vue, angular }}
   src="usage/v7/select/customization/custom-toggle-icons/demo.html"
 />

--- a/static/usage/v7/select/customization/custom-toggle-icons/index.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/index.md
@@ -1,0 +1,13 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  size="350px"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v7/select/customization/custom-toggle-icons/demo.html"
+/>

--- a/static/usage/v7/select/customization/custom-toggle-icons/javascript.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/javascript.md
@@ -1,0 +1,11 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select interface="popover" toggle-icon="add" toggle-icon-when-open="remove" aria-label="fruit" placeholder="Select fruit">
+      <ion-select-option value="apples">Apples</ion-select-option>
+      <ion-select-option value="oranges">Oranges</ion-select-option>
+      <ion-select-option value="bananas">Bananas</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/customization/custom-toggle-icons/javascript.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/javascript.md
@@ -4,7 +4,7 @@
     <ion-select
       interface="popover"
       toggle-icon="add"
-      toggle-icon-when-open="remove"
+      expanded-icon="remove"
       aria-label="fruit"
       placeholder="Select fruit"
     >

--- a/static/usage/v7/select/customization/custom-toggle-icons/javascript.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/javascript.md
@@ -1,7 +1,13 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select interface="popover" toggle-icon="add" toggle-icon-when-open="remove" aria-label="fruit" placeholder="Select fruit">
+    <ion-select
+      interface="popover"
+      toggle-icon="add"
+      toggle-icon-when-open="remove"
+      aria-label="fruit"
+      placeholder="Select fruit"
+    >
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/custom-toggle-icons/react.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/react.md
@@ -1,14 +1,16 @@
 ```tsx
 import React from 'react';
 import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/react';
+import { add, remove } from 'ionicons/icons';
+
 function Example() {
   return (
     <IonList>
       <IonItem>
         <IonSelect
           interface="popover"
-          toggleIcon="add"
-          toggleIconWhenOpen="remove"
+          toggleIcon={add}
+          toggleIconWhenOpen={remove}
           aria-label="fruit"
           placeholder="Select fruit"
         >

--- a/static/usage/v7/select/customization/custom-toggle-icons/react.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/react.md
@@ -5,7 +5,13 @@ function Example() {
   return (
     <IonList>
       <IonItem>
-        <IonSelect interface="popover" toggleIcon="add" toggleIconWhenOpen="remove" aria-label="fruit" placeholder="Select fruit">
+        <IonSelect
+          interface="popover"
+          toggleIcon="add"
+          toggleIconWhenOpen="remove"
+          aria-label="fruit"
+          placeholder="Select fruit"
+        >
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/customization/custom-toggle-icons/react.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/react.md
@@ -1,0 +1,18 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/react';
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonSelect interface="popover" toggleIcon="add" toggleIconWhenOpen="remove" aria-label="fruit" placeholder="Select fruit">
+          <IonSelectOption value="apples">Apples</IonSelectOption>
+          <IonSelectOption value="oranges">Oranges</IonSelectOption>
+          <IonSelectOption value="bananas">Bananas</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/select/customization/custom-toggle-icons/react.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/react.md
@@ -10,7 +10,7 @@ function Example() {
         <IonSelect
           interface="popover"
           toggleIcon={add}
-          toggleIconWhenOpen={remove}
+          expandedIcon={remove}
           aria-label="fruit"
           placeholder="Select fruit"
         >

--- a/static/usage/v7/select/customization/custom-toggle-icons/vue.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/vue.md
@@ -1,0 +1,22 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-select interface="popover" toggle-icon="add" toggle-icon-when-open="remove" aria-label="fruit" placeholder="Select fruit">
+        <ion-select-option value="apples">Apples</ion-select-option>
+        <ion-select-option value="oranges">Oranges</ion-select-option>
+        <ion-select-option value="bananas">Bananas</ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script>
+  import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonSelect, IonSelectOption },
+  });
+</script>
+```

--- a/static/usage/v7/select/customization/custom-toggle-icons/vue.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/vue.md
@@ -4,8 +4,8 @@
     <ion-item>
       <ion-select
         interface="popover"
-        toggle-icon="add"
-        toggle-icon-when-open="remove"
+        :toggle-icon="add"
+        :toggle-icon-when-open="remove"
         aria-label="fruit"
         placeholder="Select fruit"
       >
@@ -19,10 +19,14 @@
 
 <script>
   import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/vue';
+  import { add, remove } from 'ionicons/icons';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
     components: { IonItem, IonList, IonSelect, IonSelectOption },
+    setup() {
+      return { add, remove };
+    },
   });
 </script>
 ```

--- a/static/usage/v7/select/customization/custom-toggle-icons/vue.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/vue.md
@@ -2,7 +2,13 @@
 <template>
   <ion-list>
     <ion-item>
-      <ion-select interface="popover" toggle-icon="add" toggle-icon-when-open="remove" aria-label="fruit" placeholder="Select fruit">
+      <ion-select
+        interface="popover"
+        toggle-icon="add"
+        toggle-icon-when-open="remove"
+        aria-label="fruit"
+        placeholder="Select fruit"
+      >
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/custom-toggle-icons/vue.md
+++ b/static/usage/v7/select/customization/custom-toggle-icons/vue.md
@@ -5,7 +5,7 @@
       <ion-select
         interface="popover"
         :toggle-icon="add"
-        :toggle-icon-when-open="remove"
+        :expanded-icon="remove"
         aria-label="fruit"
         placeholder="Select fruit"
       >

--- a/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_css.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_css.md
@@ -1,0 +1,13 @@
+```css
+ion-select.always-flip::part(icon) {
+  transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+}
+
+ion-select.always-flip.select-expanded::part(icon) {
+  transform: rotate(180deg);
+}
+
+ion-select.never-flip::part(icon) {
+  transform: none;
+}
+```

--- a/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_css.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_css.md
@@ -1,6 +1,6 @@
 ```css
 ion-select.always-flip::part(icon) {
-  transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 ion-select.always-flip.select-expanded::part(icon) {

--- a/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_html.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_html.md
@@ -1,14 +1,26 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select class="always-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+    <ion-select
+      class="always-flip"
+      toggleIcon="caret-down-sharp"
+      interface="popover"
+      label="Icon flips on both modes"
+      placeholder="Select fruit"
+    >
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>
     </ion-select>
   </ion-item>
   <ion-item>
-    <ion-select class="never-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+    <ion-select
+      class="never-flip"
+      toggleIcon="caret-down-sharp"
+      interface="popover"
+      label="Icon never flips"
+      placeholder="Select fruit"
+    >
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_html.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_html.md
@@ -1,0 +1,18 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select class="always-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+      <ion-select-option value="apples">Apples</ion-select-option>
+      <ion-select-option value="oranges">Oranges</ion-select-option>
+      <ion-select-option value="bananas">Bananas</ion-select-option>
+    </ion-select>
+  </ion-item>
+  <ion-item>
+    <ion-select class="never-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+      <ion-select-option value="apples">Apples</ion-select-option>
+      <ion-select-option value="oranges">Oranges</ion-select-option>
+      <ion-select-option value="bananas">Bananas</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_ts.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/angular/example_component_ts.md
@@ -1,0 +1,10 @@
+```ts
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/select/customization/icon-flip-behavior/demo.html
+++ b/static/usage/v7/select/customization/icon-flip-behavior/demo.html
@@ -11,7 +11,7 @@
 
     <style>
       ion-select.always-flip::part(icon) {
-        transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+        transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
       }
 
       ion-select.always-flip.select-expanded::part(icon) {
@@ -30,14 +30,26 @@
         <div class="container">
           <ion-list>
             <ion-item>
-              <ion-select class="always-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+              <ion-select
+                class="always-flip"
+                toggle-icon="caret-down-sharp"
+                interface="popover"
+                label="Icon flips on both modes"
+                placeholder="Select fruit"
+              >
                 <ion-select-option value="apples">Apples</ion-select-option>
                 <ion-select-option value="oranges">Oranges</ion-select-option>
                 <ion-select-option value="bananas">Bananas</ion-select-option>
               </ion-select>
             </ion-item>
             <ion-item>
-              <ion-select class="never-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+              <ion-select
+                class="never-flip"
+                toggle-icon="caret-down-sharp"
+                interface="popover"
+                label="Icon never flips"
+                placeholder="Select fruit"
+              >
                 <ion-select-option value="apples">Apples</ion-select-option>
                 <ion-select-option value="oranges">Oranges</ion-select-option>
                 <ion-select-option value="bananas">Bananas</ion-select-option>

--- a/static/usage/v7/select/customization/icon-flip-behavior/demo.html
+++ b/static/usage/v7/select/customization/icon-flip-behavior/demo.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Select - Icon Flip Behavior</title>
+    <link rel="stylesheet" href="../../../../common.css" />
+    <script src="../../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-select.always-flip::part(icon) {
+        transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+      }
+
+      ion-select.always-flip.select-expanded::part(icon) {
+        transform: rotate(180deg);
+      }
+
+      ion-select.never-flip::part(icon) {
+        transform: none;
+      }
+    </style>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-select class="always-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+                <ion-select-option value="apples">Apples</ion-select-option>
+                <ion-select-option value="oranges">Oranges</ion-select-option>
+                <ion-select-option value="bananas">Bananas</ion-select-option>
+              </ion-select>
+            </ion-item>
+            <ion-item>
+              <ion-select class="never-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+                <ion-select-option value="apples">Apples</ion-select-option>
+                <ion-select-option value="oranges">Oranges</ion-select-option>
+                <ion-select-option value="bananas">Bananas</ion-select-option>
+              </ion-select>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/select/customization/icon-flip-behavior/index.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/index.md
@@ -12,7 +12,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
-  size="350px"
+  size="400px"
   code={{
     javascript,
     react: {

--- a/static/usage/v7/select/customization/icon-flip-behavior/index.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/index.md
@@ -1,0 +1,34 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import vue from './vue.md';
+
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="7"
+  size="350px"
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': react_main_tsx,
+        'src/main.css': react_main_css,
+      },
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/select/customization/icon-flip-behavior/demo.html"
+/>

--- a/static/usage/v7/select/customization/icon-flip-behavior/javascript.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/javascript.md
@@ -1,14 +1,26 @@
 ```html
 <ion-list>
   <ion-item>
-    <ion-select class="always-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+    <ion-select
+      class="always-flip"
+      toggle-icon="caret-down-sharp"
+      interface="popover"
+      label="Icon flips on both modes"
+      placeholder="Select fruit"
+    >
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>
     </ion-select>
   </ion-item>
   <ion-item>
-    <ion-select class="never-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+    <ion-select
+      class="never-flip"
+      toggle-icon="caret-down-sharp"
+      interface="popover"
+      label="Icon never flips"
+      placeholder="Select fruit"
+    >
       <ion-select-option value="apples">Apples</ion-select-option>
       <ion-select-option value="oranges">Oranges</ion-select-option>
       <ion-select-option value="bananas">Bananas</ion-select-option>
@@ -18,7 +30,7 @@
 
 <style>
   ion-select.always-flip::part(icon) {
-    transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+    transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   ion-select.always-flip.select-expanded::part(icon) {

--- a/static/usage/v7/select/customization/icon-flip-behavior/javascript.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/javascript.md
@@ -1,0 +1,32 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select class="always-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+      <ion-select-option value="apples">Apples</ion-select-option>
+      <ion-select-option value="oranges">Oranges</ion-select-option>
+      <ion-select-option value="bananas">Bananas</ion-select-option>
+    </ion-select>
+  </ion-item>
+  <ion-item>
+    <ion-select class="never-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+      <ion-select-option value="apples">Apples</ion-select-option>
+      <ion-select-option value="oranges">Oranges</ion-select-option>
+      <ion-select-option value="bananas">Bananas</ion-select-option>
+    </ion-select>
+  </ion-item>
+</ion-list>
+
+<style>
+  ion-select.always-flip::part(icon) {
+    transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+  }
+
+  ion-select.always-flip.select-expanded::part(icon) {
+    transform: rotate(180deg);
+  }
+
+  ion-select.never-flip::part(icon) {
+    transform: none;
+  }
+</style>
+```

--- a/static/usage/v7/select/customization/icon-flip-behavior/react/main_css.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/react/main_css.md
@@ -1,0 +1,13 @@
+```css
+ion-select.always-flip::part(icon) {
+  transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+}
+
+ion-select.always-flip.select-expanded::part(icon) {
+  transform: rotate(180deg);
+}
+
+ion-select.never-flip::part(icon) {
+  transform: none;
+}
+```

--- a/static/usage/v7/select/customization/icon-flip-behavior/react/main_css.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/react/main_css.md
@@ -1,6 +1,6 @@
 ```css
 ion-select.always-flip::part(icon) {
-  transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 ion-select.always-flip.select-expanded::part(icon) {

--- a/static/usage/v7/select/customization/icon-flip-behavior/react/main_tsx.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/react/main_tsx.md
@@ -1,0 +1,28 @@
+```tsx
+import React from 'react';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonSelect className="always-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+          <IonSelectOption value="apples">Apples</IonSelectOption>
+          <IonSelectOption value="oranges">Oranges</IonSelectOption>
+          <IonSelectOption value="bananas">Bananas</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+      <IonItem>
+        <IonSelect className="never-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+          <IonSelectOption value="apples">Apples</IonSelectOption>
+          <IonSelectOption value="oranges">Oranges</IonSelectOption>
+          <IonSelectOption value="bananas">Bananas</IonSelectOption>
+        </IonSelect>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/select/customization/icon-flip-behavior/react/main_tsx.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/react/main_tsx.md
@@ -8,14 +8,26 @@ function Example() {
   return (
     <IonList>
       <IonItem>
-        <IonSelect className="always-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+        <IonSelect
+          className="always-flip"
+          toggleIcon="caret-down-sharp"
+          interface="popover"
+          label="Icon flips on both modes"
+          placeholder="Select fruit"
+        >
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>
         </IonSelect>
       </IonItem>
       <IonItem>
-        <IonSelect className="never-flip" toggleIcon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+        <IonSelect
+          className="never-flip"
+          toggleIcon="caret-down-sharp"
+          interface="popover"
+          label="Icon never flips"
+          placeholder="Select fruit"
+        >
           <IonSelectOption value="apples">Apples</IonSelectOption>
           <IonSelectOption value="oranges">Oranges</IonSelectOption>
           <IonSelectOption value="bananas">Bananas</IonSelectOption>

--- a/static/usage/v7/select/customization/icon-flip-behavior/react/main_tsx.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/react/main_tsx.md
@@ -1,6 +1,7 @@
 ```tsx
 import React from 'react';
 import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/react';
+import { caretDownSharp } from 'ionicons/icons';
 
 import './main.css';
 
@@ -10,7 +11,7 @@ function Example() {
       <IonItem>
         <IonSelect
           className="always-flip"
-          toggleIcon="caret-down-sharp"
+          toggleIcon={caretDownSharp}
           interface="popover"
           label="Icon flips on both modes"
           placeholder="Select fruit"
@@ -23,7 +24,7 @@ function Example() {
       <IonItem>
         <IonSelect
           className="never-flip"
-          toggleIcon="caret-down-sharp"
+          toggleIcon={caretDownSharp}
           interface="popover"
           label="Icon never flips"
           placeholder="Select fruit"

--- a/static/usage/v7/select/customization/icon-flip-behavior/vue.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/vue.md
@@ -2,14 +2,26 @@
 <template>
   <ion-list>
     <ion-item>
-      <ion-select class="always-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+      <ion-select
+        class="always-flip"
+        toggle-icon="caret-down-sharp"
+        interface="popover"
+        label="Icon flips on both modes"
+        placeholder="Select fruit"
+      >
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>
       </ion-select>
     </ion-item>
     <ion-item>
-      <ion-select class="never-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+      <ion-select
+        class="never-flip"
+        toggle-icon="caret-down-sharp"
+        interface="popover"
+        label="Icon never flips"
+        placeholder="Select fruit"
+      >
         <ion-select-option value="apples">Apples</ion-select-option>
         <ion-select-option value="oranges">Oranges</ion-select-option>
         <ion-select-option value="bananas">Bananas</ion-select-option>
@@ -29,7 +41,7 @@
 
 <style>
   ion-select.always-flip::part(icon) {
-    transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+    transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   ion-select.always-flip.select-expanded::part(icon) {

--- a/static/usage/v7/select/customization/icon-flip-behavior/vue.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/vue.md
@@ -4,7 +4,7 @@
     <ion-item>
       <ion-select
         class="always-flip"
-        toggle-icon="caret-down-sharp"
+        :toggle-icon="caretDownSharp"
         interface="popover"
         label="Icon flips on both modes"
         placeholder="Select fruit"
@@ -17,7 +17,7 @@
     <ion-item>
       <ion-select
         class="never-flip"
-        toggle-icon="caret-down-sharp"
+        :toggle-icon="caretDownSharp"
         interface="popover"
         label="Icon never flips"
         placeholder="Select fruit"
@@ -32,10 +32,14 @@
 
 <script>
   import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/vue';
+  import { caretDownSharp } from 'ionicons/icons';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
     components: { IonItem, IonList, IonSelect, IonSelectOption },
+    setup() {
+      return { caretDownSharp };
+    },
   });
 </script>
 

--- a/static/usage/v7/select/customization/icon-flip-behavior/vue.md
+++ b/static/usage/v7/select/customization/icon-flip-behavior/vue.md
@@ -1,0 +1,43 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-select class="always-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon flips on both modes" placeholder="Select fruit">
+        <ion-select-option value="apples">Apples</ion-select-option>
+        <ion-select-option value="oranges">Oranges</ion-select-option>
+        <ion-select-option value="bananas">Bananas</ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item>
+      <ion-select class="never-flip" toggle-icon="caret-down-sharp" interface="popover" label="Icon never flips" placeholder="Select fruit">
+        <ion-select-option value="apples">Apples</ion-select-option>
+        <ion-select-option value="oranges">Oranges</ion-select-option>
+        <ion-select-option value="bananas">Bananas</ion-select-option>
+      </ion-select>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script>
+  import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonItem, IonList, IonSelect, IonSelectOption },
+  });
+</script>
+
+<style>
+  ion-select.always-flip::part(icon) {
+    transition: transform .15s cubic-bezier(.4, 0, .2, 1);
+  }
+
+  ion-select.always-flip.select-expanded::part(icon) {
+    transform: rotate(180deg);
+  }
+
+  ion-select.never-flip::part(icon) {
+    transform: none;
+  }
+</style>
+```


### PR DESCRIPTION
Adds two playgrounds:
- Usage for the new `toggleIcon` and `toggleIconWhenOpen` props added in https://github.com/ionic-team/ionic-framework/pull/27648
- Example CSS for customizing icon flip behavior, in lieu of a new prop as detailed [here](https://github.com/ionic-team/ionic-framework-design-documents/blob/main/projects/ionic-framework/components/select/0003-custom-icon-on-open.md#modifying-flip-behavior)

Dev build for testing: `7.0.15-dev.11687278023.161b97d8` (note that you'll need to add this to see the custom icons in the playground iframes)

Shortcut: https://ionic-docs-git-fw-2134-ionic1.vercel.app/docs/api/select#custom-toggle-icons