### PR TITLE
docs(vue): Improve documentation for removing Typescript in v7

### DIFF
--- a/docs/vue/quickstart.md
+++ b/docs/vue/quickstart.md
@@ -45,7 +45,7 @@ So, if you’d prefer to use JavaScript instead of TypeScript, you can. After ge
 1. Remove TypeScript dependencies:
 
 ```shell
-npm uninstall --save typescript @types/jest @typescript-eslint/eslint-plugin @typescript-eslint/parser @vue/cli-plugin-typescript @vue/eslint-config-typescript
+npm uninstall --save typescript @types/jest @typescript-eslint/eslint-plugin @typescript-eslint/parser @vue/cli-plugin-typescript @vue/eslint-config-typescript vue-tsc
 ```
 
 2. Change all `.ts` files to `.js`. In a blank Ionic Vue app, this should only be `src/router/index.ts` and `src/main.ts`. If you're using tests, also change the extension of files in the `tests` directory.
@@ -61,6 +61,10 @@ npm uninstall --save typescript @types/jest @typescript-eslint/eslint-plugin @ty
 7. Remove `lang="ts"` from the `script` tags in any of your Vue components that have them. In a blank Ionic Vue app, this should only be `src/App.vue` and `src/views/HomePage.vue`.
 
 8. Delete the `tsconfig.json` file.
+
+9. In package.json, change the build script from `"build": "vue-tsc && vite build"` to `"build": "vite build"`
+
+10. Install terser `npm i -D terser`.
 
 ## A look at a Vue Component
 


### PR DESCRIPTION
`npm run build` is failing. This is because the build script is using vue-tsc.

```
6:48:09 PM: $ yarn build
6:48:09 PM: yarn run v1.22.19
6:48:09 PM: $ vue-tsc && vite build
6:48:09 PM: node:internal/modules/cjs/loader:1078
6:48:09 PM:   throw err;
6:48:09 PM:   ^
6:48:09 PM: Error: Cannot find module 'typescript/package.json'
6:48:09 PM: Require stack:
6:48:09 PM: - /opt/build/repo/node_modules/vue-tsc/bin/vue-tsc.js
6:48:09 PM:     at Module._resolveFilename (node:internal/modules/cjs/loader:1075:15)
6:48:09 PM:     at Module._load (node:internal/modules/cjs/loader:920:27)
6:48:09 PM:     at Module.require (node:internal/modules/cjs/loader:1141:19)
6:48:09 PM:     at require (node:internal/modules/cjs/helpers:110:18)
6:48:09 PM:     at Object.<anonymous> (/opt/build/repo/node_modules/vue-tsc/bin/vue-tsc.js:4:15)
6:48:09 PM:     at Module._compile (node:internal/modules/cjs/loader:1254:14)
6:48:09 PM:     at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
6:48:09 PM:     at Module.load (node:internal/modules/cjs/loader:1117:32)
6:48:09 PM:     at Module._load (node:internal/modules/cjs/loader:958:12)
6:48:09 PM:     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
6:48:09 PM:   code: 'MODULE_NOT_FOUND',
6:48:09 PM:   requireStack: [ '/opt/build/repo/node_modules/vue-tsc/bin/vue-tsc.js' ]
6:48:09 PM: }
6:48:09 PM: Node.js v18.16.0
```

If I remove `vue-tsc` from the build script an error  `[vite:terser] terser not found. since vite v3, terser has become an optional dependency. you need to install it.` So I installed terser.