### PR TITLE
docs(maskito): update credit card mask format

### DIFF
--- a/static/usage/v7/input/mask/angular/example_component_ts.md
+++ b/static/usage/v7/input/mask/angular/example_component_ts.md
@@ -22,7 +22,7 @@ export class ExampleComponent {
       ' ',
       ...Array(4).fill(/\d/),
       ' ',
-      ...Array(4).fill(/\d/),
+      ...Array(3).fill(/\d/),
     ],
   };
 

--- a/static/usage/v7/input/mask/demo.html
+++ b/static/usage/v7/input/mask/demo.html
@@ -59,7 +59,7 @@
             ' ',
             ...Array(4).fill(/\d/),
             ' ',
-            ...Array(4).fill(/\d/),
+            ...Array(3).fill(/\d/),
           ],
         });
       }

--- a/static/usage/v7/input/mask/javascript/index_html.md
+++ b/static/usage/v7/input/mask/javascript/index_html.md
@@ -42,7 +42,7 @@
               ' ',
               ...Array(4).fill(/\d/),
               ' ',
-              ...Array(4).fill(/\d/),
+              ...Array(3).fill(/\d/),
             ],
           });
         }

--- a/static/usage/v7/input/mask/react.md
+++ b/static/usage/v7/input/mask/react.md
@@ -14,6 +14,8 @@ function Example() {
         ...Array(4).fill(/\d/),
         ' ',
         ...Array(4).fill(/\d/),
+        ' ',
+        ...Array(3).fill(/\d/),
       ],
     },
   });

--- a/static/usage/v7/input/mask/vue.md
+++ b/static/usage/v7/input/mask/vue.md
@@ -23,6 +23,8 @@
       ...Array(4).fill(/\d/),
       ' ',
       ...Array(4).fill(/\d/),
+      ' ',
+      ...Array(3).fill(/\d/),
     ],
     elementPredicate: (el: HTMLIonInputElement) => {
       return new Promise((resolve) => {


### PR DESCRIPTION
Updates the card input masking example to align with the mask provided from Maskito: https://tinkoff.github.io/maskito/recipes/card