### PR TITLE
fix(playground-tabs): show arrows on long list

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -417,7 +417,7 @@ export default function Playground({
         return null;
       }
       return (
-        <PlaygroundTabs className="playground__tabs">
+        <PlaygroundTabs groupId={usageTarget} className="playground__tabs">
           {Object.keys(codeSnippets[usageTarget]).map((fileName) => (
             <TabItem
               className="playground__tab-item"

--- a/src/components/global/PlaygroundTabs/index.tsx
+++ b/src/components/global/PlaygroundTabs/index.tsx
@@ -108,7 +108,7 @@ function TabsComponent(props: Props): JSX.Element {
   useEffect(() => {
     setLeftNavVisible(tabsNavEl.current?.scrollLeft > 40);
     setRightNavVisible(tabsNavEl.current?.scrollWidth > tabsNavEl.current?.offsetWidth);
-  }, []);
+  }, [groupId]);
 
   /**
    * If the selected value is not in the available tabs, fall back to the first tab.


### PR DESCRIPTION
Issue URL: resolves #2999 


## What is the current behavior?

The files tab section will render a scroll to the right button when there are multiple files that go off the container. However, if the right button is displayed and the user navigates to a different framework with a short list, then the right arrow is still showing.

Angular
![Screenshot 2023-06-15 at 1 12 50 PM](https://github.com/ionic-team/ionic-docs/assets/13530427/e04bcf59-e6ff-42d3-8633-c6e024cb8fc7)

React
![Screenshot 2023-06-15 at 1 19 02 PM](https://github.com/ionic-team/ionic-docs/assets/13530427/858091c9-82ab-4a3e-8bc3-f30425648f1c)


## What is the new behavior?

The arrow only displays when there are multiples files that go off the container.

Angular
![Screenshot 2023-06-15 at 1 12 50 PM](https://github.com/ionic-team/ionic-docs/assets/13530427/e04bcf59-e6ff-42d3-8633-c6e024cb8fc7)

React
![Screenshot 2023-06-15 at 1 18 38 PM](https://github.com/ionic-team/ionic-docs/assets/13530427/68e13f1f-ac04-4276-b5b5-050d8d0b15c2)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A