### PR TITLE
chore: enable renovate for component playground deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,10 @@
     {
       "packageNames": ["*"],
       "directoryNames": [
-        "static/code/stackblitz/v6/angular",
-        "static/code/stackblitz/v7/angular",
-        "static/code/stackblitz/v6/html",
-        "static/code/stackblitz/v7/html",
-        "static/code/stackblitz/v6/vue",
-        "static/code/stackblitz/v7/vue",
-        "static/code/stackblitz/v6/react",
-        "static/code/stackblitz/v7/react"
+        "static/code/stackblitz/*/angular",
+        "static/code/stackblitz/*/html",
+        "static/code/stackblitz/*/vue",
+        "static/code/stackblitz/*/react"
       ],
       "enabled": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
       "enabled": true
     }
   ],
+  "dependencyDashboard": true,
   "minimumReleaseAge": "3 days",
   "rebaseWhen": "never",
   "schedule": ["every weekday before 11am"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base", ":github>ionic-team/ionic-docs>"],
+  "packageRules": [
+    {
+      "packageNames": ["*"],
+      "directoryNames": [
+        "static/code/stackblitz/v6/angular",
+        "static/code/stackblitz/v7/angular",
+        "static/code/stackblitz/v6/html",
+        "static/code/stackblitz/v7/html",
+        "static/code/stackblitz/v6/vue",
+        "static/code/stackblitz/v7/vue",
+        "static/code/stackblitz/v6/react",
+        "static/code/stackblitz/v7/react"
+      ],
+      "enabled": true
+    }
+  ],
+  "minimumReleaseAge": "3 days",
+  "rebaseWhen": "never",
+  "schedule": ["every weekday before 11am"],
+  "semanticCommits": "enabled"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -3,19 +3,19 @@
   "extends": ["config:base", ":github>ionic-team/ionic-docs>"],
   "packageRules": [
     {
-      "packageNames": ["*"],
-      "directoryNames": [
-        "static/code/stackblitz/*/angular",
-        "static/code/stackblitz/*/html",
-        "static/code/stackblitz/*/vue",
-        "static/code/stackblitz/*/react"
-      ],
-      "enabled": true
+      "matchPackagePatterns": ["^@ionic/"],
+      "groupName": "ionic",
+      "schedule": ["every thursday before 11am"]
+    },
+    {
+      "matchPackagePatterns": ["^@angular/"],
+      "groupName": "angular"
     }
   ],
   "dependencyDashboard": true,
   "minimumReleaseAge": "3 days",
   "rebaseWhen": "never",
   "schedule": ["every weekday before 11am"],
-  "semanticCommits": "enabled"
+  "semanticCommits": "enabled",
+  "ignorePaths": ["./package.json", "./package-lock.json", "./docusaurus-theme-classic"]
 }


### PR DESCRIPTION
Enables the Renovate bot for managing the dependencies used by the component playground stackblitz project templates.

This PR is in favor of: https://github.com/ionic-team/ionic-docs/pull/3017