### PR TITLE
docs(modal): clarify swipe to close section

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -81,7 +81,7 @@ import CanDismissFunctionExample from '@site/static/usage/v7/modal/can-dismiss/f
 
 ### Prevent swipe to close
 
-Developers may want to prevent users from swiping to close a modal. This can be done by setting a callback function for `canDismiss` and checking if the `role` is not `gesture`.
+Developers may want to prevent users from swiping to close a card or sheet modal. This can be done by setting a callback function for `canDismiss` and checking if the `role` is not `gesture`.
 
 import CanDismissPreventSwipeToCloseExample from '@site/static/usage/v7/modal/can-dismiss/prevent-swipe-to-close/index.md';
 


### PR DESCRIPTION
There was some confusion around swipe gestures + modals on https://github.com/ionic-team/ionic-framework/issues/27753. Developer thought the swipe gesture applied to all modals, but it only applies to card and sheet modals.