### PR TITLE
chore(renovate): limit include paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "groupName": "angular"
     },
     {
-      "matchPackageNames": ["^@ionic/"],
+      "matchPackagePatterns": ["^@ionic/"],
       "allowedVersions": "^6.0.0",
       "matchFileNames": ["static/code/stackblitz/v6/**/package.json"]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
     {
       "matchPackagePatterns": ["^@angular/"],
       "groupName": "angular"
+    },
+    {
+      "matchPackageNames": ["^@ionic/"],
+      "allowedVersions": "^6.0.0",
+      "matchFileNames": ["static/code/stackblitz/v6/**/package.json"]
     }
   ],
   "dependencyDashboard": true,
@@ -16,5 +21,5 @@
   "rebaseWhen": "never",
   "schedule": ["every weekday before 11am"],
   "semanticCommits": "enabled",
-  "ignorePaths": ["./package.json", "./package-lock.json", "./docusaurus-theme-classic"]
+  "includePaths": ["static/code/stackblitz"]
 }


### PR DESCRIPTION
Based on: https://github.com/ionic-team/ionic-docs/issues/3029, Renovate is still detecting `package.json` files at the root and within the docusaurus plugin. 

This PR limits the `includePaths` to only the Stackblitz directories.

Additionally this PR tries to limit the allowed version bumps for the v6 folder paths to not attempt to bump to Ionic v7. 