### PR TITLE
docs(animations): add playground for before and after hooks

### DIFF
--- a/docs/utilities/animations.md
+++ b/docs/utilities/animations.md
@@ -326,118 +326,13 @@ import Group from '@site/static/usage/v7/animations/group/index.md';
 
 Ionic Animations provides hooks that let you alter an element before an animation runs and after an animation completes. These hooks can be used to perform DOM reads and writes as well as add or remove classes and inline styles.
 
-### Usage
-
-````mdx-code-block
-<Tabs
-  groupId="framework"
-  defaultValue="javascript"
-  values={[
-    { value: 'javascript', label: 'JavaScript' },
-    { value: 'angular', label: 'Angular' },
-    { value: 'react', label: 'React' },
-    { value: 'vue', label: 'Vue' },
-  ]
-}>
-<TabItem value="javascript">
-
-```javascript
-createAnimation()
-  .addElement(document.querySelector('.square'))
-  .duration(2000)
-  .beforeStyles({
-    opacity: 0.2
-  })
-  .afterStyles({
-    background: 'rgba(0, 255, 0, 0.5)'
-  })
-  .afterClearStyles(['opacity'])
-  .keyframes([
-    { offset: 0, transform: 'scale(1)' },
-    { offset: 0.5, transform: 'scale(1.5)' },
-    { offset: 1, transform: 'scale(1)' }
-  ])
-```
-</TabItem>
-<TabItem value="angular">
-
-```javascript
-this.animationCtrl.create()
-  .addElement(this.square.nativeElement)
-  .duration(2000)
-  .beforeStyles({
-    opacity: 0.2
-  })
-  .afterStyles({
-    background: 'rgba(0, 255, 0, 0.5)'
-  })
-  .afterClearStyles(['opacity'])
-  .keyframes([
-    { offset: 0, transform: 'scale(1)' },
-    { offset: 0.5, transform: 'scale(1.5)' },
-    { offset: 1, transform: 'scale(1)' }
-  ])
-```
-</TabItem>
-<TabItem value="react">
-
-```tsx
-<CreateAnimation
-  duration={2000}
-  beforeStyles={{
-    opacity: 0.2
-  }}
-  afterStyles={{
-    background: 'rgba(0, 255, 0, 0.5)'
-  }}
-  afterClearStyles={['opacity']}
-  keyframes={[
-    { offset: 0, transform: 'scale(1)' },
-    { offset: 0.5, transform: 'scale(1.5)' },
-    { offset: 1, transform: 'scale(1)' }
-  ]}
->
-  ...
-</CreateAnimation>
-```
-</TabItem>
-<TabItem value="vue">
-
-```javascript
-import { createAnimation } from '@ionic/vue';
-import { ref } from 'vue';
-
-...
-
-const squareRef = ref();
-
-...
-
-createAnimation()
-  .addElement(squareRef.value)
-  .duration(2000)
-  .beforeStyles({
-    opacity: 0.2
-  })
-  .afterStyles({
-    background: 'rgba(0, 255, 0, 0.5)'
-  })
-  .afterClearStyles(['opacity'])
-  .keyframes([
-    { offset: 0, transform: 'scale(1)' },
-    { offset: 0.5, transform: 'scale(1.5)' },
-    { offset: 1, transform: 'scale(1)' }
-  ])
-```
-</TabItem>
-</Tabs>
-````
-
-In this example, an inline opacity of 0.2 is set on the `.square` element prior to the animation starting. Once the animation finishes, the background color of the element is set to `rgba(0, 255, 0, 0.5)`, and the inline opacity is cleared.
+This example sets an inline opacity of `0.2` on the card prior to the animation starting. Once the animation finishes, the background color of the element is set to `rgba(0, 255, 0, 0.5)`, and the inline opacity is cleared. The animation must be stopped in order to remove the background and play it with the opacity again.
 
 See [Methods](#methods) for a complete list of hooks.
 
-<Codepen user="ionic" slug="BaBxmwo" />
+import BeforeAndAfterHooks from '@site/static/usage/v7/animations/before-and-after-hooks/index.md';
+
+<BeforeAndAfterHooks />
 
 ## Chained Animations
 

--- a/docs/utilities/animations.md
+++ b/docs/utilities/animations.md
@@ -255,7 +255,7 @@ import Group from '@site/static/usage/v7/animations/group/index.md';
 
 Ionic Animations provides hooks that let you alter an element before an animation runs and after an animation completes. These hooks can be used to perform DOM reads and writes as well as add or remove classes and inline styles.
 
-This example sets an inline opacity of `0.2` on the card prior to the animation starting. Once the animation finishes, the background color of the element is set to `rgba(0, 255, 0, 0.5)`, and the inline opacity is cleared. The animation must be stopped in order to remove the background and play it with the opacity again.
+This example sets an inline filter which inverts the background color of the card by `75%` prior to the animation starting. Once the animation finishes, the box shadow on the element is set to `rgba(255, 0, 50, 0.4) 0px 4px 16px 6px`, a red glow, and the inline filter is cleared. The animation must be stopped in order to remove the box shadow and play it with the filter again.
 
 See [Methods](#methods) for a complete list of hooks.
 

--- a/static/usage/v7/animations/before-and-after-hooks/angular/example_component_html.md
+++ b/static/usage/v7/animations/before-and-after-hooks/angular/example_component_html.md
@@ -1,0 +1,9 @@
+```html
+<ion-card>
+  <ion-card-content>Card</ion-card-content>
+</ion-card>
+
+<ion-button (click)="play()">Play</ion-button>
+<ion-button (click)="pause()">Pause</ion-button>
+<ion-button (click)="stop()">Stop</ion-button>
+```

--- a/static/usage/v7/animations/before-and-after-hooks/angular/example_component_ts.md
+++ b/static/usage/v7/animations/before-and-after-hooks/angular/example_component_ts.md
@@ -21,13 +21,13 @@ export class ExampleComponent {
       .addElement(this.cardElements.get(0).nativeElement)
       .duration(2000)
       .beforeStyles({
-        opacity: 0.2,
+        filter: 'invert(75%)',
       })
-      .beforeClearStyles(['background'])
+      .beforeClearStyles(['box-shadow'])
       .afterStyles({
-        background: 'rgba(0, 255, 0, 0.5)',
+        'box-shadow': 'rgba(255, 0, 50, 0.4) 0px 4px 16px 6px',
       })
-      .afterClearStyles(['opacity'])
+      .afterClearStyles(['filter'])
       .keyframes([
         { offset: 0, transform: 'scale(1)' },
         { offset: 0.5, transform: 'scale(1.5)' },

--- a/static/usage/v7/animations/before-and-after-hooks/angular/example_component_ts.md
+++ b/static/usage/v7/animations/before-and-after-hooks/angular/example_component_ts.md
@@ -21,23 +21,20 @@ export class ExampleComponent {
       .addElement(this.cardElements.get(0).nativeElement)
       .duration(2000)
       .beforeStyles({
-        opacity: 0.2
+        opacity: 0.2,
       })
       .beforeClearStyles(['background'])
       .afterStyles({
-        background: 'rgba(0, 255, 0, 0.5)'
+        background: 'rgba(0, 255, 0, 0.5)',
       })
       .afterClearStyles(['opacity'])
       .keyframes([
         { offset: 0, transform: 'scale(1)' },
         { offset: 0.5, transform: 'scale(1.5)' },
-        { offset: 1, transform: 'scale(1)' }
-      ])
+        { offset: 1, transform: 'scale(1)' },
+      ]);
 
-    this.animation = this.animationCtrl
-      .create()
-      .duration(2000)
-      .addAnimation([card]);
+    this.animation = this.animationCtrl.create().duration(2000).addAnimation([card]);
   }
 
   play() {

--- a/static/usage/v7/animations/before-and-after-hooks/angular/example_component_ts.md
+++ b/static/usage/v7/animations/before-and-after-hooks/angular/example_component_ts.md
@@ -1,0 +1,55 @@
+```ts
+import { Component, ElementRef, ViewChildren } from '@angular/core';
+import type { QueryList } from '@angular/core';
+import type { Animation } from '@ionic/angular';
+import { AnimationController, IonCard } from '@ionic/angular';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+})
+export class ExampleComponent {
+  @ViewChildren(IonCard, { read: ElementRef }) cardElements: QueryList<ElementRef<HTMLIonCardElement>>;
+
+  private animation: Animation;
+
+  constructor(private animationCtrl: AnimationController) {}
+
+  ngAfterViewInit() {
+    const card = this.animationCtrl
+      .create()
+      .addElement(this.cardElements.get(0).nativeElement)
+      .duration(2000)
+      .beforeStyles({
+        opacity: 0.2
+      })
+      .beforeClearStyles(['background'])
+      .afterStyles({
+        background: 'rgba(0, 255, 0, 0.5)'
+      })
+      .afterClearStyles(['opacity'])
+      .keyframes([
+        { offset: 0, transform: 'scale(1)' },
+        { offset: 0.5, transform: 'scale(1.5)' },
+        { offset: 1, transform: 'scale(1)' }
+      ])
+
+    this.animation = this.animationCtrl
+      .create()
+      .duration(2000)
+      .addAnimation([card]);
+  }
+
+  play() {
+    this.animation.play();
+  }
+
+  pause() {
+    this.animation.pause();
+  }
+
+  stop() {
+    this.animation.stop();
+  }
+}
+```

--- a/static/usage/v7/animations/before-and-after-hooks/demo.html
+++ b/static/usage/v7/animations/before-and-after-hooks/demo.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animations</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <script type="module">
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/index.esm.js';
+      window.createAnimation = createAnimation;
+
+      const card = createAnimation()
+        .addElement(document.querySelector('#card'))
+        .duration(2000)
+        .beforeStyles({
+          opacity: 0.2
+        })
+        .beforeClearStyles(['background'])
+        .afterStyles({
+          background: 'rgba(0, 255, 0, 0.5)'
+        })
+        .afterClearStyles(['opacity'])
+        .keyframes([
+          { offset: 0, transform: 'scale(1)' },
+          { offset: 0.5, transform: 'scale(1.5)' },
+          { offset: 1, transform: 'scale(1)' }
+        ]);
+
+      document.querySelector('#play').addEventListener('click', async () => {
+        await card.play();
+      });
+
+      document.querySelector('#pause').addEventListener('click', async () => {
+        await card.pause();
+      });
+
+      document.querySelector('#stop').addEventListener('click', async () => {
+        await card.stop();
+      });
+    </script>
+
+    <style>
+      .container {
+        flex-direction: column;
+      }
+
+      ion-card {
+        width: 70%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-card id="card">
+            <ion-card-content>Card</ion-card-content>
+          </ion-card>
+
+          <div>
+            <ion-button id="play">Play</ion-button>
+            <ion-button id="pause">Pause</ion-button>
+            <ion-button id="stop">Stop</ion-button>
+          </div>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/animations/before-and-after-hooks/demo.html
+++ b/static/usage/v7/animations/before-and-after-hooks/demo.html
@@ -17,17 +17,17 @@
         .addElement(document.querySelector('#card'))
         .duration(2000)
         .beforeStyles({
-          opacity: 0.2
+          opacity: 0.2,
         })
         .beforeClearStyles(['background'])
         .afterStyles({
-          background: 'rgba(0, 255, 0, 0.5)'
+          background: 'rgba(0, 255, 0, 0.5)',
         })
         .afterClearStyles(['opacity'])
         .keyframes([
           { offset: 0, transform: 'scale(1)' },
           { offset: 0.5, transform: 'scale(1.5)' },
-          { offset: 1, transform: 'scale(1)' }
+          { offset: 1, transform: 'scale(1)' },
         ]);
 
       document.querySelector('#play').addEventListener('click', async () => {

--- a/static/usage/v7/animations/before-and-after-hooks/demo.html
+++ b/static/usage/v7/animations/before-and-after-hooks/demo.html
@@ -17,13 +17,13 @@
         .addElement(document.querySelector('#card'))
         .duration(2000)
         .beforeStyles({
-          opacity: 0.2,
+          filter: 'invert(75%)',
         })
-        .beforeClearStyles(['background'])
+        .beforeClearStyles(['box-shadow'])
         .afterStyles({
-          background: 'rgba(0, 255, 0, 0.5)',
+          'box-shadow': 'rgba(255, 0, 50, 0.4) 0px 4px 16px 6px',
         })
-        .afterClearStyles(['opacity'])
+        .afterClearStyles(['filter'])
         .keyframes([
           { offset: 0, transform: 'scale(1)' },
           { offset: 0.5, transform: 'scale(1.5)' },

--- a/static/usage/v7/animations/before-and-after-hooks/index.md
+++ b/static/usage/v7/animations/before-and-after-hooks/index.md
@@ -1,0 +1,25 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/animations/before-and-after-hooks/demo.html"
+  devicePreview={true}
+/>

--- a/static/usage/v7/animations/before-and-after-hooks/javascript.md
+++ b/static/usage/v7/animations/before-and-after-hooks/javascript.md
@@ -3,12 +3,12 @@
   <ion-card-content>Card</ion-card-content>
 </ion-card>
 
-<ion-button id="play">Play</ion-button>
-<ion-button id="pause">Pause</ion-button>
-<ion-button id="stop">Stop</ion-button>
+<ion-button onclick="animation.play()">Play</ion-button>
+<ion-button onclick="animation.pause()">Pause</ion-button>
+<ion-button onclick="animation.stop()">Stop</ion-button>
 
 <script>
-  const card = createAnimation()
+  var animation = createAnimation()
     .addElement(document.querySelector('#card'))
     .duration(2000)
     .beforeStyles({
@@ -24,17 +24,5 @@
       { offset: 0.5, transform: 'scale(1.5)' },
       { offset: 1, transform: 'scale(1)' },
     ]);
-
-  document.querySelector('#play').addEventListener('click', async () => {
-    await card.play();
-  });
-
-  document.querySelector('#pause').addEventListener('click', async () => {
-    await card.pause();
-  });
-
-  document.querySelector('#stop').addEventListener('click', async () => {
-    await card.stop();
-  });
 </script>
 ```

--- a/static/usage/v7/animations/before-and-after-hooks/javascript.md
+++ b/static/usage/v7/animations/before-and-after-hooks/javascript.md
@@ -1,0 +1,40 @@
+```html
+<ion-card id="card">
+  <ion-card-content>Card</ion-card-content>
+</ion-card>
+
+<ion-button id="play">Play</ion-button>
+<ion-button id="pause">Pause</ion-button>
+<ion-button id="stop">Stop</ion-button>
+
+<script>
+  const card = createAnimation()
+    .addElement(document.querySelector('#card'))
+    .duration(2000)
+    .beforeStyles({
+      opacity: 0.2
+    })
+    .beforeClearStyles(['background'])
+    .afterStyles({
+      background: 'rgba(0, 255, 0, 0.5)'
+    })
+    .afterClearStyles(['opacity'])
+    .keyframes([
+      { offset: 0, transform: 'scale(1)' },
+      { offset: 0.5, transform: 'scale(1.5)' },
+      { offset: 1, transform: 'scale(1)' }
+    ]);
+
+  document.querySelector('#play').addEventListener('click', async () => {
+    await card.play();
+  });
+
+  document.querySelector('#pause').addEventListener('click', async () => {
+    await card.pause();
+  });
+
+  document.querySelector('#stop').addEventListener('click', async () => {
+    await card.stop();
+  });
+</script>
+```

--- a/static/usage/v7/animations/before-and-after-hooks/javascript.md
+++ b/static/usage/v7/animations/before-and-after-hooks/javascript.md
@@ -12,17 +12,17 @@
     .addElement(document.querySelector('#card'))
     .duration(2000)
     .beforeStyles({
-      opacity: 0.2
+      opacity: 0.2,
     })
     .beforeClearStyles(['background'])
     .afterStyles({
-      background: 'rgba(0, 255, 0, 0.5)'
+      background: 'rgba(0, 255, 0, 0.5)',
     })
     .afterClearStyles(['opacity'])
     .keyframes([
       { offset: 0, transform: 'scale(1)' },
       { offset: 0.5, transform: 'scale(1.5)' },
-      { offset: 1, transform: 'scale(1)' }
+      { offset: 1, transform: 'scale(1)' },
     ]);
 
   document.querySelector('#play').addEventListener('click', async () => {

--- a/static/usage/v7/animations/before-and-after-hooks/javascript.md
+++ b/static/usage/v7/animations/before-and-after-hooks/javascript.md
@@ -12,13 +12,13 @@
     .addElement(document.querySelector('#card'))
     .duration(2000)
     .beforeStyles({
-      opacity: 0.2,
+      filter: 'invert(75%)',
     })
-    .beforeClearStyles(['background'])
+    .beforeClearStyles(['box-shadow'])
     .afterStyles({
-      background: 'rgba(0, 255, 0, 0.5)',
+      'box-shadow': 'rgba(255, 0, 50, 0.4) 0px 4px 16px 6px',
     })
-    .afterClearStyles(['opacity'])
+    .afterClearStyles(['filter'])
     .keyframes([
       { offset: 0, transform: 'scale(1)' },
       { offset: 0.5, transform: 'scale(1.5)' },

--- a/static/usage/v7/animations/before-and-after-hooks/react.md
+++ b/static/usage/v7/animations/before-and-after-hooks/react.md
@@ -14,13 +14,13 @@ function Example() {
         .addElement(cardEl.current!)
         .duration(2000)
         .beforeStyles({
-          opacity: 0.2,
+          filter: 'invert(75%)',
         })
-        .beforeClearStyles(['background'])
+        .beforeClearStyles(['box-shadow'])
         .afterStyles({
-          background: 'rgba(0, 255, 0, 0.5)',
+          'box-shadow': 'rgba(255, 0, 50, 0.4) 0px 4px 16px 6px',
         })
-        .afterClearStyles(['opacity'])
+        .afterClearStyles(['filter'])
         .keyframes([
           { offset: 0, transform: 'scale(1)' },
           { offset: 0.5, transform: 'scale(1.5)' },

--- a/static/usage/v7/animations/before-and-after-hooks/react.md
+++ b/static/usage/v7/animations/before-and-after-hooks/react.md
@@ -1,0 +1,61 @@
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { IonButton, IonCard, IonCardContent, createAnimation } from '@ionic/react';
+import type { Animation } from '@ionic/react';
+
+function Example() {
+  const cardEl = useRef<HTMLIonCardElement | null>(null);
+
+  const card = useRef<Animation>();
+
+  useEffect(() => {
+    if (!card.current) {
+      card.current = createAnimation()
+        .addElement(cardEl.current!)
+        .duration(2000)
+        .beforeStyles({
+          opacity: 0.2
+        })
+        .beforeClearStyles(['background'])
+        .afterStyles({
+          background: 'rgba(0, 255, 0, 0.5)'
+        })
+        .afterClearStyles(['opacity'])
+        .keyframes([
+          { offset: 0, transform: 'scale(1)' },
+          { offset: 0.5, transform: 'scale(1.5)' },
+          { offset: 1, transform: 'scale(1)' }
+        ]);
+    }
+  }, [cardEl]);
+
+  const play = async () => {
+    await card.current?.play();
+  };
+  const pause = () => {
+    card.current?.pause();
+  };
+  const stop = () => {
+    card.current?.stop();
+  };
+
+  return (
+    <>
+      <IonCard ref={cardEl}>
+        <IonCardContent>Card</IonCardContent>
+      </IonCard>
+
+      <IonButton id="play" onClick={play}>
+        Play
+      </IonButton>
+      <IonButton id="pause" onClick={pause}>
+        Pause
+      </IonButton>
+      <IonButton id="stop" onClick={stop}>
+        Stop
+      </IonButton>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/animations/before-and-after-hooks/react.md
+++ b/static/usage/v7/animations/before-and-after-hooks/react.md
@@ -14,17 +14,17 @@ function Example() {
         .addElement(cardEl.current!)
         .duration(2000)
         .beforeStyles({
-          opacity: 0.2
+          opacity: 0.2,
         })
         .beforeClearStyles(['background'])
         .afterStyles({
-          background: 'rgba(0, 255, 0, 0.5)'
+          background: 'rgba(0, 255, 0, 0.5)',
         })
         .afterClearStyles(['opacity'])
         .keyframes([
           { offset: 0, transform: 'scale(1)' },
           { offset: 0.5, transform: 'scale(1.5)' },
-          { offset: 1, transform: 'scale(1)' }
+          { offset: 1, transform: 'scale(1)' },
         ]);
     }
   }, [cardEl]);

--- a/static/usage/v7/animations/before-and-after-hooks/vue.md
+++ b/static/usage/v7/animations/before-and-after-hooks/vue.md
@@ -31,17 +31,17 @@
           .addElement(cardEl.value.$el)
           .duration(2000)
           .beforeStyles({
-            opacity: 0.2
+            opacity: 0.2,
           })
           .beforeClearStyles(['background'])
           .afterStyles({
-            background: 'rgba(0, 255, 0, 0.5)'
+            background: 'rgba(0, 255, 0, 0.5)',
           })
           .afterClearStyles(['opacity'])
           .keyframes([
             { offset: 0, transform: 'scale(1)' },
             { offset: 0.5, transform: 'scale(1.5)' },
-            { offset: 1, transform: 'scale(1)' }
+            { offset: 1, transform: 'scale(1)' },
           ]);
       });
 

--- a/static/usage/v7/animations/before-and-after-hooks/vue.md
+++ b/static/usage/v7/animations/before-and-after-hooks/vue.md
@@ -1,0 +1,67 @@
+```html
+<template>
+  <ion-card ref="cardEl">
+    <ion-card-content>Card</ion-card-content>
+  </ion-card>
+
+  <ion-button @click="play()">Play</ion-button>
+  <ion-button @click="pause()">Pause</ion-button>
+  <ion-button @click="stop()">Stop</ion-button>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonCard, IonCardContent, createAnimation } from '@ionic/vue';
+  import type { Animation } from '@ionic/vue';
+
+  import { defineComponent, ref, onMounted } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton,
+      IonCard,
+      IonCardContent,
+    },
+    setup() {
+      const cardEl = ref(null);
+
+      let card: Animation | undefined;
+
+      onMounted(() => {
+        card = createAnimation()
+          .addElement(cardEl.value.$el)
+          .duration(2000)
+          .beforeStyles({
+            opacity: 0.2
+          })
+          .beforeClearStyles(['background'])
+          .afterStyles({
+            background: 'rgba(0, 255, 0, 0.5)'
+          })
+          .afterClearStyles(['opacity'])
+          .keyframes([
+            { offset: 0, transform: 'scale(1)' },
+            { offset: 0.5, transform: 'scale(1.5)' },
+            { offset: 1, transform: 'scale(1)' }
+          ]);
+      });
+
+      const play = async () => {
+        await card.play();
+      };
+      const pause = () => {
+        card?.pause();
+      };
+      const stop = () => {
+        card?.stop();
+      };
+
+      return {
+        play,
+        pause,
+        stop,
+        cardEl,
+      };
+    },
+  });
+</script>
+```

--- a/static/usage/v7/animations/before-and-after-hooks/vue.md
+++ b/static/usage/v7/animations/before-and-after-hooks/vue.md
@@ -31,13 +31,13 @@
           .addElement(cardEl.value.$el)
           .duration(2000)
           .beforeStyles({
-            opacity: 0.2,
+            filter: 'invert(75%)',
           })
-          .beforeClearStyles(['background'])
+          .beforeClearStyles(['box-shadow'])
           .afterStyles({
-            background: 'rgba(0, 255, 0, 0.5)',
+            'box-shadow': 'rgba(255, 0, 50, 0.4) 0px 4px 16px 6px',
           })
-          .afterClearStyles(['opacity'])
+          .afterClearStyles(['filter'])
           .keyframes([
             { offset: 0, transform: 'scale(1)' },
             { offset: 0.5, transform: 'scale(1.5)' },


### PR DESCRIPTION
This is an alternative implementation of https://github.com/ionic-team/ionic-docs/pull/1702. It replaces the "Before and After Hooks" samples with a playground. 

I copied the existing animation playgrounds including the "play", "pause" and "stop" button (see https://github.com/ionic-team/ionic-docs/pull/3026). I changed the styles from the existing docs to use a `filter` and `box-shadow` instead of opacity, making it easier to see the styles on dark mode. 

:warning: Give co-author credit to [dillionmegida](https://github.com/dillionmegida) :warning:

Preview: https://ionic-docs-git-fw-3378-ionic1.vercel.app/docs/utilities/animations#before-and-after-hooks
