### PR TITLE
docs(animations): add playground for preference based

### DIFF
--- a/docs/utilities/animations.md
+++ b/docs/utilities/animations.md
@@ -773,104 +773,13 @@ In this example we are creating a track along which we can drag the `.square` el
 
 Developers can also tailor their animations to user preferences such as `prefers-reduced-motion` and `prefers-color-scheme` using CSS Variables.
 
-### Usage
-
-```css
-.square {
-  width: 100px;
-  height: 100px;
-  opacity: 0.5;
-  background: blue;
-  margin: 10px;
-
-  --background: red;
-}
-
-@media (prefers-color-scheme: dark) {
-  .square {
-    --background: green;
-  }
-}
-```
-
-````mdx-code-block
-<Tabs
-  groupId="framework"
-  defaultValue="javascript"
-  values={[
-    { value: 'javascript', label: 'JavaScript' },
-    { value: 'angular', label: 'Angular' },
-    { value: 'react', label: 'React' },
-    { value: 'vue', label: 'Vue' },
-  ]
-}>
-<TabItem value="javascript">
-
-```javascript
-createAnimation()
-   .addElement(document.querySelector('.square'))
-   .duration(1500)
-   .iterations(Infinity)
-   .direction('alternate')
-   .fromTo('background', 'blue', 'var(--background)');
-```
-</TabItem>
-<TabItem value="angular">
-
-```javascript
-this.animationCtrl.create()
-   .addElement(this.square.nativeElement)
-   .duration(1500)
-   .iterations(Infinity)
-   .direction('alternate')
-   .fromTo('background', 'blue', 'var(--background)');
-```
-</TabItem>
-<TabItem value="react">
-
-```tsx
-<CreateAnimation
-  duration={1500}
-  iterations={Infinity}
-  direction='alternate'
-  fromTo={{
-    property: 'background',
-    fromValue: 'blue',
-    toValue: 'var(--background)'
-  }}
->
-  <div className="square"></div>
-</CreateAnimation>
-```
-</TabItem>
-<TabItem value="vue">
-
-```javascript
-import { createAnimation } from '@ionic/vue';
-import { ref } from 'vue';
-
-...
-
-const squareRef = ref();
-
-...
-
-createAnimation()
-   .addElement(squareRef.value)
-   .duration(1500)
-   .iterations(Infinity)
-   .direction('alternate')
-   .fromTo('background', 'blue', 'var(--background)');
-```
-</TabItem>
-</Tabs>
-````
-
 This method works in all supported browsers when creating animations for the first time. Most browsers are also capable of dynamically updating keyframe animations as the CSS Variables change.
 
 Safari does not currently support dynamically updating keyframe animations. For developers who need this kind of support in Safari, they can use [MediaQueryList.addListener()](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener).
 
-<Codepen user="ionic" slug="JjjYVKj" />
+import PreferenceBased from '@site/static/usage/v7/animations/preference-based/index.md';
+
+<PreferenceBased />
 
 ## Overriding Ionic Component Animations
 

--- a/static/usage/v7/animations/preference-based/angular/example_component_css.md
+++ b/static/usage/v7/animations/preference-based/angular/example_component_css.md
@@ -1,0 +1,16 @@
+```css
+ion-card {
+  color: white;
+  opacity: 0.5;
+  background: blue;
+  margin: 10px;
+
+  --background: red;
+}
+
+@media (prefers-color-scheme: dark) {
+  ion-card {
+    --background: green;
+  }
+}
+```

--- a/static/usage/v7/animations/preference-based/angular/example_component_html.md
+++ b/static/usage/v7/animations/preference-based/angular/example_component_html.md
@@ -3,7 +3,7 @@
   <ion-card-content>Card</ion-card-content>
 </ion-card>
 
-<ion-button id="play" (click)="play()">Play</ion-button>
-<ion-button id="pause" (click)="pause()">Pause</ion-button>
-<ion-button id="stop" (click)="stop()">Stop</ion-button>
+<ion-button (click)="play()">Play</ion-button>
+<ion-button (click)="pause()">Pause</ion-button>
+<ion-button (click)="stop()">Stop</ion-button>
 ```

--- a/static/usage/v7/animations/preference-based/angular/example_component_html.md
+++ b/static/usage/v7/animations/preference-based/angular/example_component_html.md
@@ -1,0 +1,9 @@
+```html
+<ion-card #card>
+  <ion-card-content>Card</ion-card-content>
+</ion-card>
+
+<ion-button id="play" (click)="play()">Play</ion-button>
+<ion-button id="pause" (click)="pause()">Pause</ion-button>
+<ion-button id="stop" (click)="stop()">Stop</ion-button>
+```

--- a/static/usage/v7/animations/preference-based/angular/example_component_ts.md
+++ b/static/usage/v7/animations/preference-based/angular/example_component_ts.md
@@ -1,0 +1,41 @@
+```ts
+import { Component, ElementRef, ViewChildren, ViewChild } from '@angular/core';
+import type { QueryList } from '@angular/core';
+import type { Animation } from '@ionic/angular';
+import { AnimationController, IonCard } from '@ionic/angular';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['./example.component.css'],
+})
+export class ExampleComponent {
+  @ViewChild(IonCard, { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;
+
+  private animation: Animation;
+
+  constructor(private animationCtrl: AnimationController) {}
+
+  ngAfterViewInit() {
+    this.animation = this.animationCtrl
+      .create()
+      .addElement(this.card.nativeElement)
+      .duration(1500)
+      .iterations(Infinity)
+      .direction('alternate')
+      .fromTo('background', 'blue', 'var(--background)');
+  }
+
+  play() {
+    this.animation.play();
+  }
+
+  pause() {
+    this.animation.pause();
+  }
+
+  stop() {
+    this.animation.stop();
+  }
+}
+```

--- a/static/usage/v7/animations/preference-based/demo.html
+++ b/static/usage/v7/animations/preference-based/demo.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Animation</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+    <script type="module">
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/index.esm.js';
+      window.createAnimation = createAnimation;
+
+      const animation = createAnimation()
+        .addElement(document.querySelector('#card'))
+        .duration(1500)
+        .iterations(Infinity)
+        .direction('alternate')
+        .fromTo('background', 'blue', 'var(--background)');
+
+      document.querySelector('#play').addEventListener('click', () => {
+        animation.play();
+      });
+
+      document.querySelector('#pause').addEventListener('click', () => {
+        animation.pause();
+      });
+
+      document.querySelector('#stop').addEventListener('click', () => {
+        animation.stop();
+      });
+    </script>
+
+    <style>
+      .container {
+        flex-direction: column;
+      }
+
+      ion-card {
+        width: 70%;
+
+        color: white;
+        opacity: 0.5;
+        background: blue;
+        margin: 10px;
+
+        --background: red;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        ion-card {
+          --background: green;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="container">
+      <ion-card id="card">
+        <ion-card-content>Card</ion-card-content>
+      </ion-card>
+
+      <div>
+        <ion-button id="play">Play</ion-button>
+        <ion-button id="pause">Pause</ion-button>
+        <ion-button id="stop">Stop</ion-button>
+      </div>
+    </div>
+  </body>
+</html>

--- a/static/usage/v7/animations/preference-based/demo.html
+++ b/static/usage/v7/animations/preference-based/demo.html
@@ -49,9 +49,14 @@
       }
 
       @media (prefers-color-scheme: dark) {
-        ion-card {
+        body ion-card {
           --background: green;
         }
+      }
+
+      /* Fallback for when the theme is changed through Docusaurus */
+      body.dark ion-card {
+        --background: green;
       }
     </style>
   </head>

--- a/static/usage/v7/animations/preference-based/demo.html
+++ b/static/usage/v7/animations/preference-based/demo.html
@@ -45,7 +45,7 @@
         background: blue;
         margin: 10px;
 
-        --background: red
+        --background: red;
       }
 
       /* Demo does not use `prefers-color-scheme` media query because Docusaurus already checks for it. Otherwise, the demo might have the wrong background on certain edge cases. */

--- a/static/usage/v7/animations/preference-based/demo.html
+++ b/static/usage/v7/animations/preference-based/demo.html
@@ -45,16 +45,10 @@
         background: blue;
         margin: 10px;
 
-        --background: red;
+        --background: red
       }
 
-      @media (prefers-color-scheme: dark) {
-        body ion-card {
-          --background: green;
-        }
-      }
-
-      /* Fallback for when the theme is changed through Docusaurus */
+      /* Demo does not use `prefers-color-scheme` media query because Docusaurus already checks for it. Otherwise, the demo might have the wrong background on certain edge cases. */
       body.dark ion-card {
         --background: green;
       }

--- a/static/usage/v7/animations/preference-based/index.md
+++ b/static/usage/v7/animations/preference-based/index.md
@@ -1,0 +1,35 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+
+import react_main_tsx from './react/main_tsx.md';
+import react_main_css from './react/main_css.md';
+
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+import angular_example_component_css from './angular/example_component_css.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react: {
+      files: {
+        'src/main.tsx': react_main_tsx,
+        'src/main.css': react_main_css,
+      },
+    },
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+        'src/app/example.component.css': angular_example_component_css,
+      },
+    },
+  }}
+  src="usage/v7/animations/preference-based/demo.html"
+  devicePreview={true}
+/>

--- a/static/usage/v7/animations/preference-based/javascript.md
+++ b/static/usage/v7/animations/preference-based/javascript.md
@@ -1,0 +1,35 @@
+```html
+<ion-card id="card">
+  <ion-card-content>Card</ion-card-content>
+</ion-card>
+
+<ion-button id="play" onclick="animation.play()">Play</ion-button>
+<ion-button id="pause" onclick="animation.pause()">Pause</ion-button>
+<ion-button id="stop" onclick="animation.stop()">Stop</ion-button>
+
+<script>
+  var animation = createAnimation()
+    .addElement(document.querySelector('#card'))
+    .duration(1500)
+    .iterations(Infinity)
+    .direction('alternate')
+    .fromTo('background', 'blue', 'var(--background)');
+</script>
+
+<style>
+  ion-card {
+    color: white;
+    opacity: 0.5;
+    background: blue;
+    margin: 10px;
+
+    --background: red;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    ion-card {
+      --background: green;
+    }
+  }
+</style>
+```

--- a/static/usage/v7/animations/preference-based/javascript.md
+++ b/static/usage/v7/animations/preference-based/javascript.md
@@ -3,9 +3,9 @@
   <ion-card-content>Card</ion-card-content>
 </ion-card>
 
-<ion-button id="play" onclick="animation.play()">Play</ion-button>
-<ion-button id="pause" onclick="animation.pause()">Pause</ion-button>
-<ion-button id="stop" onclick="animation.stop()">Stop</ion-button>
+<ion-button onclick="animation.play()">Play</ion-button>
+<ion-button onclick="animation.pause()">Pause</ion-button>
+<ion-button onclick="animation.stop()">Stop</ion-button>
 
 <script>
   var animation = createAnimation()

--- a/static/usage/v7/animations/preference-based/react/main_css.md
+++ b/static/usage/v7/animations/preference-based/react/main_css.md
@@ -1,0 +1,16 @@
+```css
+ion-card {
+  color: white;
+  opacity: 0.5;
+  background: blue;
+  margin: 10px;
+
+  --background: red;
+}
+
+@media (prefers-color-scheme: dark) {
+  ion-card {
+    --background: green;
+  }
+}
+```

--- a/static/usage/v7/animations/preference-based/react/main_tsx.md
+++ b/static/usage/v7/animations/preference-based/react/main_tsx.md
@@ -1,0 +1,53 @@
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { IonButton, IonCard, IonCardContent, createAnimation } from '@ionic/react';
+import type { Animation } from '@ionic/react';
+
+import './main.css';
+
+function Example() {
+  const cardEl = useRef<HTMLIonCardElement | null>(null);
+
+  const animation = useRef<Animation | null>(null);
+
+  useEffect(() => {
+    if (animation.current === null) {
+      animation.current = createAnimation()
+        .addElement(cardEl.current!)
+        .duration(1500)
+        .iterations(Infinity)
+        .direction('alternate')
+        .fromTo('background', 'blue', 'var(--background)');
+    }
+  }, [cardEl]);
+
+  const play = () => {
+    animation.current?.play();
+  };
+  const pause = () => {
+    animation.current?.pause();
+  };
+  const stop = () => {
+    animation.current?.stop();
+  };
+
+  return (
+    <>
+      <IonCard ref={cardEl}>
+        <IonCardContent>Card</IonCardContent>
+      </IonCard>
+
+      <IonButton id="play" onClick={play}>
+        Play
+      </IonButton>
+      <IonButton id="pause" onClick={pause}>
+        Pause
+      </IonButton>
+      <IonButton id="stop" onClick={stop}>
+        Stop
+      </IonButton>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/animations/preference-based/react/main_tsx.md
+++ b/static/usage/v7/animations/preference-based/react/main_tsx.md
@@ -37,13 +37,13 @@ function Example() {
         <IonCardContent>Card</IonCardContent>
       </IonCard>
 
-      <IonButton id="play" onClick={play}>
+      <IonButton onClick={play}>
         Play
       </IonButton>
-      <IonButton id="pause" onClick={pause}>
+      <IonButton onClick={pause}>
         Pause
       </IonButton>
-      <IonButton id="stop" onClick={stop}>
+      <IonButton onClick={stop}>
         Stop
       </IonButton>
     </>

--- a/static/usage/v7/animations/preference-based/react/main_tsx.md
+++ b/static/usage/v7/animations/preference-based/react/main_tsx.md
@@ -37,15 +37,9 @@ function Example() {
         <IonCardContent>Card</IonCardContent>
       </IonCard>
 
-      <IonButton onClick={play}>
-        Play
-      </IonButton>
-      <IonButton onClick={pause}>
-        Pause
-      </IonButton>
-      <IonButton onClick={stop}>
-        Stop
-      </IonButton>
+      <IonButton onClick={play}>Play</IonButton>
+      <IonButton onClick={pause}>Pause</IonButton>
+      <IonButton onClick={stop}>Stop</IonButton>
     </>
   );
 }

--- a/static/usage/v7/animations/preference-based/vue.md
+++ b/static/usage/v7/animations/preference-based/vue.md
@@ -4,9 +4,9 @@
     <ion-card-content>Card</ion-card-content>
   </ion-card>
 
-  <ion-button id="play" @click="play()">Play</ion-button>
-  <ion-button id="pause" @click="pause()">Pause</ion-button>
-  <ion-button id="stop" @click="stop()">Stop</ion-button>
+  <ion-button @click="play()">Play</ion-button>
+  <ion-button @click="pause()">Pause</ion-button>
+  <ion-button @click="stop()">Stop</ion-button>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/animations/preference-based/vue.md
+++ b/static/usage/v7/animations/preference-based/vue.md
@@ -1,0 +1,68 @@
+```html
+<template>
+  <ion-card ref="cardEl">
+    <ion-card-content>Card</ion-card-content>
+  </ion-card>
+
+  <ion-button id="play" @click="play()">Play</ion-button>
+  <ion-button id="pause" @click="pause()">Pause</ion-button>
+  <ion-button id="stop" @click="stop()">Stop</ion-button>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonCard, IonCardContent, createAnimation } from '@ionic/vue';
+  import type { Animation } from '@ionic/vue';
+
+  import { defineComponent, ref, onMounted } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton,
+      IonCard,
+      IonCardContent,
+    },
+    setup() {
+      const cardEl = ref(null);
+
+      let animation: Animation;
+
+      onMounted(() => {
+        animation = createAnimation()
+          .addElement(cardEl.value.$el)
+          .duration(1500)
+          .iterations(Infinity)
+          .direction('alternate')
+          .fromTo('background', 'blue', 'var(--background)');
+      });
+
+      const play = () => animation.play();
+      const pause = () => animation.pause();
+      const stop = () => animation.stop();
+
+      return {
+        play,
+        pause,
+        stop,
+        cardEl,
+      };
+    },
+  });
+</script>
+
+<style scoped>
+  ion-card {
+    color: white;
+    opacity: 0.5;
+    background: blue;
+    margin: 10px;
+
+    --background: red;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    ion-card {
+      --background: green;
+    }
+  }
+</style>
+```


### PR DESCRIPTION
This is an alternative implementation of https://github.com/ionic-team/ionic-docs/pull/1712 which replaces the "Preference-Based Animations" samples with a playground. The playground contains Vanilla JS, Angular, React, and Vue code samples, and it also links out to StackBlitz.

[Demo URL](https://ionic-docs-git-fw-3376-ionic1.vercel.app/docs/utilities/animations#preference-based-animations)

---
Change the theme through your OS's system settings to view the differences or change the theme via the site.