### PR TITLE
style(animations): buttons in StackBlitz demos do not need id

### DIFF
--- a/static/usage/v7/animations/basic/angular/example_component_html.md
+++ b/static/usage/v7/animations/basic/angular/example_component_html.md
@@ -3,7 +3,7 @@
   <ion-card-content>Card</ion-card-content>
 </ion-card>
 
-<ion-button id="play" (click)="play()">Play</ion-button>
-<ion-button id="pause" (click)="pause()">Pause</ion-button>
-<ion-button id="stop" (click)="stop()">Stop</ion-button>
+<ion-button (click)="play()">Play</ion-button>
+<ion-button (click)="pause()">Pause</ion-button>
+<ion-button (click)="stop()">Stop</ion-button>
 ```

--- a/static/usage/v7/animations/basic/javascript.md
+++ b/static/usage/v7/animations/basic/javascript.md
@@ -3,9 +3,9 @@
   <ion-card-content>Card</ion-card-content>
 </ion-card>
 
-<ion-button id="play" onclick="animation.play()">Play</ion-button>
-<ion-button id="pause" onclick="animation.pause()">Pause</ion-button>
-<ion-button id="stop" onclick="animation.stop()">Stop</ion-button>
+<ion-button onclick="animation.play()">Play</ion-button>
+<ion-button onclick="animation.pause()">Pause</ion-button>
+<ion-button onclick="animation.stop()">Stop</ion-button>
 
 <script>
   var animation = createAnimation()

--- a/static/usage/v7/animations/basic/react.md
+++ b/static/usage/v7/animations/basic/react.md
@@ -35,13 +35,13 @@ function Example() {
         <IonCardContent>Card</IonCardContent>
       </IonCard>
 
-      <IonButton id="play" onClick={play}>
+      <IonButton onClick={play}>
         Play
       </IonButton>
-      <IonButton id="pause" onClick={pause}>
+      <IonButton onClick={pause}>
         Pause
       </IonButton>
-      <IonButton id="stop" onClick={stop}>
+      <IonButton onClick={stop}>
         Stop
       </IonButton>
     </>

--- a/static/usage/v7/animations/basic/react.md
+++ b/static/usage/v7/animations/basic/react.md
@@ -35,15 +35,9 @@ function Example() {
         <IonCardContent>Card</IonCardContent>
       </IonCard>
 
-      <IonButton onClick={play}>
-        Play
-      </IonButton>
-      <IonButton onClick={pause}>
-        Pause
-      </IonButton>
-      <IonButton onClick={stop}>
-        Stop
-      </IonButton>
+      <IonButton onClick={play}>Play</IonButton>
+      <IonButton onClick={pause}>Pause</IonButton>
+      <IonButton onClick={stop}>Stop</IonButton>
     </>
   );
 }

--- a/static/usage/v7/animations/basic/vue.md
+++ b/static/usage/v7/animations/basic/vue.md
@@ -4,9 +4,9 @@
     <ion-card-content>Card</ion-card-content>
   </ion-card>
 
-  <ion-button id="play" @click="play()">Play</ion-button>
-  <ion-button id="pause" @click="pause()">Pause</ion-button>
-  <ion-button id="stop" @click="stop()">Stop</ion-button>
+  <ion-button @click="play()">Play</ion-button>
+  <ion-button @click="pause()">Pause</ion-button>
+  <ion-button @click="stop()">Stop</ion-button>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/animations/chain/angular/example_component_html.md
+++ b/static/usage/v7/animations/chain/angular/example_component_html.md
@@ -11,7 +11,7 @@
   <ion-card-content>Card 3</ion-card-content>
 </ion-card>
 
-<ion-button id="play" (click)="play()">Play</ion-button>
-<ion-button id="pause" (click)="pause()">Pause</ion-button>
-<ion-button id="stop" (click)="stop()">Stop</ion-button>
+<ion-button (click)="play()">Play</ion-button>
+<ion-button (click)="pause()">Pause</ion-button>
+<ion-button (click)="stop()">Stop</ion-button>
 ```

--- a/static/usage/v7/animations/chain/javascript.md
+++ b/static/usage/v7/animations/chain/javascript.md
@@ -11,9 +11,9 @@
   <ion-card-content>Card 3</ion-card-content>
 </ion-card>
 
-<ion-button id="play" onclick="play()">Play</ion-button>
-<ion-button id="pause" onclick="pause()">Pause</ion-button>
-<ion-button id="stop" onclick="stop()">Stop</ion-button>
+<ion-button onclick="play()">Play</ion-button>
+<ion-button onclick="pause()">Pause</ion-button>
+<ion-button onclick="stop()">Stop</ion-button>
 
 <script>
   const cardA = createAnimation()

--- a/static/usage/v7/animations/chain/react.md
+++ b/static/usage/v7/animations/chain/react.md
@@ -79,15 +79,9 @@ function Example() {
         <IonCardContent>Card 3</IonCardContent>
       </IonCard>
 
-      <IonButton onClick={play}>
-        Play
-      </IonButton>
-      <IonButton  onClick={pause}>
-        Pause
-      </IonButton>
-      <IonButton onClick={stop}>
-        Stop
-      </IonButton>
+      <IonButton onClick={play}>Play</IonButton>
+      <IonButton onClick={pause}>Pause</IonButton>
+      <IonButton onClick={stop}>Stop</IonButton>
     </>
   );
 }

--- a/static/usage/v7/animations/chain/react.md
+++ b/static/usage/v7/animations/chain/react.md
@@ -79,13 +79,13 @@ function Example() {
         <IonCardContent>Card 3</IonCardContent>
       </IonCard>
 
-      <IonButton id="play" onClick={play}>
+      <IonButton onClick={play}>
         Play
       </IonButton>
-      <IonButton id="pause" onClick={pause}>
+      <IonButton  onClick={pause}>
         Pause
       </IonButton>
-      <IonButton id="stop" onClick={stop}>
+      <IonButton onClick={stop}>
         Stop
       </IonButton>
     </>

--- a/static/usage/v7/animations/chain/vue.md
+++ b/static/usage/v7/animations/chain/vue.md
@@ -12,9 +12,9 @@
     <ion-card-content>Card 3</ion-card-content>
   </ion-card>
 
-  <ion-button id="play" @click="play()">Play</ion-button>
-  <ion-button id="pause" @click="pause()">Pause</ion-button>
-  <ion-button id="stop" @click="stop()">Stop</ion-button>
+  <ion-button @click="play()">Play</ion-button>
+  <ion-button @click="pause()">Pause</ion-button>
+  <ion-button @click="stop()">Stop</ion-button>
 </template>
 
 <script lang="ts">

--- a/static/usage/v7/animations/group/angular/example_component_html.md
+++ b/static/usage/v7/animations/group/angular/example_component_html.md
@@ -11,7 +11,7 @@
   <ion-card-content>Card 3</ion-card-content>
 </ion-card>
 
-<ion-button id="play" (click)="play()">Play</ion-button>
-<ion-button id="pause" (click)="pause()">Pause</ion-button>
-<ion-button id="stop" (click)="stop()">Stop</ion-button>
+<ion-button (click)="play()">Play</ion-button>
+<ion-button (click)="pause()">Pause</ion-button>
+<ion-button (click)="stop()">Stop</ion-button>
 ```

--- a/static/usage/v7/animations/group/javascript.md
+++ b/static/usage/v7/animations/group/javascript.md
@@ -11,9 +11,9 @@
   <ion-card-content>Card 3</ion-card-content>
 </ion-card>
 
-<ion-button id="play" onclick="animation.play()">Play</ion-button>
-<ion-button id="pause" onclick="animation.pause()">Pause</ion-button>
-<ion-button id="stop" onclick="animation.stop()">Stop</ion-button>
+<ion-button onclick="animation.play()">Play</ion-button>
+<ion-button onclick="animation.pause()">Pause</ion-button>
+<ion-button onclick="animation.stop()">Stop</ion-button>
 
 <script>
   const cardA = createAnimation()

--- a/static/usage/v7/animations/group/react.md
+++ b/static/usage/v7/animations/group/react.md
@@ -65,15 +65,9 @@ function Example() {
         <IonCardContent>Card 3</IonCardContent>
       </IonCard>
 
-      <IonButton onClick={play}>
-        Play
-      </IonButton>
-      <IonButton onClick={pause}>
-        Pause
-      </IonButton>
-      <IonButton onClick={stop}>
-        Stop
-      </IonButton>
+      <IonButton onClick={play}>Play</IonButton>
+      <IonButton onClick={pause}>Pause</IonButton>
+      <IonButton onClick={stop}>Stop</IonButton>
     </>
   );
 }

--- a/static/usage/v7/animations/group/react.md
+++ b/static/usage/v7/animations/group/react.md
@@ -65,13 +65,13 @@ function Example() {
         <IonCardContent>Card 3</IonCardContent>
       </IonCard>
 
-      <IonButton id="play" onClick={play}>
+      <IonButton onClick={play}>
         Play
       </IonButton>
-      <IonButton id="pause" onClick={pause}>
+      <IonButton onClick={pause}>
         Pause
       </IonButton>
-      <IonButton id="stop" onClick={stop}>
+      <IonButton onClick={stop}>
         Stop
       </IonButton>
     </>

--- a/static/usage/v7/animations/group/vue.md
+++ b/static/usage/v7/animations/group/vue.md
@@ -12,9 +12,9 @@
     <ion-card-content>Card 3</ion-card-content>
   </ion-card>
 
-  <ion-button id="play" @click="play()">Play</ion-button>
-  <ion-button id="pause" @click="pause()">Pause</ion-button>
-  <ion-button id="stop" @click="stop()">Stop</ion-button>
+  <ion-button @click="play()">Play</ion-button>
+  <ion-button @click="pause()">Pause</ion-button>
+  <ion-button @click="stop()">Stop</ion-button>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
While implementing https://github.com/ionic-team/ionic-docs/pull/3035 I noticed in the other examples the `id` was defined on the buttons for the Angular, Javascript, React, and Vue examples. These do not need an `id` since they call click events directly, unlike the demo file. 