### PR TITLE
docs(item-sliding): clarify expandable behavior

### DIFF
--- a/docs/api/item-sliding.md
+++ b/docs/api/item-sliding.md
@@ -39,7 +39,7 @@ import Icons from '@site/static/usage/v7/item-sliding/icons/index.md';
 
 ## Expandable Options
 
-Options can be expanded to take up the full width of the item if you swipe past a certain point. This can be combined with the `ionSwipe` event on the [item options](./item-options) to call a method when the item is fully swiped.
+Options can be expanded to take up the full width of the parent `ion-item` if you swipe past a certain point. This can be combined with the `ionSwipe` event on the [item options](./item-options) to call a method when the item is fully swiped.
 
 import Expandable from '@site/static/usage/v7/item-sliding/expandable/index.md';
 


### PR DESCRIPTION
There was confusion on https://github.com/ionic-team/ionic-framework/issues/27794 about which element is used as the reference for "full width". An expandable option will expand to cover the full width of the parent `ion-item` when swiped, so I made that clear in the docs.