### PR TITLE
chore: JP docs point to v7

### DIFF
--- a/scripts/i18n.sh
+++ b/scripts/i18n.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o nounset
 
-mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-v6/
+mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-v7/
 curl -fsSL https://github.com/ionic-team/ionic-docs/archive/refs/heads/translation/jp.tar.gz |
-  tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/version-v6/ --strip-components 2 ionic-docs-translation-jp/docs
+  tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/version-v7/ --strip-components 2 ionic-docs-translation-jp/docs
 node scripts/api-ja.js


### PR DESCRIPTION
The JP docs are currently on the v6 page, which is not the latest version. This PR updates our docs scripts to have the JP docs point to v7.

See: https://github.com/ionic-team/ionic-docs/issues/3050