### PR TITLE
chore: use correct name for JP docs

### DIFF
--- a/scripts/i18n.sh
+++ b/scripts/i18n.sh
@@ -2,7 +2,7 @@
 set -o errexit
 set -o nounset
 
-mkdir -p i18n/ja/docusaurus-plugin-content-docs/version-v6/
+mkdir -p i18n/ja/docusaurus-plugin-content-docs/current/
 curl -fsSL https://github.com/ionic-team/ionic-docs/archive/refs/heads/translation/jp.tar.gz |
-  tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/version-v6/ --strip-components 2 ionic-docs-translation-jp/docs
+  tar -zxf - -C i18n/ja/docusaurus-plugin-content-docs/current/ --strip-components 2 ionic-docs-translation-jp/docs
 node scripts/api-ja.js


### PR DESCRIPTION
The latest version keyword in docusaurus is "current" not "version-v7".

See https://github.com/ionic-team/ionic-docs/issues/3050