### PR TITLE
feat(playground): add prop to display console messages from demo

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -265,18 +265,20 @@ export default function Playground({
   }, [renderIframes]);
 
   useEffect(() => {
-    if (frameiOS.current) {
-      frameiOS.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
-        setiOSConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
-        consoleRef.current.scrollTo(0, consoleRef.current.scrollHeight);
-      });
-    }
+    if (showConsole) {
+      if (frameiOS.current) {
+        frameiOS.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
+          setiOSConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+          consoleRef.current.scrollTo(0, consoleRef.current.scrollHeight);
+        });
+      }
 
-    if (frameMD.current) {
-      frameMD.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
-        setMDConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
-        consoleRef.current.scrollTo(0, consoleRef.current.scrollHeight);
-      });
+      if (frameMD.current) {
+        frameMD.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
+          setMDConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+          consoleRef.current.scrollTo(0, consoleRef.current.scrollHeight);
+        });
+      }
     }
   }, [iframesLoaded]);
 

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -162,6 +162,7 @@ export default function Playground({
   const codeRef = useRef(null);
   const frameiOS = useRef<HTMLIFrameElement | null>(null);
   const frameMD = useRef<HTMLIFrameElement | null>(null);
+  const consoleRef = useRef<HTMLDivElement | null>(null);
 
   const defaultMode = typeof mode !== 'undefined' ? mode : Mode.iOS;
 
@@ -263,17 +264,18 @@ export default function Playground({
     setFramesLoaded();
   }, [renderIframes]);
 
-  // TODO: scroll to bottom of console
   useEffect(() => {
     if (frameiOS.current) {
       frameiOS.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
         setiOSConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+        consoleRef.current.scrollTo(0, consoleRef.current.scrollHeight);
       });
     }
 
     if (frameMD.current) {
       frameMD.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
         setMDConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+        consoleRef.current.scrollTo(0, consoleRef.current.scrollHeight);
       });
     }
   }, [iframesLoaded]);
@@ -466,7 +468,7 @@ export default function Playground({
 
   function renderConsole() {
     return (
-      <div className="playground__console">
+      <div className="playground__console" ref={consoleRef}>
         {(ionicMode === Mode.iOS ? iosConsoleItems : mdConsoleItems).map((consoleItem, i) => (
           <div key={i} className={`playground__console-item playground__console-item--${consoleItem.type}`}>
             {consoleItem.type !== 'log' && <div className="playground__console-icon">

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -185,36 +185,7 @@ export default function Playground({
   const [codeSnippets, setCodeSnippets] = useState({});
   const [renderIframes, setRenderIframes] = useState(false);
   const [iframesLoaded, setIframesLoaded] = useState(false);
-  const [consoleItems, setConsoleItems] = useState<ConsoleItem[]>([
-    {
-      type: 'log',
-      message: 'this is a log'
-    },
-    {
-      type: 'warning',
-      message: 'this is a warning'
-    },
-    {
-      type: 'error',
-      message: 'this is an error'
-    },
-    {
-      type: 'log',
-      message: 'log 1'
-    },
-    {
-      type: 'log',
-      message: 'log 2'
-    },
-    {
-      type: 'error',
-      message: 'error!'
-    },
-    {
-      type: 'log',
-      message: 'really long log really long log really long log really long log really long log really long log really long log'
-    }
-  ]);
+  const [consoleItems, setConsoleItems] = useState<ConsoleItem[]>([]);
 
   /**
    * Rather than encode isDarkTheme into the frame source
@@ -290,6 +261,20 @@ export default function Playground({
 
     setFramesLoaded();
   }, [renderIframes]);
+
+  useEffect(() => {
+    if (frameiOS.current) {
+      frameiOS.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
+        setConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+      });
+    }
+
+    if (frameMD.current) {
+      frameMD.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
+        setConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+      });
+    }
+  }, [iframesLoaded]);
 
   useEffect(() => {
     /**

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import './playground.css';
 import { EditorOptions, openAngularEditor, openHtmlEditor, openReactEditor, openVueEditor } from './stackblitz.utils';
-import { Mode, UsageTarget } from './playground.types';
+import { ConsoleItem, Mode, UsageTarget } from './playground.types';
 import useThemeContext from '@theme/hooks/useThemeContext';
 
 import Tippy from '@tippyjs/react';
@@ -109,6 +109,7 @@ interface UsageTargetOptions {
  * @param src The absolute path to the playground demo. For example: `/usage/button/basic/demo.html`
  * @param size The height of the playground. Supports `xsmall`, `small`, `medium`, `large`, 'xlarge' or any string value.
  * @param devicePreview `true` if the playground example should render in a device frame (iOS/MD).
+ * @param showConsole `true` if the playground should render a console UI that reflects console logs, warnings, and errors.
  */
 export default function Playground({
   code,
@@ -118,6 +119,7 @@ export default function Playground({
   size = 'small',
   mode,
   devicePreview,
+  showConsole,
   includeIonContent = true,
   version,
 }: {
@@ -133,6 +135,7 @@ export default function Playground({
   mode?: 'ios' | 'md';
   description?: string;
   devicePreview?: boolean;
+  showConsole?: boolean;
   includeIonContent: boolean;
   /**
    * The major version of Ionic to use in the generated Stackblitz examples.
@@ -182,6 +185,36 @@ export default function Playground({
   const [codeSnippets, setCodeSnippets] = useState({});
   const [renderIframes, setRenderIframes] = useState(false);
   const [iframesLoaded, setIframesLoaded] = useState(false);
+  const [consoleItems, setConsoleItems] = useState<ConsoleItem[]>([
+    {
+      type: 'log',
+      message: 'this is a log'
+    },
+    {
+      type: 'warning',
+      message: 'this is a warning'
+    },
+    {
+      type: 'error',
+      message: 'this is an error'
+    },
+    {
+      type: 'log',
+      message: 'log 1'
+    },
+    {
+      type: 'log',
+      message: 'log 2'
+    },
+    {
+      type: 'error',
+      message: 'error!'
+    },
+    {
+      type: 'log',
+      message: 'really long log really long log really long log really long log really long log really long log really long log'
+    }
+  ]);
 
   /**
    * Rather than encode isDarkTheme into the frame source
@@ -444,11 +477,26 @@ export default function Playground({
     );
   }
 
+  function renderConsole() {
+    return (
+      <div className="playground__console">
+        {consoleItems.map((consoleItem, i) => (
+          <div key={i} className={`playground__console-item playground__console-item--${consoleItem.type}`}>
+            {consoleItem.type !== 'log' && <div className="playground__console-icon">
+              {consoleItem.type === 'warning' ? '⚠' : '❌'}
+            </div>}
+            <code>{consoleItem.message}</code>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
   const sortedUsageTargets = useMemo(() => Object.keys(UsageTarget).sort(), []);
 
   return (
     <div className="playground" ref={hostRef}>
-      <div className="playground__container">
+      <div className={`playground__container ${showConsole ? 'playground__container--has-console' : ''}`}>
         <div className="playground__control-toolbar">
           <div className="playground__control-group">
             {sortedUsageTargets.map((lang) => {
@@ -633,6 +681,7 @@ export default function Playground({
             ]
           : []}
       </div>
+      {showConsole && renderConsole()}
       <div ref={codeRef} className="playground__code-block">
         {renderCodeSnippets()}
       </div>

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -185,7 +185,8 @@ export default function Playground({
   const [codeSnippets, setCodeSnippets] = useState({});
   const [renderIframes, setRenderIframes] = useState(false);
   const [iframesLoaded, setIframesLoaded] = useState(false);
-  const [consoleItems, setConsoleItems] = useState<ConsoleItem[]>([]);
+  const [mdConsoleItems, setMDConsoleItems] = useState<ConsoleItem[]>([]);
+  const [iosConsoleItems, setiOSConsoleItems] = useState<ConsoleItem[]>([]);
 
   /**
    * Rather than encode isDarkTheme into the frame source
@@ -262,16 +263,17 @@ export default function Playground({
     setFramesLoaded();
   }, [renderIframes]);
 
+  // TODO: scroll to bottom of console
   useEffect(() => {
     if (frameiOS.current) {
       frameiOS.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
-        setConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+        setiOSConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
       });
     }
 
     if (frameMD.current) {
       frameMD.current.contentWindow.addEventListener('console', (ev: CustomEvent) => {
-        setConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
+        setMDConsoleItems((oldConsoleItems) => [...oldConsoleItems, ev.detail]);
       });
     }
   }, [iframesLoaded]);
@@ -465,7 +467,7 @@ export default function Playground({
   function renderConsole() {
     return (
       <div className="playground__console">
-        {consoleItems.map((consoleItem, i) => (
+        {(ionicMode === Mode.iOS ? iosConsoleItems : mdConsoleItems).map((consoleItem, i) => (
           <div key={i} className={`playground__console-item playground__console-item--${consoleItem.type}`}>
             {consoleItem.type !== 'log' && <div className="playground__console-icon">
               {consoleItem.type === 'warning' ? '⚠' : '❌'}

--- a/src/components/global/Playground/playground.css
+++ b/src/components/global/Playground/playground.css
@@ -14,6 +14,14 @@
   --playground-tabs-background: var(--c-carbon-90);
   --playground-tab-btn-color: var(--c-carbon-20);
   --playground-tab-btn-border-color: transparent;
+
+  --playground-console-item-separator-color: var(--c-carbon-80);
+  --playground-console-warning-background: #332B00;
+  --playground-console-warning-color: var(--c-yellow-80);
+  --playground-console-warning-separator-color: #665500;
+  --playground-console-error-background: #290000;
+  --playground-console-error-color: var(--c-red-40);
+  --playground-console-error-separator-color: #5C0000;
 }
 
 .playground {
@@ -28,6 +36,13 @@
    * @prop --playground-tabs-background: The background color of the tabs bar not including the active tab button.
    * @prop --playground-tab-btn-color: The text color of the tab buttons.
    * @prop --playground-tab-btn-border-color: The border color of the tab buttons.
+   * @prop --playground-console-item-separator-color The color of the separator/border between console UI items.
+   * @prop --playground-console-warning-background The background color of warning items in the console UI.
+   * @prop --playground-console-warning-color The text color of warning items in the console UI.
+   * @prop --playground-console-warning-separator-color The color of the top and bottom separator/border for warning items in the console UI.
+   * @prop --playground-console-error-background The background color of error items in the console UI.
+   * @prop --playground-console-error-color The text color of error items in the console UI.
+   * @prop --playground-console-error-separator-color The color of the top and bottom separator/border for error items in the console UI.
    */
   --playground-btn-color: var(--c-indigo-90);
   --playground-btn-selected-color: var(--c-blue-90);
@@ -36,10 +51,18 @@
   --playground-btn-icon-color: var(--c-indigo-80);
   --playground-separator-color: var(--c-indigo-30);
   --playground-code-background: var(--c-indigo-10);
-
+  
   --playground-tabs-background: var(--c-indigo-20);
   --playground-tab-btn-color: var(--c-carbon-100);
   --playground-tab-btn-border-color: var(--c-indigo-30);
+
+  --playground-console-item-separator-color: var(--c-indigo-20);
+  --playground-console-warning-background: var(--c-yellow-10);
+  --playground-console-warning-color: #5C3C00;
+  --playground-console-warning-separator-color: var(--c-yellow-30);
+  --playground-console-error-background: var(--c-red-10);
+  --playground-console-error-color: var(--c-red-90);
+  --playground-console-error-separator-color: var(--c-red-30);
 
   overflow: hidden;
 
@@ -50,6 +73,11 @@
 .playground__container {
   border: 1px solid var(--playground-separator-color);
   border-radius: var(--ifm-code-border-radius);
+}
+
+.playground__container--has-console {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 /* Playground preview contains the demo example*/
@@ -211,6 +239,69 @@
   .playground .frame-visible {
     width: 100%;
   }
+}
+
+.playground__console {
+  background-color: var(--code-block-bg-c);
+  border: 1px solid var(--playground-separator-color);
+  border-top: 0;
+  border-bottom-left-radius: var(--ifm-code-border-radius);
+  border-bottom-right-radius: var(--ifm-code-border-radius);
+  overflow-y: auto;
+
+  height: 120px;
+}
+
+.playground__console-item {
+  border-top: 1px solid var(--separator-color);
+  padding: 3px 3px 3px 28px;
+
+  position: relative;
+}
+
+.playground__console-item:first-child {
+  border-top: none;
+}
+
+.playground__console-item:last-child {
+  border-bottom: 1px solid var(--separator-color);
+}
+
+.playground__console-item--log {
+  --separator-color: var(--playground-console-item-separator-color);
+}
+
+.playground__console-item--warning {
+  --separator-color: var(--playground-console-warning-separator-color);
+  background-color: var(--playground-console-warning-background);
+  border-bottom: 1px solid var(--separator-color);
+  color: var(--playground-console-warning-color);
+}
+
+.playground__console-item--error {
+  --separator-color: var(--playground-console-error-separator-color);
+  background-color: var(--playground-console-error-background);
+  border-bottom: 1px solid var(--separator-color);
+  color: var(--playground-console-error-color);
+}
+
+/* warnings and errors have both borders colored, so hide the extra from the neighboring item */
+.playground__console-item--warning + .playground__console-item,
+.playground__console-item--error + .playground__console-item {
+  border-top: none;
+}
+
+.playground__console-icon {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+}
+
+.playground__console-item code {
+  background-color: transparent;
+  padding: 0;
+  padding-block-start: 0; /* prevents text getting cut off vertically */
+  padding-block-end: 0; /* prevents border from item below getting covered up */
 }
 
 /** Tabs **/

--- a/src/components/global/Playground/playground.types.ts
+++ b/src/components/global/Playground/playground.types.ts
@@ -9,3 +9,8 @@ export enum Mode {
   iOS = 'ios',
   MD = 'md',
 }
+
+export interface ConsoleItem {
+  type: 'log' | 'warning' | 'error',
+  message: string
+}

--- a/static/usage/common.js
+++ b/static/usage/common.js
@@ -23,6 +23,39 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   /**
+   * Monkey-patch the console methods so we can dispatch
+   * events when they're called, allowing the data to be
+   * captured by the playground's console UI.
+   */
+  const _log = console.log,
+    _warn = console.warn,
+    _error = console.error;
+
+  const dispatchConsoleEvent = (type, message) => {
+    window.dispatchEvent(new CustomEvent('console', {
+      detail: {
+        type,
+        message
+      }
+    }));
+  }
+
+  console.log = function() {
+    dispatchConsoleEvent('log', arguments[0]);
+    return _log.apply(console, arguments);
+  };
+
+  console.warn = function() {
+    dispatchConsoleEvent('warning', arguments[0]);
+    return _warn.apply(console, arguments);
+  };
+
+  console.error = function() {
+    dispatchConsoleEvent('error', arguments[0]);
+    return _error.apply(console, arguments);
+  };
+
+  /**
    * The Playground needs to wait for the message listener
    * to be created before sending any messages, otherwise
    * they will be lost. Once the listener is done, fire

--- a/static/usage/common.js
+++ b/static/usage/common.js
@@ -31,29 +31,27 @@ window.addEventListener('DOMContentLoaded', () => {
     _warn = console.warn,
     _error = console.error;
 
-  const dispatchConsoleEvent = (type, message) => {
+  const dispatchConsoleEvent = (type, arguments) => {
     window.dispatchEvent(new CustomEvent('console', {
       detail: {
         type,
-        message
+        message: Object.values(arguments).join(' ')
       }
     }));
   }
 
-  // TODO: is there an easy way to capture all args?
-  // maybe turn vals into array, then do .join(' ')?
   console.log = function() {
-    dispatchConsoleEvent('log', arguments[0]);
+    dispatchConsoleEvent('log', arguments);
     return _log.apply(console, arguments);
   };
 
   console.warn = function() {
-    dispatchConsoleEvent('warning', arguments[0]);
+    dispatchConsoleEvent('warning', arguments);
     return _warn.apply(console, arguments);
   };
 
   console.error = function() {
-    dispatchConsoleEvent('error', arguments[0]);
+    dispatchConsoleEvent('error', arguments);
     return _error.apply(console, arguments);
   };
 

--- a/static/usage/common.js
+++ b/static/usage/common.js
@@ -40,6 +40,8 @@ window.addEventListener('DOMContentLoaded', () => {
     }));
   }
 
+  // TODO: is there an easy way to capture all args?
+  // maybe turn vals into array, then do .join(' ')?
   console.log = function() {
     dispatchConsoleEvent('log', arguments[0]);
     return _log.apply(console, arguments);

--- a/static/usage/v7/range/ion-change-event/angular/example_component_html.md
+++ b/static/usage/v7/range/ion-change-event/angular/example_component_html.md
@@ -1,4 +1,3 @@
 ```html
 <ion-range aria-label="Range with ionChange" (ionChange)="onIonChange($event)"></ion-range>
-<ion-label>ionChange emitted value: {{ lastEmittedValue }}</ion-label>
 ```

--- a/static/usage/v7/range/ion-change-event/angular/example_component_ts.md
+++ b/static/usage/v7/range/ion-change-event/angular/example_component_ts.md
@@ -2,17 +2,14 @@
 import { Component } from '@angular/core';
 
 import { RangeCustomEvent } from '@ionic/angular';
-import { RangeValue } from '@ionic/core';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
 })
 export class ExampleComponent {
-  lastEmittedValue: RangeValue;
-
   onIonChange(ev: Event) {
-    this.lastEmittedValue = (ev as RangeCustomEvent).detail.value;
+    console.log('ionChange emitted value:', (ev as RangeCustomEvent).detail.value);
   }
 }
 ```

--- a/static/usage/v7/range/ion-change-event/demo.html
+++ b/static/usage/v7/range/ion-change-event/demo.html
@@ -22,17 +22,14 @@
         <div class="container">
           <div class="demo">
             <ion-range aria-label="Range with ionChange"></ion-range>
-            <ion-label>ionChange emitted value: <span id="lastValue"></span></ion-label>
           </div>
         </div>
       </ion-content>
     </ion-app>
     <script>
       const range = document.querySelector('ion-range');
-      const lastValue = document.querySelector('#lastValue');
 
       range.addEventListener('ionChange', ({ detail }) => {
-        // lastValue.innerHTML = detail.value;
         console.log('ionChange emitted value: ' + detail.value);
       });
     </script>

--- a/static/usage/v7/range/ion-change-event/demo.html
+++ b/static/usage/v7/range/ion-change-event/demo.html
@@ -32,7 +32,8 @@
       const lastValue = document.querySelector('#lastValue');
 
       range.addEventListener('ionChange', ({ detail }) => {
-        lastValue.innerHTML = detail.value;
+        // lastValue.innerHTML = detail.value;
+        console.log('ionChange emitted value: ' + detail.value);
       });
     </script>
   </body>

--- a/static/usage/v7/range/ion-change-event/demo.html
+++ b/static/usage/v7/range/ion-change-event/demo.html
@@ -30,7 +30,7 @@
       const range = document.querySelector('ion-range');
 
       range.addEventListener('ionChange', ({ detail }) => {
-        console.log('ionChange emitted value: ' + detail.value);
+        console.log('ionChange emitted value:', detail.value);
       });
     </script>
   </body>

--- a/static/usage/v7/range/ion-change-event/index.md
+++ b/static/usage/v7/range/ion-change-event/index.md
@@ -9,6 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
+  showConsole={true}
   code={{
     javascript,
     react,

--- a/static/usage/v7/range/ion-change-event/javascript.md
+++ b/static/usage/v7/range/ion-change-event/javascript.md
@@ -1,13 +1,11 @@
 ```html
 <ion-range aria-label="Range with ionChange"></ion-range>
-<ion-label>ionChange emitted value: <span id="lastValue"></span></ion-label>
 
 <script>
   const range = document.querySelector('ion-range');
-  const lastEmittedValue = document.querySelector('#lastValue');
 
   range.addEventListener('ionChange', ({ detail }) => {
-    lastEmittedValue.innerHTML = detail.value;
+    console.log('ionChange emitted value: ' + detail.value);
   });
 </script>
 ```

--- a/static/usage/v7/range/ion-change-event/react.md
+++ b/static/usage/v7/range/ion-change-event/react.md
@@ -1,17 +1,13 @@
 ```tsx
-import React, { useState } from 'react';
-import { IonLabel, IonRange } from '@ionic/react';
-import { RangeValue } from '@ionic/core';
+import React from 'react';
+import { IonRange } from '@ionic/react';
+
 function Example() {
-  const [lastEmittedValue, setLastEmittedValue] = useState<RangeValue>();
   return (
-    <>
-      <IonRange
-        aria-label="Range with ionChange"
-        onIonChange={({ detail }) => setLastEmittedValue(detail.value)}
-      ></IonRange>
-      <IonLabel>ionChange emitted value: {lastEmittedValue as number}</IonLabel>
-    </>
+    <IonRange
+      aria-label="Range with ionChange"
+      onIonChange={({ detail }) => console.log('ionChange emitted value: ' + detail.value)}
+    ></IonRange>
   );
 }
 export default Example;

--- a/static/usage/v7/range/ion-change-event/vue.md
+++ b/static/usage/v7/range/ion-change-event/vue.md
@@ -1,23 +1,17 @@
 ```html
 <template>
   <ion-range aria-label="Range with ionChange" @ionChange="onIonChange"></ion-range>
-  <ion-label>ionChange emitted value: {{lastEmittedValue}}</ion-label>
 </template>
 
 <script lang="ts">
-  import { IonLabel, IonRange } from '@ionic/vue';
+  import { IonRange } from '@ionic/vue';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
-    components: { IonLabel, IonRange },
-    data() {
-      return {
-        lastEmittedValue: '',
-      };
-    },
+    components: { IonRange },
     methods: {
       onIonChange({ detail }) {
-        this.lastEmittedValue = detail.value;
+        console.log('ionChange emitted value: ' + detail.value);
       },
     },
   });


### PR DESCRIPTION
Adds a new `showConsole` prop to the playground, which displays a console UI underneath the iframe demo. Any calls to `console.log`, `console.warn`, or `console.error` made from inside the iframe will be mirrored in the console UI.

I also converted the