### PR TITLE
Update page_one_vue.md

### DIFF
--- a/static/usage/v7/nav/nav-link/vue/page_one_vue.md
+++ b/static/usage/v7/nav/nav-link/vue/page_one_vue.md
@@ -15,13 +15,13 @@
 
 <script lang="ts">
   import { IonHeader, IonTitle, IonToolbar, IonContent, IonNavLink, IonButton } from '@ionic/vue';
-  import PageTwo from './PageTwo.vue';
+  import { markRaw,defineAsyncComponent  } from "vue";
 
   export default {
     components: { IonHeader, IonTitle, IonToolbar, IonContent, IonNavLink, IonButton },
     data() {
       return {
-        component: PageTwo,
+        component: markRaw(defineAsyncComponent(() => import('./PageTwo.vue'))),
       };
     },
   };


### PR DESCRIPTION
This gets rid of a warning ```[Vue warn]: Vue received a Component which was made a reactive object.```  that Vue raises