### PR TITLE
Update page_two_vue.md

### DIFF
--- a/static/usage/v7/nav/nav-link/vue/page_two_vue.md
+++ b/static/usage/v7/nav/nav-link/vue/page_two_vue.md
@@ -27,7 +27,7 @@
     IonButtons,
     IonBackButton,
   } from '@ionic/vue';
-  import PageThree from './PageThree.vue';
+  import { markRaw, defineAsyncComponent } from "vue";
 
   export default {
     components: {
@@ -42,7 +42,7 @@
     },
     data() {
       return {
-        component: PageThree,
+        component: markRaw(defineAsyncComponent(() => import('./PageThree.vue') )),
       };
     },
   };


### PR DESCRIPTION
This gets rid of a warning ```[Vue warn]: Vue received a Component which was made a reactive object.```  that Vue raises.