### PR TITLE
fix(): consolidate docusaurus tab groupids

### DIFF
--- a/docs/developing/config/global/index.md
+++ b/docs/developing/config/global/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="global-config"
+  groupId="framework"
   defaultValue="javascript"
   values={[
     { value: 'javascript', label: 'JavaScript' },

--- a/docs/developing/config/per-component/index.md
+++ b/docs/developing/config/per-component/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-component-config"
+  groupId="framework"
   defaultValue="javascript"
   values={[
     { value: 'javascript', label: 'JavaScript' },

--- a/docs/developing/config/per-platform-fallback/index.md
+++ b/docs/developing/config/per-platform-fallback/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-platform-fallback-config"
+  groupId="framework"
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },

--- a/docs/developing/config/per-platform-overrides/index.md
+++ b/docs/developing/config/per-platform-overrides/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-platform-fallback-config"
+  groupId="framework"
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },

--- a/docs/developing/config/per-platform/index.md
+++ b/docs/developing/config/per-platform/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-platform-config"
+  groupId="framework"
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },

--- a/docs/native-setup.md
+++ b/docs/native-setup.md
@@ -41,7 +41,7 @@ Using the [Camera plugin](native/camera.md) as an example, first install it:
 
 ````mdx-code-block
 <Tabs
-  groupId="runtime"
+  groupId="framework"
   defaultValue="javascript"
   values={[
     { value: 'javascript', label: 'JavaScript' },

--- a/versioned_docs/version-v6/developing/config/global/index.md
+++ b/versioned_docs/version-v6/developing/config/global/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="global-config"
+  groupId="framework"
   defaultValue="javascript"
   values={[
     { value: 'javascript', label: 'JavaScript' },

--- a/versioned_docs/version-v6/developing/config/per-component/index.md
+++ b/versioned_docs/version-v6/developing/config/per-component/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-component-config"
+  groupId="framework"
   defaultValue="javascript"
   values={[
     { value: 'javascript', label: 'JavaScript' },

--- a/versioned_docs/version-v6/developing/config/per-platform-fallback/index.md
+++ b/versioned_docs/version-v6/developing/config/per-platform-fallback/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-platform-fallback-config"
+  groupId="framework"
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },

--- a/versioned_docs/version-v6/developing/config/per-platform-overrides/index.md
+++ b/versioned_docs/version-v6/developing/config/per-platform-overrides/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-platform-fallback-config"
+  groupId="framework"
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },

--- a/versioned_docs/version-v6/developing/config/per-platform/index.md
+++ b/versioned_docs/version-v6/developing/config/per-platform/index.md
@@ -2,7 +2,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
-  groupId="per-platform-config"
+  groupId="framework"
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },

--- a/versioned_docs/version-v6/native-setup.md
+++ b/versioned_docs/version-v6/native-setup.md
@@ -41,7 +41,7 @@ Using the [Camera plugin](native/camera.md) as an example, first install it:
 
 ````mdx-code-block
 <Tabs
-  groupId="runtime"
+  groupId="framework"
   defaultValue="javascript"
   values={[
     { value: 'javascript', label: 'JavaScript' },


### PR DESCRIPTION
I've been doing research around preserving the active framework for Playground tabs. As part of that research, I discovered that Docusaurus tabs already have this functionality [[Docusaurus docs](https://docusaurus.io/docs/markdown-features/tabs#syncing-tab-choices)] and we are already using it in the Ionic docs. Any Docusaurus tab groups with the same `groupId` will sync to the same active tab.

During my research, I also noticed a few places where we aren't consistent with using the same `groupId` for tab groups with the same options. This PR tidies those up.

All Docusaurus tab `groupId`s should now be one of the following:
* 'framework': javascript, angular, vue, react, stencil
* 'runtime': capacitor, cordova, enterprise

Example: 

If you change tabs on [this page in the current docs](https://ionicframework.com/docs/developing/config#global-config), the active tab only changes on the one tab group at a time.

If you change tabs on [the same page on the deployment for this PR](https://ionic-docs-git-tab-groupids-ionic1.vercel.app/docs/developing/config#global-config) and scroll down the page, you'll see the active tab has changed for all tab groups.