### PR TITLE
chore: format generated property types

### DIFF
--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -121,6 +121,18 @@ function formatMultiline(str) {
   return str.split('\n\n').join('<br /><br />').split('\n').join(' ');
 }
 
+function formatType(attr, type) {
+  if (attr === 'color') {
+    /**
+     * The `color` attribute has an additional type that we don't want to display.
+     * The union type is used to allow intellisense to recommend the color names,
+     * while still accepting any string value.
+     */
+    type = type.replace('string & Record<never, never>', 'string');
+  }
+  return type.replace(/\|/g, '\uff5c');
+}
+
 function renderProperties({ props: properties }) {
   if (properties.length === 0) {
     return 'No properties available for this component.';
@@ -141,7 +153,7 @@ ${properties
 | --- | --- |
 | **Description** | ${formatMultiline(docs)} |
 | **Attribute** | \`${prop.attr}\` |
-| **Type** | \`${prop.type.replace(/\|/g, '\uff5c')}\` |
+| **Type** | \`${formatType(prop.attr, prop.type)}\` |
 | **Default** | \`${prop.default}\` |
 
 `;


### PR DESCRIPTION
This is a proposed change to help reduce confusion with the type signature for the `color` attribute for certain components. Ionic Framework added a type union for `string` and `Record` to resolve intellisense not detecting the pre-defined colors when using a type union with `string`. 

This PR formats and removes that "type hack" from the generated docs, as users only care about the pre-defined colors and that they can use any valid `string`.

Output before:
```
"danger" ｜ "dark" ｜ "light" ｜ "medium" ｜ "primary" ｜ "secondary" ｜ "success" ｜ "tertiary" ｜ "warning" ｜ string & Record<never, never> ｜ undefined
```

Output after:
```
"danger" ｜ "dark" ｜ "light" ｜ "medium" ｜ "primary" ｜ "secondary" ｜ "success" ｜ "tertiary" ｜ "warning" ｜ string ｜ undefined
```