### PR TITLE
fix(): JP - alphabetize sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -238,15 +238,15 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'アクションシート',
-      collapsed: false,
-      items: ['api/action-sheet'],
-    },
-    {
-      type: 'category',
       label: 'アコーディオン',
       collapsed: false,
       items: ['api/accordion', 'api/accordion-group'],
+    },
+    {
+      type: 'category',
+      label: 'アクションシート',
+      collapsed: false,
+      items: ['api/action-sheet'],
     },
     {
       type: 'category',
@@ -316,15 +316,15 @@ module.exports = {
     },
     {
       type: 'category',
-      label: '無限スクロール',
-      collapsed: false,
-      items: ['api/infinite-scroll', 'api/infinite-scroll-content'],
-    },
-    {
-      type: 'category',
       label: 'アイコン',
       collapsed: false,
       items: ['api/icon'],
+    },
+    {
+      type: 'category',
+      label: '無限スクロール',
+      collapsed: false,
+      items: ['api/infinite-scroll', 'api/infinite-scroll-content'],
     },
     {
       type: 'category',

--- a/versioned_sidebars/version-v5-sidebars.json
+++ b/versioned_sidebars/version-v5-sidebars.json
@@ -706,6 +706,18 @@
     {
       "collapsed": false,
       "type": "category",
+      "label": "Icons",
+      "items": [
+        {
+          "type": "link",
+          "label": "ion-icon",
+          "href": "https://ionicons.com"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "type": "category",
       "label": "Infinite Scroll",
       "items": [
         {
@@ -715,18 +727,6 @@
         {
           "type": "doc",
           "id": "version-v5/api/infinite-scroll-content"
-        }
-      ]
-    },
-    {
-      "collapsed": false,
-      "type": "category",
-      "label": "Icons",
-      "items": [
-        {
-          "type": "link",
-          "label": "ion-icon",
-          "href": "https://ionicons.com"
         }
       ]
     },

--- a/versioned_sidebars/version-v6-sidebars.json
+++ b/versioned_sidebars/version-v6-sidebars.json
@@ -606,18 +606,6 @@
     },
     {
       "type": "category",
-      "label": "Action Sheet",
-      "collapsed": false,
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-v6/api/action-sheet"
-        }
-      ],
-      "collapsible": true
-    },
-    {
-      "type": "category",
       "label": "Accordion",
       "collapsed": false,
       "items": [
@@ -628,6 +616,18 @@
         {
           "type": "doc",
           "id": "version-v6/api/accordion-group"
+        }
+      ],
+      "collapsible": true
+    },
+    {
+      "type": "category",
+      "label": "Action Sheet",
+      "collapsed": false,
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-v6/api/action-sheet"
         }
       ],
       "collapsible": true
@@ -818,6 +818,18 @@
     },
     {
       "type": "category",
+      "label": "Icons",
+      "collapsed": false,
+      "items": [
+        {
+          "type": "doc",
+          "id": "version-v6/api/icon"
+        }
+      ],
+      "collapsible": true
+    },
+    {
+      "type": "category",
       "label": "Infinite Scroll",
       "collapsed": false,
       "items": [
@@ -828,18 +840,6 @@
         {
           "type": "doc",
           "id": "version-v6/api/infinite-scroll-content"
-        }
-      ],
-      "collapsible": true
-    },
-    {
-      "type": "category",
-      "label": "Icons",
-      "collapsed": false,
-      "items": [
-        {
-          "type": "doc",
-          "id": "version-v6/api/icon"
         }
       ],
       "collapsible": true


### PR DESCRIPTION
This is the same change as https://github.com/ionic-team/ionic-docs/pull/3081 but for the Japanese docs. This puts the components in the same order for the Japanese docs as for the English ones, for consistency sake.

(I figured that since this is outside the regular docs content, it might be nice to go ahead and update the Japanese branch to match.)