### PR TITLE
fix(vue): fix bug with key type

### DIFF
--- a/docs/vue/your-first-app/2-taking-photos.md
+++ b/docs/vue/your-first-app/2-taking-photos.md
@@ -140,7 +140,7 @@ With the photo(s) stored into the main array we can now display the images on th
 <ion-content>
   <ion-grid>
     <ion-row>
-      <ion-col size="6" :key="photo" v-for="photo in photos">
+      <ion-col size="6" :key="photo.filepath" v-for="photo in photos">
         <ion-img :src="photo.webviewPath"></ion-img>
       </ion-col>
     </ion-row>


### PR DESCRIPTION
Avoid :
Type '{ filepath: string; webviewPath?: string | undefined; }' is not assignable to type 'string | number | symbol | undefined'.ts(2322) runtime-core.d.ts(914, 5): The expected type comes from property 'key' which is declared here on type '{ readonly push?: string | undefined; readonly modelValue?: string | number | boolean | undefined; readonly offset?: string | undefined; readonly offsetLg?: string | undefined; ... 32 more ...; style?: unknown; } & Record<...>' (property) key?: string | number | symbol | undefined