### PR TITLE
docs(picker): describe how to set the initial value of a picker column

### DIFF
--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -73,7 +73,7 @@ interface PickerColumn {
   name: string;
   align?: string;
   /**
-   * Changing this value allows the initial value of a picker column to be set
+   * Changing this value allows the initial value of a picker column to be set.
    */
   selectedIndex?: number;
   prevSelected?: number;

--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -72,6 +72,9 @@ interface PickerButton {
 interface PickerColumn {
   name: string;
   align?: string;
+  /**
+   * Changing this value allows the initial value of a picker column to be set
+   */
   selectedIndex?: number;
   prevSelected?: number;
   prefix?: string;


### PR DESCRIPTION
## What is the current behavior?
There is no description of how to set the value of a picker.

## What is the new behavior?
Readers can find this description in the documentation.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
