### PR TITLE
chore: standardize title tag format

### DIFF
--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/accordion/custom-props
 import Slots from '@ionic-internal/component-api/v7/accordion/slots.md';
 
 <head>
-  <title>Ion-Accordion Components: How to Build & Examples | Ionic</title>
+  <title>ion-accordion: Accordion Components: How to Build & Examples</title>
   <meta name="description" content="Ion-accordion components provide collapsible sections in content to reduce vertical space and organize information. Learn how to build one and see examples." />
 </head>
 

--- a/docs/api/action-sheet.md
+++ b/docs/api/action-sheet.md
@@ -12,7 +12,7 @@ import CustomProps from '@ionic-internal/component-api/v7/action-sheet/custom-pr
 import Slots from '@ionic-internal/component-api/v7/action-sheet/slots.md';
 
 <head>
-  <title>ion-action-sheet | Action Sheet Dialog for iOS and Android Apps</title>
+  <title>ion-action-sheet: Action Sheet Dialog for iOS and Android</title>
   <meta name="description" content="Action Sheets are dialogs that display a set of options above app content and must be manually dismissed. Read to learn about use on iOS and Android devices." />
 </head>
 

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -12,7 +12,7 @@ import CustomProps from '@ionic-internal/component-api/v7/alert/custom-props.md'
 import Slots from '@ionic-internal/component-api/v7/alert/slots.md';
 
 <head>
-  <title>ion-alert: Ionic API Alert Buttons with Custom Message Prompts</title>
+  <title>ion-alert: Ionic Alert Buttons with Custom Message Prompts</title>
   <meta name="description" content="ion-alert dialog presents or collects information using inputs. Custom alert button messages appear above the app's content and must be manually dismissed." />
 </head>
 

--- a/docs/api/back-button.md
+++ b/docs/api/back-button.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/back-button/custom-pro
 import Slots from '@ionic-internal/component-api/v7/back-button/slots.md';
 
 <head>
-  <title>Back Button | ion-back-button: Custom Menu Icon for Applications</title>
+  <title>ion-back-button: Custom Menu Back Button for Applications</title>
   <meta name="description" content="The ion-back-button is a custom menu icon for Android, iOS, and Progressive Web Apps. Use Ionic Framework components to easily build applications." />
 </head>
 

--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/badge/custom-props.md'
 import Slots from '@ionic-internal/component-api/v7/badge/slots.md';
 
 <head>
-  <title>Badges | ion-badge: iOS & Android App Notification Badge Icons</title>
+  <title>ion-badge: iOS & Android App Notification Badge Icons</title>
   <meta name="description" content="Badges are inline block elements that appear near other elements on iOS & Android apps—use ion-badges as notifications that indicate how many items there are." />
 </head>
 

--- a/docs/api/button.md
+++ b/docs/api/button.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/button/custom-props.md
 import Slots from '@ionic-internal/component-api/v7/button/slots.md';
 
 <head>
-  <title>ion-button: Design and Style Buttons with Custom CSS Properties</title>
+  <title>ion-button: Style Buttons with Custom CSS Properties</title>
   <meta name="description" content="ion-button provides a clickable element for use anywhere needing standard button functionality. Design and style button elements with custom CSS properties." />
 </head>
 

--- a/docs/api/card-title.md
+++ b/docs/api/card-title.md
@@ -11,7 +11,7 @@ import Slots from '@ionic-internal/component-api/v7/card-title/slots.md';
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <head>
-  <title>ion-card-title | Ionic App Card Title Component and Properties</title>
+  <title>ion-card-title: Ionic App Card Title Component</title>
   <meta name="description" content="ion-card-title is a child component of ion-card. Read to learn more about card title properties and how this component is used on Ionic Framework apps." />
 </head>
 

--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/checkbox/custom-props.
 import Slots from '@ionic-internal/component-api/v7/checkbox/slots.md';
 
 <head>
-  <title>ion-checkboxes: Ionic App Component to Select Multiple Options</title>
+  <title>ion-checkbox: Ionic App Checkbox to Select Multiple Options</title>
   <meta name="description" content="ion-checkboxes allow selection of multiple options from a set and appear as checked (ticked) when activated. Learn about the checkbox component for Ionic apps." />
 </head>
 

--- a/docs/api/chip.md
+++ b/docs/api/chip.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/chip/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/chip/slots.md';
 
 <head>
-  <title>ion-chip:  Name, Text, Icon and Avatar for Ionic Framework Apps</title>
+  <title>ion-chip: Text, Icon and Avatar for Ionic Framework Apps</title>
   <meta name="description" content="ion-chips represent complex entities in small blocks, such as a contact. A chip can contain several different elements such as names, avatars, text, and icons." />
 </head>
 

--- a/docs/api/col.md
+++ b/docs/api/col.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/col/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/col/slots.md';
 
 <head>
-  <title>ion-col: Column Component Padding, Size and Other Properties</title>
+  <title>ion-col: Column Component Padding and Other Properties</title>
   <meta name="description" content="ion-col is a column component that goes inside a row. Content within a grid goes inside of a column. Read more on column padding, size, and other properties." />
 </head>
 

--- a/docs/api/content.md
+++ b/docs/api/content.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/content/custom-props.m
 import Slots from '@ionic-internal/component-api/v7/content/slots.md';
 
 <head>
-  <title>ion-content: Scrollable CSS Component for Ionic App Content Areas</title>
+  <title>ion-content: Scrollable Component for Ionic App Content</title>
   <meta name="description" content="ion-content provides an easy to use content area with useful methods to control the scrollable area. Learn more about this CSS component for Ionic apps." />
 </head>
 

--- a/docs/api/datetime-button.md
+++ b/docs/api/datetime-button.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/datetime-button/custom
 import Slots from '@ionic-internal/component-api/v7/datetime-button/slots.md';
 
 <head>
-  <title>ion-datetime-button: Ionic API Input for interacting with Datetime picker</title>
+  <title>ion-datetime-button: Ionic Input for Datetime Picker</title>
   <meta name="description" content="Datetime button links with a datetime instance to easily a datetime in a popover, modal, and more." />
 </head>
 

--- a/docs/api/fab-button.md
+++ b/docs/api/fab-button.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/fab-button/custom-prop
 import Slots from '@ionic-internal/component-api/v7/fab-button/slots.md';
 
 <head>
-  <title>Floating Action Button | Ionic FAB Button Icon for Primary Action</title>
+  <title>ion-fab-button: Ionic FAB Button Icon for Primary Action</title>
   <meta name="description" content="Floating Action Buttons (FABs) represent the primary action in an app. The icons are circular and, when pressed, the button may open more related actions." />
 </head>
 

--- a/docs/api/fab.md
+++ b/docs/api/fab.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/fab/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/fab/slots.md';
 
 <head>
-  <title>ion-fab: Floating Action Button for Android and iOS Ionic Apps</title>
+  <title>ion-fab: Ionic Floating Action Button for Android and iOS</title>
   <meta name="description" content="Fabs, floating action buttons, are container elements that contain one or more fab buttons. Use ion-fab when creating Android and iOS apps with Ionic Framework." />
 </head>
 

--- a/docs/api/footer.md
+++ b/docs/api/footer.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/footer/custom-props.md
 import Slots from '@ionic-internal/component-api/v7/footer/slots.md';
 
 <head>
-  <title>Page Footer | Ionic App Footer: Wrapper Root Page Component</title>
+  <title>ion-footer: Page Footer | Ionic App Footer Root Component</title>
   <meta name="description" content="A footer is a root component that sits at the bottom of a page. Ionic footers can be a wrapper for ion-toolbar to make sure the content area is sized correctly." />
 </head>
 

--- a/docs/api/grid.md
+++ b/docs/api/grid.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/grid/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/grid/slots.md';
 
 <head>
-  <title>Ion-Grid: Display Grids to Build Mobile-First Custom App Layout</title>
+  <title>ion-grid: Display Grids for Mobile-First Custom App Layout</title>
   <meta name="description" content="Ion-Grid is a mobile-first flexbox system to build custom application display layouts with a 12 column layout and different breakpoints based on screen size." />
 </head>
 

--- a/docs/api/img.md
+++ b/docs/api/img.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/img/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/img/slots.md';
 
 <head>
-  <title>Img Tag to Lazy Load Images in Viewport | ion-img Tag</title>
+  <title>ion-img: Img Tag to Lazy Load Images in Viewport</title>
   <meta name="description" content="Img tag lazy loads images whenever the tag is in the viewport. Utilize this component when generating large lists—as images are only loaded when visible." />
 </head>
 

--- a/docs/api/infinite-scroll.md
+++ b/docs/api/infinite-scroll.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/infinite-scroll/custom
 import Slots from '@ionic-internal/component-api/v7/infinite-scroll/slots.md';
 
 <head>
-  <title>Infinite Scroller | ion-infinite-scroll Action Component</title>
+  <title>ion-infinite-scroll: Infinite Scroller Action Component</title>
   <meta name="description" content="The ion-infinite-scroll component calls an action to be performed when the user scrolls a specified distance from the bottom or top of the page." />
 </head>
 

--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/input/custom-props.md'
 import Slots from '@ionic-internal/component-api/v7/input/slots.md';
 
 <head>
-  <title>ion-input: Custom Input Value Type Styling and CSS Properties</title>
+  <title>ion-input: Custom Input With Styling and CSS Properties</title>
   <meta name="description" content="ion-input is a wrapper to the HTML input element, with custom value type styling and functionality. It works on desktops and integrates with mobile keyboards." />
 </head>
 

--- a/docs/api/item-divider.md
+++ b/docs/api/item-divider.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/item-divider/custom-pr
 import Slots from '@ionic-internal/component-api/v7/item-divider/slots.md';
 
 <head>
-  <title>Item Divider | List Item Divider Block Element for Ionic Apps</title>
+  <title>ion-item-divider: Item Divider Block Element for Ionic Apps</title>
   <meta name="description" content="Item Dividers are block elements that can be used to separate items in a list. They are similar to list headers, but instead, go in between groups of items." />
 </head>
 

--- a/docs/api/item-option.md
+++ b/docs/api/item-option.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/item-option/custom-pro
 import Slots from '@ionic-internal/component-api/v7/item-option/slots.md';
 
 <head>
-  <title>ion-item-options: Option Button Components for Ionic Apps</title>
+  <title>ion-item-option: Option Button for Sliding Item in Ionic</title>
   <meta name="description" content="ion-item-option is the option button for an ion-item-sliding and must be placed inside of an <ion-item-options>. Read to learn more about properties." />
 </head>
 

--- a/docs/api/item-sliding.md
+++ b/docs/api/item-sliding.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/item-sliding/custom-pr
 import Slots from '@ionic-internal/component-api/v7/item-sliding/slots.md';
 
 <head>
-  <title>Slide Buttons | Slide Right to Left with ion-item-sliding</title>
+  <title>ion-item-sliding: Slide Buttons | Slide Right to Left</title>
   <meta name="description" content="ion-item-sliding component contains items that are dragged to reveal buttons. Options are revealed when the sliding item is swiped from left to right." />
 </head>
 

--- a/docs/api/label.md
+++ b/docs/api/label.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/label/custom-props.md'
 import Slots from '@ionic-internal/component-api/v7/label/slots.md';
 
 <head>
-  <title>Item Label Color and Properties for Applications | ion-label</title>
+  <title>ion-label: Item Label Color and Properties for Applications</title>
   <meta name="description" content="Label is a wrapper element that can be used in combination with other Ionic components. Easily design item label colors and other properties with ion-label." />
 </head>
 

--- a/docs/api/loading.md
+++ b/docs/api/loading.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/loading/custom-props.m
 import Slots from '@ionic-internal/component-api/v7/loading/slots.md';
 
 <head>
-  <title>Loading | Application Loading Indicator Overlay | ion-loading</title>
+  <title>ion-loading: Loading | Application Loading Indicator Overlay</title>
   <meta name="description" content="The ion-loading overlay indicates activity while blocking user interaction. The loading indicator appears on top of the app's content, and can be dismissed." />
 </head>
 

--- a/docs/api/menu-button.md
+++ b/docs/api/menu-button.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/menu-button/custom-pro
 import Slots from '@ionic-internal/component-api/v7/menu-button/slots.md';
 
 <head>
-  <title>Menu Button | ion-menu-button to Open an App Menu on A Page</title>
+  <title>ion-menu-button: Menu Button to Open an App Menu on a Page</title>
   <meta name="description" content="Menu Button is component that automatically creates the icon and functionality to open a menu on an app page. Read to learn more about ion-menu-button." />
 </head>
 

--- a/docs/api/menu-toggle.md
+++ b/docs/api/menu-toggle.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/menu-toggle/custom-pro
 import Slots from '@ionic-internal/component-api/v7/menu-toggle/slots.md';
 
 <head>
-  <title>ion-menu-toggle | MenuToggle Component to Open/Close Active Menus</title>
+  <title>ion-menu-toggle: MenuToggle Component to Open/Close Menus</title>
   <meta name="description" content="The MenuToggle component can be used to toggle a menu open or closed—by default, it's only visible when the selected menu is active. Read more about usage." />
 </head>
 

--- a/docs/api/nav-link.md
+++ b/docs/api/nav-link.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/nav-link/custom-props.
 import Slots from '@ionic-internal/component-api/v7/nav-link/slots.md';
 
 <head>
-  <title>ion-nav-link: The Element for Navigation to a Specified Component</title>
+  <title>ion-nav-link: Navigation Links to a Specified Component</title>
   <meta name="description" content="Navigation links navigate to specified components. It is the element form of calling the push(), pop(), and setRoot() methods. Read for more on ion-nav-link." />
 </head>
 

--- a/docs/api/nav.md
+++ b/docs/api/nav.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/nav/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/nav/slots.md';
 
 <head>
-  <title>ion-nav | Nav View Component for Ionic Framework Apps</title>
+  <title>ion-nav: Nav View Component for Ionic Framework Apps</title>
   <meta name="description" content="ion-nav is a standalone for loading arbitrary, and pushing new, components on to the stack. Loading Nav view, and pushing others, won't affect overall routers." />
 </head>
 

--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/picker/custom-props.md
 import Slots from '@ionic-internal/component-api/v7/picker/slots.md';
 
 <head>
-  <title>Picker | Display Buttons and Columns for ion-picker on Ionic Apps</title>
+  <title>ion-picker: A Dialog That Displays Buttons and Columns</title>
   <meta name="description" content="A Picker is a dialog that displays a row of buttons and columns underneath. Ion-picker appears on top of the app's content, and at the bottom of the viewport." />
 </head>
 

--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/popover/custom-props.m
 import Slots from '@ionic-internal/component-api/v7/popover/slots.md';
 
 <head>
-  <title>ion-popover: iOS / Android Popover UI Component & CSS Properties</title>
+  <title>ion-popover: iOS / Android Popover UI Dialog Component</title>
   <meta name="description" content="ion-popover is a dialog that appears on top of the current page. Learn about the popover UI component and CSS custom properties for iOS and Android devices." />
 </head>
 

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/progress-bar/custom-pr
 import Slots from '@ionic-internal/component-api/v7/progress-bar/slots.md';
 
 <head>
-  <title>Progress Bar | Horizontal App Progress Bar for Loading Indicator</title>
+  <title>ion-progress-bar: App Progress Bar for Loading Indicator</title>
   <meta name="description" content="ion-progress-bars are horizontal loading indicators that inform users about the status of ongoing app processes—such as submitting a form or saving updates." />
 </head>
 

--- a/docs/api/radio-group.md
+++ b/docs/api/radio-group.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/radio-group/custom-pro
 import Slots from '@ionic-internal/component-api/v7/radio-group/slots.md';
 
 <head>
-  <title>ion-radio-group | Radio Button Group Usage for Ionic Apps</title>
+  <title>ion-radio-group: Radio Button Group Usage for Ionic Apps</title>
   <meta name="description" content="A radio group is a group of radio buttons. Radio groups allow a user to select at most one radio button from a set. Learn more about ion-radio-group usage." />
 </head>
 

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/radio/custom-props.md'
 import Slots from '@ionic-internal/component-api/v7/radio/slots.md';
 
 <head>
-  <title>ion-radio Component: Radio Property for iOS and Android</title>
+  <title>ion-radio: Radio Component for iOS and Android</title>
   <meta name="description" content="Radio components should be used inside of ion-radio-groups on iOS and Android devices. Read to learn more about radio property usage and installation." />
 </head>
 

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/range/custom-props.md'
 import Slots from '@ionic-internal/component-api/v7/range/slots.md';
 
 <head>
-  <title>Range Slider | ion-range: Slider Knob Controls with Labels</title>
+  <title>ion-range: Range Slider Knob Controls with Labels</title>
   <meta name="description" content="ion-range lets you select from a range of values by moving the slider. It accepts dual knobs but one controls the value and labels can be placed on either side." />
 </head>
 

--- a/docs/api/reorder-group.md
+++ b/docs/api/reorder-group.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/reorder-group/custom-p
 import Slots from '@ionic-internal/component-api/v7/reorder-group/slots.md';
 
 <head>
-  <title>ion-reorder-group: Wrapper Component for Ionic Framework Apps</title>
+  <title>ion-reorder-group: Wrapper Component for Reorder Items</title>
   <meta name="description" content="ion-reorder-group is a wrapper component for items using the ion-reorder component on Ionic apps. Read to learn more about ion-reorder-group usage." />
 </head>
 

--- a/docs/api/reorder.md
+++ b/docs/api/reorder.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/reorder/custom-props.m
 import Slots from '@ionic-internal/component-api/v7/reorder/slots.md';
 
 <head>
-  <title>Reorder | ion-reorder: Drag and Drop Icon to Reorder Items</title>
+  <title>ion-reorder: Drag and Drop Icon to Reorder Items</title>
   <meta name="description" content="Ion-reorder is the anchor used to drag and drop the items inside of the ion-reorder-group. Read to learn more about custom reorder icons and items." />
 </head>
 

--- a/docs/api/ripple-effect.md
+++ b/docs/api/ripple-effect.md
@@ -11,7 +11,7 @@ import Slots from '@ionic-internal/component-api/v7/ripple-effect/slots.md';
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <head>
-  <title>ion-ripple-effect | Ripple Effect Button Component for Ionic Apps</title>
+  <title>ion-ripple-effect: Ripple Effect Component for Ionic Apps</title>
   <meta name="description" content="The ripple effect button component adds the Material Design ink ripple interaction effect. It can only be used in an ion-app and can be added to any component." />
 </head>
 

--- a/docs/api/route-redirect.md
+++ b/docs/api/route-redirect.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/route-redirect/custom-
 import Slots from '@ionic-internal/component-api/v7/route-redirect/slots.md';
 
 <head>
-  <title>ion-route-redirect Plugin: Redirect 'from' a URL 'to' Another URL</title>
+  <title>ion-route-redirect: Redirect 'from' a URL 'to' Another URL</title>
   <meta name="description" content="ion-route-redirect is used with as a direct child of an ion-router and redirects 'from' a URL 'to' another URL. Read to learn about the route redirect plugin." />
 </head>
 

--- a/docs/api/router-link.md
+++ b/docs/api/router-link.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/router-link/custom-pro
 import Slots from '@ionic-internal/component-api/v7/router-link/slots.md';
 
 <head>
-  <title>Router Link | Navigating The ion-router-link Component</title>
+  <title>ion-router-link: Navigate To a Specified Link</title>
   <meta name="description" content="Use the ion-router-link component to navigate to a specified link. The router link can accept an href for location and a direction for the transition animation." />
 </head>
 

--- a/docs/api/row.md
+++ b/docs/api/row.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/row/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/row/slots.md';
 
 <head>
-  <title>ion-row: Horizontal Row Components and Alignment | Ionic API Docs</title>
+  <title>ion-row: Horizontal Row Components of the Grid System</title>
   <meta name="description" content="Rows are horizontal components of the grid system and contain varying numbers of columns. Read our ion-row API Docs for more information on alignment and usage." />
 </head>
 

--- a/docs/api/searchbar.md
+++ b/docs/api/searchbar.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/searchbar/custom-props
 import Slots from '@ionic-internal/component-api/v7/searchbar/slots.md';
 
 <head>
-  <title>Search Bar Icon for Keyboard Text Display | Ion-Search Bar</title>
+  <title>ion-searchbar: Search Bar for Searching a Collection</title>
   <meta name="description" content="Search bars represent a text field that can be used to search through a collection. Learn to input Ion-Search Bar as an icon on Android & iOS keyboard displays." />
 </head>
 

--- a/docs/api/select-option.md
+++ b/docs/api/select-option.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/select-option/custom-p
 import Slots from '@ionic-internal/component-api/v7/select-option/slots.md';
 
 <head>
-  <title>Select Option | What Is An Option Select on Ionic Framework Apps</title>
+  <title>ion-select-option: Option For a Select Dialog</title>
   <meta name="description" content="What is an option select? Select Options are child element components of a Select—each option defined is passed and displayed in the Select dialog." />
 </head>
 

--- a/docs/api/skeleton-text.md
+++ b/docs/api/skeleton-text.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/skeleton-text/custom-p
 import Slots from '@ionic-internal/component-api/v7/skeleton-text/slots.md';
 
 <head>
-  <title>Skeleton Text | Skeleton Loading Placeholder & Framework for Text</title>
+  <title>ion-skeleton-text: Skeleton Loading Placeholder for Text</title>
   <meta name="description" content="ion-skeleton-text is a component for rendering placeholder content. The element will render a gray block at the specified width as a loading text framework." />
 </head>
 

--- a/docs/api/spinner.md
+++ b/docs/api/spinner.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/spinner/custom-props.m
 import Slots from '@ionic-internal/component-api/v7/spinner/slots.md';
 
 <head>
-  <title>ion-spinner | Animated Spinner Icon Components and Properties</title>
+  <title>ion-spinner: Animated Spinner Icon Components and Properties</title>
   <meta name="description" content="The ion-spinner component provides a variety of animated SVG spinners. These icons indicate that the app is loading or performing another process to wait on." />
 </head>
 

--- a/docs/api/split-pane.md
+++ b/docs/api/split-pane.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/split-pane/custom-prop
 import Slots from '@ionic-internal/component-api/v7/split-pane/slots.md';
 
 <head>
-  <title>ion-split-pane: Split Plane View for Menus and Multi-View Layouts</title>
+  <title>ion-split-pane: Split Plane for Menus and Multi-View Layouts</title>
   <meta name="description" content="ion-split-pane is useful when creating multi-view app layouts. It allows UI elements, like menus, to be displayed as the viewport width increases." />
 </head>
 

--- a/docs/api/tab-bar.md
+++ b/docs/api/tab-bar.md
@@ -12,7 +12,7 @@ import CustomProps from '@ionic-internal/component-api/v7/tab-bar/custom-props.m
 import Slots from '@ionic-internal/component-api/v7/tab-bar/slots.md';
 
 <head>
-  <title>ion-tab-bar with CSS Custom Properties for Tab Bar Components</title>
+  <title>ion-tab-bar: Tab Bar Component with CSS Custom Properties</title>
   <meta name="description" content="The tab bar component contains a set of tab buttons and a tab bar must be provided inside of tabs to communicate. Read more about use and CSS custom properties." />
 </head>
 

--- a/docs/api/tab.md
+++ b/docs/api/tab.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/tab/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/tab/slots.md';
 
 <head>
-  <title>ion-tab - Ionic Framework Application Component</title>
+  <title>ion-tab: Ionic Framework Application Component</title>
   <meta name="description" content="ion-tab is a child component of tabs. Each ion-tab can contain a top level navigation stack for an application or a single view. Read to learn more." />
 </head>
 

--- a/docs/api/tabs.md
+++ b/docs/api/tabs.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/tabs/custom-props.md';
 import Slots from '@ionic-internal/component-api/v7/tabs/slots.md';
 
 <head>
-  <title>Ion-Tabs: Tab-Based Component for App Top-Level Navigation</title>
+  <title>ion-tabs: Tab-Based Component for App Top-Level Navigation</title>
   <meta name="description" content="Tabs are top-level components to implement tab-based navigation. Ion-tabs have no styling & work as router outlets for navigation that behaves like native apps." />
 </head>
 

--- a/docs/api/thumbnail.md
+++ b/docs/api/thumbnail.md
@@ -10,7 +10,7 @@ import CustomProps from '@ionic-internal/component-api/v7/thumbnail/custom-props
 import Slots from '@ionic-internal/component-api/v7/thumbnail/slots.md';
 
 <head>
-  <title>ion-thumbnail | Thumbnail App Component to Wrap Images or Icons</title>
+  <title>ion-thumbnail: Thumbnail App Component for Images or Icons</title>
   <meta name="description" content="What is a thumbnail image? Thumbnail app components wrap an image or icon and can be used to display a layout of images or for previews of full-size images." />
 </head>
 

--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -12,7 +12,7 @@ import CustomProps from '@ionic-internal/component-api/v7/toast/custom-props.md'
 import Slots from '@ionic-internal/component-api/v7/toast/slots.md';
 
 <head>
-  <title>ion-toast Component: A Dismissible App Notification Alert</title>
+  <title>ion-toast: A Dismissible App Notification Alert Component</title>
   <meta name="description" content="ion-toast component is an app notification displaying system messages or feedback. Toast alerts appear above content and are dismissed to resume interaction." />
 </head>
 

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/toggle/custom-props.md
 import Slots from '@ionic-internal/component-api/v7/toggle/slots.md';
 
 <head>
-  <title>Toggle | ion-toggle: Custom Toggle Button for Ionic Applications</title>
+  <title>ion-toggle: Custom Toggle Button for Ionic Applications</title>
   <meta name="description" content="Toggle changes the state of a single option. Use ion-toggle to create customizable toggle buttons that can be switched on or off for your applications." />
 </head>
 

--- a/docs/api/toolbar.md
+++ b/docs/api/toolbar.md
@@ -9,7 +9,7 @@ import CustomProps from '@ionic-internal/component-api/v7/toolbar/custom-props.m
 import Slots from '@ionic-internal/component-api/v7/toolbar/slots.md';
 
 <head>
-  <title>Toolbar | Customize App Menu Toolbar Buttons and Icons</title>
+  <title>ion-toolbar: Customize App Menu Toolbar Buttons and Icons</title>
   <meta name="description" content="Ion-toolbar component lets you customize toolbar buttons on your app menu. Add fixed toolbars above or below content or use full screen to scroll with content." />
 </head>
 


### PR DESCRIPTION
I followed these requirements from [the design doc](https://github.com/ionic-team/ionic-framework-design-documents/blob/main/projects/ionic-framework-docs/seo/0001-title-tag.md) for titles:

* The title should be standardized to the format `component-name: Description of the page`
* Each should be unique
* Each should be descriptive and concise
* The title should be 60 characters or fewer

I tried to keep the style and content of the titles similar to the originals as much as I could while still following the above requirements. I'm not familiar enough with SEO to know if they need to be improved further.