### PR TITLE
chore(CODEOWNERS): create codeowners file and add me

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+# The folders are ordered as follows:
+
+# In each subsection folders are ordered first by depth, then alphabetically.
+# This should make it easy to add new rules without breaking existing ones.
+
+/_templates/ @mapsandapps
+/docs/api/ @mapsandapps
+/src/ @mapsandapps
+/static/usage/ @mapsandapps


### PR DESCRIPTION
I'll start with these for now and can adjust to more or less once I get a feel for how much volume this is. My sense is that on average, docs PRs take less time to review than framework PRs.

/_templates/ playground generator
/docs/api/ component docs
/src/ code for playground component & other components
/static/usage/ playgrounds