### PR TITLE
chore(angular, html, react, vue): revert package versions on stackblitz

### DIFF
--- a/static/code/stackblitz/v7/angular/package.json
+++ b/static/code/stackblitz/v7/angular/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@ionic/angular": "7.3.2-dev.11693507138.1f9ed625",
-    "@ionic/core": "7.3.2-dev.11693507138.1f9ed625"
+    "@ionic/angular": "^7.0.0",
+    "@ionic/core": "^7.0.0"
   }
 }

--- a/static/code/stackblitz/v7/html/package.json
+++ b/static/code/stackblitz/v7/html/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@ionic/core": "7.3.2-dev.11693507138.1f9ed625"
+    "@ionic/core": "^7.0.0"
   }
 }

--- a/static/code/stackblitz/v7/react/package.json
+++ b/static/code/stackblitz/v7/react/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ionic/react": "7.3.2-dev.11693507138.1f9ed625",
-    "@ionic/react-router": "7.3.2-dev.11693507138.1f9ed625",
+    "@ionic/react": "^7.0.10",
+    "@ionic/react-router": "^7.0.10",
     "@types/node": "^16.11.35",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",

--- a/static/code/stackblitz/v7/vue/package.json
+++ b/static/code/stackblitz/v7/vue/package.json
@@ -8,8 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ionic/vue": "7.3.2-dev.11693507138.1f9ed625",
-    "@ionic/vue-router": "7.3.2-dev.11693507138.1f9ed625",
+    "@ionic/vue": "^7.0.10",
+    "@ionic/vue-router": "^7.0.10",
     "vue": "^3.2.25",
     "vue-router": "4.0.13"
   },


### PR DESCRIPTION
Forgot to revert the packages after https://github.com/ionic-team/ionic-docs/pull/3097