### PR TITLE
fix(nav-link): opt-out of vue reactivity for component binding

### DIFF
--- a/static/usage/v6/nav/nav-link/vue/example_vue.md
+++ b/static/usage/v6/nav/nav-link/vue/example_vue.md
@@ -4,6 +4,7 @@
 </template>
 
 <script lang="ts">
+  import { markRaw } from 'vue';
   import { IonNav } from '@ionic/vue';
   import PageOne from './PageOne.vue';
 
@@ -11,7 +12,7 @@
     components: { IonNav },
     data() {
       return {
-        component: PageOne,
+        component: markRaw(PageOne),
       };
     },
   };

--- a/static/usage/v6/nav/nav-link/vue/page_one_vue.md
+++ b/static/usage/v6/nav/nav-link/vue/page_one_vue.md
@@ -14,6 +14,7 @@
 </template>
 
 <script lang="ts">
+  import { markRaw } from 'vue';
   import { IonHeader, IonTitle, IonToolbar, IonContent, IonNavLink, IonButton } from '@ionic/vue';
   import PageTwo from './PageTwo.vue';
 
@@ -21,7 +22,7 @@
     components: { IonHeader, IonTitle, IonToolbar, IonContent, IonNavLink, IonButton },
     data() {
       return {
-        component: PageTwo,
+        component: markRaw(PageTwo),
       };
     },
   };

--- a/static/usage/v6/nav/nav-link/vue/page_two_vue.md
+++ b/static/usage/v6/nav/nav-link/vue/page_two_vue.md
@@ -17,6 +17,7 @@
 </template>
 
 <script lang="ts">
+  import { markRaw } from 'vue';
   import {
     IonHeader,
     IonTitle,
@@ -42,7 +43,7 @@
     },
     data() {
       return {
-        component: PageThree,
+        component: markRaw(PageThree),
       };
     },
   };

--- a/static/usage/v7/nav/nav-link/vue/example_vue.md
+++ b/static/usage/v7/nav/nav-link/vue/example_vue.md
@@ -4,6 +4,7 @@
 </template>
 
 <script lang="ts">
+  import { markRaw } from 'vue';
   import { IonNav } from '@ionic/vue';
   import PageOne from './PageOne.vue';
 
@@ -11,7 +12,7 @@
     components: { IonNav },
     data() {
       return {
-        component: PageOne,
+        component: markRaw(PageOne),
       };
     },
   };

--- a/static/usage/v7/nav/nav-link/vue/page_one_vue.md
+++ b/static/usage/v7/nav/nav-link/vue/page_one_vue.md
@@ -14,6 +14,7 @@
 </template>
 
 <script lang="ts">
+  import { markRaw } from 'vue';
   import { IonHeader, IonTitle, IonToolbar, IonContent, IonNavLink, IonButton } from '@ionic/vue';
   import PageTwo from './PageTwo.vue';
 
@@ -21,7 +22,7 @@
     components: { IonHeader, IonTitle, IonToolbar, IonContent, IonNavLink, IonButton },
     data() {
       return {
-        component: PageTwo,
+        component: markRaw(PageTwo),
       };
     },
   };

--- a/static/usage/v7/nav/nav-link/vue/page_two_vue.md
+++ b/static/usage/v7/nav/nav-link/vue/page_two_vue.md
@@ -17,6 +17,7 @@
 </template>
 
 <script lang="ts">
+  import { markRaw } from 'vue';
   import {
     IonHeader,
     IonTitle,
@@ -42,7 +43,7 @@
     },
     data() {
       return {
-        component: PageThree,
+        component: markRaw(PageThree),
       };
     },
   };


### PR DESCRIPTION
In the Vue `ion-nav-link` examples, the examples will log a warning for property bindings to the components:

> [Vue warn]: Vue received a Component which was made a reactive object. This can lead to unnecessary performance overhead, and should be avoided by marking the component with `markRaw` or using `shallowRef` instead of `ref`. 

This is a result of passing a `Component` instance to a binding like `:component="component"` or `:root="component"`. 

As a result, we have marked those bindings explicitly with [`markRaw`](https://vuejs.org/api/reactivity-advanced.html#markraw), which opts them out of vue reactivity and resolves the warning.

This PR is in favor of: https://github.com/ionic-team/ionic-docs/pull/3076, https://github.com/ionic-team/ionic-docs/pull/3077.

Co-authored-by credit has been applied to the commit.