### PR TITLE
docs(angular): add standalone documentation

### DIFF
--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -1,24 +1,30 @@
 # Build Options
 
-Developers have two options for using Ionic components: Standalone or Modules. This guide covers both options as well as the benefits and downsides of each approach. Most of the Angular examples on this documentation website use the Modules approach for now.
+Developers have two options for using Ionic components: Standalone or Modules. This guide covers both options as well as the benefits and downsides of each approach.
 
-While the Standalone approach is newer and makes use of more modern Angular APIs, the Modules approach will continue to be supported in Ionic.
+While the Standalone approach is newer and makes use of more modern Angular APIs, the Modules approach will continue to be supported in Ionic. Most of the Angular examples on this documentation website use the Modules approach.
 
 ## Standalone
 
+:::info
+Ionic UI components as Angular standalone components is supported starting in Ionic v7.5.
+
+Additionally, using Ionic components as standalone components is supported in Angular applications that already make use of the standalone component APIs. See [Standalone Migration](https://angular.io/guide/standalone-migration) for more information.
+:::
+
 ### Overview
 
-Developers can use Ionic components as [Angular standalone components](https://angular.io/guide/standalone-components) which provides a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
+Developers with Angular applications that use [standalone components](https://angular.io/guide/standalone-components) can use Ionic components as standalone components which provides a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
 
 **Benefits**
 
 1. Enables treeshaking so the final build output only includes the code necessary to run your app which reduces overall build size.
 2. Avoids the use of `NgModule`s to streamline the development experience and make your code easier to understand.
-3. Allows developers to also use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
+3. Allows developers to also use newer Angular features such as [ESBuild](https://angular.io/guide/esbuild).
 
 **Drawbacks**
 
-1. Ionic components need to be imported into every Angular component they want to be used in which can be time consuming to set up.
+1. Ionic components need to be imported into every Angular component they are used in which can be time consuming to set up.
 
 ### Usage
 
@@ -26,7 +32,9 @@ Developers can use Ionic components as [Angular standalone components](https://a
 All Ionic standalone imports should be imported from the `@ionic/angular/standalone` package. Importing from the `@ionic/angular` package may pull in lazy loaded Ionic code which can interfere with treeshaking.
 :::
 
-In the example below, we are importing `IonContent` and `IonButton` from `@ionic/angular/standalone` and passed to `imports` for use in the component template. We would get a compiler error if these components were not imported and provided to the `imports` array.
+**Components**
+
+In the example below, we are importing `IonContent` and `IonButton` from `@ionic/angular/standalone` and passing them to `imports` for use in the component template. We would get a compiler error if these components were not imported and provided to the `imports` array.
 
 ```typescript
 import { Component } from '@angular/core';
@@ -43,6 +51,8 @@ export class HomePage {
   constructor() {}
 }
 ```
+
+**Bootstrapping and Configuration**
 
 Ionic Angular needs to be configured when the Angular application calls `bootstrapApplication` using the `provideIonicAngular` function. Developers can pass any [IonicConfig](../developing/config#ionicconfig) values as an object in this function. Note that `provideIonicAngular` needs to be called even if no custom config is passed.
 
@@ -69,6 +79,40 @@ bootstrapApplication(AppComponent, {
 });
 ```
 
+**Icons**
+
+The icon SVG data needs to be defined in the Angular component so it can be loaded correctly. Developers can use the `addIcons` function from `ionicons` to map the SVG data to a string name. Developers can then reference the icon by its string name using the `name` property on `IonIcon`.
+
+We recommend calling `addIcons` in the Angular component `constructor` so the data is only added if the Angular component is being used.
+
+For developers using Ionicons 7.2 or newer, passing only the SVG data will cause the string name to be automatically generated.
+
+```typescript
+import { Component } from '@angular/core';
+import { IonIcon } from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import { logoIonic } from 'ionicons/icons';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: 'home.page.html',
+  styleUrls: ['home.page.scss'],
+  standalone: true,
+  imports: [IonIcon],
+})
+export class HomePage {
+  constructor() {
+    /**
+     * On Ionicons 7.2+ this icon
+     * gets mapped to a "logo-ionic" key.
+     * Alternatively, developers can do:
+     * addIcons({ 'logo-ionic': logoIonic });
+     */
+    addIcons({ logoIonic });
+  }
+}
+```
+
 ## Modules
 
 ### Overview
@@ -82,7 +126,7 @@ Developers can also use the Modules approach by importing `IonicModule` and call
 **Drawbacks**
 
 1. Lazily loading Ionic components means that the compiler does not know which components are needed at build time. This means your final application bundle may be much larger than it needs to be.
-2. Developers are unable to use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
+2. Developers are unable to use newer Angular features such as [ESBuild](https://angular.io/guide/esbuild).
 
 ### Usage
 
@@ -107,14 +151,18 @@ export class AppModule {}
 ## Migrating from Modules to Standalone
 
 :::note
-This migration guide assumes the Angular components in your application are already standalone components.
+This migration guide assumes the Angular components in your application are already standalone components. See [Migrating to Standalone](https://angular.io/guide/standalone-migration) if you are Angular application is not already using standalone components.
 :::
 
 The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate as well as limitations to be aware of.
 
 ### Steps to Migrate
 
-1. Remove the `IonicModule` call in `main.ts` in favor of `provideIonicAngular` imported from `@ionic/angular/standalone`. Any config passed to `IonicModule.forRoot` can be passed as an object to this new function.
+1. Run `npm install @ionic/angular@latest` to ensure you are running the latest version of Ionic. Ionic UI Standalone Components is supported in Ionic v7.5 or newer.
+
+2.  Run `npm install ionicons@latest` to ensure you are running the latest version of Ionicons. Ionicons v7.2 brings usability improvements that reduce the code boilerplate needed to use icons with standalone components.
+
+3. Remove the `IonicModule` call in `main.ts` in favor of `provideIonicAngular` imported from `@ionic/angular/standalone`. Any config passed to `IonicModule.forRoot` can be passed as an object to this new function.
 
 ```diff
 import { enableProdMode, importProvidersFrom } from '@angular/core';
@@ -141,16 +189,16 @@ bootstrapApplication(AppComponent, {
 });
 ```
 
-2. Remove any references to `IonicModule` found elsewhere in your application.
+4. Remove any references to `IonicModule` found elsewhere in your application.
 
-3. Update any existing imports from `@ionic/angular` to import from `@ionic/angular/standalone` instead.
+5. Update any existing imports from `@ionic/angular` to import from `@ionic/angular/standalone` instead.
 
 ```diff
 - import { Platform } from '@ionic/angular';
 + import { Platform } from '@ionic/angular/standalone';
 ```
 
-4. Add imports for each Ionic component in the Angular component where they are used. Be sure to pass the imports to the `imports` array on your Angular component.
+6. Add imports for each Ionic component in the Angular component where they are used. Be sure to pass the imports to the `imports` array on your Angular component.
 
 
 ```diff
@@ -169,7 +217,7 @@ export class AppComponent {
 }
 ```
 
-5. If you are using Ionicons, define the icon SVG data used in each Angular component using `addIcons`. This allows you to continue referencing icons by string name in your component template. Note that you will need to do this for any additional icons added.
+7. If you are using Ionicons, define the icon SVG data used in each Angular component using `addIcons`. This allows you to continue referencing icons by string name in your component template. Note that you will need to do this for any additional icons added.
 
 ```diff
 import { Component } from '@angular/core';
@@ -191,7 +239,7 @@ export class TestComponent {
 }
 ```
 
-6. Remove the following code from your `angular.json` file is present. Note that it may appear multiple times in your `angular.json` file.
+8. Remove the following code from your `angular.json` file is present. Note that it may appear multiple times in your `angular.json` file.
 
 ```diff
 - {
@@ -202,3 +250,6 @@ export class TestComponent {
 ```
 
 ### Limitations
+
+1. Your application must already make use of standalone APIs. Using Ionic UI components as standalone components in an application that uses `NgModule` is not supported.
+2. Migrating to Ionic standalone components must be done all at the same time and cannot be done gradually. The Modules and Standalone approaches use two different build systems of Ionic that cannot be used at the same time.

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -1,0 +1,80 @@
+# Build Options
+
+Developers have two options for using Ionic components: Standalone or Modules. This guide covers both options as well as the benefits and downsides of each approach. Most of the Angular examples on this documentation website use the Modules approach for now.
+
+## Standalone
+
+### Overview
+
+Developers can use Ionic components as [Angular standalone components](https://angular.io/guide/standalone-components) which provides a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
+
+In the example below, we are importing `IonContent` and `IonButton` from `@ionic/angular/standalone` and passed to `imports` for use in the component template. We would get a compiler error if these components were not imported and provided to the `imports` array.
+
+```typescript
+import { Component } from '@angular/core';
+import { IonButton, IonContent } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: 'home.page.html',
+  styleUrls: ['home.page.scss'],
+  standalone: true,
+  imports: [IonButton, IonContent],
+})
+export class HomePage {
+  constructor() {}
+}
+```
+
+### Benefits
+
+1. Enables treeshaking so the final build output only includes the code necessary to run your app which reduces overall build size.
+2. Avoids the use of `NgModule`s to streamline the development experience and make your code easier to understand.
+3. Allows developers to also use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
+
+### Drawbacks
+
+1. Ionic components need to be imported into every Angular component they want to be used in which can be time consuming to set up.
+
+## Modules
+
+### Overview
+
+Developers can also use the Modules approach by importing `IonicModule` and calling `IonicModule.forRoot()` in the `imports` array in `app.module.ts`. This registers a version of Ionic where Ionic components will be lazily loaded as needed.
+
+In the example below, we are using `IonicModule` to create a lazily loaded version of Ionic. We can then reference any Ionic component without needing to explicitly import it.
+
+```typescript
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+
+import { IonicModule } from '@ionic/angular';
+
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule, IonicModule.forRoot()],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+### Benefits
+
+1. Since components are lazily loaded as needed, developers do not need to spend time manually importing and registering each Ionic component.
+
+### Drawbacks
+
+1. Lazily loading Ionic components means that the compiler does not know which components are needed at build time. This means your final application bundle may be much larger than it needs to be.
+2. Developers are unable to use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
+
+## Migrating from Modules to Standalone
+
+The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate as well as limitations to be aware of.
+
+### Steps to Migrate
+
+1.
+
+### Limitations

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -160,7 +160,7 @@ The Standalone option is newer than the Modules option, so developers may wish t
 
 1. Run `npm install @ionic/angular@latest` to ensure you are running the latest version of Ionic. Ionic UI Standalone Components is supported in Ionic v7.5 or newer.
 
-2.  Run `npm install ionicons@latest` to ensure you are running the latest version of Ionicons. Ionicons v7.2 brings usability improvements that reduce the code boilerplate needed to use icons with standalone components.
+2. Run `npm install ionicons@latest` to ensure you are running the latest version of Ionicons. Ionicons v7.2 brings usability improvements that reduce the code boilerplate needed to use icons with standalone components.
 
 3. Remove the `IonicModule` call in `main.ts` in favor of `provideIonicAngular` imported from `@ionic/angular/standalone`. Any config passed to `IonicModule.forRoot` can be passed as an object to this new function.
 
@@ -199,7 +199,6 @@ bootstrapApplication(AppComponent, {
 ```
 
 6. Add imports for each Ionic component in the Angular component where they are used. Be sure to pass the imports to the `imports` array on your Angular component.
-
 
 ```diff
 import { Component } from '@angular/core';

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -12,7 +12,7 @@ Ionic UI components as Angular standalone components is supported starting in Io
 
 ### Overview
 
-Developers with Angular applications that use [standalone components](https://angular.io/guide/standalone-components) can also use Ionic components as standalone components to provide a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
+Developers can use Ionic components as standalone components to take advantage of treeshaking and newer Angular features. This option involves importing specific Ionic components in the Angular components you want to use them in. Developers can use Ionic standalone components even if their Angular application is NgModule-based.
 
 See the [Standalone Migration Guide](#migrating-from-modules-to-standalone) for instructions on how to update your Ionic app to make use of Ionic standalone components.
 

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -239,7 +239,7 @@ export class TestComponent {
 }
 ```
 
-8. Remove the following code from your `angular.json` file is present. Note that it may appear multiple times in your `angular.json` file.
+8. Remove the following code from your `angular.json` file if present. Note that it may appear multiple times in your `angular.json` file.
 
 ```diff
 - {

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -154,7 +154,7 @@ The Standalone option is newer than the Modules option, so developers may wish t
 
 Migrating to Ionic standalone components must be done all at the same time and cannot be done gradually. The Modules and Standalone approaches use two different build systems of Ionic that cannot be used at the same time.
 
-### Using Ionic Standalone Components in Standalone-based Applications
+### Standalone-based Applications
 
 Follow these steps if your Angular application is already using the standalone architecture, and you want to use Ionic UI components as standalone components too.
 
@@ -254,7 +254,7 @@ export class TestComponent {
 - }
 ```
 
-### Using Ionic Standalone Components in NgModule-based Applications
+### NgModule-based Applications
 
 Follow these steps if your Angular application is still using the NgModule architecture, but you want to adopt Ionic UI components as standalone components now.
 

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -278,7 +278,7 @@ if (environment.production) {
 - imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule],
 + imports: [BrowserModule, AppRoutingModule],
   providers: [
-    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy }, 
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
 +   provideIonicAngular({ mode: 'ios' }),
   ],
   bootstrap: [AppComponent],
@@ -317,7 +317,7 @@ if (environment.production) {
 - imports: [BrowserModule, AppRoutingModule],
 + imports: [BrowserModule, AppRoutingModule, IonApp, IonRouterOutlet],
   providers: [
-    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy }, 
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular({ mode: 'ios' })
   ],
   bootstrap: [AppComponent],

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -32,26 +32,6 @@ See the [Standalone Migration Guide](#migrating-from-modules-to-standalone) for 
 All Ionic imports should be imported from the `@ionic/angular/standalone` submodule. This includes imports such as components, directives, providers, and types. Importing from `@ionic/angular` may pull in lazy loaded Ionic code which can interfere with treeshaking.
 :::
 
-**Components**
-
-In the example below, we are importing `IonContent` and `IonButton` from `@ionic/angular/standalone` and passing them to `imports` for use in the component template. We would get a compiler error if these components were not imported and provided to the `imports` array.
-
-```typescript
-import { Component } from '@angular/core';
-import { IonButton, IonContent } from '@ionic/angular/standalone';
-
-@Component({
-  selector: 'app-home',
-  templateUrl: 'home.page.html',
-  styleUrls: ['home.page.scss'],
-  standalone: true,
-  imports: [IonButton, IonContent],
-})
-export class HomePage {
-  constructor() {}
-}
-```
-
 **Bootstrapping and Configuration**
 
 Ionic Angular needs to be configured when the Angular application calls `bootstrapApplication` using the `provideIonicAngular` function. Developers can pass any [IonicConfig](../developing/config#ionicconfig) values as an object in this function. Note that `provideIonicAngular` needs to be called even if no custom config is passed.
@@ -77,6 +57,26 @@ bootstrapApplication(AppComponent, {
     provideRouter(routes),
   ],
 });
+```
+
+**Components**
+
+In the example below, we are importing `IonContent` and `IonButton` from `@ionic/angular/standalone` and passing them to `imports` for use in the component template. We would get a compiler error if these components were not imported and provided to the `imports` array.
+
+```typescript
+import { Component } from '@angular/core';
+import { IonButton, IonContent } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: 'home.page.html',
+  styleUrls: ['home.page.scss'],
+  standalone: true,
+  imports: [IonButton, IonContent],
+})
+export class HomePage {
+  constructor() {}
+}
 ```
 
 **Icons**

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -152,7 +152,7 @@ export class AppModule {}
 
 The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate.
 
-Note that migrating to Ionic standalone components must be done all at the same time and cannot be done gradually. The Modules and Standalone approaches use two different build systems of Ionic that cannot be used at the same time.
+Migrating to Ionic standalone components must be done all at the same time and cannot be done gradually. The Modules and Standalone approaches use two different build systems of Ionic that cannot be used at the same time.
 
 ### Using Ionic Standalone Components in Standalone-based Applications
 

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -2,11 +2,29 @@
 
 Developers have two options for using Ionic components: Standalone or Modules. This guide covers both options as well as the benefits and downsides of each approach. Most of the Angular examples on this documentation website use the Modules approach for now.
 
+While the Standalone approach is newer and makes use of more modern Angular APIs, the Modules approach will continue to be supported in Ionic.
+
 ## Standalone
 
 ### Overview
 
 Developers can use Ionic components as [Angular standalone components](https://angular.io/guide/standalone-components) which provides a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
+
+**Benefits**
+
+1. Enables treeshaking so the final build output only includes the code necessary to run your app which reduces overall build size.
+2. Avoids the use of `NgModule`s to streamline the development experience and make your code easier to understand.
+3. Allows developers to also use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
+
+**Drawbacks**
+
+1. Ionic components need to be imported into every Angular component they want to be used in which can be time consuming to set up.
+
+### Usage
+
+:::caution
+All Ionic standalone imports should be imported from the `@ionic/angular/standalone` package. Importing from the `@ionic/angular` package may pull in lazy loaded Ionic code which can interfere with treeshaking.
+:::
 
 In the example below, we are importing `IonContent` and `IonButton` from `@ionic/angular/standalone` and passed to `imports` for use in the component template. We would get a compiler error if these components were not imported and provided to the `imports` array.
 
@@ -26,21 +44,47 @@ export class HomePage {
 }
 ```
 
-### Benefits
+Ionic Angular needs to be configured when the Angular application calls `bootstrapApplication` using the `provideIonicAngular` function. Developers can pass any [IonicConfig](../developing/config#ionicconfig) values as an object in this function. Note that `provideIonicAngular` needs to be called even if no custom config is passed.
 
-1. Enables treeshaking so the final build output only includes the code necessary to run your app which reduces overall build size.
-2. Avoids the use of `NgModule`s to streamline the development experience and make your code easier to understand.
-3. Allows developers to also use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
+```typescript
+import { enableProdMode, importProvidersFrom } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { RouteReuseStrategy, provideRouter } from '@angular/router';
+import { provideIonicAngular, IonicRouteStrategy } from '@ionic/angular/standalone';
 
-### Drawbacks
+import { routes } from './app/app.routes';
+import { AppComponent } from './app/app.component';
+import { environment } from './environments/environment';
 
-1. Ionic components need to be imported into every Angular component they want to be used in which can be time consuming to set up.
+if (environment.production) {
+  enableProdMode();
+}
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    provideIonicAngular({ mode: 'ios' }),
+    provideRouter(routes),
+  ],
+});
+```
 
 ## Modules
 
 ### Overview
 
 Developers can also use the Modules approach by importing `IonicModule` and calling `IonicModule.forRoot()` in the `imports` array in `app.module.ts`. This registers a version of Ionic where Ionic components will be lazily loaded as needed.
+
+**Benefits**
+
+1. Since components are lazily loaded as needed, developers do not need to spend time manually importing and registering each Ionic component.
+
+**Drawbacks**
+
+1. Lazily loading Ionic components means that the compiler does not know which components are needed at build time. This means your final application bundle may be much larger than it needs to be.
+2. Developers are unable to use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
+
+### Usage
 
 In the example below, we are using `IonicModule` to create a lazily loaded version of Ionic. We can then reference any Ionic component without needing to explicitly import it.
 
@@ -60,21 +104,101 @@ import { AppComponent } from './app.component';
 export class AppModule {}
 ```
 
-### Benefits
-
-1. Since components are lazily loaded as needed, developers do not need to spend time manually importing and registering each Ionic component.
-
-### Drawbacks
-
-1. Lazily loading Ionic components means that the compiler does not know which components are needed at build time. This means your final application bundle may be much larger than it needs to be.
-2. Developers are unable to use newer Angular features such as [ESBuild Support](https://angular.io/guide/esbuild).
-
 ## Migrating from Modules to Standalone
+
+:::note
+This migration guide assumes the Angular components in your application are already standalone components.
+:::
 
 The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate as well as limitations to be aware of.
 
 ### Steps to Migrate
 
-1.
+1. Remove the `IonicModule` call in `main.ts` in favor of `provideIonicAngular` imported from `@ionic/angular/standalone`. Any config passed to `IonicModule.forRoot` can be passed as an object to this new function.
+
+```diff
+import { enableProdMode, importProvidersFrom } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { RouteReuseStrategy, provideRouter } from '@angular/router';
+- import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
++ import { provideIonicAngular, IonicRouteStrategy } from '@ionic/angular/standalone';
+
+import { routes } from './app/app.routes';
+import { AppComponent } from './app/app.component';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+-   importProvidersFrom(IonicModule.forRoot({ mode: 'md' })),
++   provideIonicAngular({ mode: 'md' }),
+    provideRouter(routes),
+  ],
+});
+```
+
+2. Remove any references to `IonicModule` found elsewhere in your application.
+
+3. Update any existing imports from `@ionic/angular` to import from `@ionic/angular/standalone` instead.
+
+```diff
+- import { Platform } from '@ionic/angular';
++ import { Platform } from '@ionic/angular/standalone';
+```
+
+4. Add imports for each Ionic component in the Angular component where they are used. Be sure to pass the imports to the `imports` array on your Angular component.
+
+
+```diff
+import { Component } from '@angular/core';
++ import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.scss'],
+  standalone: true,
++ imports: [IonApp, IonRouterOutlet],
+})
+export class AppComponent {
+  constructor() {}
+}
+```
+
+5. If you are using Ionicons, define the icon SVG data used in each Angular component using `addIcons`. This allows you to continue referencing icons by string name in your component template. Note that you will need to do this for any additional icons added.
+
+```diff
+import { Component } from '@angular/core';
++ import { IonIcon } from '@ionic/angular/standalone';
++ import { addIcons } from 'ionicons';
++ import { alarm, logoIonic } from 'ionicons/icons';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.scss'],
+  standalone: true,
++ imports: [IonIcon],
+})
+export class TestComponent {
+  constructor() {
+    addIcons({ alarm, logoIonic });
+  }
+}
+```
+
+6. Remove the following code from your `angular.json` file is present. Note that it may appear multiple times in your `angular.json` file.
+
+```diff
+- {
+-   "glob": "**/*.svg",
+-   "input": "node_modules/ionicons/dist/ionicons/svg",
+-   "output": "./svg"
+- }
+```
 
 ### Limitations

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -188,8 +188,8 @@ bootstrapApplication(AppComponent, {
      * You do not need to set "mode: 'ios'" to
      * use Ionic standalone components.
      */
--   importProvidersFrom(IonicModule.forRoot({ mode: 'md' })),
-+   provideIonicAngular({ mode: 'md' }),
+-   importProvidersFrom(IonicModule.forRoot({ mode: 'ios' })),
++   provideIonicAngular({ mode: 'ios' }),
     provideRouter(routes),
   ],
 });

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -150,13 +150,13 @@ export class AppModule {}
 
 ## Migrating from Modules to Standalone
 
-:::note
-This migration guide assumes the Angular components in your application are already standalone components. See [Migrating to Standalone](https://angular.io/guide/standalone-migration) if your Angular application is not already using standalone components.
-:::
+The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate.
 
-The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate as well as limitations to be aware of.
+Note that migrating to Ionic standalone components must be done all at the same time and cannot be done gradually. The Modules and Standalone approaches use two different build systems of Ionic that cannot be used at the same time.
 
-### Steps to Migrate
+### Using Ionic Standalone Components in Standalone-based Applications
+
+Follow these steps if your Angular application is already using the standalone architecture, and you want to use Ionic UI components as standalone components too.
 
 1. Run `npm install @ionic/angular@latest` to ensure you are running the latest version of Ionic. Ionic UI Standalone Components is supported in Ionic v7.5 or newer.
 
@@ -164,7 +164,7 @@ The Standalone option is newer than the Modules option, so developers may wish t
 
 3. Remove the `IonicModule` call in `main.ts` in favor of `provideIonicAngular` imported from `@ionic/angular/standalone`. Any config passed to `IonicModule.forRoot` can be passed as an object to this new function.
 
-```diff
+```diff title="main.ts"
 import { enableProdMode, importProvidersFrom } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter } from '@angular/router';
@@ -200,7 +200,7 @@ bootstrapApplication(AppComponent, {
 
 6. Add imports for each Ionic component in the Angular component where they are used. Be sure to pass the imports to the `imports` array on your Angular component.
 
-```diff
+```diff title="app.component.ts"
 import { Component } from '@angular/core';
 + import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
 
@@ -218,7 +218,7 @@ export class AppComponent {
 
 7. If you are using Ionicons, define the icon SVG data used in each Angular component using `addIcons`. This allows you to continue referencing icons by string name in your component template. Note that you will need to do this for any additional icons added.
 
-```diff
+```diff title="test.component.ts"
 import { Component } from '@angular/core';
 + import { IonIcon } from '@ionic/angular/standalone';
 + import { addIcons } from 'ionicons';
@@ -233,14 +233,14 @@ import { Component } from '@angular/core';
 })
 export class TestComponent {
   constructor() {
-    addIcons({ alarm, logoIonic });
++   addIcons({ alarm, logoIonic });
   }
 }
 ```
 
 8. Remove the following code from your `angular.json` file if present. Note that it may appear multiple times.
 
-```diff
+```diff title="angular.json"
 - {
 -   "glob": "**/*.svg",
 -   "input": "node_modules/ionicons/dist/ionicons/svg",
@@ -248,7 +248,122 @@ export class TestComponent {
 - }
 ```
 
-### Limitations
+### Using Ionic Standalone Components in NgModule-based Applications
 
-1. Your application must already make use of standalone APIs. Using Ionic UI components as standalone components in an application that uses `NgModule` is not supported.
-2. Migrating to Ionic standalone components must be done all at the same time and cannot be done gradually. The Modules and Standalone approaches use two different build systems of Ionic that cannot be used at the same time.
+Follow these steps if your Angular application is still using the NgModule architecture, but you want to adopt Ionic UI components as standalone components now.
+
+1. Run `npm install @ionic/angular@latest` to ensure you are running the latest version of Ionic. Ionic UI Standalone Components is supported in Ionic v7.5 or newer.
+
+2. Run `npm install ionicons@latest` to ensure you are running the latest version of Ionicons. Ionicons v7.2 brings usability improvements that reduce the code boilerplate needed to use icons with standalone components.
+
+3. Remove the `IonicModule` call in `app.module.ts` in favor of `provideIonicAngular` imported from `@ionic/angular/standalone`. Any config passed to `IonicModule.forRoot` can be passed as an object to this new function.
+
+```diff title="app.module.ts"
+import { enableProdMode, importProvidersFrom } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { RouteReuseStrategy, provideRouter } from '@angular/router';
+- import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
++ import { provideIonicAngular, IonicRouteStrategy } from '@ionic/angular/standalone';
+
+import { routes } from './app/app.routes';
+import { AppComponent } from './app/app.component';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+@NgModule({
+  declarations: [AppComponent],
+- imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule],
++ imports: [BrowserModule, AppRoutingModule],
+  providers: [
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy }, 
++   provideIonicAngular({ mode: 'ios' }),
+  ],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+4. Remove any references to `IonicModule` found elsewhere in your application.
+
+5. Update any existing imports from `@ionic/angular` to import from `@ionic/angular/standalone` instead.
+
+```diff
+- import { Platform } from '@ionic/angular';
++ import { Platform } from '@ionic/angular/standalone';
+```
+
+6. Add imports for each Ionic component in the NgModule for the Angular component where they are used. Be sure to pass the components to the `imports` array on the module.
+
+```diff title="app.module.ts"
+import { enableProdMode, importProvidersFrom } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { RouteReuseStrategy, provideRouter } from '@angular/router';
+- import { provideIonicAngular, IonicRouteStrategy } from '@ionic/angular/standalone';
++ import { provideIonicAngular, IonicRouteStrategy, IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+
+import { routes } from './app/app.routes';
+import { AppComponent } from './app/app.component';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+@NgModule({
+  declarations: [AppComponent],
+- imports: [BrowserModule, AppRoutingModule],
++ imports: [BrowserModule, AppRoutingModule, IonApp, IonRouterOutlet],
+  providers: [
+    { provide: RouteReuseStrategy, useClass: IonicRouteStrategy }, 
+    provideIonicAngular({ mode: 'ios' })
+  ],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+7. If you are using Ionicons, define the icon SVG data used in each Angular component using `addIcons`. This allows you to continue referencing icons by string name in your component template. Note that you will need to do this for any additional icons added. The `IonIcon` component should still be provided in the NgModule.
+
+```diff title="test.component.ts"
+import { Component } from '@angular/core';
++ import { addIcons } from 'ionicons';
++ import { alarm, logoIonic } from 'ionicons/icons';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: 'app.component.html',
+  styleUrls: ['app.component.scss'],
+})
+export class TestComponent {
+  constructor() {
+    addIcons({ alarm, logoIonic });
+  }
+}
+```
+
+```diff title="test.module.ts"
+import { NgModule } from '@angular/core';
+import { TestComponent } from './test.component';
++ import { IonIcon } from '@ionic/angular/standalone';
+
+@NgModule({
+  imports: [
++   IonIcon,
+  ],
+  declarations: [TestComponent]
+})
+export class TestComponentModule {}
+```
+
+8. Remove the following code from your `angular.json` file if present. Note that it may appear multiple times.
+
+```diff title="angular.json"
+- {
+-   "glob": "**/*.svg",
+-   "input": "node_modules/ionicons/dist/ionicons/svg",
+-   "output": "./svg"
+- }
+```

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -117,7 +117,7 @@ export class HomePage {
 
 ### Overview
 
-Developers can also use the Modules approach by importing `IonicModule` and calling `IonicModule.forRoot()` in the `imports` array in `app.module.ts`. This registers a version of Ionic where Ionic components will be lazily loaded as needed.
+Developers can also use the Modules approach by importing `IonicModule` and calling `IonicModule.forRoot()` in the `imports` array in `app.module.ts`. This registers a version of Ionic where Ionic components will be lazily loaded at runtime.
 
 **Benefits**
 

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -182,6 +182,12 @@ if (environment.production) {
 bootstrapApplication(AppComponent, {
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    /**
+     * The custom config serves as an example
+     * of how to pass a config to provideIonicAngular.
+     * You do not need to set "mode: 'ios'" to
+     * use Ionic standalone components.
+     */
 -   importProvidersFrom(IonicModule.forRoot({ mode: 'md' })),
 +   provideIonicAngular({ mode: 'md' }),
     provideRouter(routes),
@@ -279,6 +285,12 @@ if (environment.production) {
 + imports: [BrowserModule, AppRoutingModule],
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
+    /**
+     * The custom config serves as an example
+     * of how to pass a config to provideIonicAngular.
+     * You do not need to set "mode: 'ios'" to
+     * use Ionic standalone components.
+     */
 +   provideIonicAngular({ mode: 'ios' }),
   ],
   bootstrap: [AppComponent],

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -14,6 +14,8 @@ Ionic UI components as Angular standalone components is supported starting in Io
 
 Developers with Angular applications that use [standalone components](https://angular.io/guide/standalone-components) can also use Ionic components as standalone components to provide a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
 
+See the [Standalone Migration Guide](#migrating-from-modules-to-standalone) for instructions on how to update your Ionic app to make use of Ionic standalone components.
+
 **Benefits**
 
 1. Enables treeshaking so the final build output only includes the code necessary to run your app which reduces overall build size.

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -8,13 +8,11 @@ While the Standalone approach is newer and makes use of more modern Angular APIs
 
 :::info
 Ionic UI components as Angular standalone components is supported starting in Ionic v7.5.
-
-Additionally, using Ionic components as standalone components is supported in Angular applications that already make use of the standalone component APIs. See [Standalone Migration](https://angular.io/guide/standalone-migration) for more information.
 :::
 
 ### Overview
 
-Developers with Angular applications that use [standalone components](https://angular.io/guide/standalone-components) can use Ionic components as standalone components which provides a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
+Developers with Angular applications that use [standalone components](https://angular.io/guide/standalone-components) can also use Ionic components as standalone components to provide a simplified way to build Angular applications. This option involves importing specific Ionic components in the Angular components you want to use them in.
 
 **Benefits**
 
@@ -29,7 +27,7 @@ Developers with Angular applications that use [standalone components](https://an
 ### Usage
 
 :::caution
-All Ionic standalone imports should be imported from the `@ionic/angular/standalone` package. Importing from the `@ionic/angular` package may pull in lazy loaded Ionic code which can interfere with treeshaking.
+All Ionic imports should be imported from the `@ionic/angular/standalone` submodule. This includes imports such as components, directives, providers, and types. Importing from `@ionic/angular` may pull in lazy loaded Ionic code which can interfere with treeshaking.
 :::
 
 **Components**
@@ -151,7 +149,7 @@ export class AppModule {}
 ## Migrating from Modules to Standalone
 
 :::note
-This migration guide assumes the Angular components in your application are already standalone components. See [Migrating to Standalone](https://angular.io/guide/standalone-migration) if you are Angular application is not already using standalone components.
+This migration guide assumes the Angular components in your application are already standalone components. See [Migrating to Standalone](https://angular.io/guide/standalone-migration) if your Angular application is not already using standalone components.
 :::
 
 The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate as well as limitations to be aware of.
@@ -238,7 +236,7 @@ export class TestComponent {
 }
 ```
 
-8. Remove the following code from your `angular.json` file if present. Note that it may appear multiple times in your `angular.json` file.
+8. Remove the following code from your `angular.json` file if present. Note that it may appear multiple times.
 
 ```diff
 - {

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -281,7 +281,7 @@ if (environment.production) {
 
 @NgModule({
   declarations: [AppComponent],
-- imports: [BrowserModule, IonicModule.forRoot(), AppRoutingModule],
+- imports: [BrowserModule, IonicModule.forRoot({ mode: 'ios' }), AppRoutingModule],
 + imports: [BrowserModule, AppRoutingModule],
   providers: [
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },

--- a/docs/angular/overview.md
+++ b/docs/angular/overview.md
@@ -39,4 +39,8 @@ With Ionic 4+, the official Angular stack for building an app and routing are us
   <p>Learn about using Ionic lifecycle events in class components and with hooks</p>
 </DocsCard>
 
+<DocsCard header="Build Options" href="build-options" icon="/icons/logo-angular-icon.png">
+  <p>Learn about using Modules or Standalone Components in Ionic.</p>
+</DocsCard>
+
 </DocsCards>

--- a/sidebars.js
+++ b/sidebars.js
@@ -66,6 +66,7 @@ module.exports = {
       collapsed: false,
       items: [
         'angular/overview',
+        'angular/build-options',
         {
           type: 'category',
           label: 'Build Your First App',


### PR DESCRIPTION
This PR shows how to use Ionic UI standalone components.

Preview: https://ionic-docs-git-4612-docs-ionic1.vercel.app/docs/angular/build-options