### PR TITLE
docs(angular): add angular standalone syntax to non-playground examples

### DIFF
--- a/docs/angular/platform.md
+++ b/docs/angular/platform.md
@@ -2,6 +2,9 @@
 title: Platform
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 <head>
   <title>Platform | Ionic Platform to Customize Apps to Fit Any Device</title>
   <meta
@@ -14,6 +17,16 @@ The Platform service can be used to get information about your current device. Y
 
 ## Usage
 
+<Tabs
+  groupId="framework"
+  defaultValue="angular"
+  values={[
+    { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
+  ]}
+>
+<TabItem value="angular">
+
 ```tsx
 import { Platform } from '@ionic/angular';
 
@@ -24,6 +37,21 @@ export class MyPage {
   }
 }
 ```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```tsx
+import { Platform } from '@ionic/angular/standalone';
+
+@Component({...})
+export class MyPage {
+  constructor(public platform: Platform) {
+
+  }
+}
+```
+</TabItem>
+</Tabs>
 
 ## Methods
 

--- a/docs/angular/platform.md
+++ b/docs/angular/platform.md
@@ -37,6 +37,7 @@ export class MyPage {
   }
 }
 ```
+
 </TabItem>
 <TabItem value="angular-standalone">
 
@@ -50,6 +51,7 @@ export class MyPage {
   }
 }
 ```
+
 </TabItem>
 </Tabs>
 

--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -164,6 +164,7 @@ export class HomePage {
   swiperModules = [IonicSlides];
 }
 ```
+
 </TabItem>
 <TabItem value="angular-standalone">
 
@@ -179,6 +180,7 @@ export class HomePage {
   swiperModules = [IonicSlides];
 }
 ```
+
 </TabItem>
 </Tabs>
 

--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -2,6 +2,9 @@
 title: Migrating from ion-slides to Swiper.js
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 <head>
   <title>Set Up Swiper.js for Angular Slides [Example] | Ionic</title>
   <meta
@@ -137,7 +140,17 @@ With `ion-slides`, Ionic automatically customized dozens of Swiper properties. T
 
 It is recommended to review the [properties](https://github.com/ionic-team/ionic-framework/blob/main/core/src/components/slides/IonicSlides.ts) set by `IonicSlides` and determine which ones you would like to customize.
 
-We can install the `IonicSlides` module by importing it from `@ionic/angular` and passing it to the `modules` property of `swiper-container` as an array:
+We can install the `IonicSlides` module by importing and passing it to the `modules` property of `swiper-container` as an array:
+
+<Tabs
+  groupId="framework"
+  defaultValue="angular"
+  values={[
+    { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
+  ]}
+>
+<TabItem value="angular">
 
 ```typescript
 // home.page.ts
@@ -151,6 +164,23 @@ export class HomePage {
   swiperModules = [IonicSlides];
 }
 ```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```typescript
+// home.page.ts
+
+import { IonicSlides } from '@ionic/angular/standalone';
+
+@Component({
+  ...
+})
+export class HomePage {
+  swiperModules = [IonicSlides];
+}
+```
+</TabItem>
+</Tabs>
 
 ```html
 <!-- home.page.html -->

--- a/docs/developing/config.md
+++ b/docs/developing/config.md
@@ -2,6 +2,9 @@
 title: Config
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 Ionic Config provides a way to change the properties of components globally across an app. It can set the app mode, tab button layout, animations, and more.
 
 ## Global Config
@@ -61,6 +64,16 @@ Ionic Angular provides a `Config` provider for accessing the Ionic Config.
 
 #### Examples
 
+<Tabs
+  groupId="framework"
+  defaultValue="angular"
+  values={[
+    { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
+  ]}
+>
+<TabItem value="angular">
+
 ```ts
 import { Config } from '@ionic/angular';
 
@@ -71,6 +84,23 @@ class AppComponent {
   }
 }
 ```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```ts
+import { Config } from '@ionic/angular/standalone';
+
+@Component(...)
+class AppComponent {
+  constructor(config: Config) {
+    const mode = config.get('mode');
+  }
+}
+```
+</TabItem>
+</Tabs>
+
+
 
 ### getBoolean
 
@@ -80,6 +110,16 @@ class AppComponent {
 | **Signature**   | `getBoolean(key: string, fallback?: boolean) => boolean`                             |
 
 #### Examples
+
+<Tabs
+  groupId="framework"
+  defaultValue="angular"
+  values={[
+    { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
+  ]}
+>
+<TabItem value="angular">
 
 ```ts
 import { Config } from '@ionic/angular';
@@ -91,6 +131,21 @@ class AppComponent {
   }
 }
 ```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```ts
+import { Config } from '@ionic/angular/standalone';
+
+@Component(...)
+class AppComponent {
+  constructor(config: Config) {
+    const swipeBackEnabled = config.getBoolean('swipeBackEnabled');
+  }
+}
+```
+</TabItem>
+</Tabs>
 
 ### getNumber
 

--- a/docs/developing/config.md
+++ b/docs/developing/config.md
@@ -84,6 +84,7 @@ class AppComponent {
   }
 }
 ```
+
 </TabItem>
 <TabItem value="angular-standalone">
 
@@ -97,10 +98,9 @@ class AppComponent {
   }
 }
 ```
+
 </TabItem>
 </Tabs>
-
-
 
 ### getBoolean
 
@@ -131,6 +131,7 @@ class AppComponent {
   }
 }
 ```
+
 </TabItem>
 <TabItem value="angular-standalone">
 
@@ -144,6 +145,7 @@ class AppComponent {
   }
 }
 ```
+
 </TabItem>
 </Tabs>
 

--- a/docs/developing/config/global/index.md
+++ b/docs/developing/config/global/index.md
@@ -57,6 +57,7 @@ bootstrapApplication(AppComponent, {
   ]
 })
 ```
+
 </TabItem>
 <TabItem value="react">
 

--- a/docs/developing/config/global/index.md
+++ b/docs/developing/config/global/index.md
@@ -7,6 +7,7 @@ import TabItem from '@theme/TabItem';
   values={[
     { value: 'javascript', label: 'JavaScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]}
@@ -40,6 +41,22 @@ import { IonicModule } from '@ionic/angular';
 })
 ```
 
+</TabItem>
+<TabItem value="angular-standalone">
+
+```ts title="main.ts"
+import { provideIonicAngular } from '@ionic/angular/standalone';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    ...,
+    provideIonicAngular({
+      rippleEffect: false,
+      mode: 'md'
+    })
+  ]
+})
+```
 </TabItem>
 <TabItem value="react">
 

--- a/docs/developing/config/per-component/index.md
+++ b/docs/developing/config/per-component/index.md
@@ -7,6 +7,7 @@ import TabItem from '@theme/TabItem';
   values={[
     { value: 'javascript', label: 'JavaScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]}
@@ -58,6 +59,42 @@ import { IonicModule } from '@ionic/angular';
   ],
   ...
 });
+```
+
+**Recommended**
+
+```html
+<ion-back-button [text]="backButtonText"></ion-back-button>
+```
+
+```ts
+@Component(...)
+class MyComponent {
+  /**
+   * The back button text can be updated
+   * anytime the locale changes.
+   */
+  backButtonText = 'Go Back';
+}
+```
+
+</TabItem>
+<TabItem value="angular-standalone">
+
+**Not recommended**
+
+```ts
+import { provideIonicAngular } from '@ionic/angular/standalone';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    ...,
+    provideIonicAngular({
+      // Not recommended when your app requires reactive values
+      backButtonText: 'Go Back'
+    })
+  ]
+})
 ```
 
 **Recommended**

--- a/docs/developing/config/per-platform-fallback/index.md
+++ b/docs/developing/config/per-platform-fallback/index.md
@@ -6,6 +6,7 @@ import TabItem from '@theme/TabItem';
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]}
@@ -33,6 +34,32 @@ const getConfig = () => {
   ],
   ...
 });
+```
+
+</TabItem>
+<TabItem value="angular-standalone">
+
+```ts title="main.ts"
+import { isPlatform, provideIonicAngular } from '@ionic/angular/standalone';
+
+const getConfig = () => {
+  if (isPlatform('hybrid')) {
+    return {
+      tabButtonLayout: 'label-hide'
+    }
+  }
+
+  return {
+    tabButtonLayout: 'icon-top'
+  };
+}
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    ...,
+    provideIonicAngular(getConfig())
+  ]
+})
 ```
 
 </TabItem>

--- a/docs/developing/config/per-platform-overrides/index.md
+++ b/docs/developing/config/per-platform-overrides/index.md
@@ -6,6 +6,7 @@ import TabItem from '@theme/TabItem';
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]}
@@ -36,6 +37,35 @@ const getConfig = () => {
   ],
   ...
 });
+```
+
+</TabItem>
+<TabItem value="angular-standalone">
+
+```ts title="main.ts"
+import { isPlatform, provideIonicAngular } from '@ionic/angular/standalone';
+
+const getConfig = () => {
+  let config = {
+    animated: false
+  };
+
+  if (isPlatform('iphone')) {
+    config = {
+      ...config,
+      backButtonText: 'Previous'
+    }
+  }
+
+  return config;
+}
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    ...,
+    provideIonicAngular(getConfig())
+  ]
+})
 ```
 
 </TabItem>

--- a/docs/developing/config/per-platform/index.md
+++ b/docs/developing/config/per-platform/index.md
@@ -6,6 +6,7 @@ import TabItem from '@theme/TabItem';
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]}
@@ -29,6 +30,28 @@ import { isPlatform, IonicModule } from '@ionic/angular';
     })
   ],
   ...
+})
+```
+
+</TabItem>
+<TabItem value="angular-standalone">
+
+:::note
+Since the config is set at runtime, you will not have access to the Platform Dependency Injection. Instead, you can use the underlying functions that the provider uses directly.
+
+See the [Angular Platform Documentation](../angular/platform) for the types of platforms you can detect.
+:::
+
+```ts title="main.ts"
+import { isPlatform, provideIonicAngular } from '@ionic/angular/standalone';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    ...,
+    provideIonicAngular({
+      animated: !isPlatform('mobileweb')
+    })
+  ]
 })
 ```
 

--- a/docs/developing/hardware-back-button.md
+++ b/docs/developing/hardware-back-button.md
@@ -50,6 +50,7 @@ The `ionBackButton` event will not be emitted when running an app in a browser o
   values={[
     { value: 'javascript', label: 'JavaScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]
@@ -69,6 +70,21 @@ document.addEventListener('ionBackButton', (ev) => {
 
 ```tsx
 import { Platform } from '@ionic/angular';
+
+...
+
+constructor(private platform: Platform) {
+  this.platform.backButton.subscribeWithPriority(10, () => {
+    console.log('Handler was called!');
+  });
+}
+
+```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```tsx
+import { Platform } from '@ionic/angular/standalone';
 
 ...
 
@@ -124,6 +140,7 @@ Each hardware back button callback has a `processNextHandler` parameter. Calling
   values={[
     { value: 'javascript', label: 'JavaScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]
@@ -149,6 +166,27 @@ document.addEventListener('ionBackButton', (ev) => {
 
 ```tsx
 import { Platform } from '@ionic/angular';
+
+...
+
+constructor(private platform: Platform) {
+  this.platform.backButton.subscribeWithPriority(5, () => {
+    console.log('Another handler was called!');
+  });
+
+  this.platform.backButton.subscribeWithPriority(10, (processNextHandler) => {
+    console.log('Handler was called!');
+
+    processNextHandler();
+  });
+}
+
+```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```tsx
+import { Platform } from '@ionic/angular/standalone';
 
 ...
 
@@ -244,6 +282,7 @@ In some scenarios, it may be desirable to quit the app when pressing the hardwar
   values={[
     { value: 'javascript', label: 'JavaScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]
@@ -272,6 +311,28 @@ document.addEventListener('ionBackButton', (ev: BackButtonEvent) => {
 ```tsx
 import { Optional } from '@angular/core';
 import { IonRouterOutlet, Platform } from '@ionic/angular';
+import { App } from '@capacitor/app';
+
+...
+
+constructor(
+  private platform: Platform,
+  @Optional() private routerOutlet?: IonRouterOutlet
+) {
+  this.platform.backButton.subscribeWithPriority(-1, () => {
+    if (!this.routerOutlet.canGoBack()) {
+      App.exitApp();
+    }
+  });
+}
+
+```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```tsx
+import { Optional } from '@angular/core';
+import { IonRouterOutlet, Platform } from '@ionic/angular/standalone';
 import { App } from '@capacitor/app';
 
 ...

--- a/docs/developing/keyboard.md
+++ b/docs/developing/keyboard.md
@@ -199,6 +199,7 @@ Detecting the presence of an on-screen keyboard is useful for adjusting the posi
   values={[
     { value: 'javascript', label: 'JavaScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]
@@ -220,6 +221,25 @@ window.addEventListener('ionKeyboardDidHide', () => {
 
 ```tsx
 import { Platform } from '@ionic/angular';
+
+...
+
+constructor(private platform: Platform) {
+  this.platform.keyboardDidShow.subscribe(ev => {
+    const { keyboardHeight } = ev;
+    // Do something with the keyboard height such as translating an input above the keyboard.
+  });
+
+  this.platform.keyboardDidHide.subscribe(() => {
+    // Move input back to original location
+  });
+}
+```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```tsx
+import { Platform } from '@ionic/angular/standalone';
 
 ...
 

--- a/docs/techniques/security.md
+++ b/docs/techniques/security.md
@@ -94,6 +94,7 @@ In order to bypass the sanitizer and use unsanitized custom HTML in the relevant
   defaultValue="angular"
   values={[
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'javascript', label: 'JavaScript' },
     { value: 'react', label: 'React' },
   ]
@@ -102,6 +103,25 @@ In order to bypass the sanitizer and use unsanitized custom HTML in the relevant
 
 ```tsx
 import { IonicSafeString, ToastController } from '@ionic/angular';
+
+...
+
+constructor(private toastController: ToastController) {}
+
+async presentToast() {
+  const toast = await this.toastController.create({
+      message: new IonicSafeString('<ion-button>Hello!</ion-button>'),
+      duration: 2000
+  });
+  toast.present();
+}
+
+```
+</TabItem>
+<TabItem value="angular-standalone">
+
+```tsx
+import { IonicSafeString, ToastController } from '@ionic/angular/standalone';
 
 ...
 

--- a/docs/utilities/animations.md
+++ b/docs/utilities/animations.md
@@ -32,6 +32,7 @@ Ionic Animations, on the other hand, uses the [Web Animations API](https://devel
     { value: 'javascript', label: 'JavaScript' },
     { value: 'typescript', label: 'TypeScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]
@@ -76,6 +77,25 @@ Developers using Angular should install the latest version of `@ionic/angular`. 
 ```tsx
 
 import { Animation, AnimationController } from '@ionic/angular';
+
+...
+
+constructor(private animationCtrl: AnimationController) {
+  const animation: Animation = this.animationCtrl.create()
+    .addElement(myElementRef)
+    .duration(1000)
+    .fromTo('opacity', '1', '0.5');
+}
+
+```
+</TabItem>
+<TabItem value="angular-standalone">
+
+Developers using Angular should install the latest version of `@ionic/angular`. Animations can be created via the `AnimationController` dependency injection.
+
+```tsx
+
+import { Animation, AnimationController } from '@ionic/angular/standalone';
 
 ...
 

--- a/docs/utilities/gestures.md
+++ b/docs/utilities/gestures.md
@@ -29,6 +29,7 @@ Building complex gestures can be time consuming. Other libraries that provide cu
   values={[
     { value: 'javascript', label: 'JavaScript' },
     { value: 'angular', label: 'Angular' },
+    { value: 'angular-standalone', label: 'Angular (Standalone)' },
     { value: 'react', label: 'React' },
     { value: 'vue', label: 'Vue' },
   ]
@@ -77,6 +78,30 @@ or they can wrap their callbacks in an `NgZone.run()` call.
 
 ```tsx
 import { Gesture, GestureController } from '@ionic/angular';
+
+...
+
+constructor(private gestureCtrl: GestureController) {
+  const gesture: Gesture = this.gestureCtrl.create({
+    el: this.element.nativeElement,
+    threshold: 15,
+    gestureName: 'my-gesture',
+    onMove: ev => this.onMoveHandler(ev)
+  }, true);
+  // The `true` above ensures that callbacks run inside NgZone.
+}
+
+```
+</TabItem>
+<TabItem value="angular-standalone">
+
+Developers using Angular should install the latest version of `@ionic/angular`. Animations can be created via the `AnimationController` dependency injection.
+
+By default, gesture callbacks do not run inside of NgZone. Developers can either set the `runInsideAngularZone` parameter to `true` when creating a gesture,
+or they can wrap their callbacks in an `NgZone.run()` call.
+
+```tsx
+import { Gesture, GestureController } from '@ionic/angular/standalone';
 
 ...
 


### PR DESCRIPTION
In addition to https://github.com/ionic-team/ionic-docs/pull/3115, I updated all the non-Playground code blocks to add Angular standalone examples.

Preview: https://ionic-docs-git-standalone-examples-ionic1.vercel.app/docs
Example: https://ionic-docs-git-standalone-examples-ionic1.vercel.app/docs/developing/config