### PR TITLE
fix(playground): better handle multiple files for Javascript

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -366,13 +366,10 @@ export default function Playground({
       version,
     };
 
-    let codeBlock;
-    if (!hasUsageTargetOptions) {
-      // codeSnippets are React components, so we need to get their rendered text
-      // using outerText will preserve line breaks for formatting in Stackblitz editor
-      codeBlock = codeRef.current.querySelector('code').outerText;
-    } else {
-      codeBlock = codeRef.current.querySelector('code').outerText;
+    // using outerText will preserve line breaks for formatting in Stackblitz editor
+    let codeBlock = codeRef.current.querySelector('code').outerText;
+
+    if (hasUsageTargetOptions) {
       editorOptions.files = Object.keys(codeSnippets[usageTarget])
         .map((fileName) => ({
           [fileName]: hostRef.current!.querySelector<HTMLElement>(`#${getCodeSnippetId(usageTarget, fileName)} code`)

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -372,6 +372,7 @@ export default function Playground({
       // using outerText will preserve line breaks for formatting in Stackblitz editor
       codeBlock = codeRef.current.querySelector('code').outerText;
     } else {
+      codeBlock = codeRef.current.querySelector('code').outerText;
       editorOptions.files = Object.keys(codeSnippets[usageTarget])
         .map((fileName) => ({
           [fileName]: hostRef.current!.querySelector<HTMLElement>(`#${getCodeSnippetId(usageTarget, fileName)} code`)

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -367,7 +367,7 @@ export default function Playground({
     };
 
     // using outerText will preserve line breaks for formatting in Stackblitz editor
-    let codeBlock = codeRef.current.querySelector('code').outerText;
+    const codeBlock = codeRef.current.querySelector('code').outerText;
 
     if (hasUsageTargetOptions) {
       editorOptions.files = Object.keys(codeSnippets[usageTarget])

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -68,7 +68,7 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
 
   const package_json = defaultFiles[3];
 
-  files[indexHtml] = files[indexHtml].replace(/{{ TEMPLATE }}/g, code).replace(
+  files[indexHtml] = defaultFiles[1].replace(/{{ TEMPLATE }}/g, code).replace(
     '</head>',
     `
   <script>

--- a/static/usage/v6/modal/styling/animations/javascript/index_html.md
+++ b/static/usage/v6/modal/styling/animations/javascript/index_html.md
@@ -1,106 +1,95 @@
 ```html
-<html>
-  <head>
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/core.css" />
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/ionic.bundle.css" />
-  </head>
+<ion-header>
+  <ion-toolbar>
+    <ion-title>App</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <ion-button id="open-modal" expand="block">Open Modal</ion-button>
 
-  <body>
-    <ion-app>
-      <ion-header>
-        <ion-toolbar>
-          <ion-title>App</ion-title>
-        </ion-toolbar>
-      </ion-header>
-      <ion-content class="ion-padding">
-        <ion-button id="open-modal" expand="block">Open Modal</ion-button>
+  <ion-modal trigger="open-modal">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Modal</ion-title>
+        <ion-buttons slot="end">
+          <ion-button onclick="modal.dismiss()">Close</ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <ion-list>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=b" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Connor Smith</h2>
+            <p>Sales Rep</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=a" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Daniel Smith</h2>
+            <p>Product Designer</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=d" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Greg Smith</h2>
+            <p>Director of Operations</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=e" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Zoey Smith</h2>
+            <p>CEO</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-modal>
+</ion-content>
 
-        <ion-modal trigger="open-modal">
-          <ion-header>
-            <ion-toolbar>
-              <ion-title>Modal</ion-title>
-              <ion-buttons slot="end">
-                <ion-button onclick="modal.dismiss()">Close</ion-button>
-              </ion-buttons>
-            </ion-toolbar>
-          </ion-header>
-          <ion-content>
-            <ion-list>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=b" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Connor Smith</h2>
-                  <p>Sales Rep</p>
-                </ion-label>
-              </ion-item>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=a" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Daniel Smith</h2>
-                  <p>Product Designer</p>
-                </ion-label>
-              </ion-item>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=d" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Greg Smith</h2>
-                  <p>Director of Operations</p>
-                </ion-label>
-              </ion-item>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=e" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Zoey Smith</h2>
-                  <p>CEO</p>
-                </ion-label>
-              </ion-item>
-            </ion-list>
-          </ion-content>
-        </ion-modal>
-      </ion-content>
-    </ion-app>
+<script>
+  var modal = document.querySelector('ion-modal');
 
-    <script>
-      var modal = document.querySelector('ion-modal');
+  const enterAnimation = (baseEl) => {
+    const root = baseEl.shadowRoot;
 
-      const enterAnimation = (baseEl) => {
-        const root = baseEl.shadowRoot;
+    const backdropAnimation = createAnimation()
+      .addElement(root.querySelector('ion-backdrop'))
+      .fromTo('opacity', '0.01', 'var(--backdrop-opacity)');
 
-        const backdropAnimation = createAnimation()
-          .addElement(root.querySelector('ion-backdrop'))
-          .fromTo('opacity', '0.01', 'var(--backdrop-opacity)');
+    const wrapperAnimation = createAnimation()
+      .addElement(root.querySelector('.modal-wrapper'))
+      .keyframes([
+        { offset: 0, opacity: '0', transform: 'scale(0)' },
+        { offset: 1, opacity: '0.99', transform: 'scale(1)' },
+      ]);
 
-        const wrapperAnimation = createAnimation()
-          .addElement(root.querySelector('.modal-wrapper'))
-          .keyframes([
-            { offset: 0, opacity: '0', transform: 'scale(0)' },
-            { offset: 1, opacity: '0.99', transform: 'scale(1)' },
-          ]);
+    return createAnimation()
+      .addElement(baseEl)
+      .easing('ease-out')
+      .duration(500)
+      .addAnimation([backdropAnimation, wrapperAnimation]);
+  };
 
-        return createAnimation()
-          .addElement(baseEl)
-          .easing('ease-out')
-          .duration(500)
-          .addAnimation([backdropAnimation, wrapperAnimation]);
-      };
+  const leaveAnimation = (baseEl) => enterAnimation(baseEl).direction('reverse');
 
-      const leaveAnimation = (baseEl) => enterAnimation(baseEl).direction('reverse');
+  modal.enterAnimation = enterAnimation;
+  modal.leaveAnimation = leaveAnimation;
 
-      modal.enterAnimation = enterAnimation;
-      modal.leaveAnimation = leaveAnimation;
-
-      function dismiss() {
-        modal.dismiss();
-      }
-    </script>
-  </body>
-</html>
+  function dismiss() {
+    modal.dismiss();
+  }
+</script>
 ```

--- a/static/usage/v7/input/mask/javascript/index_html.md
+++ b/static/usage/v7/input/mask/javascript/index_html.md
@@ -1,58 +1,45 @@
 ```html
-<html>
-  <head>
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/core.css" />
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/ionic.bundle.css" />
-  </head>
+<ion-list>
+  <ion-item>
+    <ion-input id="card" label="Card number" placeholder="0000 0000 0000 0000"></ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input id="phone" label="US phone number" placeholder="+1 (xxx) xxx-xxxx"></ion-input>
+  </ion-item>
+</ion-list>
 
-  <body>
-    <ion-app>
-      <ion-content class="ion-padding">
-        <ion-list>
-          <ion-item>
-            <ion-input id="card" label="Card number" placeholder="0000 0000 0000 0000"></ion-input>
-          </ion-item>
-          <ion-item>
-            <ion-input id="phone" label="US phone number" placeholder="+1 (xxx) xxx-xxxx"></ion-input>
-          </ion-item>
-        </ion-list>
-      </ion-content>
+<script>
+  async function initPhoneMask() {
+    const ionInput = document.querySelector('#phone');
+    const nativeEl = await ionInput.getInputElement();
 
-      <script>
-        async function initPhoneMask() {
-          const ionInput = document.querySelector('#phone');
-          const nativeEl = await ionInput.getInputElement();
+    new window.Maskito(nativeEl, {
+      mask: ['+', '1', ' ', '(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/],
+    });
+  }
 
-          new window.Maskito(nativeEl, {
-            mask: ['+', '1', ' ', '(', /\d/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/],
-          });
-        }
+  async function initCardMask() {
+    const ionInput = document.querySelector('#card');
+    const nativeEl = await ionInput.getInputElement();
 
-        async function initCardMask() {
-          const ionInput = document.querySelector('#card');
-          const nativeEl = await ionInput.getInputElement();
+    new window.Maskito(nativeEl, {
+      mask: [
+        ...Array(4).fill(/\d/),
+        ' ',
+        ...Array(4).fill(/\d/),
+        ' ',
+        ...Array(4).fill(/\d/),
+        ' ',
+        ...Array(4).fill(/\d/),
+        ' ',
+        ...Array(3).fill(/\d/),
+      ],
+    });
+  }
 
-          new window.Maskito(nativeEl, {
-            mask: [
-              ...Array(4).fill(/\d/),
-              ' ',
-              ...Array(4).fill(/\d/),
-              ' ',
-              ...Array(4).fill(/\d/),
-              ' ',
-              ...Array(4).fill(/\d/),
-              ' ',
-              ...Array(3).fill(/\d/),
-            ],
-          });
-        }
-
-        window.addEventListener('appload', () => {
-          initCardMask();
-          initPhoneMask();
-        });
-      </script>
-    </ion-app>
-  </body>
-</html>
+  window.addEventListener('appload', () => {
+    initCardMask();
+    initPhoneMask();
+  });
+</script>
 ```

--- a/static/usage/v7/modal/styling/animations/javascript/index_html.md
+++ b/static/usage/v7/modal/styling/animations/javascript/index_html.md
@@ -1,106 +1,95 @@
 ```html
-<html>
-  <head>
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/core.css" />
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core/css/ionic.bundle.css" />
-  </head>
+<ion-header>
+  <ion-toolbar>
+    <ion-title>App</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <ion-button id="open-modal" expand="block">Open Modal</ion-button>
 
-  <body>
-    <ion-app>
-      <ion-header>
-        <ion-toolbar>
-          <ion-title>App</ion-title>
-        </ion-toolbar>
-      </ion-header>
-      <ion-content class="ion-padding">
-        <ion-button id="open-modal" expand="block">Open Modal</ion-button>
+  <ion-modal trigger="open-modal">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Modal</ion-title>
+        <ion-buttons slot="end">
+          <ion-button onclick="modal.dismiss()">Close</ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <ion-list>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=b" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Connor Smith</h2>
+            <p>Sales Rep</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=a" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Daniel Smith</h2>
+            <p>Product Designer</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=d" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Greg Smith</h2>
+            <p>Director of Operations</p>
+          </ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-avatar slot="start">
+            <ion-img src="https://i.pravatar.cc/300?u=e" />
+          </ion-avatar>
+          <ion-label>
+            <h2>Zoey Smith</h2>
+            <p>CEO</p>
+          </ion-label>
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-modal>
+</ion-content>
 
-        <ion-modal trigger="open-modal">
-          <ion-header>
-            <ion-toolbar>
-              <ion-title>Modal</ion-title>
-              <ion-buttons slot="end">
-                <ion-button onclick="modal.dismiss()">Close</ion-button>
-              </ion-buttons>
-            </ion-toolbar>
-          </ion-header>
-          <ion-content>
-            <ion-list>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=b" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Connor Smith</h2>
-                  <p>Sales Rep</p>
-                </ion-label>
-              </ion-item>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=a" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Daniel Smith</h2>
-                  <p>Product Designer</p>
-                </ion-label>
-              </ion-item>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=d" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Greg Smith</h2>
-                  <p>Director of Operations</p>
-                </ion-label>
-              </ion-item>
-              <ion-item>
-                <ion-avatar slot="start">
-                  <ion-img src="https://i.pravatar.cc/300?u=e" />
-                </ion-avatar>
-                <ion-label>
-                  <h2>Zoey Smith</h2>
-                  <p>CEO</p>
-                </ion-label>
-              </ion-item>
-            </ion-list>
-          </ion-content>
-        </ion-modal>
-      </ion-content>
-    </ion-app>
+<script>
+  var modal = document.querySelector('ion-modal');
 
-    <script>
-      var modal = document.querySelector('ion-modal');
+  const enterAnimation = (baseEl) => {
+    const root = baseEl.shadowRoot;
 
-      const enterAnimation = (baseEl) => {
-        const root = baseEl.shadowRoot;
+    const backdropAnimation = createAnimation()
+      .addElement(root.querySelector('ion-backdrop'))
+      .fromTo('opacity', '0.01', 'var(--backdrop-opacity)');
 
-        const backdropAnimation = createAnimation()
-          .addElement(root.querySelector('ion-backdrop'))
-          .fromTo('opacity', '0.01', 'var(--backdrop-opacity)');
+    const wrapperAnimation = createAnimation()
+      .addElement(root.querySelector('.modal-wrapper'))
+      .keyframes([
+        { offset: 0, opacity: '0', transform: 'scale(0)' },
+        { offset: 1, opacity: '0.99', transform: 'scale(1)' },
+      ]);
 
-        const wrapperAnimation = createAnimation()
-          .addElement(root.querySelector('.modal-wrapper'))
-          .keyframes([
-            { offset: 0, opacity: '0', transform: 'scale(0)' },
-            { offset: 1, opacity: '0.99', transform: 'scale(1)' },
-          ]);
+    return createAnimation()
+      .addElement(baseEl)
+      .easing('ease-out')
+      .duration(500)
+      .addAnimation([backdropAnimation, wrapperAnimation]);
+  };
 
-        return createAnimation()
-          .addElement(baseEl)
-          .easing('ease-out')
-          .duration(500)
-          .addAnimation([backdropAnimation, wrapperAnimation]);
-      };
+  const leaveAnimation = (baseEl) => enterAnimation(baseEl).direction('reverse');
 
-      const leaveAnimation = (baseEl) => enterAnimation(baseEl).direction('reverse');
+  modal.enterAnimation = enterAnimation;
+  modal.leaveAnimation = leaveAnimation;
 
-      modal.enterAnimation = enterAnimation;
-      modal.leaveAnimation = leaveAnimation;
-
-      function dismiss() {
-        modal.dismiss();
-      }
-    </script>
-  </body>
-</html>
+  function dismiss() {
+    modal.dismiss();
+  }
+</script>
 ```

--- a/static/usage/v7/theming/automatic-dark-mode/javascript.md
+++ b/static/usage/v7/theming/automatic-dark-mode/javascript.md
@@ -1,105 +1,86 @@
 ```html
-<html>
-  <head>
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/core.css" />
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/ionic.bundle.css" />
+<ion-header class="ion-no-border">
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button default-href="#"></ion-back-button>
+    </ion-buttons>
+    <ion-title>Display</ion-title>
+    <ion-buttons slot="end">
+      <ion-button color="dark">
+        <ion-icon slot="icon-only" ios="person-circle-outline" md="person-circle"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
 
-    <script>
-      window.Ionic = {
-        config: {
-          mode: 'ios',
-        },
-      };
-    </script>
-  </head>
+<ion-content>
+  <ion-list-header>Appearance</ion-list-header>
+  <ion-list inset="true">
+    <ion-item button="true">Text Size</ion-item>
+    <ion-item>
+      <ion-toggle justify="space-between">Bold Text</ion-toggle>
+    </ion-item>
+  </ion-list>
 
-  <body>
-    <ion-app>
-      <ion-header class="ion-no-border">
-        <ion-toolbar>
-          <ion-buttons slot="start">
-            <ion-back-button default-href="#"></ion-back-button>
-          </ion-buttons>
-          <ion-title>Display</ion-title>
-          <ion-buttons slot="end">
-            <ion-button color="dark">
-              <ion-icon slot="icon-only" ios="person-circle-outline" md="person-circle"></ion-icon>
-            </ion-button>
-          </ion-buttons>
-        </ion-toolbar>
-      </ion-header>
+  <ion-list-header>Brightness</ion-list-header>
+  <ion-list inset="true">
+    <ion-item>
+      <ion-range value="40">
+        <ion-icon name="sunny-outline" slot="start"></ion-icon>
+        <ion-icon name="sunny" slot="end"></ion-icon>
+      </ion-range>
+    </ion-item>
+    <ion-item>
+      <ion-toggle justify="space-between" checked>True Tone</ion-toggle>
+    </ion-item>
+  </ion-list>
 
-      <ion-content>
-        <ion-list-header>Appearance</ion-list-header>
-        <ion-list inset="true">
-          <ion-item button="true">Text Size</ion-item>
-          <ion-item>
-            <ion-toggle justify="space-between">Bold Text</ion-toggle>
-          </ion-item>
-        </ion-list>
+  <ion-list inset="true">
+    <ion-item button="true">
+      <ion-label>Night Shift</ion-label>
+      <ion-text slot="end" color="medium">9:00 PM to 8:00 AM</ion-text>
+    </ion-item>
+  </ion-list>
+</ion-content>
 
-        <ion-list-header>Brightness</ion-list-header>
-        <ion-list inset="true">
-          <ion-item>
-            <ion-range value="40">
-              <ion-icon name="sunny-outline" slot="start"></ion-icon>
-              <ion-icon name="sunny" slot="end"></ion-icon>
-            </ion-range>
-          </ion-item>
-          <ion-item>
-            <ion-toggle justify="space-between" checked>True Tone</ion-toggle>
-          </ion-item>
-        </ion-list>
+<script>
+  // Use matchMedia to check the user preference
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-        <ion-list inset="true">
-          <ion-item button="true">
-            <ion-label>Night Shift</ion-label>
-            <ion-text slot="end" color="medium">9:00 PM to 8:00 AM</ion-text>
-          </ion-item>
-        </ion-list>
-      </ion-content>
+  toggleDarkTheme(prefersDark.matches);
 
-      <script>
-        // Use matchMedia to check the user preference
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+  // Listen for changes to the prefers-color-scheme media query
+  prefersDark.addEventListener('change', (mediaQuery) => toggleDarkTheme(mediaQuery.matches));
 
-        toggleDarkTheme(prefersDark.matches);
+  // Add or remove the "dark" class on the document body
+  function toggleDarkTheme(shouldAdd) {
+    document.body.classList.toggle('dark', shouldAdd);
+  }
+</script>
 
-        // Listen for changes to the prefers-color-scheme media query
-        prefersDark.addEventListener('change', (mediaQuery) => toggleDarkTheme(mediaQuery.matches));
-
-        // Add or remove the "dark" class on the document body
-        function toggleDarkTheme(shouldAdd) {
-          document.body.classList.toggle('dark', shouldAdd);
-        }
-      </script>
-
-      <style>
-        /*
+<style>
+  /*
       * Optional CSS
       * -----------------------------------
       */
 
-        /* This sets a different background and item background in light mode on ios */
-        .ios body {
-          --ion-background-color: #f2f2f6;
-          --ion-toolbar-background: var(--ion-background-color);
-          --ion-item-background: #fff;
-        }
+  /* This sets a different background and item background in light mode on ios */
+  .ios body {
+    --ion-background-color: #f2f2f6;
+    --ion-toolbar-background: var(--ion-background-color);
+    --ion-item-background: #fff;
+  }
 
-        /* This sets a different background and item background in light mode on md */
-        .md body {
-          --ion-background-color: #f9f9f9;
-          --ion-toolbar-background: var(--ion-background-color);
-          --ion-item-background: #fff;
-        }
+  /* This sets a different background and item background in light mode on md */
+  .md body {
+    --ion-background-color: #f9f9f9;
+    --ion-toolbar-background: var(--ion-background-color);
+    --ion-item-background: #fff;
+  }
 
-        /* This is added for the flashing that happens when toggling between themes */
-        ion-item {
-          --transition: none;
-        }
-      </style>
-    </ion-app>
-  </body>
-</html>
+  /* This is added for the flashing that happens when toggling between themes */
+  ion-item {
+    --transition: none;
+  }
+</style>
 ```

--- a/static/usage/v7/theming/automatic-dark-mode/javascript.md
+++ b/static/usage/v7/theming/automatic-dark-mode/javascript.md
@@ -60,9 +60,9 @@
 
 <style>
   /*
-      * Optional CSS
-      * -----------------------------------
-      */
+   * Optional CSS
+   * -----------------------------------
+   */
 
   /* This sets a different background and item background in light mode on ios */
   .ios body {

--- a/static/usage/v7/theming/manual-dark-mode/javascript.md
+++ b/static/usage/v7/theming/manual-dark-mode/javascript.md
@@ -1,132 +1,113 @@
 ```html
-<html>
-  <head>
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/core.css" />
-    <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/ionic.bundle.css" />
+<ion-header class="ion-no-border">
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button default-href="#"></ion-back-button>
+    </ion-buttons>
+    <ion-title>Display</ion-title>
+    <ion-buttons slot="end">
+      <ion-button color="dark">
+        <ion-icon slot="icon-only" ios="person-circle-outline" md="person-circle"></ion-icon>
+      </ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
 
-    <script>
-      window.Ionic = {
-        config: {
-          mode: 'ios',
-        },
-      };
-    </script>
-  </head>
+<ion-content>
+  <ion-list-header>Appearance</ion-list-header>
+  <ion-list inset="true">
+    <ion-item>
+      <ion-toggle id="themeToggle" justify="space-between">Dark Mode</ion-toggle>
+    </ion-item>
+  </ion-list>
 
-  <body>
-    <ion-app>
-      <ion-header class="ion-no-border">
-        <ion-toolbar>
-          <ion-buttons slot="start">
-            <ion-back-button default-href="#"></ion-back-button>
-          </ion-buttons>
-          <ion-title>Display</ion-title>
-          <ion-buttons slot="end">
-            <ion-button color="dark">
-              <ion-icon slot="icon-only" ios="person-circle-outline" md="person-circle"></ion-icon>
-            </ion-button>
-          </ion-buttons>
-        </ion-toolbar>
-      </ion-header>
+  <ion-list inset="true">
+    <ion-item button="true">Text Size</ion-item>
+    <ion-item>
+      <ion-toggle justify="space-between">Bold Text</ion-toggle>
+    </ion-item>
+  </ion-list>
 
-      <ion-content>
-        <ion-list-header>Appearance</ion-list-header>
-        <ion-list inset="true">
-          <ion-item>
-            <ion-toggle id="themeToggle" justify="space-between">Dark Mode</ion-toggle>
-          </ion-item>
-        </ion-list>
+  <ion-list-header>Brightness</ion-list-header>
+  <ion-list inset="true">
+    <ion-item>
+      <ion-range value="40">
+        <ion-icon name="sunny-outline" slot="start"></ion-icon>
+        <ion-icon name="sunny" slot="end"></ion-icon>
+      </ion-range>
+    </ion-item>
+    <ion-item>
+      <ion-toggle justify="space-between" checked>True Tone</ion-toggle>
+    </ion-item>
+  </ion-list>
 
-        <ion-list inset="true">
-          <ion-item button="true">Text Size</ion-item>
-          <ion-item>
-            <ion-toggle justify="space-between">Bold Text</ion-toggle>
-          </ion-item>
-        </ion-list>
+  <ion-list inset="true">
+    <ion-item button="true">
+      <ion-label>Night Shift</ion-label>
+      <ion-text slot="end" color="medium">9:00 PM to 8:00 AM</ion-text>
+    </ion-item>
+  </ion-list>
+</ion-content>
 
-        <ion-list-header>Brightness</ion-list-header>
-        <ion-list inset="true">
-          <ion-item>
-            <ion-range value="40">
-              <ion-icon name="sunny-outline" slot="start"></ion-icon>
-              <ion-icon name="sunny" slot="end"></ion-icon>
-            </ion-range>
-          </ion-item>
-          <ion-item>
-            <ion-toggle justify="space-between" checked>True Tone</ion-toggle>
-          </ion-item>
-        </ion-list>
+<script>
+  // Query for the toggle that is used to change between themes
+  const toggle = document.querySelector('#themeToggle');
 
-        <ion-list inset="true">
-          <ion-item button="true">
-            <ion-label>Night Shift</ion-label>
-            <ion-text slot="end" color="medium">9:00 PM to 8:00 AM</ion-text>
-          </ion-item>
-        </ion-list>
-      </ion-content>
+  // Listen for the toggle check/uncheck to toggle the dark theme
+  toggle.addEventListener('ionChange', (ev) => {
+    toggleDarkTheme(ev.detail.checked);
+  });
 
-      <script>
-        // Query for the toggle that is used to change between themes
-        const toggle = document.querySelector('#themeToggle');
+  // Use matchMedia to check the user preference
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-        // Listen for the toggle check/uncheck to toggle the dark theme
-        toggle.addEventListener('ionChange', (ev) => {
-          toggleDarkTheme(ev.detail.checked);
-        });
+  // Initialize the dark theme based on the initial
+  // value of the prefers-color-scheme media query
+  initializeDarkTheme(prefersDark.matches);
 
-        // Use matchMedia to check the user preference
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+  // Listen for changes to the prefers-color-scheme media query
+  prefersDark.addEventListener('change', (mediaQuery) => initializeDarkTheme(mediaQuery.matches));
 
-        // Initialize the dark theme based on the initial
-        // value of the prefers-color-scheme media query
-        initializeDarkTheme(prefersDark.matches);
+  // Check/uncheck the toggle and update the theme based on isDark
+  function initializeDarkTheme(isDark) {
+    toggle.checked = isDark;
+    toggleDarkTheme(isDark);
+  }
 
-        // Listen for changes to the prefers-color-scheme media query
-        prefersDark.addEventListener('change', (mediaQuery) => initializeDarkTheme(mediaQuery.matches));
+  // Called by the media query to check/uncheck the toggle
+  function checkToggle(shouldCheck) {
+    toggle.checked = shouldCheck;
+  }
 
-        // Check/uncheck the toggle and update the theme based on isDark
-        function initializeDarkTheme(isDark) {
-          toggle.checked = isDark;
-          toggleDarkTheme(isDark);
-        }
+  // Add or remove the "dark" class on the document body
+  function toggleDarkTheme(shouldAdd) {
+    document.body.classList.toggle('dark', shouldAdd);
+  }
+</script>
 
-        // Called by the media query to check/uncheck the toggle
-        function checkToggle(shouldCheck) {
-          toggle.checked = shouldCheck;
-        }
-
-        // Add or remove the "dark" class on the document body
-        function toggleDarkTheme(shouldAdd) {
-          document.body.classList.toggle('dark', shouldAdd);
-        }
-      </script>
-
-      <style>
-        /*
+<style>
+  /*
       * Optional CSS
       * -----------------------------------
       */
 
-        /* This sets a different background and item background in light mode on ios */
-        .ios body {
-          --ion-background-color: #f2f2f6;
-          --ion-toolbar-background: var(--ion-background-color);
-          --ion-item-background: #fff;
-        }
+  /* This sets a different background and item background in light mode on ios */
+  .ios body {
+    --ion-background-color: #f2f2f6;
+    --ion-toolbar-background: var(--ion-background-color);
+    --ion-item-background: #fff;
+  }
 
-        /* This sets a different background and item background in light mode on md */
-        .md body {
-          --ion-background-color: #f9f9f9;
-          --ion-toolbar-background: var(--ion-background-color);
-          --ion-item-background: #fff;
-        }
+  /* This sets a different background and item background in light mode on md */
+  .md body {
+    --ion-background-color: #f9f9f9;
+    --ion-toolbar-background: var(--ion-background-color);
+    --ion-item-background: #fff;
+  }
 
-        /* This is added for the flashing that happens when toggling between themes */
-        ion-item {
-          --transition: none;
-        }
-      </style>
-    </ion-app>
-  </body>
-</html>
+  /* This is added for the flashing that happens when toggling between themes */
+  ion-item {
+    --transition: none;
+  }
+</style>
 ```

--- a/static/usage/v7/theming/manual-dark-mode/javascript.md
+++ b/static/usage/v7/theming/manual-dark-mode/javascript.md
@@ -87,9 +87,9 @@
 
 <style>
   /*
-      * Optional CSS
-      * -----------------------------------
-      */
+   * Optional CSS
+   * -----------------------------------
+   */
 
   /* This sets a different background and item background in light mode on ios */
   .ios body {


### PR DESCRIPTION
When passing a `files` object to a Javascript playground, e.g.

```jsx
<Playground
  version="7"
  code={{
    javascript: {
      files: {
        'index.html': javascript_index_html,
        'theme/variables.css': variables_css,
      },
    },
    ...
  }}
  ...
>
```


you currently need to include the full HTML (e.g. the `head`) in the playground's markdown file that becomes index.html. This means that the code sample displayed also has all the extra stuff in it instead of being streamlined like it is when there's only the single file for a Javascript playground.

<img width="897" alt="Screenshot 2023-09-18 at 9 59 57 AM" src="https://github.com/ionic-team/ionic-docs/assets/14926794/e5216fca-18a6-47ca-b773-0fd455541804">

This PR updates the playground code so that you can simplify the file and what is displayed.

Explanation of change in Playground/index.tsx:
If we pass `codeBlock` through when there are multiple files for a framework just like we've been doing when there's a single file, we'll be able to use it in stackblitz.utils.ts:

Explanation of change in stackblitz.utils.ts:
Previously, we were replacing things in the index.html that was passed in (if one was). Now, we are replacing things in the default index.html. This preserves the head, etc., from the default index.html while still allowing the code from e.g. javascript.md to be passed in.

I don't think a design doc change is needed. This seems like more of a bug with the existing functionality than a new requirement. Let me know if you disagree.

Here's a [link](https://ionic-docs-git-fw-4886-ionic1.vercel.app/docs/theming/dark-mode#automatically-enable-dark-mode) to one of the updated playgrounds in the Vercel build.