### PR TITLE
docs(vue): refactor vue code snippets to use `<script setup>`

### DIFF
--- a/static/usage/v7/avatar/basic/vue.md
+++ b/static/usage/v7/avatar/basic/vue.md
@@ -5,12 +5,7 @@
   </ion-avatar>
 </template>
 
-<script lang="ts">
-  import { IonAvatar } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonAvatar },
-  });
+<script lang="ts" setup>
+import { IonAvatar } from '@ionic/vue';
 </script>
 ```

--- a/static/usage/v7/avatar/chip/vue.md
+++ b/static/usage/v7/avatar/chip/vue.md
@@ -8,12 +8,7 @@
   </ion-chip>
 </template>
 
-<script lang="ts">
-  import { IonAvatar, IonChip, IonLabel } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonAvatar, IonChip, IonLabel },
-  });
+<script lang="ts" setup>
+import { IonAvatar, IonChip, IonLabel } from '@ionic/vue';
 </script>
 ```

--- a/static/usage/v7/avatar/item/vue.md
+++ b/static/usage/v7/avatar/item/vue.md
@@ -8,12 +8,7 @@
   </ion-item>
 </template>
 
-<script lang="ts">
-  import { IonAvatar, IonItem, IonLabel } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonAvatar, IonItem, IonLabel },
-  });
+<script lang="ts" setup>
+import { IonAvatar, IonItem, IonLabel } from '@ionic/vue';
 </script>
 ```

--- a/static/usage/v7/avatar/theming/css-properties/vue.md
+++ b/static/usage/v7/avatar/theming/css-properties/vue.md
@@ -5,13 +5,8 @@
   </ion-avatar>
 </template>
 
-<script lang="ts">
-  import { IonAvatar } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonAvatar },
-  });
+<script lang="ts" setup>
+import { IonAvatar } from '@ionic/vue';
 </script>
 
 <style scoped>

--- a/static/usage/v7/back-button/basic/vue/page_two_vue.md
+++ b/static/usage/v7/back-button/basic/vue/page_two_vue.md
@@ -14,11 +14,7 @@
   </ion-content>
 </template>
 
-<script lang="ts">
-  import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/vue';
-
-  export default {
-    components: { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar },
-  };
+<script lang="ts" setup>
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/vue';
 </script>
 ```

--- a/static/usage/v7/back-button/custom/vue/page_two_vue.md
+++ b/static/usage/v7/back-button/custom/vue/page_two_vue.md
@@ -14,15 +14,8 @@
   </ion-content>
 </template>
 
-<script lang="ts">
-  import { IonHeader, IonTitle, IonToolbar, IonContent, IonButtons, IonBackButton } from '@ionic/vue';
-  import { caretBack } from 'ionicons/icons';
-
-  export default {
-    components: { IonHeader, IonTitle, IonToolbar, IonContent, IonButtons, IonBackButton },
-    setup() {
-      return { caretBack };
-    },
-  };
+<script lang="ts" setup>
+import { IonHeader, IonTitle, IonToolbar, IonContent, IonButtons, IonBackButton } from '@ionic/vue';
+import { caretBack } from 'ionicons/icons';
 </script>
 ```


### PR DESCRIPTION
This PR aims to replace Vue's code snipets found in the docs that use the `setup()` function to use the more succint `<script setup>` syntax as discussed here: #3070 😄

The following components are to be refactored:

- [x] avatar
- [x] back-button
- [ ] backdrop
- [ ] badge
- [ ] breadcrumbs
- [ ] button
- [ ] card
- [ ] checkbox
- [ ] chip
- [ ] content
- [ ] datetime
- [ ] fab
- [ ] footer
- [ ] grid
- [ ] header
- [ ] icon
- [ ] img
- [ ] infinite-scroll
- [ ] input
- [ ] item
- [ ] item-divider
- [ ] item-group
- [ ] item-sliding
- [ ] label
- [ ] list
- [ ] list-header
- [ ] loading
- [ ] menu
- [ ] nav (nav-link only, not modal-navigation)
- [ ] note
- [ ] picker
- [ ] popover
- [ ] progress-bar
- [ ] radio
- [ ] range
- [ ] refresher
- [ ] reorder
- [ ] ripple-effect
- [ ] searchbar
- [ ] segment
- [ ] segment-button
- [ ] select
- [ ] skeleton-text
- [ ] spinner
- [ ] split-pane
- [ ] tabs
- [ ] text
- [ ] textarea
- [ ] thumbnail
- [ ] title
- [ ] toast
- [ ] toggle
- [ ] toolbar

Other:
- [ ] animations
- [ ] gestures
- [ ] theming