### PR TITLE
chore: update v7 playground dependencies for React and Vue

### DIFF
--- a/static/code/stackblitz/v7/react/package-lock.json
+++ b/static/code/stackblitz/v7/react/package-lock.json
@@ -8,8 +8,8 @@
       "name": "create-react-app-typescript",
       "version": "0.1.0",
       "dependencies": {
-        "@ionic/react": "^7.0.10",
-        "@ionic/react-router": "^7.0.10",
+        "@ionic/react": "^7.4.0",
+        "@ionic/react-router": "^7.4.0",
         "@types/node": "^16.11.35",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
@@ -2257,21 +2257,41 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@ionic/core": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.0.10.tgz",
-      "integrity": "sha512-twpnJdS/1XEXISuUGqQ1x4hp24J+8Pl++7syDWLpOG7fFQk/RIYXDPA9/NPY8Fi1jUngnA6ivdSmkFSpFES07Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.4.0.tgz",
+      "integrity": "sha512-Kuu04UljgmKz2Umcm77QCP+4O1rV67EEUtK/Kx0eIp+h+eoSkJJK4/p3EpkvrlKRDOfv4xlUnqKw7+yqhBg36w==",
       "dependencies": {
-        "@stencil/core": "^3.2.2",
-        "ionicons": "^7.1.0",
+        "@stencil/core": "^4.2.1",
+        "ionicons": "7.1.0",
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@ionic/react": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.0.10.tgz",
-      "integrity": "sha512-DggKOQ0JRsOSVY+YZicVhgz5gouL7APQ73kue3PsFK/OrtfeN/5om+XRkqO9bYHam/W/xVp3kpXSYcnsUICntA==",
+    "node_modules/@ionic/core/node_modules/ionicons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.1.0.tgz",
+      "integrity": "sha512-iE4GuEdEHARJpp0sWL7WJZCzNCf5VxpNRhAjW0fLnZPnNL5qZOJUcfup2Z2Ty7Jk8Q5hacrHfGEB1lCwOdXqGg==",
       "dependencies": {
-        "@ionic/core": "7.0.10",
+        "@stencil/core": "^2.18.0"
+      }
+    },
+    "node_modules/@ionic/core/node_modules/ionicons/node_modules/@stencil/core": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=12.10.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@ionic/react": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.4.0.tgz",
+      "integrity": "sha512-BUytiAPasBuGkHT/rc43+KpmVDoJB2lsCXWUhmyzWIVtd8dPnbYy7y3QIV85U0bpEyc21VMI8Jin9pL/U0OOog==",
+      "dependencies": {
+        "@ionic/core": "7.4.0",
         "ionicons": "^7.0.0",
         "tslib": "*"
       },
@@ -2281,11 +2301,11 @@
       }
     },
     "node_modules/@ionic/react-router": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.0.10.tgz",
-      "integrity": "sha512-auHuYx19NYtUUMqssdJE8pV/AbEKc8ti5gzO9wuSK0+LQPn7TJC85rXqUpntJK5iaz0kA91uBuuX2wF7Nf8vag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.4.0.tgz",
+      "integrity": "sha512-MmqlHtvBMxCHfyovuxaG/0Gb3OpM9tvIFcI+wg7SC35wq1KGRT0uI3On7tcX4xGKFShnGUdr221viGC/x1UVWg==",
       "dependencies": {
-        "@ionic/react": "7.0.10",
+        "@ionic/react": "7.4.0",
         "tslib": "*"
       },
       "peerDependencies": {
@@ -3237,15 +3257,15 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-I+660Oe9OMLiU+thjV1GgcI27dcvrSpF3xisHWBOU/4mzRtho3YW0cI8lSjcqyB1KirGTA6QeQ0Xif5UHqn8hw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-alYwqVwxfD0n6HKRVJqJoTzQNnf44n/sddvjNu3JMEn3sfY/Ag7rpmwUntYjtJmRut+or+9gPPgIJviCuKi4yQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=14.10.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -18208,31 +18228,48 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "@ionic/core": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.0.10.tgz",
-      "integrity": "sha512-twpnJdS/1XEXISuUGqQ1x4hp24J+8Pl++7syDWLpOG7fFQk/RIYXDPA9/NPY8Fi1jUngnA6ivdSmkFSpFES07Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.4.0.tgz",
+      "integrity": "sha512-Kuu04UljgmKz2Umcm77QCP+4O1rV67EEUtK/Kx0eIp+h+eoSkJJK4/p3EpkvrlKRDOfv4xlUnqKw7+yqhBg36w==",
       "requires": {
-        "@stencil/core": "^3.2.2",
-        "ionicons": "^7.1.0",
+        "@stencil/core": "^4.2.1",
+        "ionicons": "7.1.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "ionicons": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.1.0.tgz",
+          "integrity": "sha512-iE4GuEdEHARJpp0sWL7WJZCzNCf5VxpNRhAjW0fLnZPnNL5qZOJUcfup2Z2Ty7Jk8Q5hacrHfGEB1lCwOdXqGg==",
+          "requires": {
+            "@stencil/core": "^2.18.0"
+          },
+          "dependencies": {
+            "@stencil/core": {
+              "version": "2.22.3",
+              "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+              "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng=="
+            }
+          }
+        }
       }
     },
     "@ionic/react": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.0.10.tgz",
-      "integrity": "sha512-DggKOQ0JRsOSVY+YZicVhgz5gouL7APQ73kue3PsFK/OrtfeN/5om+XRkqO9bYHam/W/xVp3kpXSYcnsUICntA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/react/-/react-7.4.0.tgz",
+      "integrity": "sha512-BUytiAPasBuGkHT/rc43+KpmVDoJB2lsCXWUhmyzWIVtd8dPnbYy7y3QIV85U0bpEyc21VMI8Jin9pL/U0OOog==",
       "requires": {
-        "@ionic/core": "7.0.10",
+        "@ionic/core": "7.4.0",
         "ionicons": "^7.0.0",
         "tslib": "*"
       }
     },
     "@ionic/react-router": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.0.10.tgz",
-      "integrity": "sha512-auHuYx19NYtUUMqssdJE8pV/AbEKc8ti5gzO9wuSK0+LQPn7TJC85rXqUpntJK5iaz0kA91uBuuX2wF7Nf8vag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/react-router/-/react-router-7.4.0.tgz",
+      "integrity": "sha512-MmqlHtvBMxCHfyovuxaG/0Gb3OpM9tvIFcI+wg7SC35wq1KGRT0uI3On7tcX4xGKFShnGUdr221viGC/x1UVWg==",
       "requires": {
-        "@ionic/react": "7.0.10",
+        "@ionic/react": "7.4.0",
         "tslib": "*"
       }
     },
@@ -18920,9 +18957,9 @@
       }
     },
     "@stencil/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-I+660Oe9OMLiU+thjV1GgcI27dcvrSpF3xisHWBOU/4mzRtho3YW0cI8lSjcqyB1KirGTA6QeQ0Xif5UHqn8hw=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-alYwqVwxfD0n6HKRVJqJoTzQNnf44n/sddvjNu3JMEn3sfY/Ag7rpmwUntYjtJmRut+or+9gPPgIJviCuKi4yQ=="
     },
     "@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",

--- a/static/code/stackblitz/v7/react/package.json
+++ b/static/code/stackblitz/v7/react/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ionic/react": "^7.0.10",
-    "@ionic/react-router": "^7.0.10",
+    "@ionic/react": "^7.4.0",
+    "@ionic/react-router": "^7.4.0",
     "@types/node": "^16.11.35",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",

--- a/static/code/stackblitz/v7/vue/package-lock.json
+++ b/static/code/stackblitz/v7/vue/package-lock.json
@@ -8,8 +8,8 @@
       "name": "vite-vue-starter",
       "version": "0.0.0",
       "dependencies": {
-        "@ionic/vue": "^7.0.10",
-        "@ionic/vue-router": "^7.0.10",
+        "@ionic/vue": "^7.4.0",
+        "@ionic/vue-router": "^7.4.0",
         "vue": "^3.2.25",
         "vue-router": "4.0.13"
       },
@@ -48,42 +48,62 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.0.10.tgz",
-      "integrity": "sha512-twpnJdS/1XEXISuUGqQ1x4hp24J+8Pl++7syDWLpOG7fFQk/RIYXDPA9/NPY8Fi1jUngnA6ivdSmkFSpFES07Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.4.0.tgz",
+      "integrity": "sha512-Kuu04UljgmKz2Umcm77QCP+4O1rV67EEUtK/Kx0eIp+h+eoSkJJK4/p3EpkvrlKRDOfv4xlUnqKw7+yqhBg36w==",
       "dependencies": {
-        "@stencil/core": "^3.2.2",
-        "ionicons": "^7.1.0",
+        "@stencil/core": "^4.2.1",
+        "ionicons": "7.1.0",
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@ionic/vue": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-7.0.10.tgz",
-      "integrity": "sha512-3e3bHGBhhS85byghSbp3U1JP24lHrNilzN4WkBgc9aBeQvwczDNTO69qpiF69fJKDAvU1OrJaAbyomrskE9F9g==",
+    "node_modules/@ionic/core/node_modules/ionicons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.1.0.tgz",
+      "integrity": "sha512-iE4GuEdEHARJpp0sWL7WJZCzNCf5VxpNRhAjW0fLnZPnNL5qZOJUcfup2Z2Ty7Jk8Q5hacrHfGEB1lCwOdXqGg==",
       "dependencies": {
-        "@ionic/core": "7.0.10",
-        "ionicons": "^7.0.0"
+        "@stencil/core": "^2.18.0"
       }
     },
-    "node_modules/@ionic/vue-router": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/vue-router/-/vue-router-7.0.10.tgz",
-      "integrity": "sha512-NR2o3CnBr1M6YzIVuzMRj8s+qo6ySWM/H6WUJN2y3hLobGL0stt6kpTWJ05HtRCFZAb5yvSym/UfYwSRifpLMA==",
-      "dependencies": {
-        "@ionic/vue": "7.0.10"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-I+660Oe9OMLiU+thjV1GgcI27dcvrSpF3xisHWBOU/4mzRtho3YW0cI8lSjcqyB1KirGTA6QeQ0Xif5UHqn8hw==",
+    "node_modules/@ionic/core/node_modules/ionicons/node_modules/@stencil/core": {
+      "version": "2.22.3",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=14.10.0",
+        "node": ">=12.10.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@ionic/vue": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-7.4.0.tgz",
+      "integrity": "sha512-ItNI4sn9uKVEXdzpcywAz93Pia7z0zF7+G65mTiAYz5IIzqrzynnGWEZwXLfQL7bo/PApN3JvxBnJFRomriW+Q==",
+      "dependencies": {
+        "@ionic/core": "7.4.0",
+        "ionicons": "^7.0.0"
+      }
+    },
+    "node_modules/@ionic/vue-router": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/vue-router/-/vue-router-7.4.0.tgz",
+      "integrity": "sha512-o39HGFt+tsMcISMz3KS/eANZ5m88UA0FPPL/jRaasIF+ypHshTp/wxxoRtGs8X7yqZuQ2m9fleCwqMBIGYktow==",
+      "dependencies": {
+        "@ionic/vue": "7.4.0"
+      }
+    },
+    "node_modules/@stencil/core": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-alYwqVwxfD0n6HKRVJqJoTzQNnf44n/sddvjNu3JMEn3sfY/Ag7rpmwUntYjtJmRut+or+9gPPgIJviCuKi4yQ==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -797,9 +817,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/typescript": {
       "version": "4.9.4",
@@ -907,36 +927,53 @@
       "optional": true
     },
     "@ionic/core": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.0.10.tgz",
-      "integrity": "sha512-twpnJdS/1XEXISuUGqQ1x4hp24J+8Pl++7syDWLpOG7fFQk/RIYXDPA9/NPY8Fi1jUngnA6ivdSmkFSpFES07Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.4.0.tgz",
+      "integrity": "sha512-Kuu04UljgmKz2Umcm77QCP+4O1rV67EEUtK/Kx0eIp+h+eoSkJJK4/p3EpkvrlKRDOfv4xlUnqKw7+yqhBg36w==",
       "requires": {
-        "@stencil/core": "^3.2.2",
-        "ionicons": "^7.1.0",
+        "@stencil/core": "^4.2.1",
+        "ionicons": "7.1.0",
         "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "ionicons": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.1.0.tgz",
+          "integrity": "sha512-iE4GuEdEHARJpp0sWL7WJZCzNCf5VxpNRhAjW0fLnZPnNL5qZOJUcfup2Z2Ty7Jk8Q5hacrHfGEB1lCwOdXqGg==",
+          "requires": {
+            "@stencil/core": "^2.18.0"
+          },
+          "dependencies": {
+            "@stencil/core": {
+              "version": "2.22.3",
+              "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
+              "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng=="
+            }
+          }
+        }
       }
     },
     "@ionic/vue": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-7.0.10.tgz",
-      "integrity": "sha512-3e3bHGBhhS85byghSbp3U1JP24lHrNilzN4WkBgc9aBeQvwczDNTO69qpiF69fJKDAvU1OrJaAbyomrskE9F9g==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/vue/-/vue-7.4.0.tgz",
+      "integrity": "sha512-ItNI4sn9uKVEXdzpcywAz93Pia7z0zF7+G65mTiAYz5IIzqrzynnGWEZwXLfQL7bo/PApN3JvxBnJFRomriW+Q==",
       "requires": {
-        "@ionic/core": "7.0.10",
+        "@ionic/core": "7.4.0",
         "ionicons": "^7.0.0"
       }
     },
     "@ionic/vue-router": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@ionic/vue-router/-/vue-router-7.0.10.tgz",
-      "integrity": "sha512-NR2o3CnBr1M6YzIVuzMRj8s+qo6ySWM/H6WUJN2y3hLobGL0stt6kpTWJ05HtRCFZAb5yvSym/UfYwSRifpLMA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@ionic/vue-router/-/vue-router-7.4.0.tgz",
+      "integrity": "sha512-o39HGFt+tsMcISMz3KS/eANZ5m88UA0FPPL/jRaasIF+ypHshTp/wxxoRtGs8X7yqZuQ2m9fleCwqMBIGYktow==",
       "requires": {
-        "@ionic/vue": "7.0.10"
+        "@ionic/vue": "7.4.0"
       }
     },
     "@stencil/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-I+660Oe9OMLiU+thjV1GgcI27dcvrSpF3xisHWBOU/4mzRtho3YW0cI8lSjcqyB1KirGTA6QeQ0Xif5UHqn8hw=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-alYwqVwxfD0n6HKRVJqJoTzQNnf44n/sddvjNu3JMEn3sfY/Ag7rpmwUntYjtJmRut+or+9gPPgIJviCuKi4yQ=="
     },
     "@vitejs/plugin-vue": {
       "version": "2.3.4",
@@ -1391,9 +1428,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "typescript": {
       "version": "4.9.4",

--- a/static/code/stackblitz/v7/vue/package.json
+++ b/static/code/stackblitz/v7/vue/package.json
@@ -8,8 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ionic/vue": "^7.0.10",
-    "@ionic/vue-router": "^7.0.10",
+    "@ionic/vue": "^7.4.0",
+    "@ionic/vue-router": "^7.4.0",
     "vue": "^3.2.25",
     "vue-router": "4.0.13"
   },


### PR DESCRIPTION
React/Vue playgrounds are pulling in Ionic 7.0.10. We are up to 7.4.0 now, so these should be updated.