### PR TITLE
fix(playground): react stackbiltz template files

### DIFF
--- a/static/code/stackblitz/v6/react/index.html
+++ b/static/code/stackblitz/v6/react/index.html
@@ -1,3 +1,8 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
 
-<div id="root"></div>
+  <div id="root"></div>
+</html>

--- a/static/code/stackblitz/v7/react/index.html
+++ b/static/code/stackblitz/v7/react/index.html
@@ -1,3 +1,8 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
 
-<div id="root"></div>
+  <div id="root"></div>
+</html>


### PR DESCRIPTION
The React stackblitz examples have a misconfiguration in their template files for the `index.html`. This results in certain examples rendering incorrectly, such as the v7 button playground examples. The button will grow to the entire container height: https://stackblitz.com/edit/nia7fe?file=src%2Fmain.tsx

This PR updates the template file for both v6 and v7.