### PR TITLE
docs(dynamic-font): fix font family name

### DIFF
--- a/docs/layout/dynamic-font-scaling.md
+++ b/docs/layout/dynamic-font-scaling.md
@@ -61,7 +61,7 @@ We recommend using the default fonts in Ionic as they are designed to look good 
 ```css
 html {
   --ion-dynamic-font: var(--ion-default-dynamic-font);
-  --ion-font-family: 'Comic Sans';
+  --ion-font-family: 'Comic Sans MS';
 }
 ```
 


### PR DESCRIPTION
Corrects the name of the Comic Sans font, in case people copy-paste the code directly and get confused when it doesn't work.