### PR TITLE
docs(angular): include add diff sign

### DIFF
--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -429,7 +429,7 @@ import { Component } from '@angular/core';
 })
 export class TestComponent {
   constructor() {
-    addIcons({ alarm, logoIonic });
++   addIcons({ alarm, logoIonic });
   }
 }
 ```


### PR DESCRIPTION
The `Standalone-based Applications` section has the added line in a diff format. This PR makes it consistent between both modes by adding it to `NgModule-based Applications`.

[Page](https://ionic-docs-git-code-format-ionic1.vercel.app/docs/angular/build-options#ngmodule-based-applications)