### PR TITLE
chore: team is requested for review for renovatebot prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,5 @@
 /docs/api/ @mapsandapps
 /src/ @mapsandapps
 /static/usage/ @mapsandapps
+
+/static/code/stackblitz/**/*/package.json @ionic-team/framework


### PR DESCRIPTION
Right now Renovatebot PRs are not assigned to anyone for review. This PR makes it so the Ionic Framework team is a codeowner for any `package.json` change to our StackBlitz templates.