### PR TITLE
feat(playground): persist framework and mode selection

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -432,7 +432,7 @@ export default function Playground({
    * causing isBrowser to be set to false even if running the app
    * in a browser (vs. SSR). isBrowser is then updated on the next
    * render cycle.
-   * 
+   *
    * This useEffect contains code that can only run in the browser,
    * and also needs to run on that first go-around. Note that
    * isBrowser will never be set from true back to false, so the

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -187,7 +187,7 @@ export default function Playground({
      * Otherwise, if there is a saved mode from previously clicking
      * the mode button, use that.
      */
-    const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
+    const storedMode = window !== undefined ? localStorage.getItem(MODE_STORAGE_KEY) : null;
     if (storedMode) return storedMode;
 
     /**
@@ -201,7 +201,7 @@ export default function Playground({
      * If there is a saved target from previously clicking the
      * framework buttons, and there is code for it, use that.
      */
-    const storedTarget = localStorage.getItem(USAGE_TARGET_STORAGE_KEY);
+    const storedTarget = window !== undefined ? localStorage.getItem(USAGE_TARGET_STORAGE_KEY) : null;
     if (storedTarget && code[storedTarget] !== undefined) {
       return storedTarget;
     }
@@ -242,43 +242,49 @@ export default function Playground({
   const [resetCount, setResetCount] = useState(0);
 
   const setAndSaveMode = (mode: Mode) => {
-    localStorage.setItem(MODE_STORAGE_KEY, mode);
     setIonicMode(mode);
 
-    /**
-     * Tell other playgrounds on the page that the mode has
-     * updated, so they can sync up.
-     */
-    window.dispatchEvent(
-      new CustomEvent(MODE_UPDATED_EVENT, {
-        detail: mode,
-      })
-    );
+    if (window !== undefined) {
+      localStorage.setItem(MODE_STORAGE_KEY, mode);
+
+      /**
+       * Tell other playgrounds on the page that the mode has
+       * updated, so they can sync up.
+       */
+      window.dispatchEvent(
+        new CustomEvent(MODE_UPDATED_EVENT, {
+          detail: mode,
+        })
+      );
+    }
   };
 
   const setAndSaveUsageTarget = (target: UsageTarget, tab: HTMLElement) => {
-    localStorage.setItem(USAGE_TARGET_STORAGE_KEY, target);
     setUsageTarget(target);
 
-    /**
-     * This prevents the scroll position from jumping around if
-     * there is a playground above this one with code that changes
-     * in length between frameworks.
-     *
-     * Note that we don't need this when changing the mode because
-     * the two mode iframes are always the same height.
-     */
-    blockElementScrollPositionUntilNextRender(tab);
+    if (window !== undefined) {
+      localStorage.setItem(USAGE_TARGET_STORAGE_KEY, target);
 
-    /**
-     * Tell other playgrounds on the page that the framework
-     * has updated, so they can sync up.
-     */
-    window.dispatchEvent(
-      new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
-        detail: target,
-      })
-    );
+      /**
+       * This prevents the scroll position from jumping around if
+       * there is a playground above this one with code that changes
+       * in length between frameworks.
+       *
+       * Note that we don't need this when changing the mode because
+       * the two mode iframes are always the same height.
+       */
+      blockElementScrollPositionUntilNextRender(tab);
+
+      /**
+       * Tell other playgrounds on the page that the framework
+       * has updated, so they can sync up.
+       */
+      window.dispatchEvent(
+        new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
+          detail: target,
+        })
+      );
+    }
   };
 
   /**

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -244,6 +244,11 @@ export default function Playground({
   const setAndSaveMode = (mode: Mode) => {
     localStorage.setItem(MODE_STORAGE_KEY, mode);
     setIonicMode(mode);
+
+    /**
+     * Tell other playgrounds on the page that the mode has
+     * updated, so they can sync up.
+     */
     window.dispatchEvent(
       new CustomEvent(MODE_UPDATED_EVENT, {
         detail: mode,
@@ -265,6 +270,10 @@ export default function Playground({
      */
     blockElementScrollPositionUntilNextRender(tab);
 
+    /**
+     * Tell other playgrounds on the page that the framework
+     * has updated, so they can sync up.
+     */
     window.dispatchEvent(
       new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
         detail: target,
@@ -400,6 +409,10 @@ export default function Playground({
     io.observe(hostRef.current!);
   });
 
+  /**
+   * Listen for any playground on the page to have its mode or framework
+   * updated so this playground can switch to the same setting.
+   */
   useEffect(() => {
     window.addEventListener(MODE_UPDATED_EVENT, (e: CustomEvent) => {
       const mode = e.detail;

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -187,7 +187,7 @@ export default function Playground({
      * Otherwise, if there is a saved mode from previously clicking
      * the mode button, use that.
      */
-    const storedMode = window !== undefined ? localStorage.getItem(MODE_STORAGE_KEY) : null;
+    const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
     if (storedMode) return storedMode;
 
     /**
@@ -201,7 +201,7 @@ export default function Playground({
      * If there is a saved target from previously clicking the
      * framework buttons, and there is code for it, use that.
      */
-    const storedTarget = window !== undefined ? localStorage.getItem(USAGE_TARGET_STORAGE_KEY) : null;
+    const storedTarget = localStorage.getItem(USAGE_TARGET_STORAGE_KEY);
     if (storedTarget && code[storedTarget] !== undefined) {
       return storedTarget;
     }
@@ -242,49 +242,43 @@ export default function Playground({
   const [resetCount, setResetCount] = useState(0);
 
   const setAndSaveMode = (mode: Mode) => {
+    localStorage.setItem(MODE_STORAGE_KEY, mode);
     setIonicMode(mode);
 
-    if (window !== undefined) {
-      localStorage.setItem(MODE_STORAGE_KEY, mode);
-
-      /**
-       * Tell other playgrounds on the page that the mode has
-       * updated, so they can sync up.
-       */
-      window.dispatchEvent(
-        new CustomEvent(MODE_UPDATED_EVENT, {
-          detail: mode,
-        })
-      );
-    }
+    /**
+     * Tell other playgrounds on the page that the mode has
+     * updated, so they can sync up.
+     */
+    window.dispatchEvent(
+      new CustomEvent(MODE_UPDATED_EVENT, {
+        detail: mode,
+      })
+    );
   };
 
   const setAndSaveUsageTarget = (target: UsageTarget, tab: HTMLElement) => {
+    localStorage.setItem(USAGE_TARGET_STORAGE_KEY, target);
     setUsageTarget(target);
 
-    if (window !== undefined) {
-      localStorage.setItem(USAGE_TARGET_STORAGE_KEY, target);
+    /**
+     * This prevents the scroll position from jumping around if
+     * there is a playground above this one with code that changes
+     * in length between frameworks.
+     *
+     * Note that we don't need this when changing the mode because
+     * the two mode iframes are always the same height.
+     */
+    blockElementScrollPositionUntilNextRender(tab);
 
-      /**
-       * This prevents the scroll position from jumping around if
-       * there is a playground above this one with code that changes
-       * in length between frameworks.
-       *
-       * Note that we don't need this when changing the mode because
-       * the two mode iframes are always the same height.
-       */
-      blockElementScrollPositionUntilNextRender(tab);
-
-      /**
-       * Tell other playgrounds on the page that the framework
-       * has updated, so they can sync up.
-       */
-      window.dispatchEvent(
-        new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
-          detail: target,
-        })
-      );
-    }
+    /**
+     * Tell other playgrounds on the page that the framework
+     * has updated, so they can sync up.
+     */
+    window.dispatchEvent(
+      new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
+        detail: target,
+      })
+    );
   };
 
   /**

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -195,8 +195,10 @@ export default function Playground({
      * Otherwise, if there is a saved mode from previously clicking
      * the mode button, use that.
      */
-    const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-    if (storedMode) return storedMode;
+    if (isBrowser) {
+      const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
+      if (storedMode) return storedMode;
+    }
 
     /**
      * Default to iOS mode as a fallback.
@@ -209,9 +211,11 @@ export default function Playground({
      * If there is a saved target from previously clicking the
      * framework buttons, and there is code for it, use that.
      */
-    const storedTarget = localStorage.getItem(USAGE_TARGET_STORAGE_KEY);
-    if (storedTarget && code[storedTarget] !== undefined) {
-      return storedTarget;
+    if (isBrowser) {
+      const storedTarget = localStorage.getItem(USAGE_TARGET_STORAGE_KEY);
+      if (storedTarget && code[storedTarget] !== undefined) {
+        return storedTarget;
+      }
     }
 
     /**

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -15,41 +15,46 @@ import { IconHtml, IconTs, IconVue, IconDefault, IconCss, IconDots } from './ico
 
 import { useScrollPositionBlocker } from '@docusaurus/theme-common';
 
-const ControlButton = forwardRef(({
-  isSelected,
-  handleClick,
-  title,
-  label,
-  disabled,
-}: {
-  isSelected: boolean;
-  handleClick: () => void;
-  title: string;
-  label: string;
-  disabled?: boolean;
-}, ref: RefObject<HTMLButtonElement>) => {
-  const controlButton = (
-    <button
-      title={disabled ? undefined : title}
-      disabled={disabled}
-      className={`playground__control-button ${isSelected ? 'playground__control-button--selected' : ''}`}
-      onClick={handleClick}
-      data-text={label}
-      ref={ref}
-    >
-      {label}
-    </button>
-  );
-  if (disabled) {
-    return (
-      <Tippy theme="playground" arrow={false} placement="bottom" content={`Unavailable for ${label}`}>
-        {/* Tippy requires a wrapper element for disabled elements: https://atomiks.github.io/tippyjs/v5/creating-tooltips/#disabled-elements */}
-        <div>{controlButton}</div>
-      </Tippy>
+const ControlButton = forwardRef(
+  (
+    {
+      isSelected,
+      handleClick,
+      title,
+      label,
+      disabled,
+    }: {
+      isSelected: boolean;
+      handleClick: () => void;
+      title: string;
+      label: string;
+      disabled?: boolean;
+    },
+    ref: RefObject<HTMLButtonElement>
+  ) => {
+    const controlButton = (
+      <button
+        title={disabled ? undefined : title}
+        disabled={disabled}
+        className={`playground__control-button ${isSelected ? 'playground__control-button--selected' : ''}`}
+        onClick={handleClick}
+        data-text={label}
+        ref={ref}
+      >
+        {label}
+      </button>
     );
+    if (disabled) {
+      return (
+        <Tippy theme="playground" arrow={false} placement="bottom" content={`Unavailable for ${label}`}>
+          {/* Tippy requires a wrapper element for disabled elements: https://atomiks.github.io/tippyjs/v5/creating-tooltips/#disabled-elements */}
+          <div>{controlButton}</div>
+        </Tippy>
+      );
+    }
+    return controlButton;
   }
-  return controlButton;
-});
+);
 
 const CodeBlockButton = ({ language, usageTarget, setAndSaveUsageTarget, disabled }) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -239,9 +244,11 @@ export default function Playground({
   const setAndSaveMode = (mode: Mode) => {
     localStorage.setItem(MODE_STORAGE_KEY, mode);
     setIonicMode(mode);
-    window.dispatchEvent(new CustomEvent(MODE_UPDATED_EVENT, {
-      detail: mode
-    }));
+    window.dispatchEvent(
+      new CustomEvent(MODE_UPDATED_EVENT, {
+        detail: mode,
+      })
+    );
   };
 
   const setAndSaveUsageTarget = (target: UsageTarget, tab: HTMLElement) => {
@@ -252,15 +259,17 @@ export default function Playground({
      * This prevents the scroll position from jumping around if
      * there is a playground above this one with code that changes
      * in length between frameworks.
-     * 
+     *
      * Note that we don't need this when changing the mode because
      * the two mode iframes are always the same height.
      */
     blockElementScrollPositionUntilNextRender(tab);
 
-    window.dispatchEvent(new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
-      detail: target
-    }));
+    window.dispatchEvent(
+      new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
+        detail: target,
+      })
+    );
   };
 
   /**


### PR DESCRIPTION
When the framework and/or mode are changed on any playground, the new selection is stored and persisted. This applies both to all other playgrounds currently on the page, and any future page loads.

In the design doc, it was mentioned [here](https://github.com/ionic-team/ionic-framework-design-documents/blob/main/projects/ionic-framework-docs/playground/0004-framework-preference.md#synchronization) that we should not immediately update the mode for any playgrounds that haven't been scrolled to yet, for performance reasons. I elected not to do this because it doesn't seem to confer any benefit -- the iframes are not rendered at all until the playground is scrolled to, even if the mode is changed ahead of time.

There also shouldn't be any performance issues with switching modes on playgrounds that _have_ been scrolled to, since both iframes are loaded at the same time anyway, so no extra loading is incurred. (Switching modes only toggles which iframe is hidden via CSS.)

Also note that we decided ([here](https://github.com/ionic-team/ionic-framework-design-documents/blob/main/projects/ionic-framework-docs/playground/0004-framework-preference.md#out-of-scope)) not to sync playground framework selection with Docusaurus `<Tabs>` components, at least for now.