### PR TITLE
docs(angular): add more info on migrating to standalone

### DIFF
--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -415,6 +415,33 @@ if (environment.production) {
 export class AppModule {}
 ```
 
+For example, all modules that are using Ionic components need to have the Ionic components imported in their component module.
+
+```diff title="home.module.ts"
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { HomePage } from './home.page';
+
+import { HomePageRoutingModule } from './home-routing.module';
+
++ import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    HomePageRoutingModule,
++    IonContent,
++    IonHeader,
++    IonTitle,
++    IonToolbar
+  ],
+  declarations: [HomePage]
+})
+export class HomePageModule {}
+```
+
 7. If you are using Ionicons, define the icon SVG data used in each Angular component using `addIcons`. This allows you to continue referencing icons by string name in your component template. Note that you will need to do this for any additional icons added. The `IonIcon` component should still be provided in the NgModule.
 
 ```diff title="test.component.ts"


### PR DESCRIPTION
While going through migrating an NgModules app to use Ionic standalone components I got confused because the previous section mentioned adding the imports in the `@Component` and not the `@NgModule` so I have added an example to help clarify.