### PR TITLE
fix(playground): wait until playground is in view before loading stored framework/mode

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -837,5 +837,3 @@ const isFrameReady = (frame: HTMLIFrameElement) => {
 
 const USAGE_TARGET_STORAGE_KEY = 'playground_usage_target';
 const MODE_STORAGE_KEY = 'playground_mode';
-// const USAGE_TARGET_UPDATED_EVENT = 'playground-usage-target-updated';
-// const MODE_UPDATED_EVENT = 'playground-event-updated';

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -13,7 +13,6 @@ import TabItem from '@theme/TabItem';
 
 import { IconHtml, IconTs, IconVue, IconDefault, IconCss, IconDots } from './icons';
 
-import { useScrollPositionBlocker } from '@docusaurus/theme-common';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
 const ControlButton = forwardRef(
@@ -183,8 +182,6 @@ export default function Playground({
   const frameMD = useRef<HTMLIFrameElement | null>(null);
   const consoleBodyRef = useRef<HTMLDivElement | null>(null);
 
-  const { blockElementScrollPositionUntilNextRender } = useScrollPositionBlocker();
-
   const getDefaultMode = () => {
     /**
      * If a custom mode was specified, use that.
@@ -258,16 +255,6 @@ export default function Playground({
 
     if (isBrowser) {
       localStorage.setItem(MODE_STORAGE_KEY, mode);
-
-      /**
-       * Tell other playgrounds on the page that the mode has
-       * updated, so they can sync up.
-       */
-      window.dispatchEvent(
-        new CustomEvent(MODE_UPDATED_EVENT, {
-          detail: mode,
-        })
-      );
     }
   };
 
@@ -276,26 +263,6 @@ export default function Playground({
 
     if (isBrowser) {
       localStorage.setItem(USAGE_TARGET_STORAGE_KEY, target);
-
-      /**
-       * This prevents the scroll position from jumping around if
-       * there is a playground above this one with code that changes
-       * in length between frameworks.
-       *
-       * Note that we don't need this when changing the mode because
-       * the two mode iframes are always the same height.
-       */
-      blockElementScrollPositionUntilNextRender(tab);
-
-      /**
-       * Tell other playgrounds on the page that the framework
-       * has updated, so they can sync up.
-       */
-      window.dispatchEvent(
-        new CustomEvent(USAGE_TARGET_UPDATED_EVENT, {
-          detail: target,
-        })
-      );
     }
   };
 
@@ -401,72 +368,45 @@ export default function Playground({
   });
 
   /**
-   * By default, we do not render the iframe content
-   * as it could cause delays on page load. Instead
-   * we wait for even 1 pixel of the playground to
-   * scroll into view (intersect with the viewport)
-   * before loading the iframes.
+   * By default, we do not render the iframe content as it could
+   * cause delays on page load. We also do not immediately switch
+   * the framework/mode when it gets changed through another
+   * playground on the page, as switching them for every playground
+   * at once can cause memory-related crashes on some devices.
+   * 
+   * Instead, we wait for even 1 pixel of the playground to scroll
+   * into view (intersect with the viewport) before loading the
+   * iframes or auto-switching the framework/mode.
    */
   useEffect(() => {
     const io = new IntersectionObserver(
       (entries: IntersectionObserverEntry[]) => {
         const ev = entries[0];
-        if (!ev.isIntersecting || renderIframes) return;
-
-        setRenderIframes(true);
+        if (!ev.isIntersecting) return;
 
         /**
-         * Once the playground is loaded, it is never "unloaded"
-         * so we can safely disconnect the observer.
+         * Load the stored mode and/or usage target, if present
+         * from previously being toggled.
          */
-        io.disconnect();
+        if (isBrowser) {
+          const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
+          if (storedMode) setIonicMode(storedMode);
+          const storedUsageTarget = localStorage.getItem(USAGE_TARGET_STORAGE_KEY);
+          if (storedUsageTarget) setUsageTarget(storedUsageTarget);
+        }
+
+        /**
+         * If the iframes weren't already loaded, load them now.
+         */
+        if (!renderIframes) {
+          setRenderIframes(true);
+        }
       },
       { threshold: 0 }
     );
 
     io.observe(hostRef.current!);
   });
-
-  /**
-   * Sometimes, the app isn't fully hydrated on the first render,
-   * causing isBrowser to be set to false even if running the app
-   * in a browser (vs. SSR). isBrowser is then updated on the next
-   * render cycle.
-   *
-   * This useEffect contains code that can only run in the browser,
-   * and also needs to run on that first go-around. Note that
-   * isBrowser will never be set from true back to false, so the
-   * code within the if(isBrowser) check will only run once.
-   */
-  useEffect(() => {
-    if (isBrowser) {
-      /**
-       * Load the stored mode and/or usage target, if present
-       * from previously being toggled.
-       */
-      const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-      if (storedMode) setIonicMode(storedMode);
-      const storedUsageTarget = localStorage.getItem(USAGE_TARGET_STORAGE_KEY);
-      if (storedUsageTarget) setUsageTarget(storedUsageTarget);
-
-      /**
-       * Listen for any playground on the page to have its mode or framework
-       * updated so this playground can switch to the same setting.
-       */
-      window.addEventListener(MODE_UPDATED_EVENT, (e: CustomEvent) => {
-        const mode = e.detail;
-        if (Object.values(Mode).includes(mode)) {
-          setIonicMode(mode); // don't use setAndSave to avoid infinite loop
-        }
-      });
-      window.addEventListener(USAGE_TARGET_UPDATED_EVENT, (e: CustomEvent) => {
-        const usageTarget = e.detail;
-        if (Object.values(UsageTarget).includes(usageTarget)) {
-          setUsageTarget(usageTarget); // don't use setAndSave to avoid infinite loop
-        }
-      });
-    }
-  }, [isBrowser]);
 
   const isIOS = ionicMode === Mode.iOS;
   const isMD = ionicMode === Mode.MD;
@@ -897,5 +837,5 @@ const isFrameReady = (frame: HTMLIFrameElement) => {
 
 const USAGE_TARGET_STORAGE_KEY = 'playground_usage_target';
 const MODE_STORAGE_KEY = 'playground_mode';
-const USAGE_TARGET_UPDATED_EVENT = 'playground-usage-target-updated';
-const MODE_UPDATED_EVENT = 'playground-event-updated';
+// const USAGE_TARGET_UPDATED_EVENT = 'playground-usage-target-updated';
+// const MODE_UPDATED_EVENT = 'playground-event-updated';

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -476,11 +476,11 @@ export default function Playground({
    * isBrowser changes to handle playgrounds that were in view
    * from the start of the page load.
    *
-   * We also re-run when isInView changes because the event callbacks
-   * would otherwise capture a stale state value. Since we need to
-   * listen for these events only when the playground is in view,
-   * we check the state before adding the listeners at all, rather
-   * than within the callbacks.
+   * We also re-run when isInView changes because otherwise, a stale
+   * state value would be captured. Since we need to listen for these
+   * events only when the playground is in view, we check the state
+   * before adding the listeners at all, rather than within the
+   * callbacks.
    */
   useEffect(() => {
     if (isBrowser && isInView) {

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -468,14 +468,14 @@ export default function Playground({
    * sync up to the same setting. This is needed because if the
    * playground is already in view, the IntersectionObserver doesn't
    * fire until the playground is scrolled off and back on the screen.
-   * 
+   *
    * Sometimes, the app isn't fully hydrated on the first render,
    * causing isBrowser to be set to false even if running the app
    * in a browser (vs. SSR). isBrowser is then updated on the next
    * render cycle. This means we need to re-run this hook when
    * isBrowser changes to handle playgrounds that were in view
    * from the start of the page load.
-   * 
+   *
    * We also re-run when isInView changes because the event callbacks
    * would otherwise capture a stale state value. Since we need to
    * listen for these events only when the playground is in view,
@@ -491,7 +491,7 @@ export default function Playground({
     return () => {
       window.removeEventListener(MODE_UPDATED_EVENT, handleModeUpdated);
       window.removeEventListener(USAGE_TARGET_UPDATED_EVENT, handleUsageTargetUpdated);
-    }
+    };
   }, [isBrowser, isInView]);
 
   const isIOS = ionicMode === Mode.iOS;

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -373,7 +373,7 @@ export default function Playground({
    * the framework/mode when it gets changed through another
    * playground on the page, as switching them for every playground
    * at once can cause memory-related crashes on some devices.
-   * 
+   *
    * Instead, we wait for even 1 pixel of the playground to scroll
    * into view (intersect with the viewport) before loading the
    * iframes or auto-switching the framework/mode.


### PR DESCRIPTION
We've found that switching the mode for all playgrounds on the page at once can cause performance issues for some devices. Namely, if many, many playgrounds are being toggled (such as on the [Datetime page](https://ionicframework.com/docs/api/datetime)), the browser may run out of memory and forcibly refresh the page.

Instead of updating all playgrounds at once, we now only update the ones currently on the screen, and wait for others to be scrolled on-screen before updating them as well.

Slack thread for context: https://ionicteam.slack.com/archives/C02U5GFFXED/p1696944131395219