### PR TITLE
docs: change comments for pwa-elements defineCustomElements

### DIFF
--- a/docs/angular/your-first-app.md
+++ b/docs/angular/your-first-app.md
@@ -106,7 +106,7 @@ Next, import `@ionic/pwa-elements` by editing `src/main.ts`.
 ```tsx
 import { defineCustomElements } from '@ionic/pwa-elements/loader';
 
-// Call the element loader after the platform has been bootstrapped
+// Call the element loader before the bootstrapModule/bootstrapApplication call
 defineCustomElements(window);
 ```
 

--- a/docs/react/your-first-app.md
+++ b/docs/react/your-first-app.md
@@ -104,7 +104,7 @@ Next, import `@ionic/pwa-elements` by editing `src/main.tsx`.
 ```tsx
 import { defineCustomElements } from '@ionic/pwa-elements/loader';
 
-// Call the element loader after the platform has been bootstrapped
+// Call the element loader before the render call
 defineCustomElements(window);
 ```
 

--- a/docs/vue/your-first-app.md
+++ b/docs/vue/your-first-app.md
@@ -104,8 +104,6 @@ Next, import `@ionic/pwa-elements` by editing `src/main.ts`.
 ```tsx
 // Above the createApp() line
 import { defineCustomElements } from '@ionic/pwa-elements/loader';
-
-// Call the element loader after the platform has been bootstrapped
 defineCustomElements(window);
 ```
 


### PR DESCRIPTION
After talking with Liam, looks like defineCustomElements should be called before and not after the app was created/rendered/bootstrapped.
I've tested on angular (ngModules and standalone), vue and react and pwa-elements is working fine. 