### PR TITLE
feat(keyboard): replace Codepens with playgrounds using modern syntax

### DIFF
--- a/docs/developing/keyboard.md
+++ b/docs/developing/keyboard.md
@@ -2,7 +2,6 @@
 title: Keyboard
 ---
 
-import Codepen from '@components/global/Codepen';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -28,77 +27,9 @@ For a list of accepted values, see the <a href="https://developer.mozilla.org/en
 
 ### Usage
 
-````mdx-code-block
-<Tabs
-  defaultValue="javascript"
-  groupId="framework"
-  values={[
-    { value: 'javascript', label: 'JavaScript' },
-    { value: 'angular', label: 'Angular' },
-    { value: 'react', label: 'React' },
-    { value: 'vue', label: 'Vue' },
-  ]
-}>
-<TabItem value="javascript">
+import Inputmode from '@site/static/usage/v7/keyboard/inputmode/index.md';
 
-```html
-<ion-item>
-  <ion-label>Username or Email</ion-label>
-  <ion-input inputmode="email"></ion-input>
-</ion-item>
-
-<ion-item>
-  <ion-label>Enter a number</ion-label>
-  <ion-textarea inputmode="numeric"></ion-textarea>
-</ion-item>
-```
-</TabItem>
-<TabItem value="angular">
-
-```html
-<ion-item>
-  <ion-label>Username or Email</ion-label>
-  <ion-input inputmode="email"></ion-input>
-</ion-item>
-
-<ion-item>
-  <ion-label>Enter a number</ion-label>
-  <ion-textarea inputmode="numeric"></ion-textarea>
-</ion-item>
-```
-</TabItem>
-<TabItem value="react">
-
-```html
-<IonItem>
-  <IonLabel>Username or Email</IonLabel>
-  <IonInput inputmode="email"></IonInput>
-</IonItem>
-
-<IonItem>
-  <IonLabel>Enter a number</IonLabel>
-  <IonTextarea inputmode="numeric"></IonTextarea>
-</IonItem>
-```
-</TabItem>
-<TabItem value="vue">
-
-```html
-<ion-item>
-  <ion-label>Username or Email</ion-label>
-  <ion-input inputmode="email"></ion-input>
-</ion-item>
-
-<ion-item>
-  <ion-label>Enter a number</ion-label>
-  <ion-textarea inputmode="numeric"></ion-textarea>
-</ion-item>
-```
-</TabItem>
-</Tabs>
-````
-
-<Codepen user="ionic" slug="abvJVVv" height="400" />
+<Inputmode />
 
 :::note
 The `inputmode` attribute is supported on devices running Chrome 66+ and iOS Safari 12.2+: https://caniuse.com/#search=inputmode
@@ -114,57 +45,9 @@ For a list of accepted values, see the <a href="https://html.spec.whatwg.org/dev
 
 ### Usage
 
-````mdx-code-block
-<Tabs
-  groupId="framework"
-  defaultValue="javascript"
-  values={[
-    { value: 'javascript', label: 'JavaScript' },
-    { value: 'angular', label: 'Angular' },
-    { value: 'react', label: 'React' },
-    { value: 'vue', label: 'Vue' },
-  ]
-}>
-<TabItem value="javascript">
+import Enterkeyhint from '@site/static/usage/v7/keyboard/enterkeyhint/index.md';
 
-```html
-<ion-item>
-  <ion-label>Enter search query</ion-label>
-  <ion-input enterkeyhint="search" type="search"></ion-input>
-</ion-item>
-```
-</TabItem>
-<TabItem value="angular">
-
-```html
-<ion-item>
-  <ion-label>Enter search query</ion-label>
-  <ion-input enterkeyhint="search" type="search"></ion-input>
-</ion-item>
-```
-</TabItem>
-<TabItem value="react">
-
-```html
-<IonItem>
-  <IonLabel>Enter search query</IonLabel>
-  <IonInput enterkeyhint="search" type="search"></IonInput>
-</IonItem>
-```
-</TabItem>
-<TabItem value="vue">
-
-```html
-<ion-item>
-  <ion-label>Enter search query</ion-label>
-  <ion-input enterkeyhint="search" type="search"></ion-input>
-</ion-item>
-```
-</TabItem>
-</Tabs>
-````
-
-<Codepen user="ionic" slug="GRpWyRB" height="350" />
+<Enterkeyhint />
 
 :::note
 The `enterkeyhint` attribute is supported on devices running Chrome 77+ and iOS Safari 13.4+.

--- a/static/usage/v7/keyboard/enterkeyhint/angular.md
+++ b/static/usage/v7/keyboard/enterkeyhint/angular.md
@@ -1,0 +1,14 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-input enterkeyhint="search" labelPlacement="stacked" placeholder="Enter search query">
+      <code slot="label">enterkeyhint="search"</code>
+    </ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input enterkeyhint="send" labelPlacement="stacked" placeholder="Type a message">
+      <code slot="label">enterkeyhint="send"</code>
+    </ion-input>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/keyboard/enterkeyhint/demo.html
+++ b/static/usage/v7/keyboard/enterkeyhint/demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Keyboard</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-input enterkeyhint="search" label-placement="stacked" placeholder="Enter search query">
+                <code slot="label">enterkeyhint="search"</code>
+              </ion-input>
+            </ion-item>
+            <ion-item>
+              <ion-input enterkeyhint="send" label-placement="stacked" placeholder="Type a message">
+                <code slot="label">enterkeyhint="send"</code>
+              </ion-input>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/keyboard/enterkeyhint/index.md
+++ b/static/usage/v7/keyboard/enterkeyhint/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/keyboard/enterkeyhint/demo.html"
+/>

--- a/static/usage/v7/keyboard/enterkeyhint/javascript.md
+++ b/static/usage/v7/keyboard/enterkeyhint/javascript.md
@@ -1,0 +1,14 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-input enterkeyhint="search" label-placement="stacked" placeholder="Enter search query">
+      <code slot="label">enterkeyhint="search"</code>
+    </ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input enterkeyhint="send" label-placement="stacked" placeholder="Type a message">
+      <code slot="label">enterkeyhint="send"</code>
+    </ion-input>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/keyboard/enterkeyhint/react.md
+++ b/static/usage/v7/keyboard/enterkeyhint/react.md
@@ -1,0 +1,23 @@
+```tsx
+import React from 'react';
+import { IonList, IonItem, IonInput } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonInput enterkeyhint="search" labelPlacement="stacked" placeholder="Enter search query">
+          <code slot="label">enterkeyhint="search"</code>
+        </IonInput>
+      </IonItem>
+      <IonItem>
+        <IonInput enterkeyhint="send" labelPlacement="stacked" placeholder="Type a message">
+          <code slot="label">enterkeyhint="send"</code>
+        </IonInput>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```
+

--- a/static/usage/v7/keyboard/enterkeyhint/react.md
+++ b/static/usage/v7/keyboard/enterkeyhint/react.md
@@ -20,4 +20,3 @@ function Example() {
 }
 export default Example;
 ```
-

--- a/static/usage/v7/keyboard/enterkeyhint/vue.md
+++ b/static/usage/v7/keyboard/enterkeyhint/vue.md
@@ -20,7 +20,9 @@
 
   export default defineComponent({
     components: {
-      IonList, IonItem, IonInput,
+      IonList,
+      IonItem,
+      IonInput,
     },
   });
 </script>

--- a/static/usage/v7/keyboard/enterkeyhint/vue.md
+++ b/static/usage/v7/keyboard/enterkeyhint/vue.md
@@ -1,0 +1,27 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-input enterkeyhint="search" label-placement="stacked" placeholder="Enter search query">
+        <code slot="label">enterkeyhint="search"</code>
+      </ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input enterkeyhint="send" label-placement="stacked" placeholder="Type a message">
+        <code slot="label">enterkeyhint="send"</code>
+      </ion-input>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonList, IonItem, IonInput } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonList, IonItem, IonInput,
+    },
+  });
+</script>
+```

--- a/static/usage/v7/keyboard/inputmode/angular.md
+++ b/static/usage/v7/keyboard/inputmode/angular.md
@@ -1,0 +1,19 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-input inputmode="email" labelPlacement="stacked" placeholder="Enter a username or email address">
+      <code slot="label">inputmode="email"</code>
+    </ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input inputmode="numeric" labelPlacement="stacked" placeholder="Enter an integer">
+      <code slot="label">inputmode="numeric"</code>
+    </ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input inputmode="decimal" labelPlacement="stacked" placeholder="Enter a decimal">
+      <code slot="label">inputmode="decimal"</code>
+    </ion-input>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/keyboard/inputmode/demo.html
+++ b/static/usage/v7/keyboard/inputmode/demo.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Keyboard</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-list {
+        min-width: 320px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-input inputmode="email" label-placement="stacked" placeholder="Enter a username or email address">
+                <code slot="label">inputmode="email"</code>
+              </ion-input>
+            </ion-item>
+            <ion-item>
+              <ion-input inputmode="numeric" label-placement="stacked" placeholder="Enter an integer">
+                <code slot="label">inputmode="numeric"</code>
+              </ion-input>
+            </ion-item>
+            <ion-item>
+              <ion-input inputmode="decimal" label-placement="stacked" placeholder="Enter a decimal">
+                <code slot="label">inputmode="decimal"</code>
+              </ion-input>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/keyboard/inputmode/index.md
+++ b/static/usage/v7/keyboard/inputmode/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/keyboard/inputmode/demo.html"
+/>

--- a/static/usage/v7/keyboard/inputmode/javascript.md
+++ b/static/usage/v7/keyboard/inputmode/javascript.md
@@ -1,0 +1,19 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-input inputmode="email" label-placement="stacked" placeholder="Enter a username or email address">
+      <code slot="label">inputmode="email"</code>
+    </ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input inputmode="numeric" label-placement="stacked" placeholder="Enter an integer">
+      <code slot="label">inputmode="numeric"</code>
+    </ion-input>
+  </ion-item>
+  <ion-item>
+    <ion-input inputmode="decimal" label-placement="stacked" placeholder="Enter a decimal">
+      <code slot="label">inputmode="decimal"</code>
+    </ion-input>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/keyboard/inputmode/react.md
+++ b/static/usage/v7/keyboard/inputmode/react.md
@@ -1,0 +1,28 @@
+```tsx
+import React from 'react';
+import { IonList, IonItem, IonInput } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonInput inputmode="email" labelPlacement="stacked" placeholder="Enter a username or email address">
+          <code slot="label">inputmode="email"</code>
+        </IonInput>
+      </IonItem>
+      <IonItem>
+        <IonInput inputmode="numeric" labelPlacement="stacked" placeholder="Enter an integer">
+          <code slot="label">inputmode="numeric"</code>
+        </IonInput>
+      </IonItem>
+      <IonItem>
+        <IonInput inputmode="decimal" labelPlacement="stacked" placeholder="Enter a decimal">
+          <code slot="label">inputmode="decimal"</code>
+        </IonInput>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```
+

--- a/static/usage/v7/keyboard/inputmode/react.md
+++ b/static/usage/v7/keyboard/inputmode/react.md
@@ -25,4 +25,3 @@ function Example() {
 }
 export default Example;
 ```
-

--- a/static/usage/v7/keyboard/inputmode/vue.md
+++ b/static/usage/v7/keyboard/inputmode/vue.md
@@ -25,7 +25,9 @@
 
   export default defineComponent({
     components: {
-      IonList, IonItem, IonInput,
+      IonList,
+      IonItem,
+      IonInput,
     },
   });
 </script>

--- a/static/usage/v7/keyboard/inputmode/vue.md
+++ b/static/usage/v7/keyboard/inputmode/vue.md
@@ -1,0 +1,32 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-input inputmode="email" label-placement="stacked" placeholder="Enter a username or email address">
+        <code slot="label">inputmode="email"</code>
+      </ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input inputmode="numeric" label-placement="stacked" placeholder="Enter an integer">
+        <code slot="label">inputmode="numeric"</code>
+      </ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-input inputmode="decimal" label-placement="stacked" placeholder="Enter a decimal">
+        <code slot="label">inputmode="decimal"</code>
+      </ion-input>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonList, IonItem, IonInput } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonList, IonItem, IonInput,
+    },
+  });
+</script>
+```


### PR DESCRIPTION
https://ionicframework.com/docs/developing/keyboard The two code demos on this page had several problems:
1. The demos were shown using Codepens instead of proper playgrounds.
2. The inputs were using the legacy form control syntax.
3. The code shown didn't match the Codepens.

This PR resolves all three.

Shortcut: https://ionic-docs-git-keyboard-playgrounds-ionic1.vercel.app/docs/developing/keyboard