### PR TITLE
docs: clarify IonicSafeString usage

### DIFF
--- a/docs/techniques/security.md
+++ b/docs/techniques/security.md
@@ -83,7 +83,11 @@ Ionic Framework provides an application config option called `sanitizerEnabled` 
 Developers can also choose to eject from the sanitizer in certain scenarios. Ionic Framework provides the `IonicSafeString` class that allows developers to do just that.
 
 :::note
-In order to bypass the sanitizer and use unsanitized custom HTML in the relevant Ionic components, `innerHTMLTemplatesEnabled` must be set to `true` in the Ionic config. See [Enabling Custom HTML Parsing](#enabling-custom-html-parsing-via-innerhtml) for more information.
+In order to bypass the sanitizer and use unsanitized custom HTML in the relevant Ionic components, `innerHTMLTemplatesEnabled` must be set to `true` in the Ionic config.
+
+`IonicSafeString` should not be used if `innerHTMLTemplatesEnabled` is set to `false`.
+
+See [Enabling Custom HTML Parsing](#enabling-custom-html-parsing-via-innerhtml) for more information.
 :::
 
 #### Usage


### PR DESCRIPTION
I've seen some confusion in threads such as https://github.com/ionic-team/ionic-framework/issues/28365 as to when to use IonicSafeString, so I wanted to clarify this on the docs.