### PR TITLE
chore: add framework team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 # In each subsection folders are ordered first by depth, then alphabetically.
 # This should make it easy to add new rules without breaking existing ones.
 
-/_templates/ @mapsandapps
+* @ionic-team/framework
 
-/static/code/stackblitz/**/*/package.json @ionic-team/framework
-/static/code/stackblitz/**/*/package-lock.json @ionic-team/framework
+/_templates/ @mapsandapps


### PR DESCRIPTION
The Framework team should be automatically assigned to new PRs.