### PR TITLE
fix(textarea): autogrow playground can scroll to the top of contents

### DIFF
--- a/static/usage/v6/textarea/autogrow/demo.html
+++ b/static/usage/v6/textarea/autogrow/demo.html
@@ -11,6 +11,8 @@
 
     <style>
       .container {
+        display: block;
+        
         padding: 0 40px;
       }
 

--- a/static/usage/v6/textarea/autogrow/demo.html
+++ b/static/usage/v6/textarea/autogrow/demo.html
@@ -12,7 +12,7 @@
     <style>
       .container {
         display: block;
-        
+
         padding: 0 40px;
       }
 

--- a/static/usage/v7/textarea/autogrow/demo.html
+++ b/static/usage/v7/textarea/autogrow/demo.html
@@ -11,6 +11,8 @@
 
     <style>
       .container {
+        display: block;
+
         padding: 0 40px;
       }
 


### PR DESCRIPTION
The `.container` wrapper that we render around the autogrow playground example, caused the contents to be clipped and not scrollable when large amounts of text were rendered. 

This PR changes the display style of the `.container` element for these specific examples to be `display: block`. This allows the contents to be scrolled to when working with large amounts of text. 

As a result of this, the textarea container is not optically centered to the playground frame, but for autogrow I do not believe this matters for the example. 