### PR TITLE
chore(renovate): update config to ignore typescript updates in react v6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,12 @@
         "static/code/stackblitz/v6/react/package.json",
         "static/code/stackblitz/v6/vue/package.json"
       ]
+    },
+    {
+      "ignoreDeps": ["typescript"],
+      "matchFileNames": [
+        "static/code/stackblitz/v6/react/package.json"
+      ]
     }
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
I couldn't find a way to test this but I looked through the docs and issues and this seems like the right config. Let me know if I am missing something! 