### PR TITLE
docs(vue): correct routerDirection keyword

### DIFF
--- a/docs/vue/navigation.md
+++ b/docs/vue/navigation.md
@@ -138,7 +138,7 @@ Both options provide the same navigation mechanism, just fitting different use c
 
 The `router-link` attribute can be set on any Ionic Vue component, and the router will navigate to the route specified when the component is clicked. The `router-link` attribute accepts string values as well as named routes, just like `router.push` from Vue Router. For additional control, the `router-direction` and `router-animation` attributes can be set as well.
 
-The `router-direction` attribute accepts values of `forward`, `back`, or `none` and is used to control the direction of the page transition.
+The `router-direction` attribute accepts values of `forward`, `back`, or `root` and is used to control the direction of the page transition.
 
 The `router-animation` attribute accepts an `AnimationBuilder` function and is used to provide a custom page transition that is only used when clicking the component it is provided on. The `AnimationBuilder` type is a function that returns an Ionic Animation instance. See the [Animations documentation](../utilities/animations) for more information on using animations in Ionic Vue.
 


### PR DESCRIPTION
"none" is incorrectly documented as RouterDirection keyword. It should be "root" instead: https://github.com/ionic-team/ionic-framework/blob/dfafb274354523f733922ad25f57ef9d9ff4235b/core/src/components/router/utils/interface.ts#L66

See https://github.com/ionic-team/ionic-framework/issues/28475 for more information.