### PR TITLE
chore(renovate): use chore subject line for prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
   "packageRules": [
     {
       "matchPackagePatterns": ["@ionic/"],


### PR DESCRIPTION
Configures renovate to use `chore:` for commit messages.

https://docs.renovatebot.com/semantic-commits/#changing-the-semantic-commit-type