### PR TITLE
docs(toggle): update playground to have larger height

### DIFF
--- a/static/usage/v7/toggle/label-placement/index.md
+++ b/static/usage/v7/toggle/label-placement/index.md
@@ -5,4 +5,9 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/label-placement/demo.html" />
+<Playground
+  version="7"
+  code={{ javascript, react, vue, angular }}
+  src="usage/v7/toggle/label-placement/demo.html"
+  size="300px"
+/>


### PR DESCRIPTION
While testing out a PR I noticed that [Toggle's Label Placement demo](https://ionicframework.com/docs/api/toggle#label-placement) is too short to display all of the toggles on `ios`. I increased the height of the container to fit all of them.

Preview: https://ionic-docs-git-docs-fix-toggle-playgrounds-ionic1.vercel.app/docs/api/toggle#label-placement

| Before | After |
| ---| ---|
| ![before](https://github.com/ionic-team/ionic-docs/assets/6577830/427badc7-3f4a-4082-8358-054497d0bbe8) | ![after](https://github.com/ionic-team/ionic-docs/assets/6577830/a751f5e2-73ff-448b-80c8-913a8aec06d3) |
