### PR TITLE
fix(playground): support angular 17 template

### DIFF
--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -124,7 +124,7 @@ const openAngularEditor = async (code: string, options?: EditorOptions) => {
   const appModule = 'src/app/app.module.ts';
   const files = {
     'src/main.ts': defaultFiles[0],
-    'src/polyfills.ts': `import 'zone.js/dist/zone';`,
+    'src/polyfills.ts': `import 'zone.js';`,
     [appModule]: defaultFiles[1],
     'src/app/app.component.ts': defaultFiles[2],
     'src/app/app.component.css': defaultFiles[3],

--- a/static/code/stackblitz/v6/angular/package.json
+++ b/static/code/stackblitz/v6/angular/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@ionic/angular": "^6.0.0",
-    "@ionic/core": "^6.0.0"
+    "@ionic/core": "^6.0.0",
+    "@angular/platform-browser-dynamic": "17.0.1"
   }
 }

--- a/static/code/stackblitz/v7/angular/package.json
+++ b/static/code/stackblitz/v7/angular/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@ionic/angular": "^7.0.0",
-    "@ionic/core": "^7.0.0"
+    "@ionic/core": "^7.0.0",
+    "@angular/platform-browser-dynamic": "17.0.1"
   }
 }


### PR DESCRIPTION
Fixes the generated playground examples to work with the new Angular 17 templates from Stackblitz. 