### PR TITLE
docs(toast): add swipeGesture playground

### DIFF
--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -72,6 +72,14 @@ import PositionAnchor from '@site/static/usage/v7/toast/position-anchor/index.md
 
 <PositionAnchor />
 
+## Swipe to Dismiss
+
+Toasts can be swiped to dismiss by using the `swipeGesture` property. This feature is position-aware, meaning the direction that users need to swipe will change based on the value of the `position` property. Additionally, the distance users need to swipe may be impacted by the `positionAnchor` property.
+
+import SwipeGesture from '@site/static/usage/v7/toast/swipe-gesture/index.md';
+
+<SwipeGesture />
+  
 ## Layout
 
 Button containers within the toast can be displayed either on the same line as the message or stacked on separate lines using the `layout` property. The stacked layout should be used with buttons that have long text values. Additionally, buttons in a stacked toast layout can use a `side` value of either `start` or `end`, but not both.

--- a/static/usage/v7/toast/swipe-gesture/angular.md
+++ b/static/usage/v7/toast/swipe-gesture/angular.md
@@ -1,0 +1,17 @@
+```html
+<ion-content class="ion-padding">
+  <ion-button id="open-toast">Open Toast</ion-button>
+  <ion-toast
+    message="This toast can be swiped to dismiss"
+    trigger="open-toast"
+    swipeGesture="vertical"
+    position="bottom"
+    positionAnchor="footer"
+  ></ion-toast>
+</ion-content>
+<ion-footer id="footer">
+  <ion-toolbar>
+    <ion-title>Footer</ion-title>
+  </ion-toolbar>
+</ion-footer>
+```

--- a/static/usage/v7/toast/swipe-gesture/demo.html
+++ b/static/usage/v7/toast/swipe-gesture/demo.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toast</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-button id="open-toast">Open Toast</ion-button>
+          <ion-toast
+            message="This toast can be swiped to dismiss"
+            trigger="open-toast"
+            swipe-gesture="vertical"
+            position="bottom"
+            position-anchor="footer"
+          ></ion-toast>
+        </div>
+      </ion-content>
+
+      <ion-footer id="footer">
+        <ion-toolbar>
+          <ion-title>Footer</ion-title>
+        </ion-toolbar>
+      </ion-footer>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/toast/swipe-gesture/index.md
+++ b/static/usage/v7/toast/swipe-gesture/index.md
@@ -1,0 +1,19 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/toast/swipe-gesture/demo.html"
+  devicePreview={true}
+  includeIonContent={false}
+/>

--- a/static/usage/v7/toast/swipe-gesture/javascript.md
+++ b/static/usage/v7/toast/swipe-gesture/javascript.md
@@ -1,0 +1,17 @@
+```html
+<ion-content class="ion-padding">
+  <ion-button id="open-toast">Open Toast</ion-button>
+  <ion-toast
+    message="This toast can be swiped to dismiss"
+    trigger="open-toast"
+    swipe-gesture="vertical"
+    position="bottom"
+    position-anchor="footer"
+  ></ion-toast>
+</ion-content>
+<ion-footer id="footer">
+  <ion-toolbar>
+    <ion-title>Footer</ion-title>
+  </ion-toolbar>
+</ion-footer>
+```

--- a/static/usage/v7/toast/swipe-gesture/react.md
+++ b/static/usage/v7/toast/swipe-gesture/react.md
@@ -1,0 +1,27 @@
+```tsx
+import React from 'react';
+import { IonButton, IonContent, IonFooter, IonTitle, IonToast, IonToolbar } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonContent className="ion-padding">
+        <IonButton id="open-toast">Open Toast</IonButton>
+        <IonToast
+          message="This toast can be swiped to dismiss"
+          trigger="open-toast"
+          swipeGesture="vertical"
+          position="bottom"
+          positionAnchor="footer"
+        ></IonToast>
+      </IonContent>
+      <IonFooter id="footer">
+        <IonToolbar>
+          <IonTitle>Footer</IonTitle>
+        </IonToolbar>
+      </IonFooter>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/toast/swipe-gesture/vue.md
+++ b/static/usage/v7/toast/swipe-gesture/vue.md
@@ -17,19 +17,7 @@
   </ion-footer>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonButton, IonContent, IonFooter, IonTitle, IonToast, IonToolbar } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: {
-      IonButton,
-      IonContent,
-      IonFooter,
-      IonTitle,
-      IonToast,
-      IonToolbar,
-    },
-  });
 </script>
 ```

--- a/static/usage/v7/toast/swipe-gesture/vue.md
+++ b/static/usage/v7/toast/swipe-gesture/vue.md
@@ -1,0 +1,35 @@
+```html
+<template>
+  <ion-content class="ion-padding">
+    <ion-button id="open-toast">Open Toast</ion-button>
+    <ion-toast
+      message="This toast can be swiped to dismiss"
+      trigger="open-toast"
+      swipe-gesture="vertical"
+      position="bottom"
+      position-anchor="footer"
+    ></ion-toast>
+  </ion-content>
+  <ion-footer id="footer">
+    <ion-toolbar>
+      <ion-title>Footer</ion-title>
+    </ion-toolbar>
+  </ion-footer>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonContent, IonFooter, IonTitle, IonToast, IonToolbar } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton,
+      IonContent,
+      IonFooter,
+      IonTitle,
+      IonToast,
+      IonToolbar,
+    },
+  });
+</script>
+```


### PR DESCRIPTION
This adds a playground for the new `swipeGesture` feature in IonToast. I opted to use `positionAnchor` and `position` so devs can see how `swipeGesture` is impacted by both of these APIs.

Ionic v7.6 dev build: `7.5.4-dev.11699895923.130c21aa`

Preview: https://ionic-docs-git-toast-swipe-ionic1.vercel.app/docs/api/toast#swipe-to-dismiss (You'll need to install the above dev build on the stackblitz demos for the feature to work since it has not been released yet)