### PR TITLE
chore(renovate): revert typescript ignore rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,12 +27,6 @@
         "static/code/stackblitz/v6/react/package.json",
         "static/code/stackblitz/v6/vue/package.json"
       ]
-    },
-    {
-      "ignoreDeps": ["typescript"],
-      "matchFileNames": [
-        "static/code/stackblitz/v6/react/package.json"
-      ]
     }
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
Reverts ionic-team/ionic-docs#3231

As of https://github.com/ionic-team/ionic-docs/pull/3246, the Ionic React v6 playgrounds now use Vite, so we can safely use TypeScript 5.