### PR TITLE
Replace src/main.tsx by src/index.tsx

### DIFF
--- a/docs/react/your-first-app.md
+++ b/docs/react/your-first-app.md
@@ -99,7 +99,7 @@ npm install @ionic/pwa-elements
 
 After installation, open up the project in your code editor of choice.
 
-Next, import `@ionic/pwa-elements` by editing `src/main.tsx`.
+Next, import `@ionic/pwa-elements` by editing `src/index.tsx`.
 
 ```tsx
 import { defineCustomElements } from '@ionic/pwa-elements/loader';


### PR DESCRIPTION
It looks like `src/main.tsx` has been replaced by `src/index.tsx` in current version of ionic starter template (as of today at least).