### PR TITLE
chore(renovate): match explicitly the react-router and react-router-dom

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "schedule": ["on the first day of the month"]
     },
     {
-      "matchPackagePatterns": ["react-router", "react-router-dom"],
+      "matchPackageNames": ["react-router", "react-router-dom"],
       "groupName": "react-router",
       "allowedVersions": "^5.0.0"
     },


### PR DESCRIPTION
This PR updates renovate to match explicitly for the package names vs. matching based on a pattern.

Currently `@ionic/react-router` is not being upgraded for v7 since it matches "react-router" and that is set to a maximum version range of `^5.0.0`. 