### PR TITLE
chore(ci): run workflow against node v20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node_version: [19]
+        node_version: [20]
         os: [windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node_version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node_version }}
     - name: Install Dependencies


### PR DESCRIPTION
Upgrades the CI workflow to run against Node v20. Additionally updates the checkout and setup-node actions to use the latest available versions. 