### PR TITLE
feat(input, textarea, select): add section for start and end slots

### DIFF
--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -148,6 +148,20 @@ Please submit bug reports with Maskito to the [Maskito Github repository](https:
 
 :::
 
+## Start and End Slots (experimental)
+
+The `start` and `end` slots can be used to place icons, buttons, or prefix/suffix text on either side of the input.
+
+In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. See the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
+
+If slot content is meant to be interactive, it should be wrapped in an interactable element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
+Note that this feature is considered experimental because it relies on a simulated version of [Web Component slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots). As a result, the simulated behavior may not exactly match the native slot behavior.
+
+import StartEndSlots from '@site/static/usage/v7/input/start-end-slots/index.md';
+
+<StartEndSlots />
+
 ## Theming
 
 ### Colors

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -173,6 +173,18 @@ import InterfaceOptionsExample from '@site/static/usage/v7/select/customization/
 
 <InterfaceOptionsExample />
 
+## Start and End Slots
+
+The `start` and `end` slots can be used to place icons, buttons, or prefix/suffix text on either side of the input.
+
+In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. See the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
+
+If slot content is meant to be interactive, it should be wrapped in an interactable element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
+import StartEndSlots from '@site/static/usage/v7/select/start-end-slots/index.md';
+
+<StartEndSlots />
+
 ## Customization
 
 There are two units that make up the Select component and each need to be styled separately. The `ion-select` element is represented on the view by the selected value(s), or placeholder if there is none, and dropdown icon. The interface, which is defined in the [Interfaces](#interfaces) section above, is the dialog that opens when clicking on the `ion-select`. The interface contains all of the options defined by adding `ion-select-option` elements. The following sections will go over the differences between styling these.

--- a/docs/api/textarea.md
+++ b/docs/api/textarea.md
@@ -109,6 +109,20 @@ import ClearOnEditPlayground from '@site/static/usage/v7/textarea/clear-on-edit/
 
 <ClearOnEditPlayground />
 
+## Start and End Slots (experimental)
+
+The `start` and `end` slots can be used to place icons, buttons, or prefix/suffix text on either side of the textarea.
+
+In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. See the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
+
+If slot content is meant to be interactive, it should be wrapped in an interactable element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
+Note that this feature is considered experimental because it relies on a simulated version of [Web Component slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots). As a result, the simulated behavior may not exactly match the native slot behavior.
+
+import StartEndSlots from '@site/static/usage/v7/textarea/start-end-slots/index.md';
+
+<StartEndSlots />
+
 ## Migrating from Legacy Textarea Syntax
 
 A simpler textarea syntax was introduced in Ionic 7.0. This new syntax reduces the boilerplate required to setup an textarea, resolves accessibility issues, and improves the developer experience.

--- a/static/usage/v7/input/start-end-slots/angular.md
+++ b/static/usage/v7/input/start-end-slots/angular.md
@@ -1,0 +1,12 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-input labelPlacement="stacked" label="Email" placeholder="email@domain.com">
+      <ion-icon slot="start" name="lock-closed" aria-hidden="true"></ion-icon>
+      <ion-button fill="clear" slot="end" aria-label="Show/hide">
+        <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+      </ion-button>
+    </ion-input>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/input/start-end-slots/demo.html
+++ b/static/usage/v7/input/start-end-slots/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Input</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-input label-placement="stacked" label="Email" placeholder="email@domain.com">
+                <ion-icon slot="start" name="lock-closed" aria-hidden="true"></ion-icon>
+                <ion-button fill="clear" slot="end" aria-label="Show/hide">
+                  <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+                </ion-button>
+              </ion-input>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/input/start-end-slots/index.md
+++ b/static/usage/v7/input/start-end-slots/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/input/start-end-slots/demo.html"
+/>

--- a/static/usage/v7/input/start-end-slots/javascript.md
+++ b/static/usage/v7/input/start-end-slots/javascript.md
@@ -1,0 +1,12 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-input label-placement="stacked" label="Email" placeholder="email@domain.com">
+      <ion-icon slot="start" name="lock-closed" aria-hidden="true"></ion-icon>
+      <ion-button fill="clear" slot="end" aria-label="Show/hide">
+        <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+      </ion-button>
+    </ion-input>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/input/start-end-slots/react.md
+++ b/static/usage/v7/input/start-end-slots/react.md
@@ -1,0 +1,22 @@
+```tsx
+import React from 'react';
+import { IonButton, IonIcon, IonInput, IonItem, IonList } from '@ionic/react';
+import { eye, lockClosed } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonInput labelPlacement="stacked" label="Email" placeholder="email@domain.com">
+          <IonIcon slot="start" icon={lockClosed} aria-hidden="true"></IonIcon>
+          <IonButton fill="clear" slot="end" aria-label="Show/hide">
+            <IonIcon slot="icon-only" name={eye} aria-hidden="true"></IonIcon>
+          </IonButton>
+        </IonInput>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```
+

--- a/static/usage/v7/input/start-end-slots/vue.md
+++ b/static/usage/v7/input/start-end-slots/vue.md
@@ -1,0 +1,29 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-input label-placement="stacked" label="Email" placeholder="email@domain.com">
+        <ion-icon slot="start" :icon="lockClosed" aria-hidden="true"></ion-icon>
+        <ion-button fill="clear" slot="end" aria-label="Show/hide">
+          <ion-icon slot="icon-only" :icon="eye" aria-hidden="true"></ion-icon>
+        </ion-button>
+      </ion-input>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonIcon, IonInput, IonItem, IonList } from '@ionic/vue';
+  import { eye, lockClosed } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton, IonIcon, IonInput, IonItem, IonList,
+    },
+    setup() {
+      return { eye, lockClosed }
+    }
+  });
+</script>
+```

--- a/static/usage/v7/select/start-end-slots/angular.md
+++ b/static/usage/v7/select/start-end-slots/angular.md
@@ -1,0 +1,15 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select labelPlacement="stacked" label="Favorite fruit" value="apple">
+      <ion-icon slot="start" name="leaf" aria-hidden="true"></ion-icon>
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+      <ion-button fill="clear" slot="end" aria-label="Show/hide password">
+        <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+      </ion-button>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/start-end-slots/demo.html
+++ b/static/usage/v7/select/start-end-slots/demo.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Select</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-select label-placement="stacked" label="Favorite fruit" value="apple">
+                <ion-icon slot="start" name="leaf" aria-hidden="true"></ion-icon>
+                <ion-select-option value="apple">Apple</ion-select-option>
+                <ion-select-option value="banana">Banana</ion-select-option>
+                <ion-select-option value="orange">Orange</ion-select-option>
+                <ion-button fill="clear" slot="end" aria-label="Show/hide password">
+                  <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+                </ion-button>
+              </ion-select>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/select/start-end-slots/demo.html
+++ b/static/usage/v7/select/start-end-slots/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-list {
+        min-width: 400px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/select/start-end-slots/index.md
+++ b/static/usage/v7/select/start-end-slots/index.md
@@ -1,0 +1,18 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/select/start-end-slots/demo.html"
+  size="300px"
+/>

--- a/static/usage/v7/select/start-end-slots/javascript.md
+++ b/static/usage/v7/select/start-end-slots/javascript.md
@@ -1,0 +1,15 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-select label-placement="stacked" label="Favorite fruit" value="apple">
+      <ion-icon slot="start" name="leaf" aria-hidden="true"></ion-icon>
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+      <ion-button fill="clear" slot="end" aria-label="Show/hide password">
+        <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+      </ion-button>
+    </ion-select>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/select/start-end-slots/react.md
+++ b/static/usage/v7/select/start-end-slots/react.md
@@ -1,0 +1,25 @@
+```tsx
+import React from 'react';
+import { IonButton, IonIcon, IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/react';
+import { eye, leaf } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonSelect labelPlacement="stacked" label="Favorite fruit" value="apple">
+          <IonIcon slot="start" icon={leaf} aria-hidden="true"></IonIcon>
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+          <IonButton fill="clear" slot="end" aria-label="Show/hide password">
+            <IonIcon slot="icon-only" icon={eye} aria-hidden="true"></IonIcon>
+          </IonButton>
+        </IonSelect>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```
+

--- a/static/usage/v7/select/start-end-slots/vue.md
+++ b/static/usage/v7/select/start-end-slots/vue.md
@@ -1,0 +1,32 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-select label-placement="stacked" label="Favorite fruit" value="apple">
+        <ion-icon slot="start" :icon="leaf" aria-hidden="true"></ion-icon>
+        <ion-select-option value="apple">Apple</ion-select-option>
+        <ion-select-option value="banana">Banana</ion-select-option>
+        <ion-select-option value="orange">Orange</ion-select-option>
+        <ion-button fill="clear" slot="end" aria-label="Show/hide password">
+          <ion-icon slot="icon-only" :icon="eye" aria-hidden="true"></ion-icon>
+        </ion-button>
+      </ion-select>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonIcon, IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/vue';
+  import { eye, leaf } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton, IonIcon, IonItem, IonList, IonSelect, IonSelectOption
+    },
+    setup() {
+      return { eye, leaf }
+    }
+  });
+</script>
+```

--- a/static/usage/v7/textarea/start-end-slots/angular.md
+++ b/static/usage/v7/textarea/start-end-slots/angular.md
@@ -1,0 +1,12 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-textarea labelPlacement="stacked" label="Comments" placeholder="Enter your comments">
+      <ion-icon slot="start" name="lock-closed" aria-hidden="true"></ion-icon>
+      <ion-button fill="clear" slot="end" aria-label="Show/hide">
+        <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+      </ion-button>
+    </ion-textarea>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/textarea/start-end-slots/demo.html
+++ b/static/usage/v7/textarea/start-end-slots/demo.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Textarea</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-list>
+            <ion-item>
+              <ion-textarea label-placement="stacked" label="Comments" placeholder="Enter your comments">
+                <ion-icon slot="start" name="lock-closed" aria-hidden="true"></ion-icon>
+                <ion-button fill="clear" slot="end" aria-label="Show/hide">
+                  <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+                </ion-button>
+              </ion-textarea>
+            </ion-item>
+          </ion-list>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/textarea/start-end-slots/index.md
+++ b/static/usage/v7/textarea/start-end-slots/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/textarea/start-end-slots/demo.html"
+/>

--- a/static/usage/v7/textarea/start-end-slots/javascript.md
+++ b/static/usage/v7/textarea/start-end-slots/javascript.md
@@ -1,0 +1,12 @@
+```html
+<ion-list>
+  <ion-item>
+    <ion-textarea label-placement="stacked" label="Comments" placeholder="Enter your comments">
+      <ion-icon slot="start" name="lock-closed" aria-hidden="true"></ion-icon>
+      <ion-button fill="clear" slot="end" aria-label="Show/hide">
+        <ion-icon slot="icon-only" name="eye" aria-hidden="true"></ion-icon>
+      </ion-button>
+    </ion-textarea>
+  </ion-item>
+</ion-list>
+```

--- a/static/usage/v7/textarea/start-end-slots/react.md
+++ b/static/usage/v7/textarea/start-end-slots/react.md
@@ -1,0 +1,22 @@
+```tsx
+import React from 'react';
+import { IonButton, IonIcon, IonItem, IonList, IonTextarea } from '@ionic/react';
+import { eye, lockClosed } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <IonList>
+      <IonItem>
+        <IonTextarea labelPlacement="stacked" label="Comments" placeholder="Enter your comments">
+          <IonIcon slot="start" icon={lockClosed} aria-hidden="true"></IonIcon>
+          <IonButton fill="clear" slot="end" aria-label="Show/hide">
+            <IonIcon slot="icon-only" name={eye} aria-hidden="true"></IonIcon>
+          </IonButton>
+        </IonTextarea>
+      </IonItem>
+    </IonList>
+  );
+}
+export default Example;
+```
+

--- a/static/usage/v7/textarea/start-end-slots/vue.md
+++ b/static/usage/v7/textarea/start-end-slots/vue.md
@@ -1,0 +1,29 @@
+```html
+<template>
+  <ion-list>
+    <ion-item>
+      <ion-textarea label-placement="stacked" label="Comments" placeholder="Enter your comments">
+        <ion-icon slot="start" :icon="lockClosed" aria-hidden="true"></ion-icon>
+        <ion-button fill="clear" slot="end" aria-label="Show/hide">
+          <ion-icon slot="icon-only" :icon="eye" aria-hidden="true"></ion-icon>
+        </ion-button>
+      </ion-textarea>
+    </ion-item>
+  </ion-list>
+</template>
+
+<script lang="ts">
+  import { IonButton, IonIcon, IonItem, IonList, IonTextarea } from '@ionic/vue';
+  import { eye, lockClosed } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonButton, IonIcon, IonItem, IonList, IonTextarea
+    },
+    setup() {
+      return { eye, lockClosed }
+    }
+  });
+</script>
+```


### PR DESCRIPTION
Feature PR: https://github.com/ionic-team/ionic-framework/pull/28583

Adds some docs explaining usability guidelines for the new `start` and `end` slots on all three components, plus a playground for each to demonstrate best practices. Note that `ion-select` is a shadow component, so the experimental slots aren't needed.