### PR TITLE
chore(renovate): update react and react-dom

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,10 @@
       "allowedVersions": "^5.0.0"
     },
     {
+      "matchPackageNames": ["react", "react-dom"],
+      "groupName": "react",
+    },
+    {
       "matchPackagePatterns": ["@ionic/"],
       "allowedVersions": "^6.0.0",
       "groupName": "ionic",

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
     },
     {
       "matchPackageNames": ["react", "react-dom"],
-      "groupName": "react",
+      "groupName": "react"
     },
     {
       "matchPackagePatterns": ["@ionic/"],


### PR DESCRIPTION
The installed version of React on the docs is outdated. This can cause issues with other dependencies when the `package-lock.json` file is removed.

Example: https://github.com/ionic-team/ionic-docs/pull/3272#issuecomment-1831988786

A dependency we used dropped support for React 17 in a minor release. The package-lock ensured that an older version of the dep was installed (which did support React 17), but re-generating the package-lock results in the newer dep (which does not support React 18) getting installed.

Note: This won't actually do anything for now because we are using the latest version of React 17. Once we update to React 18 our installed version of react and react-dom will be kept up to date (up until v19 of react) by renovatebot.