### PR TITLE
fix(color-generator): contrast color calculation

### DIFF
--- a/src/components/page/theming/_utils/color.ts
+++ b/src/components/page/theming/_utils/color.ts
@@ -138,24 +138,22 @@ const GREEN = 0.7152;
 const BLUE = 0.0722;
 const GAMMA = 2.4;
 
-const luminance = (r, g, b) => {
-  var a = [r, g, b].map((v) => {
+const luminance = ({ r, g, b }: RGB) => {
+  const a = [r, g, b].map((v) => {
     v /= 255;
-    return v <= 0.03928
-      ? v / 12.92
-      : Math.pow((v + 0.055) / 1.055, GAMMA);
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, GAMMA);
   });
   return a[0] * RED + a[1] * GREEN + a[2] * BLUE;
-}
+};
 
-// Source: https://stackoverflow.com/a/9733420
-const contrast = (rgb1, rgb2) => {
-  var lum1 = luminance(...rgb1);
-  var lum2 = luminance(...rgb2);
-  var brightest = Math.max(lum1, lum2);
-  var darkest = Math.min(lum1, lum2);
+// Original source: https://stackoverflow.com/a/9733420
+const contrast = (rgb1: RGB, rgb2: RGB) => {
+  const lum1 = luminance(rgb1);
+  const lum2 = luminance(rgb2);
+  const brightest = Math.max(lum1, lum2);
+  const darkest = Math.min(lum1, lum2);
   return (brightest + 0.05) / (darkest + 0.05);
-}
+};
 
 export class Color {
   readonly hex: string;
@@ -201,8 +199,8 @@ export class Color {
   }
 
   contrast(): Color {
-    const blackContrastRatio = contrast([this.rgb.r, this.rgb.g, this.rgb.b], [0, 0, 0]);
-    const whiteContrastRatio = contrast([this.rgb.r, this.rgb.g, this.rgb.b], [255, 255, 255]);
+    const blackContrastRatio = contrast(this.rgb, { r: 0, g: 0, b: 0 });
+    const whiteContrastRatio = contrast(this.rgb, { r: 255, g: 255, b: 255 });
 
     return new Color(blackContrastRatio >= whiteContrastRatio ? '#000' : '#fff');
   }


### PR DESCRIPTION
This PR fixes a miscalculation in the color generator resulting in an incorrect contrast color. 

For example, with a color of `#EF3442` the expected contrast is `#000000`. However the color generator is incorrectly recommending `#ffffff`. 

This PR updates the logic for how the contrast color is determined by calculating the contrast ratio for the current color against a white and black background. The variant with the highest contrast ratio will be used as the contrast. 

The calculation for the contrast ratio was sourced from: https://stackoverflow.com/a/9733420. The code was refactored to match the existing code style for representing the `rgb` color and using the available types. 

Quick preview: https://ionic-docs-git-sp-color-generator-ionic1.vercel.app/docs/theming/color-generator