### PR TITLE
chore(google-tag-manager): switch to Docusaurus preset

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,7 @@ module.exports = {
       '@docusaurus/preset-classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
       {
-        // Will be passed to @docusaurus/plugin-content-docs (false to disable)
+        // Will be passed to @docusaurus/plugin-content-docs (false to disable).
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
@@ -60,7 +60,7 @@ module.exports = {
             },
           },
         },
-        // Will be passed to @docusaurus/plugin-google-tag-manager
+        // Will be passed to @docusaurus/plugin-google-tag-manager.
         googleTagManager: {
           containerId: 'GTM-TKMGCBC',
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -60,6 +60,10 @@ module.exports = {
             },
           },
         },
+        // Will be passed to @docusaurus/plugin-google-tag-manager
+        googleTagManager: {
+          containerId: 'GTM-TKMGCBC',
+        },
         // Will be passed to @docusaurus/theme-classic.
         theme: {
           customCss: [
@@ -269,9 +273,6 @@ module.exports = {
         },
       ],
     },
-    tagManager: {
-      trackingID: 'GTM-TKMGCBC',
-    },
     prism: {
       theme: { plain: {}, styles: [] },
       // https://github.com/FormidableLabs/prism-react-renderer/blob/5a1c93592c6475fb230bfcb8a9666b72b331638b/packages/generate-prism-languages/index.ts#L9-L24
@@ -297,7 +298,6 @@ module.exports = {
         },
       },
     ],
-    '@ionic-internal/docusaurus-plugin-tag-manager',
     function (context, options) {
       return {
         name: 'ionic-docs-ads',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@docusaurus/mdx-loader": "^2.4.3",
         "@docusaurus/plugin-client-redirects": "^2.4.3",
         "@docusaurus/preset-classic": "^2.4.3",
-        "@ionic-internal/docusaurus-plugin-tag-manager": "^2.0.0",
         "@ionic-internal/ionic-ds": "^7.0.0",
         "@mdx-js/react": "^1.6.22",
         "@prismicio/client": "^6.4.2",
@@ -3576,17 +3575,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@ionic-internal/docusaurus-plugin-tag-manager": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.15.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
     "node_modules/@ionic-internal/ionic-ds": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@docusaurus/mdx-loader": "^2.4.3",
     "@docusaurus/plugin-client-redirects": "^2.4.3",
     "@docusaurus/preset-classic": "^2.4.3",
-    "@ionic-internal/docusaurus-plugin-tag-manager": "^2.0.0",
     "@ionic-internal/ionic-ds": "^7.0.0",
     "@mdx-js/react": "^1.6.22",
     "@prismicio/client": "^6.4.2",


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

Google Tag Manager is being added through an internal package. This is no longer necessary as Docusaurus provides a plugin for this.

## What is the new behavior?

- Added Google Tag Manager through Docusaurus.
- Uninstalled the internal package.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A
