### PR TITLE
fix(playground): tabs stackblitz example loads in Safari

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -547,18 +547,29 @@ export default function Playground({
     if (hasUsageTargetOptions) {
       editorOptions.files = Object.keys(codeSnippets[usageTarget])
         .map((fileName) => {
-          /**
-           * Safari has an issue where accessing the `outerText` on a non-visible
-           * DOM element results in a string with only whitespace. To work around this,
-           * we create a clone of the element, not attached to the DOM, and parse
-           * the outerText from that.
-           */
-          const el = document.createElement('div');
-          el.innerHTML = hostRef.current!.querySelector<HTMLElement>(
+          const codeBlock = hostRef.current!.querySelector<HTMLElement>(
             `#${getCodeSnippetId(usageTarget, fileName)} code`
-          ).innerHTML;
+          );
+          let code = codeBlock.outerText;
+
+          if (code.trim().length === 0) {
+            /**
+             * Safari has an issue where accessing the `outerText` on a non-visible
+             * DOM element results in a string with only whitespace. To work around this,
+             * we create a clone of the element, not attached to the DOM, and parse
+             * the outerText from that.
+             *
+             * Only in Safari does this persist whitespace & line breaks, so we
+             * explicitly check for when the code is empty to use this workaround.
+             */
+            const el = document.createElement('div');
+            el.innerHTML = hostRef.current!.querySelector<HTMLElement>(
+              `#${getCodeSnippetId(usageTarget, fileName)} code`
+            ).innerHTML;
+            code = el.outerText;
+          }
           return {
-            [fileName]: el.outerText,
+            [fileName]: code,
           };
         })
         .reduce((acc, curr) => ({ ...acc, ...curr }), {});

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -546,10 +546,21 @@ export default function Playground({
 
     if (hasUsageTargetOptions) {
       editorOptions.files = Object.keys(codeSnippets[usageTarget])
-        .map((fileName) => ({
-          [fileName]: hostRef.current!.querySelector<HTMLElement>(`#${getCodeSnippetId(usageTarget, fileName)} code`)
-            .outerText,
-        }))
+        .map((fileName) => {
+          /**
+           * Safari has an issue where accessing the `outerText` on a non-visible
+           * DOM element results in a string with only whitespace. To work around this,
+           * we create a clone of the element, not attached to the DOM, and parse
+           * the outerText from that.
+           */
+          const el = document.createElement('div');
+          el.innerHTML = hostRef.current!.querySelector<HTMLElement>(
+            `#${getCodeSnippetId(usageTarget, fileName)} code`
+          ).innerHTML;
+          return {
+            [fileName]: el.outerText,
+          };
+        })
         .reduce((acc, curr) => ({ ...acc, ...curr }), {});
       editorOptions.dependencies = (code[usageTarget] as UsageTargetOptions).dependencies;
     }

--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -563,9 +563,7 @@ export default function Playground({
              * explicitly check for when the code is empty to use this workaround.
              */
             const el = document.createElement('div');
-            el.innerHTML = hostRef.current!.querySelector<HTMLElement>(
-              `#${getCodeSnippetId(usageTarget, fileName)} code`
-            ).innerHTML;
+            el.innerHTML = codeBlock.innerHTML;
             code = el.outerText;
           }
           return {

--- a/static/usage/v6/tabs/router/angular/app_module_ts.md
+++ b/static/usage/v6/tabs/router/angular/app_module_ts.md
@@ -11,7 +11,7 @@ import { ExampleComponent } from './example.component';
 import { AppRoutingModule } from './app-routing.module';
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, AppRoutingModule, IonicModule.forRoot()],
+  imports: [BrowserModule, FormsModule, AppRoutingModule, IonicModule.forRoot({})],
   declarations: [AppComponent, ExampleComponent],
   bootstrap: [AppComponent],
 })

--- a/static/usage/v7/tabs/router/angular/app_module_ts.md
+++ b/static/usage/v7/tabs/router/angular/app_module_ts.md
@@ -11,7 +11,7 @@ import { ExampleComponent } from './example.component';
 import { AppRoutingModule } from './app-routing.module';
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, AppRoutingModule, IonicModule.forRoot()],
+  imports: [BrowserModule, FormsModule, AppRoutingModule, IonicModule.forRoot({})],
   declarations: [AppComponent, ExampleComponent],
   bootstrap: [AppComponent],
 })


### PR DESCRIPTION
Resolves #3260

Playground examples with many files would result in an issue with Safari where the `outerText` of the parsed code block would only include whitespace, not the actual contents of the code. 

This PR updates that logic to clone the DOM node to a detached node that results in the `outerText` consistently being parsed with the actual text content & whitespace/line breaks.

While working on the tabs example I noticed that the mode replacement logic would not apply because the regular expression matches on `IonicModule.forRoot({})` not `IonicModule.forRoot()`. I've updated the v7 & v6 examples to use the correct content. 

### Testing

To test this change, open the [Tabs docs](https://ionic-docs-git-sp-fw-5649-ionic1.vercel.app/docs/api/tabs) on Safari and attempt to open it in Stackblitz. You can confirm the expected behavior by observing the Stackblitz loads correctly & the `app.module.ts` has content. 