### PR TITLE
fix(color-generator): generate correct secondary color

### DIFF
--- a/src/components/page/theming/ColorGenerator/index.tsx
+++ b/src/components/page/theming/ColorGenerator/index.tsx
@@ -12,7 +12,7 @@ import ColorInput from '../ColorInput';
 const ColorGenerator = (props) => {
   const [colors, setColors] = useState({
     primary: generateColor('#3880ff'),
-    secondary: generateColor('#5260ff'),
+    secondary: generateColor('#3dc2ff'),
     tertiary: generateColor('#5260ff'),
     success: generateColor('#2dd36f'),
     warning: generateColor('#ffc409'),


### PR DESCRIPTION
The secondary and tertiary colors are the same. The secondary color should be #3dc2ff to align with the starter apps: https://github.com/ionic-team/starters/blob/7273d04c7ba2eca71d7b96bdfa0240087fb1e49d/angular/base/src/theme/variables.scss#L15

Preview: https://ionic-docs-git-liamdebeasi-patch-2-ionic1.vercel.app/docs/theming/color-generator