### PR TITLE
chore(select): remove unneeded patch from start/end slots demo

### DIFF
--- a/static/usage/v7/select/start-end-slots/demo.html
+++ b/static/usage/v7/select/start-end-slots/demo.html
@@ -8,17 +8,6 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
-
-    <style>
-      /**
-       * This is to deal with a bug in 7.6 where a select in a list/item
-       * wrapped in a flex container will shrink to 0 width. When the bug
-       * is fixed, we can remove this.
-       */
-      ion-list {
-        min-width: 400px;
-      }
-    </style>
   </head>
 
   <body>


### PR DESCRIPTION
This code was added to get around a bug in `feature-7.6` which has since been fixed, so it isn't needed anymore.