### PR TITLE
docs(angular): note jest transformIgnorePatterns for es modules

### DIFF
--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -1,3 +1,6 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Build Options
 
 Developers have two options for using Ionic components: Standalone or Modules. This guide covers both options as well as the benefits and downsides of each approach.
@@ -179,12 +182,22 @@ export class HomePage {}
 
 Ionic Angular's standalone components use ES Modules. As a result, developers using Jest should ensure that ES Modules are transpiled to a format that Jest can use. Developers using Jest should add the following to their Jest config:
 
+<Tabs groupId="package-manager" defaultValue="npm" values={[{ value: 'npm', label: 'npm' }, { value: 'pnpm', label: 'pnpm' }]}>
+<TabItem value="npm">
+
 ```json
-{
-  ...,
-  "transformIgnorePatterns": ["node_modules/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)/)"]
-}
+
+"transformIgnorePatterns": ["<rootDir>/node_modules/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)/)"]
 ```
+</TabItem>
+<TabItem value="pnpm">
+
+```json
+
+"transformIgnorePatterns": ["<rootDir>/node_modules/.pnpm/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)@)"]
+```
+</TabItem>
+</Tabs>
 
 ### Usage with NgModule-based Applications
 
@@ -325,6 +338,28 @@ export class HomePageModule {}
 ```html title="home.page.html"
 <ion-button routerLink="/foo" routerDirection="root">Go to Foo Page</ion-button>
 ```
+
+**Testing**
+
+Ionic Angular's standalone components use ES Modules. As a result, developers using Jest should ensure that ES Modules are transpiled to a format that Jest can use. Developers using Jest should add the following to their Jest config:
+
+<Tabs groupId="package-manager" defaultValue="npm" values={[{ value: 'npm', label: 'npm' }, { value: 'pnpm', label: 'pnpm' }]}>
+<TabItem value="npm">
+
+```json
+
+"transformIgnorePatterns": ["<rootDir>/node_modules/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)/)"]
+```
+</TabItem>
+<TabItem value="pnpm">
+
+```json
+
+"transformIgnorePatterns": ["<rootDir>/node_modules/.pnpm/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)@)"]
+```
+</TabItem>
+</Tabs>
+
 
 ## Modules
 

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -189,6 +189,7 @@ Ionic Angular's standalone components use ES Modules. As a result, developers us
 
 "transformIgnorePatterns": ["<rootDir>/node_modules/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)/)"]
 ```
+
 </TabItem>
 <TabItem value="pnpm">
 
@@ -196,6 +197,7 @@ Ionic Angular's standalone components use ES Modules. As a result, developers us
 
 "transformIgnorePatterns": ["<rootDir>/node_modules/.pnpm/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)@)"]
 ```
+
 </TabItem>
 </Tabs>
 
@@ -350,6 +352,7 @@ Ionic Angular's standalone components use ES Modules. As a result, developers us
 
 "transformIgnorePatterns": ["<rootDir>/node_modules/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)/)"]
 ```
+
 </TabItem>
 <TabItem value="pnpm">
 
@@ -357,9 +360,9 @@ Ionic Angular's standalone components use ES Modules. As a result, developers us
 
 "transformIgnorePatterns": ["<rootDir>/node_modules/.pnpm/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)@)"]
 ```
+
 </TabItem>
 </Tabs>
-
 
 ## Modules
 

--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -175,6 +175,17 @@ export class HomePage {}
 <ion-button routerLink="/foo" routerDirection="root">Go to Foo Page</ion-button>
 ```
 
+**Testing**
+
+Ionic Angular's standalone components use ES Modules. As a result, developers using Jest should ensure that ES Modules are transpiled to a format that Jest can use. Developers using Jest should add the following to their Jest config:
+
+```json
+{
+  ...,
+  "transformIgnorePatterns": ["node_modules/(?!(@ionic/angular|@ionic/core|ionicons|@stencil/core|@angular/*)/)"]
+}
+```
+
 ### Usage with NgModule-based Applications
 
 :::caution


### PR DESCRIPTION
Developers have noted that Ionic's standalone components do not work with Jest by default: https://github.com/ionic-team/ionic-framework/issues/28667

This is happening because Ionic's components are ES Modules which Jest does not support. Developers need to use `transformIgnorePatterns` to ensure the ES Modules are transpired to a format Jest can use.