### PR TITLE
docs(usage): update playgrounds to use correct path

### DIFF
--- a/static/usage/v8/accordion/accessibility/animations/index.md
+++ b/static/usage/v8/accordion/accessibility/animations/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/accordion/accessibility/animations/demo.html"
+  src="usage/v8/accordion/accessibility/animations/demo.html"
 />

--- a/static/usage/v8/accordion/basic/index.md
+++ b/static/usage/v8/accordion/basic/index.md
@@ -13,6 +13,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/accordion/basic/demo.html"
+  src="usage/v8/accordion/basic/demo.html"
   size="210px"
 />

--- a/static/usage/v8/accordion/customization/advanced-expansion-styles/index.md
+++ b/static/usage/v8/accordion/customization/advanced-expansion-styles/index.md
@@ -31,5 +31,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
     },
   }}
   size="250px"
-  src="usage/v7/accordion/customization/advanced-expansion-styles/demo.html"
+  src="usage/v8/accordion/customization/advanced-expansion-styles/demo.html"
 />

--- a/static/usage/v8/accordion/customization/expansion-styles/index.md
+++ b/static/usage/v8/accordion/customization/expansion-styles/index.md
@@ -14,5 +14,5 @@ import angular from './angular.md';
     angular,
   }}
   size="250px"
-  src="usage/v7/accordion/customization/expansion-styles/demo.html"
+  src="usage/v8/accordion/customization/expansion-styles/demo.html"
 />

--- a/static/usage/v8/accordion/customization/icons/index.md
+++ b/static/usage/v8/accordion/customization/icons/index.md
@@ -14,5 +14,5 @@ import angular from './angular.md';
     angular,
   }}
   size="250px"
-  src="usage/v7/accordion/customization/icons/demo.html"
+  src="usage/v8/accordion/customization/icons/demo.html"
 />

--- a/static/usage/v8/accordion/customization/theming/index.md
+++ b/static/usage/v8/accordion/customization/theming/index.md
@@ -29,5 +29,5 @@ import angular_global_css from './angular/global_css.md';
     },
   }}
   size="250px"
-  src="usage/v7/accordion/customization/theming/demo.html"
+  src="usage/v8/accordion/customization/theming/demo.html"
 />

--- a/static/usage/v8/accordion/disable-group/index.md
+++ b/static/usage/v8/accordion/disable-group/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/accordion/disable-group/demo.html"
+  src="usage/v8/accordion/disable-group/demo.html"
 />

--- a/static/usage/v8/accordion/disable/group/index.md
+++ b/static/usage/v8/accordion/disable/group/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/accordion/disable/group/demo.html"
+  src="usage/v8/accordion/disable/group/demo.html"
 />

--- a/static/usage/v8/accordion/disable/individual/index.md
+++ b/static/usage/v8/accordion/disable/individual/index.md
@@ -14,5 +14,5 @@ import angular from './angular.md';
     angular,
   }}
   size="210px"
-  src="usage/v7/accordion/disable/individual/demo.html"
+  src="usage/v8/accordion/disable/individual/demo.html"
 />

--- a/static/usage/v8/accordion/listen-changes/index.md
+++ b/static/usage/v8/accordion/listen-changes/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
     },
   }}
   size="320px"
-  src="usage/v7/accordion/listen-changes/demo.html"
+  src="usage/v8/accordion/listen-changes/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/accordion/multiple/index.md
+++ b/static/usage/v8/accordion/multiple/index.md
@@ -14,5 +14,5 @@ import angular from './angular.md';
     angular,
   }}
   size="320px"
-  src="usage/v7/accordion/multiple/demo.html"
+  src="usage/v8/accordion/multiple/demo.html"
 />

--- a/static/usage/v8/accordion/readonly/group/index.md
+++ b/static/usage/v8/accordion/readonly/group/index.md
@@ -14,5 +14,5 @@ import angular from './angular.md';
     angular,
   }}
   size="210px"
-  src="usage/v7/accordion/readonly/group/demo.html"
+  src="usage/v8/accordion/readonly/group/demo.html"
 />

--- a/static/usage/v8/accordion/readonly/individual/index.md
+++ b/static/usage/v8/accordion/readonly/individual/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/accordion/readonly/individual/demo.html"
+  src="usage/v8/accordion/readonly/individual/demo.html"
 />

--- a/static/usage/v8/accordion/toggle/index.md
+++ b/static/usage/v8/accordion/toggle/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
     },
   }}
   size="medium"
-  src="usage/v7/accordion/toggle/demo.html"
+  src="usage/v8/accordion/toggle/demo.html"
 />

--- a/static/usage/v8/action-sheet/controller/index.md
+++ b/static/usage/v8/action-sheet/controller/index.md
@@ -22,6 +22,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/action-sheet/controller/demo.html"
+  src="usage/v8/action-sheet/controller/demo.html"
   devicePreview
 />

--- a/static/usage/v8/action-sheet/inline/isOpen/index.md
+++ b/static/usage/v8/action-sheet/inline/isOpen/index.md
@@ -22,6 +22,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/action-sheet/inline/isOpen/demo.html"
+  src="usage/v8/action-sheet/inline/isOpen/demo.html"
   devicePreview
 />

--- a/static/usage/v8/action-sheet/inline/trigger/index.md
+++ b/static/usage/v8/action-sheet/inline/trigger/index.md
@@ -22,6 +22,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/action-sheet/inline/trigger/demo.html"
+  src="usage/v8/action-sheet/inline/trigger/demo.html"
   devicePreview
 />

--- a/static/usage/v8/action-sheet/role-info-on-dismiss/index.md
+++ b/static/usage/v8/action-sheet/role-info-on-dismiss/index.md
@@ -30,7 +30,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/action-sheet/role-info-on-dismiss/demo.html"
+  src="usage/v8/action-sheet/role-info-on-dismiss/demo.html"
   devicePreview
   showConsole
 />

--- a/static/usage/v8/action-sheet/theming/css-properties/index.md
+++ b/static/usage/v8/action-sheet/theming/css-properties/index.md
@@ -30,6 +30,6 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/action-sheet/theming/css-properties/demo.html"
+  src="usage/v8/action-sheet/theming/css-properties/demo.html"
   devicePreview
 />

--- a/static/usage/v8/action-sheet/theming/styling/index.md
+++ b/static/usage/v8/action-sheet/theming/styling/index.md
@@ -30,6 +30,6 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/action-sheet/theming/styling/demo.html"
+  src="usage/v8/action-sheet/theming/styling/demo.html"
   devicePreview
 />

--- a/static/usage/v8/alert/buttons/index.md
+++ b/static/usage/v8/alert/buttons/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/alert/buttons/demo.html"
+  src="usage/v8/alert/buttons/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/alert/customization/index.md
+++ b/static/usage/v8/alert/customization/index.md
@@ -30,5 +30,5 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/alert/customization/demo.html"
+  src="usage/v8/alert/customization/demo.html"
 />

--- a/static/usage/v8/alert/inputs/radios/index.md
+++ b/static/usage/v8/alert/inputs/radios/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/alert/inputs/radios/demo.html"
+  src="usage/v8/alert/inputs/radios/demo.html"
 />

--- a/static/usage/v8/alert/inputs/text-inputs/index.md
+++ b/static/usage/v8/alert/inputs/text-inputs/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/alert/inputs/text-inputs/demo.html"
+  src="usage/v8/alert/inputs/text-inputs/demo.html"
 />

--- a/static/usage/v8/alert/presenting/controller/index.md
+++ b/static/usage/v8/alert/presenting/controller/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/alert/presenting/controller/demo.html"
+  src="usage/v8/alert/presenting/controller/demo.html"
 />

--- a/static/usage/v8/alert/presenting/isOpen/index.md
+++ b/static/usage/v8/alert/presenting/isOpen/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/alert/presenting/isOpen/demo.html"
+  src="usage/v8/alert/presenting/isOpen/demo.html"
 />

--- a/static/usage/v8/alert/presenting/trigger/index.md
+++ b/static/usage/v8/alert/presenting/trigger/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/alert/presenting/trigger/demo.html"
+  src="usage/v8/alert/presenting/trigger/demo.html"
 />

--- a/static/usage/v8/animations/basic/index.md
+++ b/static/usage/v8/animations/basic/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/animations/basic/demo.html"
+  src="usage/v8/animations/basic/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/animations/before-and-after-hooks/index.md
+++ b/static/usage/v8/animations/before-and-after-hooks/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/animations/before-and-after-hooks/demo.html"
+  src="usage/v8/animations/before-and-after-hooks/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/animations/chain/index.md
+++ b/static/usage/v8/animations/chain/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/animations/chain/demo.html"
+  src="usage/v8/animations/chain/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/animations/gesture/index.md
+++ b/static/usage/v8/animations/gesture/index.md
@@ -30,6 +30,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/animations/gesture/demo.html"
+  src="usage/v8/animations/gesture/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/animations/group/index.md
+++ b/static/usage/v8/animations/group/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/animations/group/demo.html"
+  src="usage/v8/animations/group/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/animations/keyframes/index.md
+++ b/static/usage/v8/animations/keyframes/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/animations/keyframes/demo.html"
+  src="usage/v8/animations/keyframes/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/animations/modal-override/index.md
+++ b/static/usage/v8/animations/modal-override/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/animations/modal-override/demo.html"
+  src="usage/v8/animations/modal-override/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/animations/preference-based/index.md
+++ b/static/usage/v8/animations/preference-based/index.md
@@ -30,6 +30,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/animations/preference-based/demo.html"
+  src="usage/v8/animations/preference-based/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/avatar/basic/index.md
+++ b/static/usage/v8/avatar/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/avatar/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/avatar/basic/demo.html" />

--- a/static/usage/v8/avatar/chip/index.md
+++ b/static/usage/v8/avatar/chip/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/avatar/chip/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/avatar/chip/demo.html" />

--- a/static/usage/v8/avatar/item/index.md
+++ b/static/usage/v8/avatar/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/avatar/item/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/avatar/item/demo.html" />

--- a/static/usage/v8/avatar/theming/css-properties/index.md
+++ b/static/usage/v8/avatar/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/avatar/theming/css-properties/demo.html"
+  src="usage/v8/avatar/theming/css-properties/demo.html"
   size="250px"
 />

--- a/static/usage/v8/back-button/basic/index.md
+++ b/static/usage/v8/back-button/basic/index.md
@@ -44,7 +44,7 @@ import vue_page_two from './vue/page_two_vue.md';
       },
     },
   }}
-  src="usage/v7/back-button/basic/demo.html"
+  src="usage/v8/back-button/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/back-button/custom/index.md
+++ b/static/usage/v8/back-button/custom/index.md
@@ -44,7 +44,7 @@ import vue_page_two from './vue/page_two_vue.md';
       },
     },
   }}
-  src="usage/v7/back-button/custom/demo.html"
+  src="usage/v8/back-button/custom/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/backdrop/basic/index.md
+++ b/static/usage/v8/backdrop/basic/index.md
@@ -28,6 +28,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/backdrop/basic/demo.html"
+  src="usage/v8/backdrop/basic/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/backdrop/styling/index.md
+++ b/static/usage/v8/backdrop/styling/index.md
@@ -28,6 +28,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/backdrop/styling/demo.html"
+  src="usage/v8/backdrop/styling/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/badge/basic/index.md
+++ b/static/usage/v8/badge/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/badge/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/badge/basic/demo.html" />

--- a/static/usage/v8/badge/theming/colors/index.md
+++ b/static/usage/v8/badge/theming/colors/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/badge/theming/colors/demo.html"
+  src="usage/v8/badge/theming/colors/demo.html"
 />

--- a/static/usage/v8/badge/theming/css-properties/index.md
+++ b/static/usage/v8/badge/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/badge/theming/css-properties/demo.html"
+  src="usage/v8/badge/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/basic/index.md
+++ b/static/usage/v8/breadcrumbs/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/breadcrumbs/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/breadcrumbs/basic/demo.html" />

--- a/static/usage/v8/breadcrumbs/collapsing-items/expand-on-click/index.md
+++ b/static/usage/v8/breadcrumbs/collapsing-items/expand-on-click/index.md
@@ -20,5 +20,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/breadcrumbs/collapsing-items/expand-on-click/demo.html"
+  src="usage/v8/breadcrumbs/collapsing-items/expand-on-click/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/collapsing-items/items-before-after/index.md
+++ b/static/usage/v8/breadcrumbs/collapsing-items/items-before-after/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="300px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/breadcrumbs/collapsing-items/items-before-after/demo.html"
+  src="usage/v8/breadcrumbs/collapsing-items/items-before-after/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/collapsing-items/max-items/index.md
+++ b/static/usage/v8/breadcrumbs/collapsing-items/max-items/index.md
@@ -8,5 +8,5 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/breadcrumbs/collapsing-items/max-items/demo.html"
+  src="usage/v8/breadcrumbs/collapsing-items/max-items/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/collapsing-items/popover-on-click/index.md
+++ b/static/usage/v8/breadcrumbs/collapsing-items/popover-on-click/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/breadcrumbs/collapsing-items/popover-on-click/demo.html"
+  src="usage/v8/breadcrumbs/collapsing-items/popover-on-click/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/icons/custom-separators/index.md
+++ b/static/usage/v8/breadcrumbs/icons/custom-separators/index.md
@@ -8,5 +8,5 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/breadcrumbs/icons/custom-separators/demo.html"
+  src="usage/v8/breadcrumbs/icons/custom-separators/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/icons/icons-on-items/index.md
+++ b/static/usage/v8/breadcrumbs/icons/icons-on-items/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="300px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/breadcrumbs/icons/icons-on-items/demo.html"
+  src="usage/v8/breadcrumbs/icons/icons-on-items/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/theming/colors/index.md
+++ b/static/usage/v8/breadcrumbs/theming/colors/index.md
@@ -8,5 +8,5 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/breadcrumbs/theming/colors/demo.html"
+  src="usage/v8/breadcrumbs/theming/colors/demo.html"
 />

--- a/static/usage/v8/breadcrumbs/theming/css-properties/index.md
+++ b/static/usage/v8/breadcrumbs/theming/css-properties/index.md
@@ -27,5 +27,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/breadcrumbs/theming/css-properties/demo.html"
+  src="usage/v8/breadcrumbs/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/button/basic/index.md
+++ b/static/usage/v8/button/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/basic/demo.html" />

--- a/static/usage/v8/button/expand/index.md
+++ b/static/usage/v8/button/expand/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/expand/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/expand/demo.html" />

--- a/static/usage/v8/button/fill/index.md
+++ b/static/usage/v8/button/fill/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/fill/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/fill/demo.html" />

--- a/static/usage/v8/button/icons/index.md
+++ b/static/usage/v8/button/icons/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/icons/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/icons/demo.html" />

--- a/static/usage/v8/button/shape/index.md
+++ b/static/usage/v8/button/shape/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/shape/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/shape/demo.html" />

--- a/static/usage/v8/button/size/index.md
+++ b/static/usage/v8/button/size/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/size/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/size/demo.html" />

--- a/static/usage/v8/button/text-wrapping/index.md
+++ b/static/usage/v8/button/text-wrapping/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/text-wrapping/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/text-wrapping/demo.html" />

--- a/static/usage/v8/button/theming/colors/index.md
+++ b/static/usage/v8/button/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/button/theming/colors/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/button/theming/colors/demo.html" />

--- a/static/usage/v8/button/theming/css-properties/index.md
+++ b/static/usage/v8/button/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/button/theming/css-properties/demo.html"
+  src="usage/v8/button/theming/css-properties/demo.html"
   size="250px"
 />

--- a/static/usage/v8/buttons/basic/index.md
+++ b/static/usage/v8/buttons/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/buttons/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/buttons/basic/demo.html" />

--- a/static/usage/v8/buttons/placement/index.md
+++ b/static/usage/v8/buttons/placement/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/buttons/placement/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/buttons/placement/demo.html" />

--- a/static/usage/v8/buttons/types/index.md
+++ b/static/usage/v8/buttons/types/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/buttons/types/demo.html"
+  src="usage/v8/buttons/types/demo.html"
   size="medium"
 />

--- a/static/usage/v8/card/basic/index.md
+++ b/static/usage/v8/card/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/card/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/card/basic/demo.html" />

--- a/static/usage/v8/card/buttons/index.md
+++ b/static/usage/v8/card/buttons/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/card/buttons/demo.html" size="300px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/card/buttons/demo.html" size="300px" />

--- a/static/usage/v8/card/list/index.md
+++ b/static/usage/v8/card/list/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/card/list/demo.html"
+  src="usage/v8/card/list/demo.html"
   size="400px"
 />

--- a/static/usage/v8/card/media/index.md
+++ b/static/usage/v8/card/media/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/card/media/demo.html" size="350px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/card/media/demo.html" size="350px" />

--- a/static/usage/v8/card/theming/colors/index.md
+++ b/static/usage/v8/card/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/card/theming/colors/demo.html"
+  src="usage/v8/card/theming/colors/demo.html"
   size="large"
 />

--- a/static/usage/v8/card/theming/css-properties/index.md
+++ b/static/usage/v8/card/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/card/theming/css-properties/demo.html"
+  src="usage/v8/card/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/checkbox/alignment/index.md
+++ b/static/usage/v8/checkbox/alignment/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/checkbox/alignment/demo.html"
+  src="usage/v8/checkbox/alignment/demo.html"
 />

--- a/static/usage/v8/checkbox/basic/index.md
+++ b/static/usage/v8/checkbox/basic/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/checkbox/basic/demo.html"
+  src="usage/v8/checkbox/basic/demo.html"
 />

--- a/static/usage/v8/checkbox/indeterminate/index.md
+++ b/static/usage/v8/checkbox/indeterminate/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/checkbox/indeterminate/demo.html"
+  src="usage/v8/checkbox/indeterminate/demo.html"
 />

--- a/static/usage/v8/checkbox/justify/index.md
+++ b/static/usage/v8/checkbox/justify/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/checkbox/justify/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/checkbox/justify/demo.html" />

--- a/static/usage/v8/checkbox/label-placement/index.md
+++ b/static/usage/v8/checkbox/label-placement/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/checkbox/label-placement/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/checkbox/label-placement/demo.html" />

--- a/static/usage/v8/checkbox/theming/css-properties/index.md
+++ b/static/usage/v8/checkbox/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/checkbox/theming/css-properties/demo.html"
+  src="usage/v8/checkbox/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/chip/basic/index.md
+++ b/static/usage/v8/chip/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/chip/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/chip/basic/demo.html" />

--- a/static/usage/v8/chip/slots/index.md
+++ b/static/usage/v8/chip/slots/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/chip/slots/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/chip/slots/demo.html" />

--- a/static/usage/v8/chip/theming/colors/index.md
+++ b/static/usage/v8/chip/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/chip/theming/colors/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/chip/theming/colors/demo.html" />

--- a/static/usage/v8/chip/theming/css-properties/index.md
+++ b/static/usage/v8/chip/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/chip/theming/css-properties/demo.html"
+  src="usage/v8/chip/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/content/basic/index.md
+++ b/static/usage/v8/content/basic/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/content/basic/demo.html"
+  src="usage/v8/content/basic/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/content/fixed/index.md
+++ b/static/usage/v8/content/fixed/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/content/fixed/demo.html"
+  src="usage/v8/content/fixed/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/content/fullscreen/index.md
+++ b/static/usage/v8/content/fullscreen/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/content/fullscreen/demo.html"
+  src="usage/v8/content/fullscreen/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/content/header-footer/index.md
+++ b/static/usage/v8/content/header-footer/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/content/header-footer/demo.html"
+  src="usage/v8/content/header-footer/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/content/scroll-events/index.md
+++ b/static/usage/v8/content/scroll-events/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/content/scroll-events/demo.html"
+  src="usage/v8/content/scroll-events/demo.html"
   includeIonContent={false}
   devicePreview={true}
   showConsole={true}

--- a/static/usage/v8/content/scroll-methods/index.md
+++ b/static/usage/v8/content/scroll-methods/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/content/scroll-methods/demo.html"
+  src="usage/v8/content/scroll-methods/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/content/theming/colors/index.md
+++ b/static/usage/v8/content/theming/colors/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/content/theming/colors/demo.html"
+  src="usage/v8/content/theming/colors/demo.html"
   includeIonContent={false}
   size="xlarge"
 />

--- a/static/usage/v8/content/theming/css-properties/index.md
+++ b/static/usage/v8/content/theming/css-properties/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/content/theming/css-properties/demo.html"
+  src="usage/v8/content/theming/css-properties/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/content/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/content/theming/css-shadow-parts/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/content/theming/css-shadow-parts/demo.html"
+  src="usage/v8/content/theming/css-shadow-parts/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/content/theming/safe-area/index.md
+++ b/static/usage/v8/content/theming/safe-area/index.md
@@ -30,7 +30,7 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/content/theming/safe-area/demo.html"
+  src="usage/v8/content/theming/safe-area/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/datetime-button/basic/index.md
+++ b/static/usage/v8/datetime-button/basic/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime-button/basic/demo.html"
+  src="usage/v8/datetime-button/basic/demo.html"
 />

--- a/static/usage/v8/datetime/basic/index.md
+++ b/static/usage/v8/datetime/basic/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/basic/demo.html"
+  src="usage/v8/datetime/basic/demo.html"
 />

--- a/static/usage/v8/datetime/buttons/customizing-button-texts/index.md
+++ b/static/usage/v8/datetime/buttons/customizing-button-texts/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="500px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/buttons/customizing-button-texts/demo.html"
+  src="usage/v8/datetime/buttons/customizing-button-texts/demo.html"
 />

--- a/static/usage/v8/datetime/buttons/customizing-buttons/index.md
+++ b/static/usage/v8/datetime/buttons/customizing-buttons/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="500px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/buttons/customizing-buttons/demo.html"
+  src="usage/v8/datetime/buttons/customizing-buttons/demo.html"
 />

--- a/static/usage/v8/datetime/buttons/showing-confirmation-buttons/index.md
+++ b/static/usage/v8/datetime/buttons/showing-confirmation-buttons/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="500px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/buttons/showing-confirmation-buttons/demo.html"
+  src="usage/v8/datetime/buttons/showing-confirmation-buttons/demo.html"
 />

--- a/static/usage/v8/datetime/date-constraints/advanced/index.md
+++ b/static/usage/v8/datetime/date-constraints/advanced/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/datetime/date-constraints/advanced/demo.html"
+  src="usage/v8/datetime/date-constraints/advanced/demo.html"
 />

--- a/static/usage/v8/datetime/date-constraints/max-min/index.md
+++ b/static/usage/v8/datetime/date-constraints/max-min/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/date-constraints/max-min/demo.html"
+  src="usage/v8/datetime/date-constraints/max-min/demo.html"
 />

--- a/static/usage/v8/datetime/date-constraints/values/index.md
+++ b/static/usage/v8/datetime/date-constraints/values/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/date-constraints/values/demo.html"
+  src="usage/v8/datetime/date-constraints/values/demo.html"
 />

--- a/static/usage/v8/datetime/highlightedDates/array/index.md
+++ b/static/usage/v8/datetime/highlightedDates/array/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/datetime/highlightedDates/array/demo.html"
+  src="usage/v8/datetime/highlightedDates/array/demo.html"
 />

--- a/static/usage/v8/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v8/datetime/highlightedDates/callback/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/datetime/highlightedDates/callback/demo.html"
+  src="usage/v8/datetime/highlightedDates/callback/demo.html"
 />

--- a/static/usage/v8/datetime/localization/custom-locale/index.md
+++ b/static/usage/v8/datetime/localization/custom-locale/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/localization/custom-locale/demo.html"
+  src="usage/v8/datetime/localization/custom-locale/demo.html"
 />

--- a/static/usage/v8/datetime/localization/first-day-of-week/index.md
+++ b/static/usage/v8/datetime/localization/first-day-of-week/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/localization/first-day-of-week/demo.html"
+  src="usage/v8/datetime/localization/first-day-of-week/demo.html"
 />

--- a/static/usage/v8/datetime/localization/hour-cycle/index.md
+++ b/static/usage/v8/datetime/localization/hour-cycle/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/localization/hour-cycle/demo.html"
+  src="usage/v8/datetime/localization/hour-cycle/demo.html"
 />

--- a/static/usage/v8/datetime/localization/locale-extension-tags/index.md
+++ b/static/usage/v8/datetime/localization/locale-extension-tags/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/localization/locale-extension-tags/demo.html"
+  src="usage/v8/datetime/localization/locale-extension-tags/demo.html"
 />

--- a/static/usage/v8/datetime/localization/time-label/index.md
+++ b/static/usage/v8/datetime/localization/time-label/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/localization/time-label/demo.html"
+  src="usage/v8/datetime/localization/time-label/demo.html"
 />

--- a/static/usage/v8/datetime/multiple/index.md
+++ b/static/usage/v8/datetime/multiple/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/multiple/demo.html"
+  src="usage/v8/datetime/multiple/demo.html"
 />

--- a/static/usage/v8/datetime/presentation/date/index.md
+++ b/static/usage/v8/datetime/presentation/date/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/presentation/date/demo.html"
+  src="usage/v8/datetime/presentation/date/demo.html"
 />

--- a/static/usage/v8/datetime/presentation/month-and-year/index.md
+++ b/static/usage/v8/datetime/presentation/month-and-year/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="240px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/presentation/month-and-year/demo.html"
+  src="usage/v8/datetime/presentation/month-and-year/demo.html"
 />

--- a/static/usage/v8/datetime/presentation/time/index.md
+++ b/static/usage/v8/datetime/presentation/time/index.md
@@ -8,5 +8,5 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/presentation/time/demo.html"
+  src="usage/v8/datetime/presentation/time/demo.html"
 />

--- a/static/usage/v8/datetime/presentation/wheel/index.md
+++ b/static/usage/v8/datetime/presentation/wheel/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/presentation/wheel/demo.html"
+  src="usage/v8/datetime/presentation/wheel/demo.html"
 />

--- a/static/usage/v8/datetime/styling/calendar-days/index.md
+++ b/static/usage/v8/datetime/styling/calendar-days/index.md
@@ -30,6 +30,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/datetime/styling/calendar-days/demo.html"
+  src="usage/v8/datetime/styling/calendar-days/demo.html"
   size="medium"
 />

--- a/static/usage/v8/datetime/styling/global-theming/index.md
+++ b/static/usage/v8/datetime/styling/global-theming/index.md
@@ -29,5 +29,5 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/datetime/styling/global-theming/demo.html"
+  src="usage/v8/datetime/styling/global-theming/demo.html"
 />

--- a/static/usage/v8/datetime/styling/wheel-styling/index.md
+++ b/static/usage/v8/datetime/styling/wheel-styling/index.md
@@ -30,6 +30,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/datetime/styling/wheel-styling/demo.html"
+  src="usage/v8/datetime/styling/wheel-styling/demo.html"
   size="250px"
 />

--- a/static/usage/v8/datetime/theming/index.md
+++ b/static/usage/v8/datetime/theming/index.md
@@ -31,5 +31,5 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/datetime/theming/demo.html"
+  src="usage/v8/datetime/theming/demo.html"
 />

--- a/static/usage/v8/datetime/title/customizing-title/index.md
+++ b/static/usage/v8/datetime/title/customizing-title/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="large"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/title/customizing-title/demo.html"
+  src="usage/v8/datetime/title/customizing-title/demo.html"
 />

--- a/static/usage/v8/datetime/title/showing-default-title/index.md
+++ b/static/usage/v8/datetime/title/showing-default-title/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="large"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/datetime/title/showing-default-title/demo.html"
+  src="usage/v8/datetime/title/showing-default-title/demo.html"
 />

--- a/static/usage/v8/fab/basic/index.md
+++ b/static/usage/v8/fab/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/fab/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/fab/basic/demo.html" />

--- a/static/usage/v8/fab/button-sizing/index.md
+++ b/static/usage/v8/fab/button-sizing/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/fab/button-sizing/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/fab/button-sizing/demo.html" />

--- a/static/usage/v8/fab/list-side/index.md
+++ b/static/usage/v8/fab/list-side/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/fab/list-side/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/fab/list-side/demo.html" />

--- a/static/usage/v8/fab/positioning/index.md
+++ b/static/usage/v8/fab/positioning/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/fab/positioning/demo.html"
+  src="usage/v8/fab/positioning/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/fab/safe-area/index.md
+++ b/static/usage/v8/fab/safe-area/index.md
@@ -30,6 +30,6 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/fab/safe-area/demo.html"
+  src="usage/v8/fab/safe-area/demo.html"
   devicePreview={true}
 />

--- a/static/usage/v8/fab/theming/colors/index.md
+++ b/static/usage/v8/fab/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/fab/theming/colors/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/fab/theming/colors/demo.html" />

--- a/static/usage/v8/fab/theming/css-custom-properties/index.md
+++ b/static/usage/v8/fab/theming/css-custom-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/fab/theming/css-custom-properties/demo.html"
+  src="usage/v8/fab/theming/css-custom-properties/demo.html"
 />

--- a/static/usage/v8/fab/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/fab/theming/css-shadow-parts/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/fab/theming/css-shadow-parts/demo.html"
+  src="usage/v8/fab/theming/css-shadow-parts/demo.html"
 />

--- a/static/usage/v8/footer/basic/index.md
+++ b/static/usage/v8/footer/basic/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/footer/basic/demo.html"
+  src="usage/v8/footer/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/footer/custom-scroll-target/index.md
+++ b/static/usage/v8/footer/custom-scroll-target/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/footer/custom-scroll-target/demo.html"
+  src="usage/v8/footer/custom-scroll-target/demo.html"
   devicePreview
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/footer/fade/index.md
+++ b/static/usage/v8/footer/fade/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/footer/fade/demo.html"
+  src="usage/v8/footer/fade/demo.html"
   devicePreview
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/footer/no-border/index.md
+++ b/static/usage/v8/footer/no-border/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/footer/no-border/demo.html"
+  src="usage/v8/footer/no-border/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/footer/translucent/index.md
+++ b/static/usage/v8/footer/translucent/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/footer/translucent/demo.html"
+  src="usage/v8/footer/translucent/demo.html"
   devicePreview
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/gestures/basic/index.md
+++ b/static/usage/v8/gestures/basic/index.md
@@ -30,5 +30,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/gestures/basic/demo.html"
+  src="usage/v8/gestures/basic/demo.html"
 />

--- a/static/usage/v8/gestures/double-click/index.md
+++ b/static/usage/v8/gestures/double-click/index.md
@@ -30,5 +30,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/gestures/double-click/demo.html"
+  src="usage/v8/gestures/double-click/demo.html"
 />

--- a/static/usage/v8/grid/basic/index.md
+++ b/static/usage/v8/grid/basic/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/basic/demo.html"
+  src="usage/v8/grid/basic/demo.html"
   size="200px"
 />

--- a/static/usage/v8/grid/customizing/column-number/index.md
+++ b/static/usage/v8/grid/customizing/column-number/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/customizing/column-number/demo.html"
+  src="usage/v8/grid/customizing/column-number/demo.html"
   size="100px"
 />

--- a/static/usage/v8/grid/customizing/padding/index.md
+++ b/static/usage/v8/grid/customizing/padding/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/customizing/padding/demo.html"
+  src="usage/v8/grid/customizing/padding/demo.html"
   size="150px"
 />

--- a/static/usage/v8/grid/customizing/width/index.md
+++ b/static/usage/v8/grid/customizing/width/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/customizing/width/demo.html"
+  src="usage/v8/grid/customizing/width/demo.html"
   size="100px"
 />

--- a/static/usage/v8/grid/fixed/index.md
+++ b/static/usage/v8/grid/fixed/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/fixed/demo.html"
+  src="usage/v8/grid/fixed/demo.html"
   size="100px"
 />

--- a/static/usage/v8/grid/horizontal-alignment/index.md
+++ b/static/usage/v8/grid/horizontal-alignment/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/horizontal-alignment/demo.html"
+  src="usage/v8/grid/horizontal-alignment/demo.html"
   size="400px"
 />

--- a/static/usage/v8/grid/offset-responsive/index.md
+++ b/static/usage/v8/grid/offset-responsive/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/offset-responsive/demo.html"
+  src="usage/v8/grid/offset-responsive/demo.html"
   size="250px"
 />

--- a/static/usage/v8/grid/offset/index.md
+++ b/static/usage/v8/grid/offset/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/offset/demo.html"
+  src="usage/v8/grid/offset/demo.html"
   size="200px"
 />

--- a/static/usage/v8/grid/push-pull-responsive/index.md
+++ b/static/usage/v8/grid/push-pull-responsive/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/push-pull-responsive/demo.html"
+  src="usage/v8/grid/push-pull-responsive/demo.html"
   size="200px"
 />

--- a/static/usage/v8/grid/push-pull/index.md
+++ b/static/usage/v8/grid/push-pull/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/push-pull/demo.html"
+  src="usage/v8/grid/push-pull/demo.html"
   size="200px"
 />

--- a/static/usage/v8/grid/size-auto/index.md
+++ b/static/usage/v8/grid/size-auto/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/size-auto/demo.html"
+  src="usage/v8/grid/size-auto/demo.html"
   size="250px"
 />

--- a/static/usage/v8/grid/size-responsive/index.md
+++ b/static/usage/v8/grid/size-responsive/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/size-responsive/demo.html"
+  src="usage/v8/grid/size-responsive/demo.html"
   size="250px"
 />

--- a/static/usage/v8/grid/size/index.md
+++ b/static/usage/v8/grid/size/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/size/demo.html"
+  src="usage/v8/grid/size/demo.html"
   size="200px"
 />

--- a/static/usage/v8/grid/vertical-alignment/index.md
+++ b/static/usage/v8/grid/vertical-alignment/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/grid/vertical-alignment/demo.html"
+  src="usage/v8/grid/vertical-alignment/demo.html"
   size="400px"
 />

--- a/static/usage/v8/header/basic/index.md
+++ b/static/usage/v8/header/basic/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/header/basic/demo.html"
+  src="usage/v8/header/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/header/condense/index.md
+++ b/static/usage/v8/header/condense/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/header/condense/demo.html"
+  src="usage/v8/header/condense/demo.html"
   devicePreview
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/header/custom-scroll-target/index.md
+++ b/static/usage/v8/header/custom-scroll-target/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/header/custom-scroll-target/demo.html"
+  src="usage/v8/header/custom-scroll-target/demo.html"
   devicePreview
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/header/fade/index.md
+++ b/static/usage/v8/header/fade/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/header/fade/demo.html"
+  src="usage/v8/header/fade/demo.html"
   devicePreview
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/header/no-border/index.md
+++ b/static/usage/v8/header/no-border/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/header/no-border/demo.html"
+  src="usage/v8/header/no-border/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/header/translucent/index.md
+++ b/static/usage/v8/header/translucent/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/header/translucent/demo.html"
+  src="usage/v8/header/translucent/demo.html"
   devicePreview
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/icon/basic/index.md
+++ b/static/usage/v8/icon/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version={7} size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v7/icon/basic/demo.html" />
+<Playground version={7} size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v8/icon/basic/demo.html" />

--- a/static/usage/v8/img/basic/index.md
+++ b/static/usage/v8/img/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/img/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/img/basic/demo.html" />

--- a/static/usage/v8/infinite-scroll/basic/index.md
+++ b/static/usage/v8/infinite-scroll/basic/index.md
@@ -20,5 +20,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/infinite-scroll/basic/demo.html"
+  src="usage/v8/infinite-scroll/basic/demo.html"
 />

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/index.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/index.md
@@ -30,5 +30,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/infinite-scroll/custom-infinite-scroll-content/demo.html"
+  src="usage/v8/infinite-scroll/custom-infinite-scroll-content/demo.html"
 />

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/index.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/index.md
@@ -20,5 +20,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/infinite-scroll/infinite-scroll-content/demo.html"
+  src="usage/v8/infinite-scroll/infinite-scroll-content/demo.html"
 />

--- a/static/usage/v8/input/basic/index.md
+++ b/static/usage/v8/input/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/input/basic/demo.html" size="300px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/input/basic/demo.html" size="300px" />

--- a/static/usage/v8/input/clear/index.md
+++ b/static/usage/v8/input/clear/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/input/clear/demo.html" size="250px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/input/clear/demo.html" size="250px" />

--- a/static/usage/v8/input/counter-alignment/index.md
+++ b/static/usage/v8/input/counter-alignment/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/input/counter-alignment/demo.html"
+  src="usage/v8/input/counter-alignment/demo.html"
 />

--- a/static/usage/v8/input/counter/index.md
+++ b/static/usage/v8/input/counter/index.md
@@ -20,5 +20,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/input/counter/demo.html"
+  src="usage/v8/input/counter/demo.html"
 />

--- a/static/usage/v8/input/fill/index.md
+++ b/static/usage/v8/input/fill/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/input/fill/demo.html"
+  src="usage/v8/input/fill/demo.html"
   size="250px"
   mode="md"
 />

--- a/static/usage/v8/input/filtering/index.md
+++ b/static/usage/v8/input/filtering/index.md
@@ -20,5 +20,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/input/filtering/demo.html"
+  src="usage/v8/input/filtering/demo.html"
 />

--- a/static/usage/v8/input/helper-error/index.md
+++ b/static/usage/v8/input/helper-error/index.md
@@ -13,6 +13,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/input/helper-error/demo.html"
+  src="usage/v8/input/helper-error/demo.html"
   size="150px"
 />

--- a/static/usage/v8/input/label-placement/index.md
+++ b/static/usage/v8/input/label-placement/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/input/label-placement/demo.html"
+  src="usage/v8/input/label-placement/demo.html"
   size="300px"
 />

--- a/static/usage/v8/input/label-slot/index.md
+++ b/static/usage/v8/input/label-slot/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/input/label-slot/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/input/label-slot/demo.html" />

--- a/static/usage/v8/input/mask/index.md
+++ b/static/usage/v8/input/mask/index.md
@@ -53,6 +53,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/input/mask/demo.html"
+  src="usage/v8/input/mask/demo.html"
   size="300px"
 />

--- a/static/usage/v8/input/no-visible-label/index.md
+++ b/static/usage/v8/input/no-visible-label/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/input/no-visible-label/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/input/no-visible-label/demo.html" />

--- a/static/usage/v8/input/set-focus/index.md
+++ b/static/usage/v8/input/set-focus/index.md
@@ -13,5 +13,5 @@ import react from './react.md';
     angular,
     react,
   }}
-  src="usage/v7/input/set-focus/demo.html"
+  src="usage/v8/input/set-focus/demo.html"
 />

--- a/static/usage/v8/input/theming/colors/index.md
+++ b/static/usage/v8/input/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/input/theming/colors/demo.html"
+  src="usage/v8/input/theming/colors/demo.html"
   size="200px"
 />

--- a/static/usage/v8/input/theming/css-properties/index.md
+++ b/static/usage/v8/input/theming/css-properties/index.md
@@ -30,6 +30,6 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/input/theming/css-properties/demo.html"
+  src="usage/v8/input/theming/css-properties/demo.html"
   size="100px"
 />

--- a/static/usage/v8/input/types/index.md
+++ b/static/usage/v8/input/types/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/input/types/demo.html" size="300px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/input/types/demo.html" size="300px" />

--- a/static/usage/v8/item-divider/basic/index.md
+++ b/static/usage/v8/item-divider/basic/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item-divider/basic/demo.html"
+  src="usage/v8/item-divider/basic/demo.html"
   size="medium"
 />

--- a/static/usage/v8/item-divider/theming/colors/index.md
+++ b/static/usage/v8/item-divider/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item-divider/theming/colors/demo.html"
+  src="usage/v8/item-divider/theming/colors/demo.html"
   size="medium"
 />

--- a/static/usage/v8/item-divider/theming/css-properties/index.md
+++ b/static/usage/v8/item-divider/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/item-divider/theming/css-properties/demo.html"
+  src="usage/v8/item-divider/theming/css-properties/demo.html"
   size="100px"
 />

--- a/static/usage/v8/item-group/basic/index.md
+++ b/static/usage/v8/item-group/basic/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item-group/basic/demo.html"
+  src="usage/v8/item-group/basic/demo.html"
   size="medium"
 />

--- a/static/usage/v8/item-group/sliding-items/index.md
+++ b/static/usage/v8/item-group/sliding-items/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item-group/sliding-items/demo.html"
+  src="usage/v8/item-group/sliding-items/demo.html"
   size="medium"
 />

--- a/static/usage/v8/item-sliding/basic/index.md
+++ b/static/usage/v8/item-sliding/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item-sliding/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item-sliding/basic/demo.html" />

--- a/static/usage/v8/item-sliding/expandable/index.md
+++ b/static/usage/v8/item-sliding/expandable/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item-sliding/expandable/demo.html"
+  src="usage/v8/item-sliding/expandable/demo.html"
   size="100px"
 />

--- a/static/usage/v8/item-sliding/icons/index.md
+++ b/static/usage/v8/item-sliding/icons/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item-sliding/icons/demo.html"
+  src="usage/v8/item-sliding/icons/demo.html"
   size="300px"
 />

--- a/static/usage/v8/item/basic/index.md
+++ b/static/usage/v8/item/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item/basic/demo.html" size="medium" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item/basic/demo.html" size="medium" />

--- a/static/usage/v8/item/buttons/index.md
+++ b/static/usage/v8/item/buttons/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item/buttons/demo.html" size="250px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item/buttons/demo.html" size="250px" />

--- a/static/usage/v8/item/clickable/index.md
+++ b/static/usage/v8/item/clickable/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item/clickable/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item/clickable/demo.html" />

--- a/static/usage/v8/item/content-types/actions/index.md
+++ b/static/usage/v8/item/content-types/actions/index.md
@@ -13,7 +13,7 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/item/content-types/actions/demo.html"
+  src="usage/v8/item/content-types/actions/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/item/content-types/controls/index.md
+++ b/static/usage/v8/item/content-types/controls/index.md
@@ -13,7 +13,7 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/item/content-types/controls/demo.html"
+  src="usage/v8/item/content-types/controls/demo.html"
   includeIonContent={false}
   devicePreview={true}
 />

--- a/static/usage/v8/item/content-types/metadata/index.md
+++ b/static/usage/v8/item/content-types/metadata/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/item/content-types/metadata/demo.html"
+  src="usage/v8/item/content-types/metadata/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/item/content-types/supporting-visuals/index.md
+++ b/static/usage/v8/item/content-types/supporting-visuals/index.md
@@ -13,6 +13,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/item/content-types/supporting-visuals/demo.html"
+  src="usage/v8/item/content-types/supporting-visuals/demo.html"
   size="250px"
 />

--- a/static/usage/v8/item/content-types/text/index.md
+++ b/static/usage/v8/item/content-types/text/index.md
@@ -28,7 +28,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/item/content-types/text/demo.html"
+  src="usage/v8/item/content-types/text/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/item/detail-arrows/index.md
+++ b/static/usage/v8/item/detail-arrows/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item/detail-arrows/demo.html"
+  src="usage/v8/item/detail-arrows/demo.html"
   size="350px"
 />

--- a/static/usage/v8/item/icons/index.md
+++ b/static/usage/v8/item/icons/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item/icons/demo.html" size="250px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item/icons/demo.html" size="250px" />

--- a/static/usage/v8/item/inputs/index.md
+++ b/static/usage/v8/item/inputs/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item/inputs/demo.html" size="large" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item/inputs/demo.html" size="large" />

--- a/static/usage/v8/item/lines/index.md
+++ b/static/usage/v8/item/lines/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item/lines/demo.html" size="medium" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item/lines/demo.html" size="medium" />

--- a/static/usage/v8/item/media/index.md
+++ b/static/usage/v8/item/media/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item/media/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/item/media/demo.html" />

--- a/static/usage/v8/item/theming/colors/index.md
+++ b/static/usage/v8/item/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/item/theming/colors/demo.html"
+  src="usage/v8/item/theming/colors/demo.html"
   size="500px"
 />

--- a/static/usage/v8/item/theming/css-properties/index.md
+++ b/static/usage/v8/item/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/item/theming/css-properties/demo.html"
+  src="usage/v8/item/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/item/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/item/theming/css-shadow-parts/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/item/theming/css-shadow-parts/demo.html"
+  src="usage/v8/item/theming/css-shadow-parts/demo.html"
 />

--- a/static/usage/v8/item/theming/input-highlight/index.md
+++ b/static/usage/v8/item/theming/input-highlight/index.md
@@ -28,6 +28,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/item/theming/input-highlight/demo.html"
+  src="usage/v8/item/theming/input-highlight/demo.html"
   size="250px"
 />

--- a/static/usage/v8/keyboard/enterkeyhint/index.md
+++ b/static/usage/v8/keyboard/enterkeyhint/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/keyboard/enterkeyhint/demo.html"
+  src="usage/v8/keyboard/enterkeyhint/demo.html"
 />

--- a/static/usage/v8/keyboard/inputmode/index.md
+++ b/static/usage/v8/keyboard/inputmode/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/keyboard/inputmode/demo.html"
+  src="usage/v8/keyboard/inputmode/demo.html"
 />

--- a/static/usage/v8/label/basic/index.md
+++ b/static/usage/v8/label/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/label/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/label/basic/demo.html" />

--- a/static/usage/v8/label/input/index.md
+++ b/static/usage/v8/label/input/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/label/input/demo.html" size="medium" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/label/input/demo.html" size="medium" />

--- a/static/usage/v8/label/item/index.md
+++ b/static/usage/v8/label/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/label/item/demo.html" size="medium" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/label/item/demo.html" size="medium" />

--- a/static/usage/v8/label/theming/colors/index.md
+++ b/static/usage/v8/label/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/label/theming/colors/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/label/theming/colors/demo.html" />

--- a/static/usage/v8/layout/dynamic-font-scaling/index.md
+++ b/static/usage/v8/layout/dynamic-font-scaling/index.md
@@ -28,7 +28,7 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/layout/dynamic-font-scaling/demo.html"
+  src="usage/v8/layout/dynamic-font-scaling/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/list-header/basic/index.md
+++ b/static/usage/v8/list-header/basic/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/list-header/basic/demo.html"
+  src="usage/v8/list-header/basic/demo.html"
   size="325px"
 />

--- a/static/usage/v8/list-header/buttons/index.md
+++ b/static/usage/v8/list-header/buttons/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/list-header/buttons/demo.html"
+  src="usage/v8/list-header/buttons/demo.html"
   size="325px"
 />

--- a/static/usage/v8/list-header/lines/index.md
+++ b/static/usage/v8/list-header/lines/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/list-header/lines/demo.html"
+  src="usage/v8/list-header/lines/demo.html"
   size="500px"
 />

--- a/static/usage/v8/list-header/theming/colors/index.md
+++ b/static/usage/v8/list-header/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/list-header/theming/colors/demo.html"
+  src="usage/v8/list-header/theming/colors/demo.html"
   size="650px"
 />

--- a/static/usage/v8/list-header/theming/css-properties/index.md
+++ b/static/usage/v8/list-header/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/list-header/theming/css-properties/demo.html"
+  src="usage/v8/list-header/theming/css-properties/demo.html"
   size="100px"
 />

--- a/static/usage/v8/list/basic/index.md
+++ b/static/usage/v8/list/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/list/basic/demo.html" size="300px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/list/basic/demo.html" size="300px" />

--- a/static/usage/v8/list/inset/index.md
+++ b/static/usage/v8/list/inset/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/list/inset/demo.html"
+  src="usage/v8/list/inset/demo.html"
   size="350px"
   includeIonContent={false}
 />

--- a/static/usage/v8/list/lines/index.md
+++ b/static/usage/v8/list/lines/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/list/lines/demo.html" size="500px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/list/lines/demo.html" size="500px" />

--- a/static/usage/v8/loading/controller/index.md
+++ b/static/usage/v8/loading/controller/index.md
@@ -20,5 +20,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/loading/controller/demo.html"
+  src="usage/v8/loading/controller/demo.html"
 />

--- a/static/usage/v8/loading/inline/index.md
+++ b/static/usage/v8/loading/inline/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/loading/inline/demo.html"
+  src="usage/v8/loading/inline/demo.html"
 />

--- a/static/usage/v8/loading/spinners/index.md
+++ b/static/usage/v8/loading/spinners/index.md
@@ -13,5 +13,5 @@ import vue from './vue.md';
     vue,
     angular,
   }}
-  src="usage/v7/loading/spinners/demo.html"
+  src="usage/v8/loading/spinners/demo.html"
 />

--- a/static/usage/v8/loading/theming/index.md
+++ b/static/usage/v8/loading/theming/index.md
@@ -28,5 +28,5 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/loading/theming/demo.html"
+  src="usage/v8/loading/theming/demo.html"
 />

--- a/static/usage/v8/menu/basic/index.md
+++ b/static/usage/v8/menu/basic/index.md
@@ -13,6 +13,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/menu/basic/demo.html"
+  src="usage/v8/menu/basic/demo.html"
   devicePreview
 />

--- a/static/usage/v8/menu/multiple/index.md
+++ b/static/usage/v8/menu/multiple/index.md
@@ -22,6 +22,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/menu/multiple/demo.html"
+  src="usage/v8/menu/multiple/demo.html"
   devicePreview
 />

--- a/static/usage/v8/menu/sides/index.md
+++ b/static/usage/v8/menu/sides/index.md
@@ -13,6 +13,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/menu/sides/demo.html"
+  src="usage/v8/menu/sides/demo.html"
   devicePreview
 />

--- a/static/usage/v8/menu/theming/index.md
+++ b/static/usage/v8/menu/theming/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/menu/theming/demo.html"
+  src="usage/v8/menu/theming/demo.html"
   devicePreview
 />

--- a/static/usage/v8/menu/toggle/index.md
+++ b/static/usage/v8/menu/toggle/index.md
@@ -13,6 +13,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/menu/toggle/demo.html"
+  src="usage/v8/menu/toggle/demo.html"
   devicePreview
 />

--- a/static/usage/v8/menu/type/index.md
+++ b/static/usage/v8/menu/type/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/menu/type/demo.html"
+  src="usage/v8/menu/type/demo.html"
   devicePreview
 />

--- a/static/usage/v8/modal/can-dismiss/boolean/index.md
+++ b/static/usage/v8/modal/can-dismiss/boolean/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/can-dismiss/boolean/demo.html"
+  src="usage/v8/modal/can-dismiss/boolean/demo.html"
   devicePreview
 />

--- a/static/usage/v8/modal/can-dismiss/child-state/index.md
+++ b/static/usage/v8/modal/can-dismiss/child-state/index.md
@@ -37,6 +37,6 @@ import angular_app_module_ts from './angular/app_module_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/can-dismiss/child-state/demo.html"
+  src="usage/v8/modal/can-dismiss/child-state/demo.html"
   devicePreview
 />

--- a/static/usage/v8/modal/can-dismiss/function/index.md
+++ b/static/usage/v8/modal/can-dismiss/function/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/can-dismiss/function/demo.html"
+  src="usage/v8/modal/can-dismiss/function/demo.html"
   devicePreview
 />

--- a/static/usage/v8/modal/can-dismiss/prevent-swipe-to-close/index.md
+++ b/static/usage/v8/modal/can-dismiss/prevent-swipe-to-close/index.md
@@ -21,7 +21,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/can-dismiss/prevent-swipe-to-close/demo.html"
+  src="usage/v8/modal/can-dismiss/prevent-swipe-to-close/demo.html"
   devicePreview
   mode="ios"
 />

--- a/static/usage/v8/modal/card/basic/index.md
+++ b/static/usage/v8/modal/card/basic/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/card/basic/demo.html"
+  src="usage/v8/modal/card/basic/demo.html"
   devicePreview
   mode="ios"
 />

--- a/static/usage/v8/modal/controller/index.md
+++ b/static/usage/v8/modal/controller/index.md
@@ -33,7 +33,7 @@ import angular_modal_example_component_html from './angular/modal-example_compon
       },
     },
   }}
-  src="usage/v7/modal/controller/demo.html"
+  src="usage/v8/modal/controller/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/custom-dialogs/index.md
+++ b/static/usage/v8/modal/custom-dialogs/index.md
@@ -27,7 +27,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/modal/custom-dialogs/demo.html"
+  src="usage/v8/modal/custom-dialogs/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/inline/basic/index.md
+++ b/static/usage/v8/modal/inline/basic/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/inline/basic/demo.html"
+  src="usage/v8/modal/inline/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/inline/is-open/index.md
+++ b/static/usage/v8/modal/inline/is-open/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/inline/is-open/demo.html"
+  src="usage/v8/modal/inline/is-open/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/performance/mount/index.md
+++ b/static/usage/v8/modal/performance/mount/index.md
@@ -13,7 +13,7 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/modal/performance/mount/demo.html"
+  src="usage/v8/modal/performance/mount/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/sheet/auto-height/index.md
+++ b/static/usage/v8/modal/sheet/auto-height/index.md
@@ -27,7 +27,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/modal/sheet/auto-height/demo.html"
+  src="usage/v8/modal/sheet/auto-height/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/sheet/background-content/index.md
+++ b/static/usage/v8/modal/sheet/background-content/index.md
@@ -22,7 +22,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/modal/sheet/background-content/demo.html"
+  src="usage/v8/modal/sheet/background-content/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/sheet/basic/index.md
+++ b/static/usage/v8/modal/sheet/basic/index.md
@@ -13,7 +13,7 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/modal/sheet/basic/demo.html"
+  src="usage/v8/modal/sheet/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/sheet/handle-behavior/index.md
+++ b/static/usage/v8/modal/sheet/handle-behavior/index.md
@@ -13,7 +13,7 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/modal/sheet/handle-behavior/demo.html"
+  src="usage/v8/modal/sheet/handle-behavior/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/styling/animations/index.md
+++ b/static/usage/v8/modal/styling/animations/index.md
@@ -27,7 +27,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/modal/styling/animations/demo.html"
+  src="usage/v8/modal/styling/animations/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/modal/styling/theming/index.md
+++ b/static/usage/v8/modal/styling/theming/index.md
@@ -27,7 +27,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/modal/styling/theming/demo.html"
+  src="usage/v8/modal/styling/theming/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/nav/modal-navigation/index.md
+++ b/static/usage/v8/nav/modal-navigation/index.md
@@ -50,7 +50,7 @@ import vue_page_three from './vue/page_three_vue.md';
       },
     },
   }}
-  src="usage/v7/nav/modal-navigation/demo.html"
+  src="usage/v8/nav/modal-navigation/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/nav/nav-link/index.md
+++ b/static/usage/v8/nav/nav-link/index.md
@@ -50,6 +50,6 @@ import vue_page_three from './vue/page_three_vue.md';
       },
     },
   }}
-  src="usage/v7/nav/nav-link/demo.html"
+  src="usage/v8/nav/nav-link/demo.html"
   devicePreview
 />

--- a/static/usage/v8/note/basic/index.md
+++ b/static/usage/v8/note/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/note/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/note/basic/demo.html" />

--- a/static/usage/v8/note/item/index.md
+++ b/static/usage/v8/note/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/note/item/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/note/item/demo.html" />

--- a/static/usage/v8/note/theming/colors/index.md
+++ b/static/usage/v8/note/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/note/theming/colors/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/note/theming/colors/demo.html" />

--- a/static/usage/v8/note/theming/css-properties/index.md
+++ b/static/usage/v8/note/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/note/theming/css-properties/demo.html"
+  src="usage/v8/note/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/picker/controller/index.md
+++ b/static/usage/v8/picker/controller/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/picker/controller/demo.html"
+  src="usage/v8/picker/controller/demo.html"
   size="medium"
   showConsole={true}
 />

--- a/static/usage/v8/picker/inline/isOpen/index.md
+++ b/static/usage/v8/picker/inline/isOpen/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/picker/inline/isOpen/demo.html"
+  src="usage/v8/picker/inline/isOpen/demo.html"
   size="medium"
   showConsole={true}
 />

--- a/static/usage/v8/picker/inline/trigger/index.md
+++ b/static/usage/v8/picker/inline/trigger/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/picker/inline/trigger/demo.html"
+  src="usage/v8/picker/inline/trigger/demo.html"
   size="medium"
   showConsole={true}
 />

--- a/static/usage/v8/picker/multiple-column/index.md
+++ b/static/usage/v8/picker/multiple-column/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/picker/multiple-column/demo.html"
+  src="usage/v8/picker/multiple-column/demo.html"
   size="medium"
   showConsole={true}
 />

--- a/static/usage/v8/popover/customization/positioning/index.md
+++ b/static/usage/v8/popover/customization/positioning/index.md
@@ -30,5 +30,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/popover/customization/positioning/demo.html"
+  src="usage/v8/popover/customization/positioning/demo.html"
 />

--- a/static/usage/v8/popover/customization/sizing/index.md
+++ b/static/usage/v8/popover/customization/sizing/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="300px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/popover/customization/sizing/demo.html"
+  src="usage/v8/popover/customization/sizing/demo.html"
 />

--- a/static/usage/v8/popover/customization/styling/index.md
+++ b/static/usage/v8/popover/customization/styling/index.md
@@ -28,5 +28,5 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/popover/customization/styling/demo.html"
+  src="usage/v8/popover/customization/styling/demo.html"
 />

--- a/static/usage/v8/popover/nested/index.md
+++ b/static/usage/v8/popover/nested/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/popover/nested/demo.html"
+  src="usage/v8/popover/nested/demo.html"
 />

--- a/static/usage/v8/popover/performance/mount/index.md
+++ b/static/usage/v8/popover/performance/mount/index.md
@@ -14,5 +14,5 @@ import angular from './angular.md';
     angular,
   }}
   size="medium"
-  src="usage/v7/popover/performance/mount/demo.html"
+  src="usage/v8/popover/performance/mount/demo.html"
 />

--- a/static/usage/v8/popover/presenting/controller/index.md
+++ b/static/usage/v8/popover/presenting/controller/index.md
@@ -34,6 +34,6 @@ import angular_app_module from './angular/app_module_ts.md';
       },
     },
   }}
-  src="usage/v7/popover/presenting/controller/demo.html"
+  src="usage/v8/popover/presenting/controller/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/popover/presenting/inline-isopen/index.md
+++ b/static/usage/v8/popover/presenting/inline-isopen/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/popover/presenting/inline-isopen/demo.html"
+  src="usage/v8/popover/presenting/inline-isopen/demo.html"
 />

--- a/static/usage/v8/popover/presenting/inline-trigger/index.md
+++ b/static/usage/v8/popover/presenting/inline-trigger/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="300px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/popover/presenting/inline-trigger/demo.html"
+  src="usage/v8/popover/presenting/inline-trigger/demo.html"
 />

--- a/static/usage/v8/progress-bar/buffer/index.md
+++ b/static/usage/v8/progress-bar/buffer/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/progress-bar/buffer/demo.html"
+  src="usage/v8/progress-bar/buffer/demo.html"
 />

--- a/static/usage/v8/progress-bar/determinate/index.md
+++ b/static/usage/v8/progress-bar/determinate/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/progress-bar/determinate/demo.html"
+  src="usage/v8/progress-bar/determinate/demo.html"
 />

--- a/static/usage/v8/progress-bar/indeterminate/index.md
+++ b/static/usage/v8/progress-bar/indeterminate/index.md
@@ -8,5 +8,5 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/progress-bar/indeterminate/demo.html"
+  src="usage/v8/progress-bar/indeterminate/demo.html"
 />

--- a/static/usage/v8/progress-bar/theming/colors/index.md
+++ b/static/usage/v8/progress-bar/theming/colors/index.md
@@ -8,5 +8,5 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/progress-bar/theming/colors/demo.html"
+  src="usage/v8/progress-bar/theming/colors/demo.html"
 />

--- a/static/usage/v8/progress-bar/theming/css-properties/index.md
+++ b/static/usage/v8/progress-bar/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/progress-bar/theming/css-properties/demo.html"
+  src="usage/v8/progress-bar/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/progress-bar/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/progress-bar/theming/css-shadow-parts/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/progress-bar/theming/css-shadow-parts/demo.html"
+  src="usage/v8/progress-bar/theming/css-shadow-parts/demo.html"
 />

--- a/static/usage/v8/radio/alignment/index.md
+++ b/static/usage/v8/radio/alignment/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/radio/alignment/demo.html"
+  src="usage/v8/radio/alignment/demo.html"
 />

--- a/static/usage/v8/radio/basic/index.md
+++ b/static/usage/v8/radio/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/radio/basic/demo.html" />

--- a/static/usage/v8/radio/empty-selection/index.md
+++ b/static/usage/v8/radio/empty-selection/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/empty-selection/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/radio/empty-selection/demo.html" />

--- a/static/usage/v8/radio/justify/index.md
+++ b/static/usage/v8/radio/justify/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/justify/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/radio/justify/demo.html" />

--- a/static/usage/v8/radio/label-placement/index.md
+++ b/static/usage/v8/radio/label-placement/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/radio/label-placement/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/radio/label-placement/demo.html" />

--- a/static/usage/v8/radio/theming/colors/index.md
+++ b/static/usage/v8/radio/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/radio/theming/colors/demo.html"
+  src="usage/v8/radio/theming/colors/demo.html"
   size="100px"
 />

--- a/static/usage/v8/radio/theming/css-properties/index.md
+++ b/static/usage/v8/radio/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/radio/theming/css-properties/demo.html"
+  src="usage/v8/radio/theming/css-properties/demo.html"
   size="100px"
 />

--- a/static/usage/v8/radio/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/radio/theming/css-shadow-parts/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/radio/theming/css-shadow-parts/demo.html"
+  src="usage/v8/radio/theming/css-shadow-parts/demo.html"
   size="100px"
 />

--- a/static/usage/v8/range/basic/index.md
+++ b/static/usage/v8/range/basic/index.md
@@ -7,4 +7,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/range/basic/demo.html" />

--- a/static/usage/v8/range/dual-knobs/index.md
+++ b/static/usage/v8/range/dual-knobs/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/dual-knobs/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/range/dual-knobs/demo.html" />

--- a/static/usage/v8/range/ion-change-event/index.md
+++ b/static/usage/v8/range/ion-change-event/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/range/ion-change-event/demo.html"
+  src="usage/v8/range/ion-change-event/demo.html"
 />

--- a/static/usage/v8/range/ion-knob-move-event/index.md
+++ b/static/usage/v8/range/ion-knob-move-event/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/range/ion-knob-move-event/demo.html"
+  src="usage/v8/range/ion-knob-move-event/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/range/label-slot/index.md
+++ b/static/usage/v8/range/label-slot/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/label-slot/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/range/label-slot/demo.html" />

--- a/static/usage/v8/range/labels/index.md
+++ b/static/usage/v8/range/labels/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/labels/demo.html" size="300px" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/range/labels/demo.html" size="300px" />

--- a/static/usage/v8/range/no-visible-label/index.md
+++ b/static/usage/v8/range/no-visible-label/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/no-visible-label/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/range/no-visible-label/demo.html" />

--- a/static/usage/v8/range/pins/index.md
+++ b/static/usage/v8/range/pins/index.md
@@ -20,5 +20,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/range/pins/demo.html"
+  src="usage/v8/range/pins/demo.html"
 />

--- a/static/usage/v8/range/slots/index.md
+++ b/static/usage/v8/range/slots/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/slots/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/range/slots/demo.html" />

--- a/static/usage/v8/range/snapping-ticks/index.md
+++ b/static/usage/v8/range/snapping-ticks/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/range/snapping-ticks/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/range/snapping-ticks/demo.html" />

--- a/static/usage/v8/range/theming/css-properties/index.md
+++ b/static/usage/v8/range/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/range/theming/css-properties/demo.html"
+  src="usage/v8/range/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/range/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/range/theming/css-shadow-parts/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/range/theming/css-shadow-parts/demo.html"
+  src="usage/v8/range/theming/css-shadow-parts/demo.html"
 />

--- a/static/usage/v8/refresher/advanced/index.md
+++ b/static/usage/v8/refresher/advanced/index.md
@@ -30,7 +30,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/refresher/advanced/demo.html"
+  src="usage/v8/refresher/advanced/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/refresher/basic/index.md
+++ b/static/usage/v8/refresher/basic/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/refresher/basic/demo.html"
+  src="usage/v8/refresher/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/refresher/custom-content/index.md
+++ b/static/usage/v8/refresher/custom-content/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/refresher/custom-content/demo.html"
+  src="usage/v8/refresher/custom-content/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/refresher/custom-scroll-target/index.md
+++ b/static/usage/v8/refresher/custom-scroll-target/index.md
@@ -28,7 +28,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/refresher/custom-scroll-target/demo.html"
+  src="usage/v8/refresher/custom-scroll-target/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/refresher/pull-properties/index.md
+++ b/static/usage/v8/refresher/pull-properties/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/refresher/pull-properties/demo.html"
+  src="usage/v8/refresher/pull-properties/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/reorder/basic/index.md
+++ b/static/usage/v8/reorder/basic/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/reorder/basic/demo.html"
+  src="usage/v8/reorder/basic/demo.html"
   size="300px"
   showConsole={true}
 />

--- a/static/usage/v8/reorder/custom-icon/index.md
+++ b/static/usage/v8/reorder/custom-icon/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/reorder/custom-icon/demo.html"
+  src="usage/v8/reorder/custom-icon/demo.html"
   size="300px"
   showConsole={true}
 />

--- a/static/usage/v8/reorder/custom-scroll-target/index.md
+++ b/static/usage/v8/reorder/custom-scroll-target/index.md
@@ -30,7 +30,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/reorder/custom-scroll-target/demo.html"
+  src="usage/v8/reorder/custom-scroll-target/demo.html"
   size="300px"
   includeIonContent={false}
   showConsole={true}

--- a/static/usage/v8/reorder/toggling-disabled/index.md
+++ b/static/usage/v8/reorder/toggling-disabled/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/reorder/toggling-disabled/demo.html"
+  src="usage/v8/reorder/toggling-disabled/demo.html"
   size="350px"
   showConsole={true}
 />

--- a/static/usage/v8/reorder/updating-data/index.md
+++ b/static/usage/v8/reorder/updating-data/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/reorder/updating-data/demo.html"
+  src="usage/v8/reorder/updating-data/demo.html"
   size="300px"
   showConsole={true}
 />

--- a/static/usage/v8/reorder/wrapper/index.md
+++ b/static/usage/v8/reorder/wrapper/index.md
@@ -20,7 +20,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/reorder/wrapper/demo.html"
+  src="usage/v8/reorder/wrapper/demo.html"
   size="300px"
   showConsole={true}
 />

--- a/static/usage/v8/ripple-effect/basic/index.md
+++ b/static/usage/v8/ripple-effect/basic/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/ripple-effect/basic/demo.html"
+  src="usage/v8/ripple-effect/basic/demo.html"
   size="300px"
 />

--- a/static/usage/v8/ripple-effect/customizing/index.md
+++ b/static/usage/v8/ripple-effect/customizing/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/ripple-effect/customizing/demo.html"
+  src="usage/v8/ripple-effect/customizing/demo.html"
   size="175px"
 />

--- a/static/usage/v8/ripple-effect/type/index.md
+++ b/static/usage/v8/ripple-effect/type/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/ripple-effect/type/demo.html"
+  src="usage/v8/ripple-effect/type/demo.html"
   size="175px"
 />

--- a/static/usage/v8/router/basic/index.md
+++ b/static/usage/v8/router/basic/index.md
@@ -5,7 +5,7 @@ import javascript from './javascript.md';
 <Playground
   version="7"
   code={{ javascript }}
-  src="usage/v7/router/basic/demo.html"
+  src="usage/v8/router/basic/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/searchbar/basic/index.md
+++ b/static/usage/v8/searchbar/basic/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/searchbar/basic/demo.html"
+  src="usage/v8/searchbar/basic/demo.html"
   size="300px"
 />

--- a/static/usage/v8/searchbar/cancel-button/index.md
+++ b/static/usage/v8/searchbar/cancel-button/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/searchbar/cancel-button/demo.html"
+  src="usage/v8/searchbar/cancel-button/demo.html"
   size="250px"
 />

--- a/static/usage/v8/searchbar/clear-button/index.md
+++ b/static/usage/v8/searchbar/clear-button/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/searchbar/clear-button/demo.html"
+  src="usage/v8/searchbar/clear-button/demo.html"
   size="250px"
 />

--- a/static/usage/v8/searchbar/debounce/index.md
+++ b/static/usage/v8/searchbar/debounce/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/searchbar/debounce/demo.html"
+  src="usage/v8/searchbar/debounce/demo.html"
   size="large"
 />

--- a/static/usage/v8/searchbar/search-icon/index.md
+++ b/static/usage/v8/searchbar/search-icon/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/searchbar/search-icon/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/searchbar/search-icon/demo.html" />

--- a/static/usage/v8/searchbar/theming/colors/index.md
+++ b/static/usage/v8/searchbar/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/searchbar/theming/colors/demo.html"
+  src="usage/v8/searchbar/theming/colors/demo.html"
   size="large"
 />

--- a/static/usage/v8/searchbar/theming/css-properties/index.md
+++ b/static/usage/v8/searchbar/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/searchbar/theming/css-properties/demo.html"
+  src="usage/v8/searchbar/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/segment-button/basic/index.md
+++ b/static/usage/v8/segment-button/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/segment-button/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/segment-button/basic/demo.html" />

--- a/static/usage/v8/segment-button/layout/index.md
+++ b/static/usage/v8/segment-button/layout/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/segment-button/layout/demo.html"
+  src="usage/v8/segment-button/layout/demo.html"
   size="medium"
 />

--- a/static/usage/v8/segment-button/theming/css-properties/index.md
+++ b/static/usage/v8/segment-button/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/segment-button/theming/css-properties/demo.html"
+  src="usage/v8/segment-button/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/segment-button/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/segment-button/theming/css-shadow-parts/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/segment-button/theming/css-shadow-parts/demo.html"
+  src="usage/v8/segment-button/theming/css-shadow-parts/demo.html"
 />

--- a/static/usage/v8/segment/basic/index.md
+++ b/static/usage/v8/segment/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/segment/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/segment/basic/demo.html" />

--- a/static/usage/v8/segment/scrollable/index.md
+++ b/static/usage/v8/segment/scrollable/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/segment/scrollable/demo.html"
+  src="usage/v8/segment/scrollable/demo.html"
   size="100px"
 />

--- a/static/usage/v8/segment/theming/colors/index.md
+++ b/static/usage/v8/segment/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/segment/theming/colors/demo.html"
+  src="usage/v8/segment/theming/colors/demo.html"
   size="large"
 />

--- a/static/usage/v8/segment/theming/css-properties/index.md
+++ b/static/usage/v8/segment/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/segment/theming/css-properties/demo.html"
+  src="usage/v8/segment/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/select/basic/multiple-selection/index.md
+++ b/static/usage/v8/select/basic/multiple-selection/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="300px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/basic/multiple-selection/demo.html"
+  src="usage/v8/select/basic/multiple-selection/demo.html"
 />

--- a/static/usage/v8/select/basic/responding-to-interaction/index.md
+++ b/static/usage/v8/select/basic/responding-to-interaction/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/select/basic/responding-to-interaction/demo.html"
+  src="usage/v8/select/basic/responding-to-interaction/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/select/basic/single-selection/index.md
+++ b/static/usage/v8/select/basic/single-selection/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="300px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/basic/single-selection/demo.html"
+  src="usage/v8/select/basic/single-selection/demo.html"
 />

--- a/static/usage/v8/select/customization/button-text/index.md
+++ b/static/usage/v8/select/customization/button-text/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="350px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/customization/button-text/demo.html"
+  src="usage/v8/select/customization/button-text/demo.html"
 />

--- a/static/usage/v8/select/customization/custom-toggle-icons/index.md
+++ b/static/usage/v8/select/customization/custom-toggle-icons/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="400px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/customization/custom-toggle-icons/demo.html"
+  src="usage/v8/select/customization/custom-toggle-icons/demo.html"
 />

--- a/static/usage/v8/select/customization/icon-flip-behavior/index.md
+++ b/static/usage/v8/select/customization/icon-flip-behavior/index.md
@@ -30,5 +30,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/select/customization/icon-flip-behavior/demo.html"
+  src="usage/v8/select/customization/icon-flip-behavior/demo.html"
 />

--- a/static/usage/v8/select/customization/interface-options/index.md
+++ b/static/usage/v8/select/customization/interface-options/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/select/customization/interface-options/demo.html"
+  src="usage/v8/select/customization/interface-options/demo.html"
 />

--- a/static/usage/v8/select/customization/styling-select/index.md
+++ b/static/usage/v8/select/customization/styling-select/index.md
@@ -30,5 +30,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/select/customization/styling-select/demo.html"
+  src="usage/v8/select/customization/styling-select/demo.html"
 />

--- a/static/usage/v8/select/fill/index.md
+++ b/static/usage/v8/select/fill/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/fill/demo.html"
+  src="usage/v8/select/fill/demo.html"
   size="300px"
   mode="md"
 />

--- a/static/usage/v8/select/interfaces/action-sheet/index.md
+++ b/static/usage/v8/select/interfaces/action-sheet/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="medium"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/interfaces/action-sheet/demo.html"
+  src="usage/v8/select/interfaces/action-sheet/demo.html"
 />

--- a/static/usage/v8/select/interfaces/popover/index.md
+++ b/static/usage/v8/select/interfaces/popover/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="400px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/interfaces/popover/demo.html"
+  src="usage/v8/select/interfaces/popover/demo.html"
 />

--- a/static/usage/v8/select/justify/index.md
+++ b/static/usage/v8/select/justify/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/justify/demo.html"
+  src="usage/v8/select/justify/demo.html"
   size="300px"
 />

--- a/static/usage/v8/select/label-placement/index.md
+++ b/static/usage/v8/select/label-placement/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/label-placement/demo.html"
+  src="usage/v8/select/label-placement/demo.html"
   size="300px"
 />

--- a/static/usage/v8/select/label-slot/index.md
+++ b/static/usage/v8/select/label-slot/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/label-slot/demo.html"
+  src="usage/v8/select/label-slot/demo.html"
   size="300px"
 />

--- a/static/usage/v8/select/no-visible-label/index.md
+++ b/static/usage/v8/select/no-visible-label/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/select/no-visible-label/demo.html"
+  src="usage/v8/select/no-visible-label/demo.html"
   size="300px"
 />

--- a/static/usage/v8/select/objects-as-values/multiple-selection/index.md
+++ b/static/usage/v8/select/objects-as-values/multiple-selection/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/select/objects-as-values/multiple-selection/demo.html"
+  src="usage/v8/select/objects-as-values/multiple-selection/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/select/objects-as-values/using-comparewith/index.md
+++ b/static/usage/v8/select/objects-as-values/using-comparewith/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/select/objects-as-values/using-comparewith/demo.html"
+  src="usage/v8/select/objects-as-values/using-comparewith/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/select/typeahead/index.md
+++ b/static/usage/v8/select/typeahead/index.md
@@ -46,7 +46,7 @@ import angular_types_ts from './angular/angular_types_ts.md';
       },
     },
   }}
-  src="usage/v7/select/typeahead/demo.html"
+  src="usage/v8/select/typeahead/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/skeleton-text/basic/index.md
+++ b/static/usage/v8/skeleton-text/basic/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/skeleton-text/basic/demo.html"
+  src="usage/v8/skeleton-text/basic/demo.html"
   size="250px"
 />

--- a/static/usage/v8/skeleton-text/theming/css-properties/index.md
+++ b/static/usage/v8/skeleton-text/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/skeleton-text/theming/css-properties/demo.html"
+  src="usage/v8/skeleton-text/theming/css-properties/demo.html"
   size="250px"
 />

--- a/static/usage/v8/spinner/basic/index.md
+++ b/static/usage/v8/spinner/basic/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/spinner/basic/demo.html"
+  src="usage/v8/spinner/basic/demo.html"
   size="500px"
 />

--- a/static/usage/v8/spinner/theming/colors/index.md
+++ b/static/usage/v8/spinner/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/spinner/theming/colors/demo.html"
+  src="usage/v8/spinner/theming/colors/demo.html"
   size="100px"
 />

--- a/static/usage/v8/spinner/theming/css-properties/index.md
+++ b/static/usage/v8/spinner/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/spinner/theming/css-properties/demo.html"
+  src="usage/v8/spinner/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/spinner/theming/resizing/index.md
+++ b/static/usage/v8/spinner/theming/resizing/index.md
@@ -28,5 +28,5 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/spinner/theming/resizing/demo.html"
+  src="usage/v8/spinner/theming/resizing/demo.html"
 />

--- a/static/usage/v8/split-pane/basic/index.md
+++ b/static/usage/v8/split-pane/basic/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/split-pane/basic/demo.html"
+  src="usage/v8/split-pane/basic/demo.html"
   size="500px"
 />

--- a/static/usage/v8/split-pane/theming/css-properties/index.md
+++ b/static/usage/v8/split-pane/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/split-pane/theming/css-properties/demo.html"
+  src="usage/v8/split-pane/theming/css-properties/demo.html"
   size="500px"
 />

--- a/static/usage/v8/tabs/router/index.md
+++ b/static/usage/v8/tabs/router/index.md
@@ -88,6 +88,6 @@ import react_search_page_tsx from './react/search_page_tsx.md';
       },
     },
   }}
-  src="usage/v7/tabs/router/demo.html"
+  src="usage/v8/tabs/router/demo.html"
   devicePreview
 />

--- a/static/usage/v8/text/basic/index.md
+++ b/static/usage/v8/text/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/text/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/text/basic/demo.html" />

--- a/static/usage/v8/textarea/autogrow/index.md
+++ b/static/usage/v8/textarea/autogrow/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="small"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/textarea/autogrow/demo.html"
+  src="usage/v8/textarea/autogrow/demo.html"
 />

--- a/static/usage/v8/textarea/basic/index.md
+++ b/static/usage/v8/textarea/basic/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="250px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/textarea/basic/demo.html"
+  src="usage/v8/textarea/basic/demo.html"
 />

--- a/static/usage/v8/textarea/clear-on-edit/index.md
+++ b/static/usage/v8/textarea/clear-on-edit/index.md
@@ -9,5 +9,5 @@ import angular from './angular.md';
   version="7"
   size="xsmall"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/textarea/clear-on-edit/demo.html"
+  src="usage/v8/textarea/clear-on-edit/demo.html"
 />

--- a/static/usage/v8/textarea/counter/index.md
+++ b/static/usage/v8/textarea/counter/index.md
@@ -20,6 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/textarea/counter/demo.html"
+  src="usage/v8/textarea/counter/demo.html"
   size="250px"
 />

--- a/static/usage/v8/textarea/fill/index.md
+++ b/static/usage/v8/textarea/fill/index.md
@@ -9,6 +9,6 @@ import angular from './angular.md';
   version="7"
   size="250px"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/textarea/fill/demo.html"
+  src="usage/v8/textarea/fill/demo.html"
   mode="md"
 />

--- a/static/usage/v8/textarea/helper-error/index.md
+++ b/static/usage/v8/textarea/helper-error/index.md
@@ -13,6 +13,6 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/textarea/helper-error/demo.html"
+  src="usage/v8/textarea/helper-error/demo.html"
   size="200px"
 />

--- a/static/usage/v8/textarea/label-placement/index.md
+++ b/static/usage/v8/textarea/label-placement/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/textarea/label-placement/demo.html"
+  src="usage/v8/textarea/label-placement/demo.html"
   size="300px"
 />

--- a/static/usage/v8/textarea/label-slot/index.md
+++ b/static/usage/v8/textarea/label-slot/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/textarea/label-slot/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/textarea/label-slot/demo.html" />

--- a/static/usage/v8/textarea/no-visible-label/index.md
+++ b/static/usage/v8/textarea/no-visible-label/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/textarea/no-visible-label/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/textarea/no-visible-label/demo.html" />

--- a/static/usage/v8/textarea/theming/index.md
+++ b/static/usage/v8/textarea/theming/index.md
@@ -31,5 +31,5 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/textarea/theming/demo.html"
+  src="usage/v8/textarea/theming/demo.html"
 />

--- a/static/usage/v8/theming/automatic-dark-mode/index.md
+++ b/static/usage/v8/theming/automatic-dark-mode/index.md
@@ -44,7 +44,7 @@ import variables_css from './theme/variables_css.md';
       },
     },
   }}
-  src="usage/v7/theming/automatic-dark-mode/demo.html"
+  src="usage/v8/theming/automatic-dark-mode/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/theming/manual-dark-mode/index.md
+++ b/static/usage/v8/theming/manual-dark-mode/index.md
@@ -44,7 +44,7 @@ import variables_css from './theme/variables_css.md';
       },
     },
   }}
-  src="usage/v7/theming/manual-dark-mode/demo.html"
+  src="usage/v8/theming/manual-dark-mode/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/thumbnail/basic/index.md
+++ b/static/usage/v8/thumbnail/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/thumbnail/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/thumbnail/basic/demo.html" />

--- a/static/usage/v8/thumbnail/item/index.md
+++ b/static/usage/v8/thumbnail/item/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/thumbnail/item/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/thumbnail/item/demo.html" />

--- a/static/usage/v8/thumbnail/theming/css-properties/index.md
+++ b/static/usage/v8/thumbnail/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/thumbnail/theming/css-properties/demo.html"
+  src="usage/v8/thumbnail/theming/css-properties/demo.html"
   size="250px"
 />

--- a/static/usage/v8/title/basic/index.md
+++ b/static/usage/v8/title/basic/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/title/basic/demo.html"
+  src="usage/v8/title/basic/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/title/collapsible-large-title/basic/index.md
+++ b/static/usage/v8/title/collapsible-large-title/basic/index.md
@@ -9,7 +9,7 @@ import angular from './angular.md';
   version="7"
   mode="ios"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/title/collapsible-large-title/basic/demo.html"
+  src="usage/v8/title/collapsible-large-title/basic/demo.html"
   devicePreview={true}
   includeIonContent={false}
   mode="ios"

--- a/static/usage/v8/title/collapsible-large-title/buttons/index.md
+++ b/static/usage/v8/title/collapsible-large-title/buttons/index.md
@@ -9,7 +9,7 @@ import angular from './angular.md';
   version="7"
   mode="ios"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/title/collapsible-large-title/buttons/demo.html"
+  src="usage/v8/title/collapsible-large-title/buttons/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/title/theming/css-properties/index.md
+++ b/static/usage/v8/title/theming/css-properties/index.md
@@ -28,7 +28,7 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/title/theming/css-properties/demo.html"
+  src="usage/v8/title/theming/css-properties/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/toast/buttons/index.md
+++ b/static/usage/v8/toast/buttons/index.md
@@ -21,6 +21,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/toast/buttons/demo.html"
+  src="usage/v8/toast/buttons/demo.html"
   showConsole={true}
 />

--- a/static/usage/v8/toast/icon/index.md
+++ b/static/usage/v8/toast/icon/index.md
@@ -14,5 +14,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/toast/icon/demo.html"
+  src="usage/v8/toast/icon/demo.html"
 />

--- a/static/usage/v8/toast/inline/basic/index.md
+++ b/static/usage/v8/toast/inline/basic/index.md
@@ -13,7 +13,7 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/toast/inline/basic/demo.html"
+  src="usage/v8/toast/inline/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/toast/inline/is-open/index.md
+++ b/static/usage/v8/toast/inline/is-open/index.md
@@ -20,7 +20,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/toast/inline/is-open/demo.html"
+  src="usage/v8/toast/inline/is-open/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/toast/layout/index.md
+++ b/static/usage/v8/toast/layout/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/toast/layout/demo.html"
+  src="usage/v8/toast/layout/demo.html"
 />

--- a/static/usage/v8/toast/position-anchor/index.md
+++ b/static/usage/v8/toast/position-anchor/index.md
@@ -13,7 +13,7 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/toast/position-anchor/demo.html"
+  src="usage/v8/toast/position-anchor/demo.html"
   devicePreview={true}
   includeIonContent={false}
 />

--- a/static/usage/v8/toast/presenting/controller/index.md
+++ b/static/usage/v8/toast/presenting/controller/index.md
@@ -21,5 +21,5 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       },
     },
   }}
-  src="usage/v7/toast/presenting/controller/demo.html"
+  src="usage/v8/toast/presenting/controller/demo.html"
 />

--- a/static/usage/v8/toast/theming/index.md
+++ b/static/usage/v8/toast/theming/index.md
@@ -30,5 +30,5 @@ import angular_global_css from './angular/global_css.md';
       },
     },
   }}
-  src="usage/v7/toast/theming/demo.html"
+  src="usage/v8/toast/theming/demo.html"
 />

--- a/static/usage/v8/toggle/alignment/index.md
+++ b/static/usage/v8/toggle/alignment/index.md
@@ -13,5 +13,5 @@ import angular from './angular.md';
     vue,
     angular,
   }}
-  src="usage/v7/toggle/alignment/demo.html"
+  src="usage/v8/toggle/alignment/demo.html"
 />

--- a/static/usage/v8/toggle/basic/index.md
+++ b/static/usage/v8/toggle/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/basic/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/toggle/basic/demo.html" />

--- a/static/usage/v8/toggle/justify/index.md
+++ b/static/usage/v8/toggle/justify/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/justify/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/toggle/justify/demo.html" />

--- a/static/usage/v8/toggle/label-placement/index.md
+++ b/static/usage/v8/toggle/label-placement/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/toggle/label-placement/demo.html"
+  src="usage/v8/toggle/label-placement/demo.html"
   size="300px"
 />

--- a/static/usage/v8/toggle/list/index.md
+++ b/static/usage/v8/toggle/list/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/list/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/toggle/list/demo.html" />

--- a/static/usage/v8/toggle/on-off/index.md
+++ b/static/usage/v8/toggle/on-off/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/on-off/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/toggle/on-off/demo.html" />

--- a/static/usage/v8/toggle/theming/colors/index.md
+++ b/static/usage/v8/toggle/theming/colors/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/toggle/theming/colors/demo.html" />
+<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v8/toggle/theming/colors/demo.html" />

--- a/static/usage/v8/toggle/theming/css-properties/index.md
+++ b/static/usage/v8/toggle/theming/css-properties/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/toggle/theming/css-properties/demo.html"
+  src="usage/v8/toggle/theming/css-properties/demo.html"
 />

--- a/static/usage/v8/toggle/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/toggle/theming/css-shadow-parts/index.md
@@ -28,5 +28,5 @@ import angular_example_component_html from './angular/example_component_html.md'
       },
     },
   }}
-  src="usage/v7/toggle/theming/css-shadow-parts/demo.html"
+  src="usage/v8/toggle/theming/css-shadow-parts/demo.html"
 />

--- a/static/usage/v8/toolbar/basic/index.md
+++ b/static/usage/v8/toolbar/basic/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/toolbar/basic/demo.html"
+  src="usage/v8/toolbar/basic/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/toolbar/buttons/index.md
+++ b/static/usage/v8/toolbar/buttons/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/toolbar/buttons/demo.html"
+  src="usage/v8/toolbar/buttons/demo.html"
   size="500px"
 />

--- a/static/usage/v8/toolbar/progress-bars/index.md
+++ b/static/usage/v8/toolbar/progress-bars/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/toolbar/progress-bars/demo.html"
+  src="usage/v8/toolbar/progress-bars/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/toolbar/searchbars/index.md
+++ b/static/usage/v8/toolbar/searchbars/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/toolbar/searchbars/demo.html"
+  src="usage/v8/toolbar/searchbars/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/toolbar/segments/index.md
+++ b/static/usage/v8/toolbar/segments/index.md
@@ -8,7 +8,7 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/toolbar/segments/demo.html"
+  src="usage/v8/toolbar/segments/demo.html"
   devicePreview
   includeIonContent={false}
 />

--- a/static/usage/v8/toolbar/theming/colors/index.md
+++ b/static/usage/v8/toolbar/theming/colors/index.md
@@ -8,6 +8,6 @@ import angular from './angular.md';
 <Playground
   version="7"
   code={{ javascript, react, vue, angular }}
-  src="usage/v7/toolbar/theming/colors/demo.html"
+  src="usage/v8/toolbar/theming/colors/demo.html"
   size="large"
 />

--- a/static/usage/v8/toolbar/theming/css-properties/index.md
+++ b/static/usage/v8/toolbar/theming/css-properties/index.md
@@ -28,6 +28,6 @@ import angular_example_component_css from './angular/example_component_css.md';
       },
     },
   }}
-  src="usage/v7/toolbar/theming/css-properties/demo.html"
+  src="usage/v8/toolbar/theming/css-properties/demo.html"
   size="250px"
 />


### PR DESCRIPTION
Playgrounds for v8 were using v7 path to the demo.