### PR TITLE
docs: show how to account for this

### DIFF
--- a/docs/troubleshooting/runtime.md
+++ b/docs/troubleshooting/runtime.md
@@ -218,4 +218,4 @@ The first way to bind `this` is to use the `bind()` method on a function instanc
 
 The second way to bind `this` is to use an [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) when defining the callback. This works because JavaScript does not create a new `this` binding for arrow functions.
 
-See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this for more information on how `this` works in JavaScript.
+See its [MDN page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this) for more information on how `this` works in JavaScript.

--- a/docs/troubleshooting/runtime.md
+++ b/docs/troubleshooting/runtime.md
@@ -212,9 +212,9 @@ class MyApp {
 
 ## Accessing `this` in a function callback returns `undefined` {#accessing-this}
 
-Certain components, such as [counterFormatter on ion-input](../api/input#counterformatter) and [pinFormatter on ion-range](../api/input#pinformatter), allow developers to pass callbacks. It's important that developers bind the correct `this` value if they plan to access `this` from within the context of the callback. Developers may need to access `this` when using Angular components or when using class components in React. There are two ways to bind `this`:
+Certain components, such as [counterFormatter on ion-input](../api/input#counterformatter) and [pinFormatter on ion-range](../api/input#pinformatter), allow developers to pass callbacks. It's important that you bind the correct `this` value if you plan to access `this` from within the context of the callback. You may need to access `this` when using Angular components or when using class components in React. There are two ways to bind `this`:
 
-The first way to bind `this` is to use the `bind()` method on a function instance. If a developer wanted to pass a callback called `counterFormatterFn`, then they would write `counterFormatterFn.bind(this)`.
+The first way to bind `this` is to use the `bind()` method on a function instance. If you want to pass a callback called `counterFormatterFn`, then you would write `counterFormatterFn.bind(this)`.
 
 The second way to bind `this` is to use an [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) when defining the callback. This works because JavaScript does not create a new `this` binding for arrow functions.
 

--- a/docs/troubleshooting/runtime.md
+++ b/docs/troubleshooting/runtime.md
@@ -209,6 +209,7 @@ class MyApp {
 ```
 
 <!-- This is referenced in Ionic Framework component documentation so we explicitly define the anchor so it remains consistent. -->
+
 ## Accessing `this` in a function callback returns `undefined` {#accessing-this}
 
 Certain components, such as [counterFormatter on ion-input](../api/input#counterformatter) and [pinFormatter on ion-range](../api/input#pinformatter), allow developers to pass callbacks. It's important that developers bind the correct `this` value if they plan to access `this` from within the context of the callback. Developers may need to access `this` when using Angular components or when using class components in React. There are two ways to bind `this`:

--- a/docs/troubleshooting/runtime.md
+++ b/docs/troubleshooting/runtime.md
@@ -207,3 +207,14 @@ class MyApp {
   }
 }
 ```
+
+<!-- This is referenced in Ionic Framework component documentation so we explicitly define the anchor so it remains consistent. -->
+## Accessing `this` in a function callback returns `undefined` {#accessing-this}
+
+Certain components, such as [counterFormatter on ion-input](../api/input#counterformatter) and [pinFormatter on ion-range](../api/input#pinformatter), allow developers to pass callbacks. It's important that developers bind the correct `this` value if they plan to access `this` from within the context of the callback. Developers may need to access `this` when using Angular components or when using class components in React. There are two ways to bind `this`:
+
+The first way to bind `this` is to use the `bind()` method on a function instance. If a developer wanted to pass a callback called `counterFormatterFn`, then they would write `counterFormatterFn.bind(this)`.
+
+The second way to bind `this` is to use an [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) when defining the callback. This works because JavaScript does not create a new `this` binding for arrow functions.
+
+See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this for more information on how `this` works in JavaScript.


### PR DESCRIPTION
In https://github.com/ionic-team/ionic-framework/issues/28694 there was some confusion around how to access `this` inside of a callback function passed to a property on Ionic components. The root issue was due to how the `this` context is determined with developers being responsible for setting the appropriate `this` context.

The team agreed that it would be good to document this behavior so developers are aware of it. I plan to link to this new section from the relevant component props in a separate PR on the Ionic Framework repo.