### PR TITLE
docs(infinite-scroll): clarify virtual scroll element

### DIFF
--- a/docs/api/infinite-scroll.md
+++ b/docs/api/infinite-scroll.md
@@ -43,7 +43,7 @@ import CustomContent from '@site/static/usage/v7/infinite-scroll/custom-infinite
 
 ## Usage with Virtual Scroll
 
-Infinite scroll requires a scroll container to function. When using a virtual scrolling solution, you will need to disable scrolling on the `ion-content` and indicate which element container is responsible for the scroll container with the `.ion-content-scroll-host` class target.
+Infinite scroll requires a scroll container. When using a virtual scrolling solution, you will need to disable scrolling on the `ion-content` and indicate which element container is responsible for the scroll container with the `.ion-content-scroll-host` class target.
 
 ```html
 <ion-content scroll-y="false">
@@ -55,6 +55,12 @@ Infinite scroll requires a scroll container to function. When using a virtual sc
   </ion-infinite-scroll>
 </ion-content>
 ```
+
+:::note
+
+`virtual-scroll-element` refers to scroll container responsible for scrolling the content. This may be a component provided directly by the virtual scroll solution you are using.
+
+:::
 
 ## Accessibility
 

--- a/docs/api/infinite-scroll.md
+++ b/docs/api/infinite-scroll.md
@@ -58,7 +58,7 @@ Infinite scroll requires a scroll container. When using a virtual scrolling solu
 
 :::note
 
-`virtual-scroll-element` refers to scroll container responsible for scrolling the content. This may be a component provided directly by the virtual scroll solution you are using.
+`virtual-scroll-element` refers to the scroll container responsible for scrolling the content. This may be a component provided directly by the virtual scroll solution you are using.
 
 :::
 


### PR DESCRIPTION
We received feedback from the community in Discord that the `virtual-scroll-element` was not clear that it referred to the component/scroll container from the virtual scroll library. 

This PR updates the content to describe that in greater detail. 