### PR TITLE
docs(popover): warn about popover attribute on v5

### DIFF
--- a/versioned_docs/version-v5/api/popover.md
+++ b/versioned_docs/version-v5/api/popover.md
@@ -18,7 +18,7 @@ import Slots from '@ionic-internal/component-api/v5/popover/slots.md';
 
 :::warning
 Popovers in Ionic v5 may collide with the [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
- feature on newer versions of browsers which can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
+feature on newer versions of browsers which can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
 :::
 
 A Popover is a dialog that appears on top of the current page. It can be used for anything, but generally it is used for overflow actions that don't fit in the navigation bar.

--- a/versioned_docs/version-v5/api/popover.md
+++ b/versioned_docs/version-v5/api/popover.md
@@ -17,7 +17,7 @@ import Slots from '@ionic-internal/component-api/v5/popover/slots.md';
 # ion-popover
 
 :::warning
-Popover in Ionic v5 may collide with [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
+Popovers in Ionic v5 may collide with [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
  feature on newer versions of browsers that can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
 :::
 

--- a/versioned_docs/version-v5/api/popover.md
+++ b/versioned_docs/version-v5/api/popover.md
@@ -16,6 +16,11 @@ import Slots from '@ionic-internal/component-api/v5/popover/slots.md';
 
 # ion-popover
 
+:::warning
+Popover in Ionic v4 may collide with [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
+ feature on newer versions of browsers that can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
+:::
+
 A Popover is a dialog that appears on top of the current page. It can be used for anything, but generally it is used for overflow actions that don't fit in the navigation bar.
 
 ## Presenting

--- a/versioned_docs/version-v5/api/popover.md
+++ b/versioned_docs/version-v5/api/popover.md
@@ -17,8 +17,8 @@ import Slots from '@ionic-internal/component-api/v5/popover/slots.md';
 # ion-popover
 
 :::warning
-Popovers in Ionic v5 may collide with [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
- feature on newer versions of browsers that can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
+Popovers in Ionic v5 may collide with the [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
+ feature on newer versions of browsers which can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
 :::
 
 A Popover is a dialog that appears on top of the current page. It can be used for anything, but generally it is used for overflow actions that don't fit in the navigation bar.

--- a/versioned_docs/version-v5/api/popover.md
+++ b/versioned_docs/version-v5/api/popover.md
@@ -17,7 +17,7 @@ import Slots from '@ionic-internal/component-api/v5/popover/slots.md';
 # ion-popover
 
 :::warning
-Popover in Ionic v4 may collide with [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
+Popover in Ionic v5 may collide with [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
  feature on newer versions of browsers that can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
 :::
 


### PR DESCRIPTION
[There is some developer confusion](https://github.com/ionic-team/ionic-framework/issues/28741) about Ionic's popover not displaying in newer version of Chrome due to the new `popover` attribute. This PR documents the limitation in Ionic v5. I'll do this for v4 as well, but that's in a separate branch

Ionic v6 and v7 apps are not impacted.