### PR TITLE
docs(popover): warn about popover attribute on v4

### DIFF
--- a/src/demos/api/popover/index.html
+++ b/src/demos/api/popover/index.html
@@ -36,6 +36,10 @@
 
     <ion-content fullscreen class="ion-padding">
       <ion-button expand="block">Show Popover</ion-button>
+      <p>
+        Note: Popovers in Ionic v4 may collide with the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover" target="_blank">popover</a>
+        feature on newer versions of browsers which can cause Ionic's popovers to not render. We recommend upgrading to the latest version of Ionic to avoid this issue.
+      </p>
     </ion-content>
   </ion-app>
   <script>


### PR DESCRIPTION
[There is some developer confusion](https://github.com/ionic-team/ionic-framework/issues/28741) about Ionic's popover not displaying in newer version of Chrome due to the new `popover` attribute. This PR documents the limitation in Ionic v4.

Ionic v6 and v7 apps are not impacted.

Note that the main body of the documentation is generated via files from Ionic Framework. In order to update this, I'd need to publish a new version of Ionic v4. As a result, I decided to document this limitation inside of the popover demo as the demo is defined in this repo.