### PR TITLE
docs(support): add support for Ionic 8

### DIFF
--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -18,6 +18,7 @@ In pursuit of [adaptive styling](../core-concepts/fundamentals.md#adaptive-styli
 
 | Framework |        Android         |  iOS  |
 | :-------: | :--------------------: | :---: |
+| Ionic v8  | 5.1+ with Chromium 89+ | 15.0+ |
 | Ionic v7  | 5.1+ with Chromium 79+ | 14.0+ |
 | Ionic v6  | 5.0+ with Chromium 60+ | 13.0+ |
 | Ionic v5  |          5.0+          | 11.0+ |
@@ -37,10 +38,10 @@ To figure out what version of the webview a device is running, log `window.navig
 
 Because Ionic is based on web technologies, it works just as well on desktop browsers as it does on mobile devices. For more information on desktop layouts, see [Cross Platform](../core-concepts/cross-platform.md#desktop).
 
-|   Browser   | Ionic v7 | Ionic v6 | Ionic v5 | Ionic v4 |
-| :---------: | :------: | :------: | :------: | :------: |
-| **Chrome**  |   79+    |   60+    |    ✔     |    ✔     |
-| **Safari**  |   14+    |   13+    |    ✔     |    ✔     |
-|  **Edge**   |   79+    |   79+    |   79+    |    ✔     |
-| **Firefox** |   70+    |   63+    |    ✔     |    ✔     |
-|  **IE 11**  |  **X**   |  **X**   |  **X**   |  **X**   |
+|   Browser   | Ionic v8 | Ionic v7 | Ionic v6 | Ionic v5 | Ionic v4 |
+| :---------: | :------: | :------: | :------: | :------: | :------: |
+| **Chrome**  |    89+   |   79+    |   60+    |    ✔     |    ✔     |
+| **Safari**  |    15+   |   14+    |   13+    |    ✔     |    ✔     |
+|  **Edge**   |    89+   |   79+    |   79+    |   79+    |    ✔     |
+| **Firefox** |    75+   |   70+    |   63+    |    ✔     |    ✔     |
+|  **IE 11**  |   **X**  |   **X**   |  **X**   |  **X**   |  **X**   |

--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -40,8 +40,8 @@ Because Ionic is based on web technologies, it works just as well on desktop bro
 
 |   Browser   | Ionic v8 | Ionic v7 | Ionic v6 | Ionic v5 | Ionic v4 |
 | :---------: | :------: | :------: | :------: | :------: | :------: |
-| **Chrome**  |    89+   |   79+    |   60+    |    ✔     |    ✔     |
-| **Safari**  |    15+   |   14+    |   13+    |    ✔     |    ✔     |
-|  **Edge**   |    89+   |   79+    |   79+    |   79+    |    ✔     |
-| **Firefox** |    75+   |   70+    |   63+    |    ✔     |    ✔     |
-|  **IE 11**  |   **X**  |   **X**   |  **X**   |  **X**   |  **X**   |
+| **Chrome**  |   89+    |   79+    |   60+    |    ✔     |    ✔     |
+| **Safari**  |   15+    |   14+    |   13+    |    ✔     |    ✔     |
+|  **Edge**   |   89+    |   79+    |   79+    |   79+    |    ✔     |
+| **Firefox** |   75+    |   70+    |   63+    |    ✔     |    ✔     |
+|  **IE 11**  |  **X**   |  **X**   |  **X**   |  **X**   |  **X**   |

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -44,7 +44,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v8     |           v16           |          v17.2          |   4.9.3+   |  
+|    v8     |           v16           |          v17.x          |   4.9.3+   |  
 |    v7     |           v14           |        v17.x[^2]        |    4.6+    |
 |    v6     |           v12           |        v15.x[^1]        |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -22,7 +22,7 @@ The current status of each Ionic Framework version is:
 
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :--------------: | :----------: | :--------------: | :---------------: |
-|   V8    |    Pre-Release   |      TBD     |       TBD        |        TBD        |
+|   V8    |   Pre-Release    |     TBD      |       TBD        |        TBD        |
 |   V7    |    **Active**    | Mar 29, 2023 |       TBD        |        TBD        |
 |   V6    | Extended Support | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
 |   V5    |  End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
@@ -44,7 +44,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v8     |           v16           |          v17.x          |   4.9.3+   |  
+|    v8     |           v16           |          v17.x          |   4.9.3+   |
 |    v7     |           v14           |        v17.x[^2]        |    4.6+    |
 |    v6     |           v12           |        v15.x[^1]        |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -22,6 +22,7 @@ The current status of each Ionic Framework version is:
 
 | Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :--------------: | :----------: | :--------------: | :---------------: |
+|   V8    |    Pre-Release   |      TBD     |       TBD        |        TBD        |
 |   V7    |    **Active**    | Mar 29, 2023 |       TBD        |        TBD        |
 |   V6    | Extended Support | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
 |   V5    |  End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
@@ -43,6 +44,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
+|    v8     |           v16           |          v17.2          |   4.9.3+   |  
 |    v7     |           v14           |        v17.x[^2]        |    4.6+    |
 |    v6     |           v12           |        v15.x[^1]        |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |
@@ -62,6 +64,7 @@ Note that later versions of Ionic do not support iOS 13; see [mobile support tab
 
 | Framework | Required React Version | TypeScript |
 | :-------: | :--------------------: | :--------: |
+|    v8     |          v17+          |    3.7+    |
 |    v7     |          v17+          |    3.7+    |
 |    v6     |          v17+          |    3.7+    |
 |    v5     |         v16.8+         |    3.7+    |
@@ -71,6 +74,7 @@ Note that later versions of Ionic do not support iOS 13; see [mobile support tab
 
 | Framework | Required Vue Version | TypeScript |
 | :-------: | :------------------: | :--------: |
+|    v8     |       v3.0.6+        |    3.9+    |
 |    v7     |       v3.0.6+        |    3.9+    |
 |    v6     |       v3.0.6+        |    3.9+    |
 |    v5     |        v3.0+         |    3.9+    |


### PR DESCRIPTION
This PR adds the JS Framework and Browser/Platform support for Ionic 8 according to https://github.com/ionic-team/ionic-framework/blob/2c20a6bdb4449ee9a3ac7766e6673b8797c53bda/BREAKING.md