### PR TITLE
docs(many): remove implications that we support desktop apps

### DIFF
--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -10,7 +10,7 @@ import Slots from '@ionic-internal/component-api/v7/input/slots.md';
 
 <head>
   <title>ion-input: Custom Input With Styling and CSS Properties</title>
-  <meta name="description" content="ion-input is a wrapper to the HTML input element, with custom value type styling and functionality. It works on desktops and integrates with mobile keyboards." />
+  <meta name="description" content="ion-input is a wrapper to the HTML input element, with custom value type styling and functionality. It integrates with the keyboard on mobile devices." />
 </head>
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
@@ -18,7 +18,7 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 <EncapsulationPill type="scoped" />
 
 
-The input component is a wrapper to the HTML input element with custom styling and additional functionality. It accepts most of the same properties as the HTML input, but works great on desktop devices and integrates with the keyboard on mobile devices.
+The input component is a wrapper to the HTML input element with custom styling and additional functionality. It accepts most of the same properties as the HTML input and integrates with the keyboard on mobile devices.
 
 
 ## Basic Usage

--- a/docs/components.md
+++ b/docs/components.md
@@ -67,7 +67,7 @@ Ionic apps are made of high-level building blocks called Components, which allow
 </DocsCard>
 
 <DocsCard header="Icons" href="api/icon" img="/icons/feature-component-icons-icon.png">
-  <p>Beautifully designed icons for use in web, iOS, Android, and desktop apps.</p>
+  <p>Beautifully designed icons for use in web, iOS, and Android apps.</p>
 </DocsCard>
 
 <DocsCard header="Grid" href="api/grid" icon="/icons/component-grid-icon.png">

--- a/docs/core-concepts/cross-platform.md
+++ b/docs/core-concepts/cross-platform.md
@@ -35,9 +35,9 @@ This bit of code can be incredibly helpful when targeting environments where acc
 
 Many native APIs that people use (for example, the File API), are not available in the browser. The APIs are always improving and catching up to native, so it is recommended to research them. Taking the first two points into consideration, it's fairly easy to create a nice experience that will adapt for the platform the app is running on.
 
-## Desktop
+## Responsive UI
 
-When planning to deploy an app to desktop, either using <a href="https://electronjs.org" target="_blank">Electron</a> or as a <strong>Progressive Web App</strong>, it is important to ensure the app works smoothly on larger devices.
+When planning to deploy an app that may be used across a variety of devices, it is important to ensure the app works smoothly on larger screen sizes.
 
 ### Layout
 
@@ -63,7 +63,7 @@ Many people rarely notice the layout of an app, but it can have a massive impact
 </ion-content>
 ```
 
-This will render 5 items with a width of 100% each. This may look great on a mobile device, as seen below, but viewing this on a desktop browser is a different story. The items become stretched to fill the entire screen because of the wide screen width, leaving screen space unused.
+This will render 5 items with a width of 100% each. This may look great on a phone, but viewing this on a larger screen is a different story. The items become stretched to fill the entire screen because of the wide screen width, leaving screen space unused.
 
 <img src={require('@site/static/img/building/cross-platform-items.png').default} />
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -37,7 +37,7 @@ import DocsCards from '@components/global/DocsCards';
   </div>
 </div>
 
-### Build awesome apps across mobile, desktop, and web, with the React you know and love.
+### Build awesome apps across mobile and web, with the React you know and love.
 
 Ionic React is native React version of Ionic Framework, the free, open source SDK powering millions of mission-critical apps all over the world.
 

--- a/docs/react/quickstart.md
+++ b/docs/react/quickstart.md
@@ -384,7 +384,7 @@ export const IconExample: React.FC = () => {
 
 ## Build a Native App
 
-We now have the basics of an Ionic React app down, including some UI components and navigation. The great thing about Ionic’s components is that they work anywhere, including iOS, Android, and PWAs. To deploy to mobile, desktop, and beyond, we use Ionic’s cross-platform app runtime [Capacitor](https://capacitorjs.com). It provides a consistent, web-focused set of APIs that enable an app to stay as close to web-standards as possible while accessing rich native device features on platforms that support them.
+We now have the basics of an Ionic React app down, including some UI components and navigation. The great thing about Ionic’s components is that they work anywhere, including iOS, Android, and PWAs. To deploy to mobile and beyond, we use Ionic’s cross-platform app runtime [Capacitor](https://capacitorjs.com). It provides a consistent, web-focused set of APIs that enable an app to stay as close to web-standards as possible while accessing rich native device features on platforms that support them.
 
 Adding native functionality is easy. First, add Capacitor to your project:
 

--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -12,7 +12,7 @@ title: Browser Support
 
 Ionic's earliest goal was to make it easy to develop mobile apps using web technologies like HTML, CSS, and JavaScript. Because of this foundation in web technologies, Ionic can run anywhere the web runs — iOS, Android, browsers, PWAs, and more.
 
-## Mobile Browsers
+## Mobile Platforms
 
 In pursuit of [adaptive styling](../core-concepts/fundamentals.md#adaptive-styling), Ionic fully supports and is well tested on the mobile platforms listed below:
 
@@ -33,9 +33,9 @@ Starting with Android 5.0, the webview was moved to a separate application that 
 
 To figure out what version of the webview a device is running, log `window.navigator.userAgent` to the console when inspecting the application using Chrome Dev Tools.
 
-## Desktop Browsers
+## Browsers
 
-Because Ionic is based on web technologies, it works just as well on desktop browsers as it does on mobile devices. For more information on desktop layouts, see [Cross Platform](../core-concepts/cross-platform.md#desktop).
+Ionic supports the following browsers:
 
 |   Browser   | Ionic v7 | Ionic v6 | Ionic v5 | Ionic v4 |
 | :---------: | :------: | :------: | :------: | :------: |

--- a/docs/vue/quickstart.md
+++ b/docs/vue/quickstart.md
@@ -670,7 +670,7 @@ The configuration above will prevent all files from being prefetched and, instea
 
 ## Build a Native App
 
-We now have the basics of an Ionic Vue app down, including some UI components and navigation. The great thing about Ionic Framework’s components is that they work anywhere, including iOS, Android, and PWAs. To deploy to mobile, desktop, and beyond, we use Ionic’s cross-platform app runtime [Capacitor](https://capacitorjs.com). It provides a consistent, web-focused set of APIs that enable an app to stay as close to web-standards as possible while accessing rich native device features on platforms that support them.
+We now have the basics of an Ionic Vue app down, including some UI components and navigation. The great thing about Ionic Framework’s components is that they work anywhere, including iOS, Android, and PWAs. To deploy to mobile and beyond, we use Ionic’s cross-platform app runtime [Capacitor](https://capacitorjs.com). It provides a consistent, web-focused set of APIs that enable an app to stay as close to web-standards as possible while accessing rich native device features on platforms that support them.
 
 Adding native functionality is easy. First, add Capacitor to your project:
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const BASE_URL = '/docs';
 module.exports = {
   title: 'Ionic Documentation',
   tagline:
-    'Ionic is the app platform for web developers. Build amazing mobile, web, and desktop apps all with one shared code base and open web standards',
+    'Ionic is the app platform for web developers. Build amazing mobile and web apps with one shared code base and open web standards',
   url: 'https://ionicframework.com',
   baseUrl: `${BASE_URL}/`,
   i18n: {

--- a/scripts/data/meta-override.json
+++ b/scripts/data/meta-override.json
@@ -98,7 +98,7 @@
     },
     "ion-input": {
       "title": "ion-input: Custom Input Value Type Styling and CSS Properties",
-      "description": "ion-input is a wrapper to the HTML input element, with custom value type styling and functionality. It works on desktops and integrates with mobile keyboards."
+      "description": "ion-input is a wrapper to the HTML input element, with custom value type styling and functionality. It integrates with the keyboard on mobile devices."
     },
     "ion-item": {
       "title": "ion-item: Input, Edit, or Delete iOS and Android Item Elements",


### PR DESCRIPTION
This is a companion PR to #3365. 

I didn't necessarily try to eliminate every single mention of desktop. My objective was to eliminate any impression that we support desktop apps and formats. These are all just proposals – some of these changes may require further discussion about whether we want to change them or what the text should be.

It would be nice to remove the reference to the [desktop apps course](https://github.com/ionic-team/ionic-docs/blob/desktop-misc/docs/developer-resources/courses.md#building-desktop-apps-with-ionic-and-electron) (developer-resources/courses.md), but I don't know how the courses get selected or if that would be ok to remove.