### PR TITLE
fix(playground): use correct usage target or mode, when limited

### DIFF
--- a/src/components/global/Playground/index.tsx
+++ b/src/components/global/Playground/index.tsx
@@ -433,12 +433,8 @@ export default function Playground({
          * Load the stored mode and/or usage target, if present
          * from previously being toggled.
          */
-        if (isBrowser) {
-          const storedMode = localStorage.getItem(MODE_STORAGE_KEY);
-          if (storedMode) setIonicMode(storedMode);
-          const storedUsageTarget = localStorage.getItem(USAGE_TARGET_STORAGE_KEY);
-          if (storedUsageTarget) setUsageTarget(storedUsageTarget);
-        }
+        setIonicMode(getDefaultMode());
+        setUsageTarget(getDefaultUsageTarget());
 
         /**
          * If the iframes weren't already loaded, load them now.


### PR DESCRIPTION
This PR fixes a bug: When the options for a playground's usage target or mode are limited, one of the unavailable options could show as selected. For mode, the playground would even show in the mode that wasn't supposed to be available.

**Reproduction (mode):**

1. set any playground to "md" mode
2. load this page https://ionicframework.com/docs/api/buttons#collapsible-buttons
3. see that it has md mode selected and is also displaying in md mode even though md mode is not available in the switcher

![Screenshot 2024-01-05 at 2 13 46 PM](https://github.com/ionic-team/ionic-docs/assets/14926794/62f64917-9e65-4092-94f1-643438b7f409)



**Reproduction (framework):**

1. set any playground to a framework other than JavaScript
2. load https://ionicframework.com/docs/api/router
3. see that it has the other framework selected, when it should have JavaScript selected

![Screenshot 2024-01-05 at 2 13 15 PM](https://github.com/ionic-team/ionic-docs/assets/14926794/918e674a-8781-482d-8e3b-cdcde33d8db4)
