### PR TITLE
Correct names for swiper element events use "swiper-" prefix

### DIFF
--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -279,6 +279,22 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 All events available in Swiper Element can be found at <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#events</a>.
 :::
 
+::: note
+https://swiperjs.com/element#events says "All Swiper events are available as native DOM events but with lowercase names and swiper prefix (prefix configurable with events-prefix). So you need to prefix the (init) method with either **swiper** or another prefix of your choice. 
+
+```
+<swiper-container 
+  (swiperinit)="mySlidesDidInitFunction()" // default event prefix is "swiper"
+
+  OR 
+
+<swiper-container                          // set event prefix to "whatever"
+  events-prefix="whatever" 
+  (whateverinit)="mySlidesDidInitFunction()"
+```
+
+:::
+
 ## Methods
 
 Most methods have been removed in favor of directly accessing the properties of the Swiper instance. To access the Swiper instance, first get a reference to the `<swiper-container>` element (such as through `ViewChild`), then access its `swiper` prop:


### PR DESCRIPTION
on ionic 7.5.5, swiper 11.0.4 the events table should probably be rewritten to have the prefix "swiper" added to all the events. 

event called "init" in table -> swiperinit
and so on, for all events.

Reasons:
1) I found that (init) didn't trig, but (swiperinit) found in the Swiper Element Docs did the trick.

2) There are forum answers putting us on this track too:
https://forum.ionicframework.com/t/ionic-7-angular-and-swiper-11-0-3-event-did-not-trigger/237358


**Nice caveat I found**, had me fooled at first:

The (click) event DOES work without the "swipe" prefix, but that's a generic click handler, not the Swipe click handler:

```
<swiper-container (click)="handler()"
```
receives a regular click event

```
<swiper-container (swiperclick)="handler()"
```
event.detail contains pointerup data. This is the ACTUAL Swipe (click) implementation, see https://swiperjs.com/swiper-api#event-click


I didn't edit the full table -- I'm not a guru and I could be barking up the wrong tree here, so I added this as a note for now    o_O