### PR TITLE
chore(demoURL): update docs demo url for v7

### DIFF
--- a/static/usage/v7/img/basic/angular.md
+++ b/static/usage/v7/img/basic/angular.md
@@ -1,6 +1,6 @@
 ```html
 <ion-img
-  src="https://docs-demo.ionic.io/assets/madison.jpg"
+  src="https://ionic-docs-demo-v7.vercel.app/assets/madison.jpg"
   alt="The Wisconsin State Capitol building in Madison, WI at night"
 ></ion-img>
 ```

--- a/static/usage/v7/img/basic/demo.html
+++ b/static/usage/v7/img/basic/demo.html
@@ -21,7 +21,7 @@
       <ion-content>
         <div class="container">
           <ion-img
-            src="https://docs-demo.ionic.io/assets/madison.jpg"
+            src="https://ionic-docs-demo-v7.vercel.app/assets/madison.jpg"
             alt="The Wisconsin State Capitol building in Madison, WI at night"
           ></ion-img>
         </div>

--- a/static/usage/v7/img/basic/javascript.md
+++ b/static/usage/v7/img/basic/javascript.md
@@ -1,6 +1,6 @@
 ```html
 <ion-img
-  src="https://docs-demo.ionic.io/assets/madison.jpg"
+  src="https://ionic-docs-demo-v7.vercel.app/assets/madison.jpg"
   alt="The Wisconsin State Capitol building in Madison, WI at night"
 ></ion-img>
 ```

--- a/static/usage/v7/img/basic/react.md
+++ b/static/usage/v7/img/basic/react.md
@@ -5,7 +5,7 @@ import { IonImg } from '@ionic/react';
 function Example() {
   return (
     <IonImg
-      src="https://docs-demo.ionic.io/assets/madison.jpg"
+      src="https://ionic-docs-demo-v7.vercel.app/assets/madison.jpg"
       alt="The Wisconsin State Capitol building in Madison, WI at night"
     ></IonImg>
   );

--- a/static/usage/v7/img/basic/vue.md
+++ b/static/usage/v7/img/basic/vue.md
@@ -1,7 +1,7 @@
 ```html
 <template>
   <ion-img
-    src="https://docs-demo.ionic.io/assets/madison.jpg"
+    src="https://ionic-docs-demo-v7.vercel.app/assets/madison.jpg"
     alt="The Wisconsin State Capitol building in Madison, WI at night"
   ></ion-img>
 </template>

--- a/versioned_docs/version-v7/index.md
+++ b/versioned_docs/version-v7/index.md
@@ -3,8 +3,8 @@ title: Introduction to Ionic
 sidebar_label: Overview
 slug: /
 hide_table_of_contents: true
-demoUrl: https://docs-demo.ionic.io/
-demoSourceUrl: https://github.com/ionic-team/docs-demo
+demoUrl: https://ionic-docs-demo-v7.vercel.app/
+demoSourceUrl: https://github.com/ionic-team/docs-demo/tree/7.x
 ---
 
 import DocsCard from '@components/global/DocsCard';


### PR DESCRIPTION
Issue URL: internal


## What is the current behavior?

v7 docs demo was using the latest URL.


## What is the new behavior?

v7 docs demo is using the version 7 URL.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A