### PR TITLE
docs(label): clarify usage for text wrapping

### DIFF
--- a/static/usage/v7/label/item/angular.md
+++ b/static/usage/v7/label/item/angular.md
@@ -5,14 +5,14 @@
 
 <ion-item>
   <ion-label>
-    Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
+    Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
     adipiscing elit.
   </ion-label>
 </ion-item>
 
 <ion-item>
-  <ion-label class="ion-text-wrap">
-    Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
+  <ion-label class="ion-text-nowrap">
+    Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
     adipiscing elit.
   </ion-label>
 </ion-item>

--- a/static/usage/v7/label/item/demo.html
+++ b/static/usage/v7/label/item/demo.html
@@ -25,15 +25,15 @@
           </ion-item>
 
           <ion-item>
-            <ion-label class="ion-text-nowrap">
-              Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet,
+            <ion-label>
+              Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet,
               consectetur adipiscing elit.
             </ion-label>
           </ion-item>
 
           <ion-item>
-            <ion-label>
-              Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet,
+            <ion-label class="ion-text-nowrap">
+              Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet,
               consectetur adipiscing elit.
             </ion-label>
           </ion-item>

--- a/static/usage/v7/label/item/demo.html
+++ b/static/usage/v7/label/item/demo.html
@@ -25,14 +25,14 @@
           </ion-item>
 
           <ion-item>
-            <ion-label>
+            <ion-label class="ion-text-nowrap">
               Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet,
               consectetur adipiscing elit.
             </ion-label>
           </ion-item>
 
           <ion-item>
-            <ion-label class="ion-text-wrap">
+            <ion-label>
               Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet,
               consectetur adipiscing elit.
             </ion-label>

--- a/static/usage/v7/label/item/javascript.md
+++ b/static/usage/v7/label/item/javascript.md
@@ -5,14 +5,14 @@
 
 <ion-item>
   <ion-label>
-    Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
+    Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
     adipiscing elit.
   </ion-label>
 </ion-item>
 
 <ion-item>
-  <ion-label class="ion-text-wrap">
-    Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
+  <ion-label class="ion-text-nowrap">
+    Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
     adipiscing elit.
   </ion-label>
 </ion-item>

--- a/static/usage/v7/label/item/react.md
+++ b/static/usage/v7/label/item/react.md
@@ -11,14 +11,14 @@ function Example() {
 
       <IonItem>
         <IonLabel>
-          Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet,
+          Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet,
           consectetur adipiscing elit.
         </IonLabel>
       </IonItem>
 
       <IonItem>
-        <IonLabel class="ion-text-wrap">
-          Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet,
+        <IonLabel class="ion-text-nowrap">
+          Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet,
           consectetur adipiscing elit.
         </IonLabel>
       </IonItem>

--- a/static/usage/v7/label/item/vue.md
+++ b/static/usage/v7/label/item/vue.md
@@ -6,15 +6,15 @@
 
   <ion-item>
     <ion-label>
-      Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet,
-      consectetur adipiscing elit.
+      Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
+      adipiscing elit.
     </ion-label>
   </ion-item>
 
   <ion-item>
-    <ion-label class="ion-text-wrap">
-      Multi-line text that should wrap when it is too long to fit on one line. Lorem ipsum dolor sit amet, consectetur
-      adipiscing elit.
+    <ion-label class="ion-text-nowrap">
+      Multi-line text that should ellipsis when it is too long to fit on one line. Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit.
     </ion-label>
   </ion-item>
 


### PR DESCRIPTION
As reported in https://github.com/ionic-team/ionic-framework/issues/28825, we previously updated the docs for Item to reflect the new line wrapping behavior but missed updating the docs for Label.


[Vercel preview](https://ionic-docs-git-st-label-truncation-ionic1.vercel.app/docs/api/label#item-labels)