### PR TITLE
docs(angular): use ngmodules for the first app

### DIFF
--- a/docs/angular/your-first-app.md
+++ b/docs/angular/your-first-app.md
@@ -77,6 +77,12 @@ Next, create an Ionic Angular app that uses the “Tabs” starter template and 
 ionic start photo-gallery tabs --type=angular --capacitor
 ```
 
+:::note
+
+When prompted to choose between `NgModules` and `Standalone`, opt for `NgModules` as this tutorial follows the `NgModules` approach.
+
+:::
+
 This starter project comes complete with three pre-built pages and best practices for Ionic development. With common building blocks already in place, we can add more features easily!
 
 Next, change into the app folder:


### PR DESCRIPTION
There was a [confusion](https://github.com/ionic-team/ionic-docs/pull/3320) regarding to what to select when it came to Angular `NgModules` or `Standalone` when it came to the [Angular Build Your App](https://ionicframework.com/docs/angular/your-first-app#create-an-app).

This PR aims to let devs know that the tutorial is using `NgModules`.

[Preview link](https://github.com/ionic-team/ionic-docs/pull/3320)