### PR TITLE
fix: release notes generation from changelog

### DIFF
--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -43,7 +43,7 @@ const getReleases = async () => {
           return releasePattern.test(release.tag_name);
         })
         .map((release) => {
-          const body = renderMarkdown(release.body.replace(/^#.*/, '')).contents;
+          const body = renderMarkdown(release.body.replace(/^#.*/, '')).value;
           const published_at = parseDate(release.published_at);
           const version = release.tag_name.replace('v', '');
           const type = getVersionType(version);


### PR DESCRIPTION
Fixes the generation of the release notes page: https://ionic-docs-git-sp-release-notes-ionic1.vercel.app/docs/reference/release-notes