### PR TITLE
refactor(md): remove unused Docusaurus properties

### DIFF
--- a/docs/core-concepts/cross-platform.md
+++ b/docs/core-concepts/cross-platform.md
@@ -1,5 +1,5 @@
 ---
-disableHtmlPreviews: true
+title: Cross Platform
 ---
 
 # Cross Platform

--- a/docs/layout/css-utilities.md
+++ b/docs/layout/css-utilities.md
@@ -1,7 +1,5 @@
 ---
 title: CSS Utilities
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 <head>

--- a/docs/layout/global-stylesheets.md
+++ b/docs/layout/global-stylesheets.md
@@ -1,7 +1,5 @@
 ---
 title: Global Stylesheets
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 <head>

--- a/docs/layout/structure.md
+++ b/docs/layout/structure.md
@@ -1,6 +1,5 @@
 ---
 title: Structure
-initialTab: 'preview'
 ---
 
 import DocsCard from '@components/global/DocsCard';

--- a/docs/techniques/security.md
+++ b/docs/techniques/security.md
@@ -1,6 +1,5 @@
 ---
 title: Security
-disableHtmlPreviews: true
 ---
 
 <head>

--- a/docs/theming/advanced.md
+++ b/docs/theming/advanced.md
@@ -1,8 +1,6 @@
 ---
 title: Advanced Theming
 sidebar_label: Advanced
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 import CodeColor from '@components/page/theming/CodeColor';

--- a/docs/theming/colors.md
+++ b/docs/theming/colors.md
@@ -1,7 +1,5 @@
 ---
 title: Colors
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 import LayeredColorsSelect from '@components/page/theming/LayeredColorsSelect';

--- a/docs/theming/dark-mode.md
+++ b/docs/theming/dark-mode.md
@@ -1,7 +1,5 @@
 ---
 title: Dark Mode
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 <head>

--- a/docs/troubleshooting/build.md
+++ b/docs/troubleshooting/build.md
@@ -1,5 +1,4 @@
 ---
-disableHtmlPreviews: true
 title: Build Errors
 ---
 

--- a/versioned_docs/version-v5/core-concepts/cross-platform.md
+++ b/versioned_docs/version-v5/core-concepts/cross-platform.md
@@ -1,5 +1,5 @@
 ---
-disableHtmlPreviews: true
+title: Cross Platform
 ---
 
 # Cross Platform

--- a/versioned_docs/version-v5/layout/css-utilities.md
+++ b/versioned_docs/version-v5/layout/css-utilities.md
@@ -1,6 +1,5 @@
 ---
-initialTab: 'preview'
-inlineHtmlPreviews: true
+title: CSS Utilities
 ---
 
 # CSS Utilities

--- a/versioned_docs/version-v5/layout/global-stylesheets.md
+++ b/versioned_docs/version-v5/layout/global-stylesheets.md
@@ -1,6 +1,5 @@
 ---
-initialTab: 'preview'
-inlineHtmlPreviews: true
+title: Global Stylesheets
 ---
 
 # Global Stylesheets

--- a/versioned_docs/version-v5/layout/grid.md
+++ b/versioned_docs/version-v5/layout/grid.md
@@ -1,6 +1,4 @@
 ---
-initialTab: 'preview'
-inlineHtmlPreviews: true
 title: Responsive Grid System and Column Layout Based on Screen Size
 description: Ionic's responsive grid is a powerful mobile-first flexbox system for building custom layouts based on a 12 column layout with breakpoints based on screen size.
 sidebar_label: Responsive Grid

--- a/versioned_docs/version-v5/layout/structure.md
+++ b/versioned_docs/version-v5/layout/structure.md
@@ -1,5 +1,5 @@
 ---
-initialTab: 'preview'
+title: Structure
 ---
 
 import DocsCard from '@components/global/DocsCard';

--- a/versioned_docs/version-v5/techniques/security.md
+++ b/versioned_docs/version-v5/techniques/security.md
@@ -1,5 +1,5 @@
 ---
-disableHtmlPreviews: true
+title: Security
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-v5/theming/advanced.md
+++ b/versioned_docs/version-v5/theming/advanced.md
@@ -1,7 +1,6 @@
 ---
+title: Advanced Theming
 sidebar_label: Advanced
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 import CodeColor from '@components/page/theming/CodeColor';

--- a/versioned_docs/version-v5/theming/colors.md
+++ b/versioned_docs/version-v5/theming/colors.md
@@ -1,6 +1,5 @@
 ---
-initialTab: 'preview'
-inlineHtmlPreviews: true
+title: Colors
 ---
 
 import LayeredColorsSelect from '@components/page/theming/LayeredColorsSelect';

--- a/versioned_docs/version-v5/theming/dark-mode.md
+++ b/versioned_docs/version-v5/theming/dark-mode.md
@@ -1,6 +1,5 @@
 ---
-initialTab: 'preview'
-inlineHtmlPreviews: true
+title: Dark Mode
 ---
 
 import Codepen from '@components/global/Codepen';

--- a/versioned_docs/version-v5/theming/platform-styles.md
+++ b/versioned_docs/version-v5/theming/platform-styles.md
@@ -2,7 +2,6 @@
 title: 'Ionic Platform Styles | Platform-Specific Styles for Ionic Apps'
 description: "Ionic provides platform-specific styles based on the app's device. Styling the components to match the device guidelines allows the app to feel native to users."
 sidebar_label: Platform Styles
-disableHtmlPreviews: true
 ---
 
 # Platform Styles

--- a/versioned_docs/version-v5/theming/themes.md
+++ b/versioned_docs/version-v5/theming/themes.md
@@ -2,8 +2,6 @@
 title: 'Ionic App Themes | Change Default App Background Themes & Colors'
 description: 'Several global variables change the default theme of an entire application. Create a custom background and text color theme for your app with Ionic themes.'
 sidebar_label: Themes
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 import CodeColor from '@components/page/theming/CodeColor';

--- a/versioned_docs/version-v5/troubleshooting/build.md
+++ b/versioned_docs/version-v5/troubleshooting/build.md
@@ -1,5 +1,5 @@
 ---
-disableHtmlPreviews: true
+title: Build Errors
 ---
 
 # Build Errors

--- a/versioned_docs/version-v6/core-concepts/cross-platform.md
+++ b/versioned_docs/version-v6/core-concepts/cross-platform.md
@@ -1,5 +1,5 @@
 ---
-disableHtmlPreviews: true
+title: Cross Platform
 ---
 
 # Cross Platform

--- a/versioned_docs/version-v6/layout/css-utilities.md
+++ b/versioned_docs/version-v6/layout/css-utilities.md
@@ -1,7 +1,5 @@
 ---
 title: CSS Utilities
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 <head>

--- a/versioned_docs/version-v6/layout/global-stylesheets.md
+++ b/versioned_docs/version-v6/layout/global-stylesheets.md
@@ -1,7 +1,5 @@
 ---
 title: Global Stylesheets
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 <head>

--- a/versioned_docs/version-v6/layout/structure.md
+++ b/versioned_docs/version-v6/layout/structure.md
@@ -1,6 +1,5 @@
 ---
 title: Structure
-initialTab: 'preview'
 ---
 
 import DocsCard from '@components/global/DocsCard';

--- a/versioned_docs/version-v6/techniques/security.md
+++ b/versioned_docs/version-v6/techniques/security.md
@@ -1,6 +1,5 @@
 ---
 title: Security
-disableHtmlPreviews: true
 ---
 
 <head>

--- a/versioned_docs/version-v6/theming/advanced.md
+++ b/versioned_docs/version-v6/theming/advanced.md
@@ -1,8 +1,6 @@
 ---
 title: Advanced Theming
 sidebar_label: Advanced
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 import CodeColor from '@components/page/theming/CodeColor';

--- a/versioned_docs/version-v6/theming/colors.md
+++ b/versioned_docs/version-v6/theming/colors.md
@@ -1,7 +1,5 @@
 ---
 title: Colors
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 import LayeredColorsSelect from '@components/page/theming/LayeredColorsSelect';

--- a/versioned_docs/version-v6/theming/dark-mode.md
+++ b/versioned_docs/version-v6/theming/dark-mode.md
@@ -1,7 +1,5 @@
 ---
 title: Dark Mode
-initialTab: 'preview'
-inlineHtmlPreviews: true
 ---
 
 import Codepen from '@components/global/Codepen';

--- a/versioned_docs/version-v6/troubleshooting/build.md
+++ b/versioned_docs/version-v6/troubleshooting/build.md
@@ -1,5 +1,4 @@
 ---
-disableHtmlPreviews: true
 title: Build Errors
 ---
 


### PR DESCRIPTION
The docs repo has a list of [options](https://docusaurus.io/docs/3.0.1/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter) to pass to Docusaurus. Those options are both official and custom.

`initialTab`, `inlineHtmlPreviews`, and `disableHtmlPreviews` are no longer being used. I removed all the instances.