### PR TITLE
docs(datetime, datetime-button): document formatOptions property

### DIFF
--- a/docs/api/datetime-button.md
+++ b/docs/api/datetime-button.md
@@ -35,6 +35,14 @@ import Basic from '@site/static/usage/v7/datetime-button/basic/index.md';
 
 The localized text on `ion-datetime-button` is determined by the `locale` property on the associated `ion-datetime` instance. See [Datetime Localization](./datetime#localization) for more details.
 
+## Format Options
+
+You can customize the format of the date and time in a Datetime Button by providing `formatOptions`. See [Datetime Format Options](./datetime#format-options) for more details.
+
+import FormatOptions from '@site/static/usage/v7/datetime-button/format-options/index.md';
+
+<FormatOptions />
+
 ## Usage with Modals and Popovers
 
 `ion-datetime-button` must be associated with a mounted `ion-datetime` instance. As a result, [Inline Modals](./modal#inline-modals-recommended) and [Inline Popovers](./popover#inline-popovers) with the `keepContentsMounted` property set to `true` must be used.

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -14,6 +14,8 @@ import MaxMin from '@site/static/usage/v7/datetime/date-constraints/max-min/inde
 import Values from '@site/static/usage/v7/datetime/date-constraints/values/index.md';
 import Advanced from '@site/static/usage/v7/datetime/date-constraints/advanced/index.md';
 
+import FormatOptions from '@site/static/usage/v7/datetime/format-options/index.md';
+
 import CustomLocale from '@site/static/usage/v7/datetime/localization/custom-locale/index.md';
 import HourCycle from '@site/static/usage/v7/datetime/localization/hour-cycle/index.md';
 import FirstDayOfWeek from '@site/static/usage/v7/datetime/localization/first-day-of-week/index.md';
@@ -246,18 +248,6 @@ import Wheel from '@site/static/usage/v7/datetime/presentation/wheel/index.md';
 
 <Wheel />
 
-## Format Options
-
-You can customize the format of the date in the header text and the time in the time button of a Datetime component by providing `formatOptions`. The `date` and `time` in the `formatObjects` property should each be an [`Intl.DateTimeFormatOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) object. If `formatObjects` is not provided, default formats will be used for dates and times.
-
-If `timeZone` or `timeZoneName` are provided, they will be ignored, and the time zone will be set to UTC. This ensures that the displayed value matches the selected value, rather than being converted to the user's current time zone.
-
-Be careful with the options you provide, as they may not match the selected presentation. For example, providing `minute: 'numeric'` for a presentation of `month` may lead to unexpected behavior, displaying a month where only a time might be expected.
-
-import FormatOptions from '@site/static/usage/v7/datetime/format-options/index.md';
-
-<FormatOptions />
-
 ## Multiple Date Selection
 
 If the `multiple` property is set to `true`, multiple dates can be selected from the calendar picker. Clicking a selected date will deselect it.
@@ -279,6 +269,16 @@ By default, `ion-datetime` does not show any header or title associated with the
 ### Customizing the Title
 
 <CustomizingTitle />
+
+## Format Options
+
+You can customize the format of the date in the header text and the time in the time button of a Datetime component by providing `formatOptions`. The `date` and `time` in the `formatObjects` property should each be an [`Intl.DateTimeFormatOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) object. If `formatObjects` is not provided, default formats will be used for dates and times.
+
+If `timeZone` or `timeZoneName` are provided, they will be ignored, and the time zone will be set to UTC. This ensures that the displayed value matches the selected value, rather than being converted to the user's current time zone.
+
+Be careful with the options you provide, as they may not match the selected presentation. For example, providing `minute: 'numeric'` for a presentation of `month` may lead to unexpected behavior, displaying a month where only a time might be expected.
+
+<FormatOptions />
 
 ## Buttons
 

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -274,7 +274,7 @@ By default, `ion-datetime` does not show any header or title associated with the
 
 You can customize the format of the date in the header text and the time in the time button of a Datetime component by providing `formatOptions`. The `date` and `time` in the `formatObjects` property should each be an [`Intl.DateTimeFormatOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) object. If `formatObjects` is not provided, default formats will be used for dates and times.
 
-If `timeZone` or `timeZoneName` are provided, they will be ignored, and the time zone will be set to UTC. This ensures that the displayed value matches the selected value, rather than being converted to the user's current time zone.
+Datetime [does not manipulate or set](#time-zones) the time zone. If `timeZone` or `timeZoneName` are provided, they will be ignored, and the time zone will be set to UTC. This ensures that the displayed value matches the selected value, rather than being converted to the user's current time zone.
 
 Be careful with the options you provide, as they may not match the selected presentation. For example, providing `minute: 'numeric'` for a presentation of `month` may lead to unexpected behavior, displaying a month where only a time might be expected.
 

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -246,6 +246,18 @@ import Wheel from '@site/static/usage/v7/datetime/presentation/wheel/index.md';
 
 <Wheel />
 
+## Format Options
+
+You can customize the format of the date in the header text and the time in the time button of a Datetime component by providing `formatOptions`. The `date` and `time` in the `formatObjects` property should each be an [`Intl.DateTimeFormatOptions`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#options) object. If `formatObjects` is not provided, default formats will be used for dates and times.
+
+If `timeZone` or `timeZoneName` are provided, they will be ignored, and the time zone will be set to UTC. This ensures that the displayed value matches the selected value, rather than being converted to the user's current time zone.
+
+Be careful with the options you provide, as they may not match the selected presentation. For example, providing `minute: 'numeric'` for a presentation of `month` may lead to unexpected behavior, displaying a month where only a time might be expected.
+
+import FormatOptions from '@site/static/usage/v7/datetime/format-options/index.md';
+
+<FormatOptions />
+
 ## Multiple Date Selection
 
 If the `multiple` property is set to `true`, multiple dates can be selected from the calendar picker. Clicking a selected date will deselect it.

--- a/static/usage/v7/datetime-button/format-options/angular.md
+++ b/static/usage/v7/datetime-button/format-options/angular.md
@@ -1,0 +1,24 @@
+```html
+<ion-datetime-button datetime="datetime"></ion-datetime-button>
+
+<ion-modal [keepContentsMounted]="true">
+  <ng-template>
+    <ion-datetime
+      id="datetime"
+      presentation="date-time"
+      value="2023-11-02T01:22:00"
+      [formatOptions]="{
+        date: {
+          weekday: 'short',
+          month: 'long',
+          day: '2-digit',
+        },
+        time: {
+          hour: '2-digit',
+          minute: '2-digit',
+        },
+      }"
+    ></ion-datetime>
+  </ng-template>
+</ion-modal>
+```

--- a/static/usage/v7/datetime-button/format-options/demo.html
+++ b/static/usage/v7/datetime-button/format-options/demo.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Datetime Button</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-datetime-button datetime="datetime"></ion-datetime-button>
+
+          <ion-modal keep-contents-mounted="{true}">
+            <ion-datetime id="datetime" presentation="date-time" value="2023-11-02T01:22:00"></ion-datetime>
+          </ion-modal>
+        </div>
+      </ion-content>
+    </ion-app>
+
+    <script>
+      const datetime = document.querySelector('ion-datetime');
+      datetime.formatOptions = {
+        date: {
+          weekday: 'short',
+          month: 'long',
+          day: '2-digit',
+        },
+        time: {
+          hour: '2-digit',
+          minute: '2-digit',
+        },
+      };
+    </script>
+  </body>
+</html>

--- a/static/usage/v7/datetime-button/format-options/index.md
+++ b/static/usage/v7/datetime-button/format-options/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/datetime-button/format-options/demo.html"
+/>

--- a/static/usage/v7/datetime-button/format-options/index.md
+++ b/static/usage/v7/datetime-button/format-options/index.md
@@ -7,6 +7,7 @@ import angular from './angular.md';
 
 <Playground
   version="7"
+  size="large"
   code={{
     javascript,
     react,

--- a/static/usage/v7/datetime-button/format-options/javascript.md
+++ b/static/usage/v7/datetime-button/format-options/javascript.md
@@ -1,0 +1,22 @@
+```html
+<ion-datetime-button datetime="datetime"></ion-datetime-button>
+
+<ion-modal keep-contents-mounted="{true}">
+  <ion-datetime id="datetime" presentation="date-time" value="2023-11-02T01:22:00"></ion-datetime>
+</ion-modal>
+
+<script>
+  const datetime = document.querySelector('ion-datetime');
+  datetime.formatOptions = {
+    date: {
+      weekday: 'short',
+      month: 'long',
+      day: '2-digit',
+    },
+    time: {
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  };
+</script>
+```

--- a/static/usage/v7/datetime-button/format-options/react.md
+++ b/static/usage/v7/datetime-button/format-options/react.md
@@ -1,0 +1,32 @@
+```tsx
+import React from 'react';
+import { IonDatetime, IonDatetimeButton, IonModal } from '@ionic/react';
+
+function Example() {
+  return (
+    <>
+      <IonDatetimeButton datetime="datetime"></IonDatetimeButton>
+
+      <IonModal keepContentsMounted={true}>
+        <IonDatetime
+          id="datetime"
+          presentation="date-time"
+          value="2023-11-02T01:22:00"
+          formatOptions={{
+            date: {
+              weekday: 'short',
+              month: 'long',
+              day: '2-digit',
+            },
+            time: {
+              hour: '2-digit',
+              minute: '2-digit',
+            },
+          }}
+        ></IonDatetime>
+      </IonModal>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/datetime-button/format-options/vue.md
+++ b/static/usage/v7/datetime-button/format-options/vue.md
@@ -1,0 +1,31 @@
+```html
+<template>
+  <ion-datetime-button datetime="datetime"></ion-datetime-button>
+
+  <ion-modal :keep-contents-mounted="true">
+    <ion-datetime
+      id="datetime"
+      presentation="date-time"
+      value="2023-11-02T01:22:00"
+      :format-options="formatOptions"
+    ></ion-datetime>
+  </ion-modal>
+</template>
+
+<script lang="ts" setup>
+  import { IonDatetime, IonDatetimeButton, IonModal } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  const formatOptions = {
+    date: {
+      weekday: 'short',
+      month: 'long',
+      day: '2-digit',
+    },
+    time: {
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  };
+</script>
+```

--- a/static/usage/v7/datetime/format-options/angular.md
+++ b/static/usage/v7/datetime/format-options/angular.md
@@ -1,0 +1,11 @@
+```html
+<ion-datetime
+  value="2023-11-02T01:22:00"
+  [formatOptions]="{
+      time: { hour: '2-digit', minute: '2-digit' },
+      date: { day: '2-digit', month: 'long' },
+    }"
+>
+  <span slot="title">Select Date</span>
+</ion-datetime>
+```

--- a/static/usage/v7/datetime/format-options/demo.html
+++ b/static/usage/v7/datetime/format-options/demo.html
@@ -8,6 +8,11 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+    <style>
+      ion-datetime {
+        width: 350px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/datetime/format-options/demo.html
+++ b/static/usage/v7/datetime/format-options/demo.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Datetime</title>
+    <link rel="stylesheet" href="../../../common.css" />
+    <script src="../../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-datetime value="2023-11-02T01:22:00">
+            <span slot="title">Select Date</span>
+          </ion-datetime>
+        </div>
+      </ion-content>
+    </ion-app>
+
+    <script>
+      const datetime = document.querySelector('ion-datetime');
+      datetime.formatOptions = {
+        time: { hour: '2-digit', minute: '2-digit' },
+        date: { day: '2-digit', month: 'long' },
+      };
+    </script>
+  </body>
+</html>

--- a/static/usage/v7/datetime/format-options/index.md
+++ b/static/usage/v7/datetime/format-options/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/datetime/format-options/demo.html"
+/>

--- a/static/usage/v7/datetime/format-options/index.md
+++ b/static/usage/v7/datetime/format-options/index.md
@@ -7,6 +7,7 @@ import angular from './angular.md';
 
 <Playground
   version="7"
+  size="large"
   code={{
     javascript,
     react,

--- a/static/usage/v7/datetime/format-options/javascript.md
+++ b/static/usage/v7/datetime/format-options/javascript.md
@@ -1,0 +1,13 @@
+```html
+<ion-datetime value="2023-11-02T01:22:00">
+  <span slot="title">Select Date</span>
+</ion-datetime>
+
+<script>
+  const datetime = document.querySelector('ion-datetime');
+  datetime.formatOptions = {
+    time: { hour: '2-digit', minute: '2-digit' },
+    date: { day: '2-digit', month: 'long' },
+  };
+</script>
+```

--- a/static/usage/v7/datetime/format-options/react.md
+++ b/static/usage/v7/datetime/format-options/react.md
@@ -1,0 +1,19 @@
+```tsx
+import React from 'react';
+import { IonDatetime } from '@ionic/react';
+
+function Example() {
+  return (
+    <IonDatetime
+      value="2023-11-02T01:22:00"
+      formatOptions={{
+        time: { hour: '2-digit', minute: '2-digit' },
+        date: { day: '2-digit', month: 'long' },
+      }}
+    >
+      <span slot="title">Select Date</span>
+    </IonDatetime>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/datetime/format-options/vue.md
+++ b/static/usage/v7/datetime/format-options/vue.md
@@ -1,0 +1,17 @@
+```html
+<template>
+  <ion-datetime value="2023-11-02T01:22:00" :format-options="formatOptions">
+    <span slot="title">Select Date</span>
+  </ion-datetime>
+</template>
+
+<script lang="ts" setup>
+  import { IonDatetime } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  const formatOptions = {
+    time: { hour: '2-digit', minute: '2-digit' },
+    date: { day: '2-digit', month: 'long' },
+  };
+</script>
+```


### PR DESCRIPTION
Framework dev build: `7.7.2-dev.11707941206.120570b8`

Dependent upon https://github.com/ionic-team/ionic-framework/pull/29009 and https://github.com/ionic-team/ionic-framework/pull/29059

[Design doc](https://github.com/ionic-team/ionic-framework-design-documents/blob/7df5993be0b1cc331e70bf72d1d3a6fbae9f39da/projects/ionic-framework/components/datetime/0006-format-options.md#documentation)