### PR TITLE
docs(theming): add type to prevent compilation error in dark mode playground

### DIFF
--- a/static/usage/v7/theming/automatic-dark-mode/angular/example_component_ts.md
+++ b/static/usage/v7/theming/automatic-dark-mode/angular/example_component_ts.md
@@ -17,7 +17,7 @@ export class ExampleComponent implements OnInit {
   }
 
   // Add or remove the "dark" class on the document body
-  toggleDarkTheme(shouldAdd) {
+  toggleDarkTheme(shouldAdd: boolean) {
     document.body.classList.toggle('dark', shouldAdd);
   }
 }


### PR DESCRIPTION
Without type on the parameter, the following error is displayed error TS7006: Parameter 'shouldAdd' implicitly has an 'any' type.