### PR TITLE
docs(input): clarify color property description

### DIFF
--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -171,7 +171,7 @@ import StartEndSlots from '@site/static/usage/v7/input/start-end-slots/index.md'
 Setting the `color` property changes the color palette for each input. On `ios` mode, this property changes the caret color. On `md` mode, this property changes the caret color and the highlight/underline color.
 
 :::note
-The `color` property does *not* change the text color of the input. For that, use the [`--color` CSS property](#css-custom-properties).
+The `color` property does *not* change the text color of the input. For that, use the [`--color` CSS property](#css-custom-properties-1).
 :::
 
 import Colors from '@site/static/usage/v7/input/theming/colors/index.md';

--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -170,6 +170,10 @@ import StartEndSlots from '@site/static/usage/v7/input/start-end-slots/index.md'
 
 Setting the `color` property changes the color palette for each input. On `ios` mode, this property changes the caret color. On `md` mode, this property changes the caret color and the highlight/underline color.
 
+:::note
+The `color` property does *not* change the text color of the input. For that, use the [`--color` CSS property](#css-custom-properties).
+:::
+
 import Colors from '@site/static/usage/v7/input/theming/colors/index.md';
 
 <Colors />


### PR DESCRIPTION
Resolves #3463

More than one issue has been reported about the input color playground not changing the color of the text, even though this is intended behavior. This PR adds a note that hopefully clarifies things.

Note that the text color *did* change in Ionic v6, so only the v7 docs have been updated.

Shortcut: https://ionic-docs-git-input-color-clarify-ionic1.vercel.app/docs/api/input#colors