### PR TITLE
chore: increase memory limit temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "prebuild": "npm run generate-markdown; scripts/i18n.sh; if [ -n \"$CROWDIN_PERSONAL_TOKEN\" ]; then npm run crowdin:sync; fi",
-    "build": "npm run build:${VERCEL_ENV:-preview}",
+    "build": "NODE_OPTIONS=--max_old_space_size=8192 npm run build:${VERCEL_ENV:-preview}",
     "build:preview": "docusaurus build --locale en",
     "build:production": "docusaurus build",
     "clear": "docusaurus clear",


### PR DESCRIPTION
Node is running out of memory while building the docs site on production. This is because we are building Ionic 4-8 docs sites as well as the JP docs site. This was not happening during development because we did not hit the memory limit (since JP is only built during production).

In an effort to get the Ionic 8 docs released this PR bumps the memory limit temporarily. Long term we need to investigate a way to lower the overall memory footprint of this build process.