### PR TITLE
docs: add correct breaking changes url

### DIFF
--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -177,6 +177,6 @@ iOS >=15
 
 ## Need Help Upgrading?
 
-Be sure to look at the [Ionic 8 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-8x). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
+Be sure to look at the [Ionic 8 Breaking Changes Guide](https://github.com/ionic-team/ionic-framework/blob/feature-8.0/BREAKING.md#version-8x). There were several changes to default property and CSS Variable values that developers may need to be aware of. Only the breaking changes that require user action are listed on this page.
 
 If you need help upgrading, please post a thread on the [Ionic Forum](https://forum.ionicframework.com/).


### PR DESCRIPTION
The v8 breaking changes are available on the `feature-8.0` branch, so we need to link there until v8 is merged into `main`.