### PR TITLE
chore: remove trailing slash to avoid flash of 404 page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,6 +15,11 @@ const VERSIONS_JSON = require('./versions.json');
  * that are built with Docusaurus. The
  * Ionic v3 and v4 docs are built with other tools, so those
  * versions are not included here.
+ *
+ * Note that the urls specified in this file should
+ * NOT have a trailing slash otherwise users will
+ * briefly get a 404 Page Not Found error before
+ * the docuementation website loads.
  */
 const ARCHIVED_VERSIONS_JSON = require('./versionsArchived.json');
 

--- a/versionsArchived.json
+++ b/versionsArchived.json
@@ -1,3 +1,3 @@
 {
-  "v5": "https://ionic-docs-5utg8ms4c-ionic1.vercel.app/docs/v5/"
+  "v5": "https://ionic-docs-5utg8ms4c-ionic1.vercel.app/docs/v5"
 }


### PR DESCRIPTION
Jared told me that to avoid the flash of the 404 page when going to the v5 docs you need to link to it without the trailing slash.