### PR TITLE
docs(updating): show how to migrate custom step color usages

### DIFF
--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -125,7 +125,7 @@ button {
 }
 ```
 
-`--ion-color-step-[number]` usages for **background color** can be migrated by renaming the token to `--ion-text-color-step-[number]` and subtracting the number from 1000.
+`--ion-color-step-[number]` usages for **text color** can be migrated by renaming the token to `--ion-text-color-step-[number]` and subtracting the number from 1000.
 
 **Example**:
 

--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -110,9 +110,9 @@ For more information on the new dark theme files, refer to the [Dark Mode docume
 
 ### Step Color Tokens
 
-To better support the high contrast theme in Ionic 8, separate step colors tokens were introduced for text and background color. Previously both text and background color were controlled by a single set of `--ion-color-step-[number]` tokens.
+To better support the high contrast theme in Ionic 8, separate step colors tokens have been introduced for text and background color. Previously both text and background color were controlled by a single set of `--ion-color-step-[number]` tokens.
 
-Using the new dark theme imported noted above will also import these new step color tokens. However, developers will need to manually migrate any step color tokens that were manually defined in an application.
+Using the new dark theme import noted above will also import these new step color tokens. However, developers will need to update any step color tokens that were manually defined in an application.
 
 `--ion-color-step-[number]` usages for **background color** can be migrated by renaming the token to `--ion-background-color-step-[number]`.
 

--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -112,7 +112,7 @@ For more information on the new dark theme files, refer to the [Dark Mode docume
 
 To better support the high contrast theme in Ionic 8, separate step colors tokens have been introduced for text and background color. Previously both text and background color were controlled by a single set of `--ion-color-step-[number]` tokens.
 
-Using the new dark theme import noted above will also import these new step color tokens. However, developers will need to update any step color tokens that were manually defined in an application.
+Using the newly imported dark theme mentioned above will also import these new step color tokens. However, developers will need to update any step color tokens that were manually defined in an application.
 
 `--ion-color-step-[number]` usages for **background color** can be migrated by renaming the token to `--ion-background-color-step-[number]`.
 

--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -108,6 +108,34 @@ While migrating to include the new dark theme files is unlikely to cause breakin
 
 For more information on the new dark theme files, refer to the [Dark Mode documentation](../theming/dark-mode).
 
+### Step Color Tokens
+
+To better support the high contrast theme in Ionic 8, separate step colors tokens were introduced for text and background color. Previously both text and background color were controlled by a single set of `--ion-color-step-[number]` tokens.
+
+Using the new dark theme imported noted above will also import these new step color tokens. However, developers will need to manually migrate any step color tokens that were manually defined in an application.
+
+`--ion-color-step-[number]` usages for **background color** can be migrated by renaming the token to `--ion-background-color-step-[number]`.
+
+**Example**:
+
+```diff
+button {
+- background: var(--ion-color-step-400);
++ background: var(--ion-background-color-step-400);
+}
+```
+
+`--ion-color-step-[number]` usages for **background color** can be migrated by renaming the token to `--ion-text-color-step-[number]` and subtracting the number from 1000.
+
+**Example**:
+
+```diff
+button {
+- color: var(--ion-color-step-400);
++ color: var(--ion-text-color-step-600); /* 1000 - 400 = 600 */
+}
+```
+
 ### Dynamic Font
 
 The `core.css` file has been updated to enable dynamic font scaling by default.


### PR DESCRIPTION
Our documentation shows how to import the new theme file for dark mode, but it does not show how to migrate the old step color tokens to the new format if devs have some manually defined.

Preview: https://ionic-docs-git-color-step-migration-ionic1.vercel.app/docs/v8/updating/8-0#step-color-tokens