### PR TITLE
Fixed dead Android WebView link.

### DIFF
--- a/versioned_docs/version-v7/core-concepts/webview.md
+++ b/versioned_docs/version-v7/core-concepts/webview.md
@@ -47,4 +47,4 @@ For Cordova apps, the [Ionic Web View plugin](https://github.com/ionic-team/cord
 ### Implementations
 
 - **iOS**: <a href="https://developer.apple.com/documentation/webkit/wkwebview" target="_blank">WKWebView</a>
-- **Android**: <a href="https://developer.chrome.com/multidevice/webview/overview" target="_blank">Web View for Android</a>
+- **Android**: <a href="https://developer.android.com/reference/android/webkit/WebView" target="_blank">WebView for Android</a>


### PR DESCRIPTION
The previous link navigated to a missing page (404) in the Android developer docs. This link routes to a similar page as the iOS variant.

Another possible link would have been `https://developer.android.com/develop/ui/views/layout/webapps/webview`, but this seemed more technical to me.