### PR TITLE
docs(input): add start/end slot section back into v7 docs

### DIFF
--- a/static/usage/v7/input/start-end-slots/demo.html
+++ b/static/usage/v7/input/start-end-slots/demo.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Input</title>
-    <link rel="stylesheet" href="../../../common.css" />
-    <script src="../../../common.js"></script>
+    <link rel="stylesheet" href="../../common.css" />
+    <script src="../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
   </head>

--- a/versioned_docs/version-v7/api/input.md
+++ b/versioned_docs/version-v7/api/input.md
@@ -147,6 +147,22 @@ Please submit bug reports with Maskito to the [Maskito Github repository](https:
 
 :::
 
+## Start and End Slots (experimental)
+
+The `start` and `end` slots can be used to place icons, buttons, or prefix/suffix text on either side of the input.
+
+Note that this feature is considered experimental because it relies on a simulated version of [Web Component slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots). As a result, the simulated behavior may not exactly match the native slot behavior.
+
+:::note
+In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. See the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
+
+If slot content is meant to be interacted with, it should be wrapped in an interactive element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+:::
+
+import StartEndSlots from '@site/static/usage/v7/input/start-end-slots/index.md';
+
+<StartEndSlots />
+
 ## Theming
 
 ### Colors


### PR DESCRIPTION
This section was originally added to the v7 docs as part of https://github.com/ionic-team/ionic-docs/pull/3271. For whatever reason, it didn't make it into the versioned docs when the v8 beta docs were created, so now it's missing from v7 but present in v8. This PR restores the section to the v7 docs.

Shortcut: https://ionic-docs-git-input-slot-sync-ionic1.vercel.app/docs/api/input#start-and-end-slots-experimental