### PR TITLE
docs(config): use correct v8 tag for API generation

### DIFF
--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -52,9 +52,7 @@ module.exports = function (context, options) {
 
       let npmTag = 'latest';
       if (currentVersion.banner === 'unreleased') {
-        // TODO create a ticket to re-enable this once v8 is released.
-        // npmTag = 'next';
-        npmTag = '7.5.8-dev.11702398696.1ab62ea9';
+        npmTag = 'next';
       } else if (currentVersion.path !== undefined) {
         npmTag = currentVersion.path.slice(1);
       }


### PR DESCRIPTION
The API generation script is using an outdated version of the Ionic 8 beta that existed before the beta was publicly released on the `next` tag. Unfortunately, this was also before the `ionInputModeChange` event was marked as internal for the new picker component. As a result, this event is showing up [as part of the public API](https://ionicframework.com/docs/v8/api/picker#events):

![image](https://github.com/ionic-team/ionic-docs/assets/2721089/34e999c5-56fd-42ae-ab28-cd9973410dc6)

This PR updates the config to use the `next` tag so that the latest version of the Ionic 8 beta is always used.

Preview: https://ionic-docs-git-picker-api-docs-ionic1.vercel.app/docs/v8/api/picker#events