### PR TITLE
docs: note event bubbling

### DIFF
--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -36,6 +36,12 @@ import Toggle from '@site/static/usage/v8/accordion/toggle/index.md';
 
 ## Listen for Accordion State Changes
 
+:::caution
+Most `ionChange` events emitted by other components such as [Input](./input) and [Textarea](./textarea) bubble. As a result, these events will bubble up and cause your `ionChange` listener on the Accordion Group to fire if the associated components are used inside of an Accordion.
+
+When using other components that emit `ionChange` inside of Accordion it is recommended to have the `ionChange` callback on Accordion Group check the `target` key on the event passed to the callback to verify that `ionChange` is coming from the Accordion Group and not any descendants.
+:::
+
 Developers can listen for the `ionChange` event to be notified when accordions expand or collapse.
 
 import ListenChanges from '@site/static/usage/v8/accordion/listen-changes/index.md';

--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -168,11 +168,9 @@ function renderEvents({ events }) {
   }
 
   return `
-| Name | Description |
-| --- | --- |
-${events.map((event) => `| \`${event.event}\` | ${formatMultiline(event.docs)} |`).join('\n')}
-
-`;
+| Name | Description | Bubbles |
+| --- | --- | --- |
+${events.map((event) => `| \`${event.event}\` | ${formatMultiline(event.docs)} | \`${event.bubbles}\` |`).join('\n')}`;
 }
 
 function renderMethods({ methods }) {

--- a/versioned_docs/version-v7/api/accordion.md
+++ b/versioned_docs/version-v7/api/accordion.md
@@ -39,6 +39,12 @@ import Toggle from '@site/static/usage/v7/accordion/toggle/index.md';
 
 ## Listen for Accordion State Changes
 
+:::caution
+Most `ionChange` events emitted by other components such as [Input](./input) and [Textarea](./textarea) bubble. As a result, these events will bubble up and cause your `ionChange` listener on the Accordion Group to fire if the associated components are used inside of an Accordion.
+
+When using other components that emit `ionChange` inside of Accordion it is recommended to have the `ionChange` callback on Accordion Group check the `target` key on the event passed to the callback to verify that `ionChange` is coming from the Accordion Group and not any descendants.
+:::
+
 Developers can listen for the `ionChange` event to be notified when accordions expand or collapse.
 
 import ListenChanges from '@site/static/usage/v7/accordion/listen-changes/index.md';


### PR DESCRIPTION
I've [seen](https://github.com/ionic-team/ionic-framework/issues/27724) [a](https://github.com/ionic-team/ionic-framework/issues/27986) [few](https://github.com/ionic-team/ionic-framework/issues/28794) instances of developers getting confused about the `ionChange` handler on accordion groups firing when a descendant component such as an input/checkbox has their value changed. This is happening because `ionChange` events bubble, so when Input emits `ionChange` that event bubbles up to the accordion group and causes the `ionChange` callback there to fire.

I think it's worth calling this behavior out on the docs. I made the following changes:

1. Updated the API generation script to note which events bubble.
2. Updated the accordion docs for v7 and v8 to specifically call out this behavior. Most components that emit `ionChange` do not typically have descendants that also fire `ionChange`, so accordion is a bit of an outlier here.