### PR TITLE
docs(v8): update with latest migration recommendations

### DIFF
--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -120,6 +120,17 @@ Developers who want to disable dynamic font scaling can set `--ion-dynamic-font:
 
 For more information on the dynamic font, refer to the [Dynamic Font Scaling documentation](../layout/dynamic-font-scaling).
 
+### (Angular Only) `angular.json` CSS import order
+
+The `angular.json` file currently imports `src/theme/variables.scss` before importing `src/global.scss`. This may cause the incorrect styles to be applied when customizing the new [Dark Theme](#dark-theme) changes.
+
+We recommend having the `src/global.scss` file get imported first instead:
+
+```diff
+- "styles": ["src/theme/variables.scss", "src/global.scss"],
++ "styles": ["src/global.scss", "src/theme/variables.scss"],
+```
+
 ## Required Changes
 
 ### Browser Support
@@ -146,6 +157,12 @@ iOS >=15
 1. Remove any usages of the `size` property. CSS should be used to specify the visible width of the input instead.
 2. Remove any usages of the `accept` property.
 3. Migrate any remaining instances of Input to use the [modern form control syntax](../api/input#migrating-from-legacy-input-syntax). Additionally, remove any usages of the `legacy` property as the legacy form control syntax has been removed.
+
+### Item
+
+1. Remove any usages of the `counter` or `counterFormatter` properties. Use the properties of the same names on `ion-input` and `ion-textarea` instead.
+2. Remove any usages of the `helper` or `error` slots. Use the `helperText` and `errorText` properties on `ion-input` and `ion-textarea` instead.
+3. Remove any usages of the `fill` or `shape` properties. Use the properties of the same names on `ion-input`, `ion-textarea`, and `ion-select` instead.
 
 ### Nav
 


### PR DESCRIPTION
This PR makes the following changes:

1. Adds the latest Ionic 8 beta 2 breaking changes to the migration guide
2. Adds a recommended migration step for Angular apps to avoid confusing when customizing the new dark theme imports. See https://github.com/ionic-team/starters/pull/1834#issue-2162290173 for more information.