### PR TITLE
chore(renovate): account for v7 deps with minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "packageRules": [
     {
       "matchPackagePatterns": ["@ionic/"],
+      "minimumReleaseAge": "0 days",
       "groupName": "ionic",
       "schedule": ["every weekday before 11am"]
     },


### PR DESCRIPTION
This is a continuation of https://github.com/ionic-team/ionic-docs/pull/3536. In that PR I only updated `minimumReleaseAge` for the v6 dependencies. I did not do it for the remaining deps.