### PR TITLE
fix(toast): use className for react examples

### DIFF
--- a/static/usage/v7/toast/theming/react/main_tsx.md
+++ b/static/usage/v7/toast/theming/react/main_tsx.md
@@ -12,7 +12,7 @@ function Example() {
         trigger="open-toast"
         duration={3000}
         message="Hello Styled World!"
-        class="custom-toast"
+        className="custom-toast"
         buttons={[
           {
             text: 'Dismiss',

--- a/static/usage/v8/toast/theming/react/main_tsx.md
+++ b/static/usage/v8/toast/theming/react/main_tsx.md
@@ -12,7 +12,7 @@ function Example() {
         trigger="open-toast"
         duration={3000}
         message="Hello Styled World!"
-        class="custom-toast"
+        className="custom-toast"
         buttons={[
           {
             text: 'Dismiss',


### PR DESCRIPTION
Resolves #3550

Updates the React playground examples to use `className` instead of `class`. 