### PR TITLE
Add another step If the project is using Jest with jest-preset-angular

### DIFF
--- a/versioned_docs/version-v7/updating/6-0.md
+++ b/versioned_docs/version-v7/updating/6-0.md
@@ -32,6 +32,24 @@ npm install @ionic/angular@6 @ionic/angular-server@6
 3. Remove any usage of `Config.set()`. Instead, set your config in `IonicModule.forRoot()`. See the [Angular Config Documentation](../developing/config) for more examples.
 4. Remove any usage of the `setupConfig` function previously exported from `@ionic/angular`. Set your config in `IonicModule.forRoot()` instead.
 
+5. If you are using Jest as your testing suite with `jest-preset-angular` instead of `karma` and `Jasmine`, you should add the following `transformIgnorePatterns` to either `jest.config.js` or the `jest` field in `package.json`:
+
+```js title="jest.config.js"
+module.exports = {
+  ...
+  transformIgnorePatterns: ['/node_modules/(?!(@ionic/core|@ionic/angular|@stencil/core|.*\\.mjs$))']
+}
+```
+
+```json title="package.json"
+  {
+    ...
+    "jest": {
+      "transformIgnorePatterns": ["/node_modules/(?!(@ionic/core|@ionic/angular|@stencil/core|.*\\.mjs$))"]
+    }
+  }
+```
+
 ### React
 
 1. Ionic 6 supports React 17+. Update to the latest version of React:


### PR DESCRIPTION
We have to add this configuration because there are now several projects using Jest instead of Karma and Jasmine, I had to spend hours investigating until I found the solution, this could have been avoided If on the documentation we had explained this before.