### PR TITLE
docs(checkbox): show how to prevent toggling checkbox with link

### DIFF
--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -65,6 +65,14 @@ import Justify from '@site/static/usage/v8/checkbox/justify/index.md';
 import Indeterminate from '@site/static/usage/v8/checkbox/indeterminate/index.md';
 
 <Indeterminate />
+  
+## Links inside of Labels
+
+Checkbox labels can sometimes be accompanied with links. These links can provide more information related to the checkbox. However, clicking the link should not check the checkbox. To achieve this, we can use [stopPropagation](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation) to prevent the click event from bubbling. When using this approach, the rest of the label still remains clickable.
+
+import LabelLink from '@site/static/usage/v8/checkbox/label-link/index.md';
+
+<LabelLink />
 
 ## Theming
 

--- a/static/usage/v7/checkbox/label-link/angular.md
+++ b/static/usage/v7/checkbox/label-link/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-checkbox>I agree to the <a href="#" (click)="$event.stopPropagation()">terms and conditions</a></ion-checkbox>
+```

--- a/static/usage/v7/checkbox/label-link/demo.html
+++ b/static/usage/v7/checkbox/label-link/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkbox</title>
+    <link rel="stylesheet" href="../../common.css" />
+    <script src="../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-checkbox
+            >I agree to the <a href="#" onclick="event.stopPropagation()">terms and conditions</a></ion-checkbox
+          >
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v7/checkbox/label-link/index.md
+++ b/static/usage/v7/checkbox/label-link/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v7/checkbox/label-link/demo.html"
+/>

--- a/static/usage/v7/checkbox/label-link/javascript.md
+++ b/static/usage/v7/checkbox/label-link/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-checkbox>I agree to the <a href="#" onclick="event.stopPropagation()">terms and conditions</a></ion-checkbox>
+```

--- a/static/usage/v7/checkbox/label-link/react.md
+++ b/static/usage/v7/checkbox/label-link/react.md
@@ -1,0 +1,29 @@
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { IonCheckbox } from '@ionic/react';
+
+function Example() {
+  const ref = useRef<HTMLAnchorElement>(null);
+
+  /**
+   * IonCheckbox will be listening for the native click event here so we need
+   * to call stopPropagation when the native click event instead of when the
+   * synthetic click event fires.
+   */
+  useEffect(() => {
+    ref.current?.addEventListener('click', (event) => {
+      event.stopPropagation();
+    });
+  }, [ref]);
+
+  return (
+    <IonCheckbox>
+      I agree to the{' '}
+      <a href="#" ref={ref}>
+        terms and conditions
+      </a>
+    </IonCheckbox>
+  );
+}
+export default Example;
+```

--- a/static/usage/v7/checkbox/label-link/vue.md
+++ b/static/usage/v7/checkbox/label-link/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-checkbox>I agree to the <a href="#" @click="$event.stopPropagation()">terms and conditions</a></ion-checkbox>
+</template>
+
+<script lang="ts">
+  import { IonCheckbox } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonCheckbox },
+  });
+</script>
+```

--- a/static/usage/v8/checkbox/label-link/angular.md
+++ b/static/usage/v8/checkbox/label-link/angular.md
@@ -1,0 +1,3 @@
+```html
+<ion-checkbox>I agree to the <a href="#" (click)="$event.stopPropagation()">terms and conditions</a></ion-checkbox>
+```

--- a/static/usage/v8/checkbox/label-link/demo.html
+++ b/static/usage/v8/checkbox/label-link/demo.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Checkbox</title>
+    <link rel="stylesheet" href="../../common.css" />
+    <script src="../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-checkbox
+            >I agree to the <a href="#" onclick="event.stopPropagation()">terms and conditions</a></ion-checkbox
+          >
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v8/checkbox/label-link/index.md
+++ b/static/usage/v8/checkbox/label-link/index.md
@@ -1,0 +1,17 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+import angular from './angular.md';
+
+<Playground
+  version="8"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular,
+  }}
+  src="usage/v8/checkbox/label-link/demo.html"
+/>

--- a/static/usage/v8/checkbox/label-link/javascript.md
+++ b/static/usage/v8/checkbox/label-link/javascript.md
@@ -1,0 +1,3 @@
+```html
+<ion-checkbox>I agree to the <a href="#" onclick="event.stopPropagation()">terms and conditions</a></ion-checkbox>
+```

--- a/static/usage/v8/checkbox/label-link/react.md
+++ b/static/usage/v8/checkbox/label-link/react.md
@@ -1,0 +1,29 @@
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { IonCheckbox } from '@ionic/react';
+
+function Example() {
+  const ref = useRef<HTMLAnchorElement>(null);
+
+  /**
+   * IonCheckbox will be listening for the native click event here so we need
+   * to call stopPropagation when the native click event instead of when the
+   * synthetic click event fires.
+   */
+  useEffect(() => {
+    ref.current?.addEventListener('click', (event) => {
+      event.stopPropagation();
+    });
+  }, [ref]);
+
+  return (
+    <IonCheckbox>
+      I agree to the{' '}
+      <a href="#" ref={ref}>
+        terms and conditions
+      </a>
+    </IonCheckbox>
+  );
+}
+export default Example;
+```

--- a/static/usage/v8/checkbox/label-link/vue.md
+++ b/static/usage/v8/checkbox/label-link/vue.md
@@ -1,0 +1,14 @@
+```html
+<template>
+  <ion-checkbox>I agree to the <a href="#" @click="$event.stopPropagation()">terms and conditions</a></ion-checkbox>
+</template>
+
+<script lang="ts">
+  import { IonCheckbox } from '@ionic/vue';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: { IonCheckbox },
+  });
+</script>
+```

--- a/versioned_docs/version-v7/api/checkbox.md
+++ b/versioned_docs/version-v7/api/checkbox.md
@@ -67,6 +67,14 @@ import Indeterminate from '@site/static/usage/v7/checkbox/indeterminate/index.md
 
 <Indeterminate />
 
+## Links inside of Labels
+
+Checkbox labels can sometimes be accompanied with links. These links can provide more information related to the checkbox. However, clicking the link should not check the checkbox. To achieve this, we can use [stopPropagation](https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation) to prevent the click event from bubbling. When using this approach, the rest of the label still remains clickable.
+
+import LabelLink from '@site/static/usage/v7/checkbox/label-link/index.md';
+
+<LabelLink />
+
 ## Theming
 
 ### CSS Custom Properties


### PR DESCRIPTION
See https://github.com/ionic-team/ionic-framework/issues/29304

Developers wanted to know how to add a link to the checkbox label (such as a link that opens a terms and conditions dialog). However, they do not want the checkbox to toggle when the link is clicked. We've had multiple devs ask about this, so I think it's worth making a demo.