### PR TITLE
docs(migration): add info about removing old light palette colors

### DIFF
--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -86,7 +86,7 @@ Previous versions shipped a set of default color variables for the light theme:
   --ion-color-primary-rgb: 56, 128, 255;
   --ion-color-primary-contrast: #ffffff;
   --ion-color-primary-contrast-rgb: 255, 255, 255;
-  ...
+  /* ... */
 }
 ```
 

--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -90,7 +90,9 @@ Previous versions shipped a set of default color variables for the light theme:
 }
 ```
 
-If you are not using a custom color scheme, these color variables should all be removed. In Ionic Framework version 8, the default colors have been updated to improve accessibility. The new palette is also automatically included with all Ionic apps. Removing the old color variables ensures that the latest palette is not overwritten.
+In Ionic Framework version 8, the default color palette is included as long as `core.css` is imported. Removing the old color variables ensures that the latest palette is not overwritten.
+
+Developers who are customizing this color palette can continue to keep the custom variables values, but any of the variables that use the default values should be removed.
 
 You can read more about the new color palette in the [Ionic v8 announcement](https://ionic.io/blog/announcing-the-ionic-8-beta).
 

--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -74,6 +74,26 @@ npm install @ionic/core@next
 
 The following changes are not required to update to Ionic 8 as your application will continue to work. However, we recommend making the following changes to ensure you can use the new features in Ionic 8.
 
+### Light Theme
+
+Previous versions shipped a set of default color variables for the light theme:
+
+```css
+/** Ionic CSS Variables **/
+:root {
+  /** primary **/
+  --ion-color-primary: #3880ff;
+  --ion-color-primary-rgb: 56, 128, 255;
+  --ion-color-primary-contrast: #ffffff;
+  --ion-color-primary-contrast-rgb: 255, 255, 255;
+  ...
+}
+```
+
+If you are not using a custom color scheme, these color variables should all be removed. In Ionic Framework version 8, the default colors have been updated to improve accessibility. The new palette is also automatically included with all Ionic apps. Removing the old color variables ensures that the latest palette is not overwritten.
+
+You can read more about the new color palette in the [Ionic v8 announcement](https://ionic.io/blog/announcing-the-ionic-8-beta).
+
 ### Dark Theme
 
 In previous versions, it was recommended to define the dark theme in the following way:


### PR DESCRIPTION
While going through the migration guide, I noticed that we don't call out having to remove the old light palette colors in order for the updated colors to appear.