### PR TITLE
docs(high-contrast): fix typo in Angular dark palette import

### DIFF
--- a/docs/theming/high-contrast-mode.md
+++ b/docs/theming/high-contrast-mode.md
@@ -31,9 +31,9 @@ The high contrast palette can be enabled by importing the following stylesheet i
 
 <TabItem value="angular">
 
-```css
+```scss
 @import '@ionic/angular/css/palettes/high-contrast.always.css'; // Light palette
-// @import '@ionic/angular/css/palettes/high-contrast.always.css'; // Dark palette
+// @import '@ionic/angular/css/palettes/high-contrast-dark.always.css'; // Dark palette
 ```
 
 </TabItem>


### PR DESCRIPTION
1. Fixes the dark palette import to use the right file name (previously the light and dark palette imports were the same)
2. Changes the code block to `scss` so the comment renders properly