### PR TITLE
chore(renovate): do not bump v7 deps to v8

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,18 @@
     {
       "matchPackagePatterns": ["@ionic/"],
       "minimumReleaseAge": "0 days",
+      "allowedVersions": "^7.0.0",
+      "groupName": "ionic",
+      "matchFileNames": [
+        "static/code/stackblitz/v7/angular/package.json",
+        "static/code/stackblitz/v7/html/package.json",
+        "static/code/stackblitz/v7/react/package.json",
+        "static/code/stackblitz/v7/vue/package.json"
+      ]
+    },
+    {
+      "matchPackagePatterns": ["@ionic/"],
+      "minimumReleaseAge": "0 days",
       "allowedVersions": "^6.0.0",
       "groupName": "ionic",
       "matchFileNames": [


### PR DESCRIPTION
Renovate bot is trying to bump the v7 playground deps to v8. This change prevents it from doing that: https://github.com/ionic-team/ionic-docs/pull/3603