### PR TITLE
chore(renovate): remove v6, add v8

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,18 @@
     {
       "matchPackagePatterns": ["@ionic/"],
       "minimumReleaseAge": "0 days",
+      "allowedVersions": "^8.0.0",
+      "groupName": "ionic",
+      "matchFileNames": [
+        "static/code/stackblitz/v8/angular/package.json",
+        "static/code/stackblitz/v8/html/package.json",
+        "static/code/stackblitz/v8/react/package.json",
+        "static/code/stackblitz/v8/vue/package.json"
+      ]
+    },
+    {
+      "matchPackagePatterns": ["@ionic/"],
+      "minimumReleaseAge": "0 days",
       "allowedVersions": "^7.0.0",
       "groupName": "ionic",
       "matchFileNames": [
@@ -50,6 +62,7 @@
     },
     {
       "matchPackagePatterns": ["@ionic/"],
+      "enabled": false,
       "minimumReleaseAge": "0 days",
       "allowedVersions": "^6.0.0",
       "groupName": "ionic",


### PR DESCRIPTION
- v6 docs are archived, so they will not be deployed anymore. As a result, we don't need to keep bumping the Renovatebot deps for v6 playgrounds
- Adds v8 dependency so they only get updated to v8.x. Without this, they would start getting updated to v9 once Ionic 9 comes out.