### PR TITLE
chore: disable renovate on v6 playgrounds

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,19 +59,6 @@
         "static/code/stackblitz/v7/react/package.json",
         "static/code/stackblitz/v7/vue/package.json"
       ]
-    },
-    {
-      "matchPackagePatterns": ["@ionic/"],
-      "enabled": false,
-      "minimumReleaseAge": "0 days",
-      "allowedVersions": "^6.0.0",
-      "groupName": "ionic",
-      "matchFileNames": [
-        "static/code/stackblitz/v6/angular/package.json",
-        "static/code/stackblitz/v6/html/package.json",
-        "static/code/stackblitz/v6/react/package.json",
-        "static/code/stackblitz/v6/vue/package.json"
-      ]
     }
   ],
   "dependencyDashboard": true,
@@ -81,5 +68,8 @@
   "semanticCommits": "enabled",
   "includePaths": [
     "static/code/stackblitz/**/*/package.json"
+  ],
+  "ignorePaths": [
+    "static/code/stackblitz/v6/**"
   ]
 }


### PR DESCRIPTION
Disables Renovate from suggesting dependency updates on v6 playgrounds. 

You can preview the effect of these changes here: https://github.com/sean-perkins/ionic-docs/issues. You will observe no PRs target v6 playgrounds.