### PR TITLE
docs(updating): add correct npm tag for v8

### DIFF
--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -21,13 +21,13 @@ For a **complete list of breaking changes** from Ionic 7 to Ionic 8, please refe
 2. Update to the latest version of Ionic 8:
 
 ```shell
-npm install @ionic/angular@next
+npm install @ionic/angular@latest
 ```
 
 If you are using Ionic Angular Server and Ionic Angular Toolkit, be sure to update those as well:
 
 ```shell
-npm install @ionic/angular@next @ionic/angular-server@next @ionic/angular-toolkit@11
+npm install @ionic/angular@latest @ionic/angular-server@latest @ionic/angular-toolkit@11
 ```
 
 > Note: `@ionic/angular-toolkit@11` requires a minimum of Angular 17. If you are still on Angular 16, then you may want to only update to to `@ionic/angular-toolkit@10` instead.
@@ -45,7 +45,7 @@ npm install react@latest react-dom@latest
 2. Update to the latest version of Ionic 8:
 
 ```shell
-npm install @ionic/react@next @ionic/react-router@next
+npm install @ionic/react@latest @ionic/react-router@latest
 ```
 
 ### Vue
@@ -59,7 +59,7 @@ npm install vue@latest vue-router@latest
 2. Update to the latest version of Ionic 8:
 
 ```shell
-npm install @ionic/vue@next @ionic/vue-router@next
+npm install @ionic/vue@latest @ionic/vue-router@latest
 ```
 
 ### Core
@@ -67,7 +67,7 @@ npm install @ionic/vue@next @ionic/vue-router@next
 1. Update to the latest version of Ionic 8:
 
 ```shell
-npm install @ionic/core@next
+npm install @ionic/core@latest
 ```
 
 ## Recommended Changes


### PR DESCRIPTION
The upgrade guide still referenced the `next` tag for upgrades. 