### PR TITLE
docs(vue): remove the coming soon page

### DIFF
--- a/docs/vue/testing.md
+++ b/docs/vue/testing.md
@@ -1,3 +1,0 @@
-# Testing
-
-Coming Soon!

--- a/sidebars.js
+++ b/sidebars.js
@@ -173,7 +173,6 @@ module.exports = {
         'vue/platform',
         'vue/pwa',
         'vue/storage',
-        'vue/testing',
         'vue/troubleshooting',
         'vue/performance',
       ],

--- a/versioned_docs/version-v7/vue/testing.md
+++ b/versioned_docs/version-v7/vue/testing.md
@@ -1,3 +1,0 @@
-# Testing
-
-Coming Soon!

--- a/versioned_sidebars/version-v7-sidebars.json
+++ b/versioned_sidebars/version-v7-sidebars.json
@@ -184,7 +184,6 @@
         "vue/platform",
         "vue/pwa",
         "vue/storage",
-        "vue/testing",
         "vue/troubleshooting",
         "vue/performance"
       ]


### PR DESCRIPTION
There are no plans to update this page. It's been decided to remove it entirely.