### PR TITLE
fix(redirects): add redirects for v8 links

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,7 @@
       "destination": "https://ionic.io/resources"
     },
     { "source": "/docs/next/:match*", "destination": "/docs/:match*" },
+    { "source": "/docs/v8/:match*", "destination": "/docs/:match*" },
     {
       "source": "/docs/react/your-first-app/2-taking-photos",
       "destination": "/docs/react/your-first-app/taking-photos"

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,7 @@
       "source": "/docs/ja/",
       "destination": "/docs/ja"
     },
+    { "source": "/docs/ja/v8/:match*", "destination": "/docs/ja/:match*" },
     {
       "source": "/docs/(v5|next)?/developer-resources/:path*",
       "destination": "https://ionic.io/resources"


### PR DESCRIPTION
This PR will redirect pages formerly hosted under v8 to the main site (since v8 is now the latest)

**It will need to be reverted once v8 is archived**