### PR TITLE
fix: use module with syntax for json files

### DIFF
--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import * as utils from './utils.mjs';
-import cliJSON from './data/cli.json' assert { type: 'json' };
-import cliOverrides from './data/meta-override.json' assert { type: 'json' };
+import cliJSON from './data/cli.json' with { type: 'json' };
+import cliOverrides from './data/meta-override.json' with { type: 'json' };
 
 const commandToKebab = (str) =>
   str


### PR DESCRIPTION
The local cli script uses deprecated functionality that will cause an exception when using in Node v21.2+: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules