### PR TITLE
feat: segment css properties by mode

### DIFF
--- a/docs/api/accordion-group.md
+++ b/docs/api/accordion-group.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/accordion-group/props.md';
 import Events from '@ionic-internal/component-api/v8/accordion-group/events.md';
 import Methods from '@ionic-internal/component-api/v8/accordion-group/methods.md';
 import Parts from '@ionic-internal/component-api/v8/accordion-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/accordion-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/accordion-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/accordion-group/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/accordion/props.md';
 import Events from '@ionic-internal/component-api/v8/accordion/events.md';
 import Methods from '@ionic-internal/component-api/v8/accordion/methods.md';
 import Parts from '@ionic-internal/component-api/v8/accordion/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/accordion/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/accordion/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/accordion/slots.md';
 
 <head>

--- a/docs/api/action-sheet.md
+++ b/docs/api/action-sheet.md
@@ -8,7 +8,7 @@ import Props from '@ionic-internal/component-api/v8/action-sheet/props.md';
 import Events from '@ionic-internal/component-api/v8/action-sheet/events.md';
 import Methods from '@ionic-internal/component-api/v8/action-sheet/methods.md';
 import Parts from '@ionic-internal/component-api/v8/action-sheet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/action-sheet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/action-sheet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/action-sheet/slots.md';
 
 <head>

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -8,7 +8,7 @@ import Props from '@ionic-internal/component-api/v8/alert/props.md';
 import Events from '@ionic-internal/component-api/v8/alert/events.md';
 import Methods from '@ionic-internal/component-api/v8/alert/methods.md';
 import Parts from '@ionic-internal/component-api/v8/alert/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/alert/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/alert/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/alert/slots.md';
 
 <head>

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/app/props.md';
 import Events from '@ionic-internal/component-api/v8/app/events.md';
 import Methods from '@ionic-internal/component-api/v8/app/methods.md';
 import Parts from '@ionic-internal/component-api/v8/app/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/app/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/app/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/app/slots.md';
 
 <head>

--- a/docs/api/avatar.md
+++ b/docs/api/avatar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/avatar/props.md';
 import Events from '@ionic-internal/component-api/v8/avatar/events.md';
 import Methods from '@ionic-internal/component-api/v8/avatar/methods.md';
 import Parts from '@ionic-internal/component-api/v8/avatar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/avatar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/avatar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/avatar/slots.md';
 
 <head>

--- a/docs/api/back-button.md
+++ b/docs/api/back-button.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/back-button/props.md';
 import Events from '@ionic-internal/component-api/v8/back-button/events.md';
 import Methods from '@ionic-internal/component-api/v8/back-button/methods.md';
 import Parts from '@ionic-internal/component-api/v8/back-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/back-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/back-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/back-button/slots.md';
 
 <head>

--- a/docs/api/backdrop.md
+++ b/docs/api/backdrop.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/backdrop/props.md';
 import Events from '@ionic-internal/component-api/v8/backdrop/events.md';
 import Methods from '@ionic-internal/component-api/v8/backdrop/methods.md';
 import Parts from '@ionic-internal/component-api/v8/backdrop/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/backdrop/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/backdrop/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/backdrop/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/badge/props.md';
 import Events from '@ionic-internal/component-api/v8/badge/events.md';
 import Methods from '@ionic-internal/component-api/v8/badge/methods.md';
 import Parts from '@ionic-internal/component-api/v8/badge/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/badge/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/badge/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/badge/slots.md';
 
 <head>

--- a/docs/api/breadcrumb.md
+++ b/docs/api/breadcrumb.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/breadcrumb/props.md';
 import Events from '@ionic-internal/component-api/v8/breadcrumb/events.md';
 import Methods from '@ionic-internal/component-api/v8/breadcrumb/methods.md';
 import Parts from '@ionic-internal/component-api/v8/breadcrumb/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/breadcrumb/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/breadcrumb/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/breadcrumb/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/breadcrumbs.md
+++ b/docs/api/breadcrumbs.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/breadcrumbs/props.md';
 import Events from '@ionic-internal/component-api/v8/breadcrumbs/events.md';
 import Methods from '@ionic-internal/component-api/v8/breadcrumbs/methods.md';
 import Parts from '@ionic-internal/component-api/v8/breadcrumbs/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/breadcrumbs/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/breadcrumbs/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/breadcrumbs/slots.md';
 
 

--- a/docs/api/button.md
+++ b/docs/api/button.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/button/props.md';
 import Events from '@ionic-internal/component-api/v8/button/events.md';
 import Methods from '@ionic-internal/component-api/v8/button/methods.md';
 import Parts from '@ionic-internal/component-api/v8/button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/button/slots.md';
 
 <head>

--- a/docs/api/buttons.md
+++ b/docs/api/buttons.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/buttons/props.md';
 import Events from '@ionic-internal/component-api/v8/buttons/events.md';
 import Methods from '@ionic-internal/component-api/v8/buttons/methods.md';
 import Parts from '@ionic-internal/component-api/v8/buttons/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/buttons/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/buttons/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/buttons/slots.md';
 
 <head>

--- a/docs/api/card-content.md
+++ b/docs/api/card-content.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/card-content/props.md';
 import Events from '@ionic-internal/component-api/v8/card-content/events.md';
 import Methods from '@ionic-internal/component-api/v8/card-content/methods.md';
 import Parts from '@ionic-internal/component-api/v8/card-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/card-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/card-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/card-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/card-header.md
+++ b/docs/api/card-header.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/card-header/props.md';
 import Events from '@ionic-internal/component-api/v8/card-header/events.md';
 import Methods from '@ionic-internal/component-api/v8/card-header/methods.md';
 import Parts from '@ionic-internal/component-api/v8/card-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/card-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/card-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/card-header/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/card-subtitle.md
+++ b/docs/api/card-subtitle.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/card-subtitle/props.md';
 import Events from '@ionic-internal/component-api/v8/card-subtitle/events.md';
 import Methods from '@ionic-internal/component-api/v8/card-subtitle/methods.md';
 import Parts from '@ionic-internal/component-api/v8/card-subtitle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/card-subtitle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/card-subtitle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/card-subtitle/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/card-title.md
+++ b/docs/api/card-title.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/card-title/props.md';
 import Events from '@ionic-internal/component-api/v8/card-title/events.md';
 import Methods from '@ionic-internal/component-api/v8/card-title/methods.md';
 import Parts from '@ionic-internal/component-api/v8/card-title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/card-title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/card-title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/card-title/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/card.md
+++ b/docs/api/card.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/card/props.md';
 import Events from '@ionic-internal/component-api/v8/card/events.md';
 import Methods from '@ionic-internal/component-api/v8/card/methods.md';
 import Parts from '@ionic-internal/component-api/v8/card/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/card/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/card/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/card/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/checkbox/props.md';
 import Events from '@ionic-internal/component-api/v8/checkbox/events.md';
 import Methods from '@ionic-internal/component-api/v8/checkbox/methods.md';
 import Parts from '@ionic-internal/component-api/v8/checkbox/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/checkbox/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/checkbox/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/checkbox/slots.md';
 
 <head>

--- a/docs/api/chip.md
+++ b/docs/api/chip.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/chip/props.md';
 import Events from '@ionic-internal/component-api/v8/chip/events.md';
 import Methods from '@ionic-internal/component-api/v8/chip/methods.md';
 import Parts from '@ionic-internal/component-api/v8/chip/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/chip/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/chip/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/chip/slots.md';
 
 <head>

--- a/docs/api/col.md
+++ b/docs/api/col.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/col/props.md';
 import Events from '@ionic-internal/component-api/v8/col/events.md';
 import Methods from '@ionic-internal/component-api/v8/col/methods.md';
 import Parts from '@ionic-internal/component-api/v8/col/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/col/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/col/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/col/slots.md';
 
 <head>

--- a/docs/api/content.md
+++ b/docs/api/content.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/content/props.md';
 import Events from '@ionic-internal/component-api/v8/content/events.md';
 import Methods from '@ionic-internal/component-api/v8/content/methods.md';
 import Parts from '@ionic-internal/component-api/v8/content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/content/slots.md';
 
 <head>

--- a/docs/api/datetime-button.md
+++ b/docs/api/datetime-button.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/datetime-button/props.md';
 import Events from '@ionic-internal/component-api/v8/datetime-button/events.md';
 import Methods from '@ionic-internal/component-api/v8/datetime-button/methods.md';
 import Parts from '@ionic-internal/component-api/v8/datetime-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/datetime-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/datetime-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/datetime-button/slots.md';
 
 <head>

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/datetime/props.md';
 import Events from '@ionic-internal/component-api/v8/datetime/events.md';
 import Methods from '@ionic-internal/component-api/v8/datetime/methods.md';
 import Parts from '@ionic-internal/component-api/v8/datetime/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/datetime/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/datetime/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/datetime/slots.md';
 
 import Basic from '@site/static/usage/v8/datetime/basic/index.md';

--- a/docs/api/fab-button.md
+++ b/docs/api/fab-button.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/fab-button/props.md';
 import Events from '@ionic-internal/component-api/v8/fab-button/events.md';
 import Methods from '@ionic-internal/component-api/v8/fab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v8/fab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/fab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/fab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/fab-button/slots.md';
 
 <head>

--- a/docs/api/fab-list.md
+++ b/docs/api/fab-list.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/fab-list/props.md';
 import Events from '@ionic-internal/component-api/v8/fab-list/events.md';
 import Methods from '@ionic-internal/component-api/v8/fab-list/methods.md';
 import Parts from '@ionic-internal/component-api/v8/fab-list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/fab-list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/fab-list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/fab-list/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/fab.md
+++ b/docs/api/fab.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/fab/props.md';
 import Events from '@ionic-internal/component-api/v8/fab/events.md';
 import Methods from '@ionic-internal/component-api/v8/fab/methods.md';
 import Parts from '@ionic-internal/component-api/v8/fab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/fab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/fab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/fab/slots.md';
 
 <head>

--- a/docs/api/footer.md
+++ b/docs/api/footer.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/footer/props.md';
 import Events from '@ionic-internal/component-api/v8/footer/events.md';
 import Methods from '@ionic-internal/component-api/v8/footer/methods.md';
 import Parts from '@ionic-internal/component-api/v8/footer/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/footer/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/footer/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/footer/slots.md';
 
 <head>

--- a/docs/api/grid.md
+++ b/docs/api/grid.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/grid/props.md';
 import Events from '@ionic-internal/component-api/v8/grid/events.md';
 import Methods from '@ionic-internal/component-api/v8/grid/methods.md';
 import Parts from '@ionic-internal/component-api/v8/grid/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/grid/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/grid/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/grid/slots.md';
 
 <head>

--- a/docs/api/header.md
+++ b/docs/api/header.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/header/props.md';
 import Events from '@ionic-internal/component-api/v8/header/events.md';
 import Methods from '@ionic-internal/component-api/v8/header/methods.md';
 import Parts from '@ionic-internal/component-api/v8/header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/header/slots.md';
 
 <head>

--- a/docs/api/img.md
+++ b/docs/api/img.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/img/props.md';
 import Events from '@ionic-internal/component-api/v8/img/events.md';
 import Methods from '@ionic-internal/component-api/v8/img/methods.md';
 import Parts from '@ionic-internal/component-api/v8/img/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/img/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/img/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/img/slots.md';
 
 <head>

--- a/docs/api/infinite-scroll-content.md
+++ b/docs/api/infinite-scroll-content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/infinite-scroll-content/prop
 import Events from '@ionic-internal/component-api/v8/infinite-scroll-content/events.md';
 import Methods from '@ionic-internal/component-api/v8/infinite-scroll-content/methods.md';
 import Parts from '@ionic-internal/component-api/v8/infinite-scroll-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/infinite-scroll-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/infinite-scroll-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/infinite-scroll-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/infinite-scroll.md
+++ b/docs/api/infinite-scroll.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/infinite-scroll/props.md';
 import Events from '@ionic-internal/component-api/v8/infinite-scroll/events.md';
 import Methods from '@ionic-internal/component-api/v8/infinite-scroll/methods.md';
 import Parts from '@ionic-internal/component-api/v8/infinite-scroll/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/infinite-scroll/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/infinite-scroll/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/infinite-scroll/slots.md';
 
 <head>

--- a/docs/api/input-password-toggle.md
+++ b/docs/api/input-password-toggle.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/input-password-toggle/props.
 import Events from '@ionic-internal/component-api/v8/input-password-toggle/events.md';
 import Methods from '@ionic-internal/component-api/v8/input-password-toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v8/input-password-toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/input-password-toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/input-password-toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/input-password-toggle/slots.md';
 
 <head>

--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/input/props.md';
 import Events from '@ionic-internal/component-api/v8/input/events.md';
 import Methods from '@ionic-internal/component-api/v8/input/methods.md';
 import Parts from '@ionic-internal/component-api/v8/input/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/input/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/input/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/input/slots.md';
 
 <head>

--- a/docs/api/item-divider.md
+++ b/docs/api/item-divider.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/item-divider/props.md';
 import Events from '@ionic-internal/component-api/v8/item-divider/events.md';
 import Methods from '@ionic-internal/component-api/v8/item-divider/methods.md';
 import Parts from '@ionic-internal/component-api/v8/item-divider/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/item-divider/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/item-divider/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/item-divider/slots.md';
 
 <head>

--- a/docs/api/item-group.md
+++ b/docs/api/item-group.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/item-group/props.md';
 import Events from '@ionic-internal/component-api/v8/item-group/events.md';
 import Methods from '@ionic-internal/component-api/v8/item-group/methods.md';
 import Parts from '@ionic-internal/component-api/v8/item-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/item-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/item-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/item-group/slots.md';
 
 <head>

--- a/docs/api/item-option.md
+++ b/docs/api/item-option.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/item-option/props.md';
 import Events from '@ionic-internal/component-api/v8/item-option/events.md';
 import Methods from '@ionic-internal/component-api/v8/item-option/methods.md';
 import Parts from '@ionic-internal/component-api/v8/item-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/item-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/item-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/item-option/slots.md';
 
 <head>

--- a/docs/api/item-options.md
+++ b/docs/api/item-options.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/item-options/props.md';
 import Events from '@ionic-internal/component-api/v8/item-options/events.md';
 import Methods from '@ionic-internal/component-api/v8/item-options/methods.md';
 import Parts from '@ionic-internal/component-api/v8/item-options/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/item-options/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/item-options/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/item-options/slots.md';
 
 <head>

--- a/docs/api/item-sliding.md
+++ b/docs/api/item-sliding.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/item-sliding/props.md';
 import Events from '@ionic-internal/component-api/v8/item-sliding/events.md';
 import Methods from '@ionic-internal/component-api/v8/item-sliding/methods.md';
 import Parts from '@ionic-internal/component-api/v8/item-sliding/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/item-sliding/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/item-sliding/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/item-sliding/slots.md';
 
 <head>

--- a/docs/api/item.md
+++ b/docs/api/item.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/item/props.md';
 import Events from '@ionic-internal/component-api/v8/item/events.md';
 import Methods from '@ionic-internal/component-api/v8/item/methods.md';
 import Parts from '@ionic-internal/component-api/v8/item/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/item/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/item/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/item/slots.md';
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/docs/api/label.md
+++ b/docs/api/label.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/label/props.md';
 import Events from '@ionic-internal/component-api/v8/label/events.md';
 import Methods from '@ionic-internal/component-api/v8/label/methods.md';
 import Parts from '@ionic-internal/component-api/v8/label/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/label/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/label/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/label/slots.md';
 
 <head>

--- a/docs/api/list-header.md
+++ b/docs/api/list-header.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/list-header/props.md';
 import Events from '@ionic-internal/component-api/v8/list-header/events.md';
 import Methods from '@ionic-internal/component-api/v8/list-header/methods.md';
 import Parts from '@ionic-internal/component-api/v8/list-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/list-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/list-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/list-header/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/list/props.md';
 import Events from '@ionic-internal/component-api/v8/list/events.md';
 import Methods from '@ionic-internal/component-api/v8/list/methods.md';
 import Parts from '@ionic-internal/component-api/v8/list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/list/slots.md';
 
 <head>

--- a/docs/api/loading.md
+++ b/docs/api/loading.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/loading/props.md';
 import Events from '@ionic-internal/component-api/v8/loading/events.md';
 import Methods from '@ionic-internal/component-api/v8/loading/methods.md';
 import Parts from '@ionic-internal/component-api/v8/loading/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/loading/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/loading/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/loading/slots.md';
 
 <head>

--- a/docs/api/menu-button.md
+++ b/docs/api/menu-button.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/menu-button/props.md';
 import Events from '@ionic-internal/component-api/v8/menu-button/events.md';
 import Methods from '@ionic-internal/component-api/v8/menu-button/methods.md';
 import Parts from '@ionic-internal/component-api/v8/menu-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/menu-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/menu-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/menu-button/slots.md';
 
 <head>

--- a/docs/api/menu-toggle.md
+++ b/docs/api/menu-toggle.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/menu-toggle/props.md';
 import Events from '@ionic-internal/component-api/v8/menu-toggle/events.md';
 import Methods from '@ionic-internal/component-api/v8/menu-toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v8/menu-toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/menu-toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/menu-toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/menu-toggle/slots.md';
 
 <head>

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/menu/props.md';
 import Events from '@ionic-internal/component-api/v8/menu/events.md';
 import Methods from '@ionic-internal/component-api/v8/menu/methods.md';
 import Parts from '@ionic-internal/component-api/v8/menu/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/menu/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/menu/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/menu/slots.md';
 
 <head>

--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/modal/props.md';
 import Events from '@ionic-internal/component-api/v8/modal/events.md';
 import Methods from '@ionic-internal/component-api/v8/modal/methods.md';
 import Parts from '@ionic-internal/component-api/v8/modal/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/modal/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/modal/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/modal/slots.md';
 
 <head>

--- a/docs/api/nav-link.md
+++ b/docs/api/nav-link.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/nav-link/props.md';
 import Events from '@ionic-internal/component-api/v8/nav-link/events.md';
 import Methods from '@ionic-internal/component-api/v8/nav-link/methods.md';
 import Parts from '@ionic-internal/component-api/v8/nav-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/nav-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/nav-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/nav-link/slots.md';
 
 <head>

--- a/docs/api/nav.md
+++ b/docs/api/nav.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/nav/props.md';
 import Events from '@ionic-internal/component-api/v8/nav/events.md';
 import Methods from '@ionic-internal/component-api/v8/nav/methods.md';
 import Parts from '@ionic-internal/component-api/v8/nav/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/nav/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/nav/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/nav/slots.md';
 
 <head>

--- a/docs/api/note.md
+++ b/docs/api/note.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/note/props.md';
 import Events from '@ionic-internal/component-api/v8/note/events.md';
 import Methods from '@ionic-internal/component-api/v8/note/methods.md';
 import Parts from '@ionic-internal/component-api/v8/note/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/note/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/note/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/note/slots.md';
 
 <head>

--- a/docs/api/picker-column-option.md
+++ b/docs/api/picker-column-option.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/picker-column-option/props.m
 import Events from '@ionic-internal/component-api/v8/picker-column-option/events.md';
 import Methods from '@ionic-internal/component-api/v8/picker-column-option/methods.md';
 import Parts from '@ionic-internal/component-api/v8/picker-column-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/picker-column-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/picker-column-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/picker-column-option/slots.md';
 
 <head>

--- a/docs/api/picker-column.md
+++ b/docs/api/picker-column.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/picker-column/props.md';
 import Events from '@ionic-internal/component-api/v8/picker-column/events.md';
 import Methods from '@ionic-internal/component-api/v8/picker-column/methods.md';
 import Parts from '@ionic-internal/component-api/v8/picker-column/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/picker-column/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/picker-column/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/picker-column/slots.md';
 
 <head>

--- a/docs/api/picker-legacy.md
+++ b/docs/api/picker-legacy.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/picker-legacy/props.md';
 import Events from '@ionic-internal/component-api/v8/picker-legacy/events.md';
 import Methods from '@ionic-internal/component-api/v8/picker-legacy/methods.md';
 import Parts from '@ionic-internal/component-api/v8/picker-legacy/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/picker-legacy/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/picker-legacy/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/picker-legacy/slots.md';
 
 <head>

--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/picker/props.md';
 import Events from '@ionic-internal/component-api/v8/picker/events.md';
 import Methods from '@ionic-internal/component-api/v8/picker/methods.md';
 import Parts from '@ionic-internal/component-api/v8/picker/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/picker/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/picker/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/picker/slots.md';
 
 <head>

--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/popover/props.md';
 import Events from '@ionic-internal/component-api/v8/popover/events.md';
 import Methods from '@ionic-internal/component-api/v8/popover/methods.md';
 import Parts from '@ionic-internal/component-api/v8/popover/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/popover/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/popover/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/popover/slots.md';
 
 <head>

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/progress-bar/props.md';
 import Events from '@ionic-internal/component-api/v8/progress-bar/events.md';
 import Methods from '@ionic-internal/component-api/v8/progress-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v8/progress-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/progress-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/progress-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/progress-bar/slots.md';
 
 <head>

--- a/docs/api/radio-group.md
+++ b/docs/api/radio-group.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/radio-group/props.md';
 import Events from '@ionic-internal/component-api/v8/radio-group/events.md';
 import Methods from '@ionic-internal/component-api/v8/radio-group/methods.md';
 import Parts from '@ionic-internal/component-api/v8/radio-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/radio-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/radio-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/radio-group/slots.md';
 
 <head>

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/radio/props.md';
 import Events from '@ionic-internal/component-api/v8/radio/events.md';
 import Methods from '@ionic-internal/component-api/v8/radio/methods.md';
 import Parts from '@ionic-internal/component-api/v8/radio/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/radio/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/radio/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/radio/slots.md';
 
 <head>

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/range/props.md';
 import Events from '@ionic-internal/component-api/v8/range/events.md';
 import Methods from '@ionic-internal/component-api/v8/range/methods.md';
 import Parts from '@ionic-internal/component-api/v8/range/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/range/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/range/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/range/slots.md';
 
 <head>

--- a/docs/api/refresher-content.md
+++ b/docs/api/refresher-content.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/refresher-content/props.md';
 import Events from '@ionic-internal/component-api/v8/refresher-content/events.md';
 import Methods from '@ionic-internal/component-api/v8/refresher-content/methods.md';
 import Parts from '@ionic-internal/component-api/v8/refresher-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/refresher-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/refresher-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/refresher-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/refresher.md
+++ b/docs/api/refresher.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/refresher/props.md';
 import Events from '@ionic-internal/component-api/v8/refresher/events.md';
 import Methods from '@ionic-internal/component-api/v8/refresher/methods.md';
 import Parts from '@ionic-internal/component-api/v8/refresher/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/refresher/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/refresher/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/refresher/slots.md';
 
 <head>

--- a/docs/api/reorder-group.md
+++ b/docs/api/reorder-group.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/reorder-group/props.md';
 import Events from '@ionic-internal/component-api/v8/reorder-group/events.md';
 import Methods from '@ionic-internal/component-api/v8/reorder-group/methods.md';
 import Parts from '@ionic-internal/component-api/v8/reorder-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/reorder-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/reorder-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/reorder-group/slots.md';
 
 <head>

--- a/docs/api/reorder.md
+++ b/docs/api/reorder.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/reorder/props.md';
 import Events from '@ionic-internal/component-api/v8/reorder/events.md';
 import Methods from '@ionic-internal/component-api/v8/reorder/methods.md';
 import Parts from '@ionic-internal/component-api/v8/reorder/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/reorder/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/reorder/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/reorder/slots.md';
 
 <head>

--- a/docs/api/ripple-effect.md
+++ b/docs/api/ripple-effect.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/ripple-effect/props.md';
 import Events from '@ionic-internal/component-api/v8/ripple-effect/events.md';
 import Methods from '@ionic-internal/component-api/v8/ripple-effect/methods.md';
 import Parts from '@ionic-internal/component-api/v8/ripple-effect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/ripple-effect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/ripple-effect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/ripple-effect/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/docs/api/route-redirect.md
+++ b/docs/api/route-redirect.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/route-redirect/props.md';
 import Events from '@ionic-internal/component-api/v8/route-redirect/events.md';
 import Methods from '@ionic-internal/component-api/v8/route-redirect/methods.md';
 import Parts from '@ionic-internal/component-api/v8/route-redirect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/route-redirect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/route-redirect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/route-redirect/slots.md';
 
 <head>

--- a/docs/api/route.md
+++ b/docs/api/route.md
@@ -8,7 +8,7 @@ import Props from '@ionic-internal/component-api/v8/route/props.md';
 import Events from '@ionic-internal/component-api/v8/route/events.md';
 import Methods from '@ionic-internal/component-api/v8/route/methods.md';
 import Parts from '@ionic-internal/component-api/v8/route/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/route/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/route/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/route/slots.md';
 
 <head>

--- a/docs/api/router-link.md
+++ b/docs/api/router-link.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/router-link/props.md';
 import Events from '@ionic-internal/component-api/v8/router-link/events.md';
 import Methods from '@ionic-internal/component-api/v8/router-link/methods.md';
 import Parts from '@ionic-internal/component-api/v8/router-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/router-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/router-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/router-link/slots.md';
 
 <head>

--- a/docs/api/router-outlet.md
+++ b/docs/api/router-outlet.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/router-outlet/props.md';
 import Events from '@ionic-internal/component-api/v8/router-outlet/events.md';
 import Methods from '@ionic-internal/component-api/v8/router-outlet/methods.md';
 import Parts from '@ionic-internal/component-api/v8/router-outlet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/router-outlet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/router-outlet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/router-outlet/slots.md';
 
 

--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/router/props.md';
 import Events from '@ionic-internal/component-api/v8/router/events.md';
 import Methods from '@ionic-internal/component-api/v8/router/methods.md';
 import Parts from '@ionic-internal/component-api/v8/router/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/router/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/router/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/router/slots.md';
 
 <head>

--- a/docs/api/row.md
+++ b/docs/api/row.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/row/props.md';
 import Events from '@ionic-internal/component-api/v8/row/events.md';
 import Methods from '@ionic-internal/component-api/v8/row/methods.md';
 import Parts from '@ionic-internal/component-api/v8/row/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/row/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/row/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/row/slots.md';
 
 <head>

--- a/docs/api/searchbar.md
+++ b/docs/api/searchbar.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/searchbar/props.md';
 import Events from '@ionic-internal/component-api/v8/searchbar/events.md';
 import Methods from '@ionic-internal/component-api/v8/searchbar/methods.md';
 import Parts from '@ionic-internal/component-api/v8/searchbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/searchbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/searchbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/searchbar/slots.md';
 
 <head>

--- a/docs/api/segment-button.md
+++ b/docs/api/segment-button.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/segment-button/props.md';
 import Events from '@ionic-internal/component-api/v8/segment-button/events.md';
 import Methods from '@ionic-internal/component-api/v8/segment-button/methods.md';
 import Parts from '@ionic-internal/component-api/v8/segment-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/segment-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/segment-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/segment-button/slots.md';
 
 <head>

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/segment/props.md';
 import Events from '@ionic-internal/component-api/v8/segment/events.md';
 import Methods from '@ionic-internal/component-api/v8/segment/methods.md';
 import Parts from '@ionic-internal/component-api/v8/segment/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/segment/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/segment/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/segment/slots.md';
 
 <head>

--- a/docs/api/select-option.md
+++ b/docs/api/select-option.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/select-option/props.md';
 import Events from '@ionic-internal/component-api/v8/select-option/events.md';
 import Methods from '@ionic-internal/component-api/v8/select-option/methods.md';
 import Parts from '@ionic-internal/component-api/v8/select-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/select-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/select-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/select-option/slots.md';
 
 <head>

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/select/props.md';
 import Events from '@ionic-internal/component-api/v8/select/events.md';
 import Methods from '@ionic-internal/component-api/v8/select/methods.md';
 import Parts from '@ionic-internal/component-api/v8/select/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/select/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/select/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/select/slots.md';
 
 <head>

--- a/docs/api/skeleton-text.md
+++ b/docs/api/skeleton-text.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/skeleton-text/props.md';
 import Events from '@ionic-internal/component-api/v8/skeleton-text/events.md';
 import Methods from '@ionic-internal/component-api/v8/skeleton-text/methods.md';
 import Parts from '@ionic-internal/component-api/v8/skeleton-text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/skeleton-text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/skeleton-text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/skeleton-text/slots.md';
 
 <head>

--- a/docs/api/spinner.md
+++ b/docs/api/spinner.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/spinner/props.md';
 import Events from '@ionic-internal/component-api/v8/spinner/events.md';
 import Methods from '@ionic-internal/component-api/v8/spinner/methods.md';
 import Parts from '@ionic-internal/component-api/v8/spinner/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/spinner/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/spinner/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/spinner/slots.md';
 
 <head>

--- a/docs/api/split-pane.md
+++ b/docs/api/split-pane.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/split-pane/props.md';
 import Events from '@ionic-internal/component-api/v8/split-pane/events.md';
 import Methods from '@ionic-internal/component-api/v8/split-pane/methods.md';
 import Parts from '@ionic-internal/component-api/v8/split-pane/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/split-pane/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/split-pane/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/split-pane/slots.md';
 
 <head>

--- a/docs/api/tab-bar.md
+++ b/docs/api/tab-bar.md
@@ -8,7 +8,7 @@ import Props from '@ionic-internal/component-api/v8/tab-bar/props.md';
 import Events from '@ionic-internal/component-api/v8/tab-bar/events.md';
 import Methods from '@ionic-internal/component-api/v8/tab-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v8/tab-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/tab-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/tab-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/tab-bar/slots.md';
 
 <head>

--- a/docs/api/tab-button.md
+++ b/docs/api/tab-button.md
@@ -8,11 +8,11 @@ import Props from '@ionic-internal/component-api/v8/tab-button/props.md';
 import Events from '@ionic-internal/component-api/v8/tab-button/events.md';
 import Methods from '@ionic-internal/component-api/v8/tab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v8/tab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/tab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/tab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/tab-button/slots.md';
 
 
-
+ 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 
 <EncapsulationPill type="shadow" />

--- a/docs/api/tab.md
+++ b/docs/api/tab.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/tab/props.md';
 import Events from '@ionic-internal/component-api/v8/tab/events.md';
 import Methods from '@ionic-internal/component-api/v8/tab/methods.md';
 import Parts from '@ionic-internal/component-api/v8/tab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/tab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/tab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/tab/slots.md';
 
 <head>

--- a/docs/api/tabs.md
+++ b/docs/api/tabs.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/tabs/props.md';
 import Events from '@ionic-internal/component-api/v8/tabs/events.md';
 import Methods from '@ionic-internal/component-api/v8/tabs/methods.md';
 import Parts from '@ionic-internal/component-api/v8/tabs/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/tabs/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/tabs/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/tabs/slots.md';
 
 <head>

--- a/docs/api/text.md
+++ b/docs/api/text.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/text/props.md';
 import Events from '@ionic-internal/component-api/v8/text/events.md';
 import Methods from '@ionic-internal/component-api/v8/text/methods.md';
 import Parts from '@ionic-internal/component-api/v8/text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/text/slots.md';
 
 <head>

--- a/docs/api/textarea.md
+++ b/docs/api/textarea.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/textarea/props.md';
 import Events from '@ionic-internal/component-api/v8/textarea/events.md';
 import Methods from '@ionic-internal/component-api/v8/textarea/methods.md';
 import Parts from '@ionic-internal/component-api/v8/textarea/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/textarea/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/textarea/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/textarea/slots.md';
 
 <head>

--- a/docs/api/thumbnail.md
+++ b/docs/api/thumbnail.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v8/thumbnail/props.md';
 import Events from '@ionic-internal/component-api/v8/thumbnail/events.md';
 import Methods from '@ionic-internal/component-api/v8/thumbnail/methods.md';
 import Parts from '@ionic-internal/component-api/v8/thumbnail/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/thumbnail/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/thumbnail/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/thumbnail/slots.md';
 
 <head>

--- a/docs/api/title.md
+++ b/docs/api/title.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/title/props.md';
 import Events from '@ionic-internal/component-api/v8/title/events.md';
 import Methods from '@ionic-internal/component-api/v8/title/methods.md';
 import Parts from '@ionic-internal/component-api/v8/title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/title/slots.md';
 
 <head>

--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -8,7 +8,7 @@ import Props from '@ionic-internal/component-api/v8/toast/props.md';
 import Events from '@ionic-internal/component-api/v8/toast/events.md';
 import Methods from '@ionic-internal/component-api/v8/toast/methods.md';
 import Parts from '@ionic-internal/component-api/v8/toast/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/toast/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/toast/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/toast/slots.md';
 
 <head>

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/toggle/props.md';
 import Events from '@ionic-internal/component-api/v8/toggle/events.md';
 import Methods from '@ionic-internal/component-api/v8/toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v8/toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/toggle/slots.md';
 
 <head>

--- a/docs/api/toolbar.md
+++ b/docs/api/toolbar.md
@@ -5,7 +5,7 @@ import Props from '@ionic-internal/component-api/v8/toolbar/props.md';
 import Events from '@ionic-internal/component-api/v8/toolbar/events.md';
 import Methods from '@ionic-internal/component-api/v8/toolbar/methods.md';
 import Parts from '@ionic-internal/component-api/v8/toolbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v8/toolbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v8/toolbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v8/toolbar/slots.md';
 
 <head>

--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -76,7 +76,7 @@ module.exports = function (context, options) {
           createData(`${basePath}/events.md`, data.events),
           createData(`${basePath}/methods.md`, data.methods),
           createData(`${basePath}/parts.md`, data.parts),
-          createData(`${basePath}/custom-props.md`, data.customProps),
+          createData(`${basePath}/custom-props.mdx`, data.customProps),
           createData(`${basePath}/slots.md`, data.slots)
         );
       }
@@ -214,11 +214,51 @@ function renderCustomProps({ styles: customProps }) {
     return 'No CSS custom properties available for this component.';
   }
 
-  return `
+  const iosProps = customProps.filter((prop) => prop.mode === 'ios');
+  const mdProps = customProps.filter((prop) => prop.mode === 'md');
+
+  if (iosProps.length > 0 || mdProps.length > 0) {
+    // If the component has mode-specific custom props, render them in tabs for iOS and MD
+    return `
+import Tabs from '@theme/Tabs';
+
+import TabItem from '@theme/TabItem';
+
+\`\`\`\`mdx-code-block
+<Tabs
+  groupId="mode"
+  defaultValue="ios"
+  values={[
+    { value: 'ios', label: 'iOS' },
+    { value: 'md', label: 'MD' },
+  ]
+}>
+<TabItem value="ios">
+
 | Name | Description |
 | --- | --- |
-${customProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
+${iosProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
 
+</TabItem>
+
+<TabItem value="md">
+
+| Name | Description |
+| --- | --- |
+${mdProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
+
+</TabItem>
+</Tabs>
+
+\`\`\`\`
+
+`;
+  }
+  // Otherwise render the custom props without the tabs for iOS and MD
+  return `
+  | Name | Description |
+| --- | --- |
+${customProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
 `;
 }
 

--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -210,12 +210,20 @@ ${parts.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).jo
 }
 
 function renderCustomProps({ styles: customProps }) {
-  if (customProps.length === 0) {
-    return 'No CSS custom properties available for this component.';
-  }
-
   const iosProps = customProps.filter((prop) => prop.mode === 'ios');
   const mdProps = customProps.filter((prop) => prop.mode === 'md');
+
+  const renderTable = (props) => {
+    if (props.length === 0) {
+      return 'No CSS custom properties available for this component.';
+    }
+
+    return `
+    | Name | Description |
+  | --- | --- |
+  ${props.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
+  `;
+  };
 
   if (iosProps.length > 0 || mdProps.length > 0) {
     // If the component has mode-specific custom props, render them in tabs for iOS and MD
@@ -235,17 +243,13 @@ import TabItem from '@theme/TabItem';
 }>
 <TabItem value="ios">
 
-| Name | Description |
-| --- | --- |
-${iosProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
+${renderTable(iosProps)}
 
 </TabItem>
 
 <TabItem value="md">
 
-| Name | Description |
-| --- | --- |
-${mdProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
+${renderTable(mdProps)}
 
 </TabItem>
 </Tabs>
@@ -255,11 +259,7 @@ ${mdProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).
 `;
   }
   // Otherwise render the custom props without the tabs for iOS and MD
-  return `
-  | Name | Description |
-| --- | --- |
-${customProps.map((prop) => `| \`${prop.name}\` | ${formatMultiline(prop.docs)} |`).join('\n')}
-`;
+  return renderTable(customProps);
 }
 
 function renderSlots({ slots }) {

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'fs';
 import * as utils from './utils.mjs';
-import cliJSON from './data/cli.json' assert { type: 'json' };
-import cliOverrides from './data/meta-override.json' assert { type: 'json' };
+import cliJSON from './data/cli.json' with { type: 'json' };
+import cliOverrides from './data/meta-override.json' with { type: 'json' };
 
 const commandToKebab = (str) =>
   str

--- a/versioned_docs/version-v5/api/action-sheet.md
+++ b/versioned_docs/version-v5/api/action-sheet.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/action-sheet/props.md';
 import Events from '@ionic-internal/component-api/v5/action-sheet/events.md';
 import Methods from '@ionic-internal/component-api/v5/action-sheet/methods.md';
 import Parts from '@ionic-internal/component-api/v5/action-sheet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/action-sheet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/action-sheet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/action-sheet/slots.md';
 
 # ion-action-sheet

--- a/versioned_docs/version-v5/api/alert.md
+++ b/versioned_docs/version-v5/api/alert.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/alert/props.md';
 import Events from '@ionic-internal/component-api/v5/alert/events.md';
 import Methods from '@ionic-internal/component-api/v5/alert/methods.md';
 import Parts from '@ionic-internal/component-api/v5/alert/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/alert/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/alert/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/alert/slots.md';
 
 # ion-alert

--- a/versioned_docs/version-v5/api/app.md
+++ b/versioned_docs/version-v5/api/app.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/app/props.md';
 import Events from '@ionic-internal/component-api/v5/app/events.md';
 import Methods from '@ionic-internal/component-api/v5/app/methods.md';
 import Parts from '@ionic-internal/component-api/v5/app/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/app/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/app/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/app/slots.md';
 
 # ion-app

--- a/versioned_docs/version-v5/api/avatar.md
+++ b/versioned_docs/version-v5/api/avatar.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/avatar/props.md';
 import Events from '@ionic-internal/component-api/v5/avatar/events.md';
 import Methods from '@ionic-internal/component-api/v5/avatar/methods.md';
 import Parts from '@ionic-internal/component-api/v5/avatar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/avatar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/avatar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/avatar/slots.md';
 
 # ion-avatar

--- a/versioned_docs/version-v5/api/back-button.md
+++ b/versioned_docs/version-v5/api/back-button.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/back-button/props.md';
 import Events from '@ionic-internal/component-api/v5/back-button/events.md';
 import Methods from '@ionic-internal/component-api/v5/back-button/methods.md';
 import Parts from '@ionic-internal/component-api/v5/back-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/back-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/back-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/back-button/slots.md';
 
 # ion-back-button

--- a/versioned_docs/version-v5/api/backdrop.md
+++ b/versioned_docs/version-v5/api/backdrop.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/backdrop/props.md';
 import Events from '@ionic-internal/component-api/v5/backdrop/events.md';
 import Methods from '@ionic-internal/component-api/v5/backdrop/methods.md';
 import Parts from '@ionic-internal/component-api/v5/backdrop/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/backdrop/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/backdrop/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/backdrop/slots.md';
 
 # ion-backdrop

--- a/versioned_docs/version-v5/api/badge.md
+++ b/versioned_docs/version-v5/api/badge.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/badge/props.md';
 import Events from '@ionic-internal/component-api/v5/badge/events.md';
 import Methods from '@ionic-internal/component-api/v5/badge/methods.md';
 import Parts from '@ionic-internal/component-api/v5/badge/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/badge/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/badge/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/badge/slots.md';
 
 # ion-badge

--- a/versioned_docs/version-v5/api/button.md
+++ b/versioned_docs/version-v5/api/button.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/button/props.md';
 import Events from '@ionic-internal/component-api/v5/button/events.md';
 import Methods from '@ionic-internal/component-api/v5/button/methods.md';
 import Parts from '@ionic-internal/component-api/v5/button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/button/slots.md';
 
 # ion-button

--- a/versioned_docs/version-v5/api/buttons.md
+++ b/versioned_docs/version-v5/api/buttons.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/buttons/props.md';
 import Events from '@ionic-internal/component-api/v5/buttons/events.md';
 import Methods from '@ionic-internal/component-api/v5/buttons/methods.md';
 import Parts from '@ionic-internal/component-api/v5/buttons/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/buttons/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/buttons/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/buttons/slots.md';
 
 # ion-buttons

--- a/versioned_docs/version-v5/api/card-content.md
+++ b/versioned_docs/version-v5/api/card-content.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/card-content/props.md';
 import Events from '@ionic-internal/component-api/v5/card-content/events.md';
 import Methods from '@ionic-internal/component-api/v5/card-content/methods.md';
 import Parts from '@ionic-internal/component-api/v5/card-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/card-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/card-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/card-content/slots.md';
 
 # ion-card-content

--- a/versioned_docs/version-v5/api/card-header.md
+++ b/versioned_docs/version-v5/api/card-header.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/card-header/props.md';
 import Events from '@ionic-internal/component-api/v5/card-header/events.md';
 import Methods from '@ionic-internal/component-api/v5/card-header/methods.md';
 import Parts from '@ionic-internal/component-api/v5/card-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/card-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/card-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/card-header/slots.md';
 
 # ion-card-header

--- a/versioned_docs/version-v5/api/card-subtitle.md
+++ b/versioned_docs/version-v5/api/card-subtitle.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/card-subtitle/props.md';
 import Events from '@ionic-internal/component-api/v5/card-subtitle/events.md';
 import Methods from '@ionic-internal/component-api/v5/card-subtitle/methods.md';
 import Parts from '@ionic-internal/component-api/v5/card-subtitle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/card-subtitle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/card-subtitle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/card-subtitle/slots.md';
 
 # ion-card-subtitle

--- a/versioned_docs/version-v5/api/card-title.md
+++ b/versioned_docs/version-v5/api/card-title.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/card-title/props.md';
 import Events from '@ionic-internal/component-api/v5/card-title/events.md';
 import Methods from '@ionic-internal/component-api/v5/card-title/methods.md';
 import Parts from '@ionic-internal/component-api/v5/card-title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/card-title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/card-title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/card-title/slots.md';
 
 # ion-card-title

--- a/versioned_docs/version-v5/api/card.md
+++ b/versioned_docs/version-v5/api/card.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/card/props.md';
 import Events from '@ionic-internal/component-api/v5/card/events.md';
 import Methods from '@ionic-internal/component-api/v5/card/methods.md';
 import Parts from '@ionic-internal/component-api/v5/card/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/card/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/card/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/card/slots.md';
 
 # ion-card

--- a/versioned_docs/version-v5/api/checkbox.md
+++ b/versioned_docs/version-v5/api/checkbox.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/checkbox/props.md';
 import Events from '@ionic-internal/component-api/v5/checkbox/events.md';
 import Methods from '@ionic-internal/component-api/v5/checkbox/methods.md';
 import Parts from '@ionic-internal/component-api/v5/checkbox/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/checkbox/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/checkbox/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/checkbox/slots.md';
 
 # ion-checkbox

--- a/versioned_docs/version-v5/api/chip.md
+++ b/versioned_docs/version-v5/api/chip.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/chip/props.md';
 import Events from '@ionic-internal/component-api/v5/chip/events.md';
 import Methods from '@ionic-internal/component-api/v5/chip/methods.md';
 import Parts from '@ionic-internal/component-api/v5/chip/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/chip/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/chip/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/chip/slots.md';
 
 # ion-chip

--- a/versioned_docs/version-v5/api/col.md
+++ b/versioned_docs/version-v5/api/col.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/col/props.md';
 import Events from '@ionic-internal/component-api/v5/col/events.md';
 import Methods from '@ionic-internal/component-api/v5/col/methods.md';
 import Parts from '@ionic-internal/component-api/v5/col/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/col/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/col/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/col/slots.md';
 
 # ion-col

--- a/versioned_docs/version-v5/api/content.md
+++ b/versioned_docs/version-v5/api/content.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/content/props.md';
 import Events from '@ionic-internal/component-api/v5/content/events.md';
 import Methods from '@ionic-internal/component-api/v5/content/methods.md';
 import Parts from '@ionic-internal/component-api/v5/content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/content/slots.md';
 
 # ion-content

--- a/versioned_docs/version-v5/api/datetime.md
+++ b/versioned_docs/version-v5/api/datetime.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/datetime/props.md';
 import Events from '@ionic-internal/component-api/v5/datetime/events.md';
 import Methods from '@ionic-internal/component-api/v5/datetime/methods.md';
 import Parts from '@ionic-internal/component-api/v5/datetime/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/datetime/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/datetime/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/datetime/slots.md';
 
 # ion-datetime

--- a/versioned_docs/version-v5/api/fab-button.md
+++ b/versioned_docs/version-v5/api/fab-button.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/fab-button/props.md';
 import Events from '@ionic-internal/component-api/v5/fab-button/events.md';
 import Methods from '@ionic-internal/component-api/v5/fab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v5/fab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/fab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/fab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/fab-button/slots.md';
 
 # ion-fab-button

--- a/versioned_docs/version-v5/api/fab-list.md
+++ b/versioned_docs/version-v5/api/fab-list.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/fab-list/props.md';
 import Events from '@ionic-internal/component-api/v5/fab-list/events.md';
 import Methods from '@ionic-internal/component-api/v5/fab-list/methods.md';
 import Parts from '@ionic-internal/component-api/v5/fab-list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/fab-list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/fab-list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/fab-list/slots.md';
 
 # ion-fab-list

--- a/versioned_docs/version-v5/api/fab.md
+++ b/versioned_docs/version-v5/api/fab.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/fab/props.md';
 import Events from '@ionic-internal/component-api/v5/fab/events.md';
 import Methods from '@ionic-internal/component-api/v5/fab/methods.md';
 import Parts from '@ionic-internal/component-api/v5/fab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/fab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/fab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/fab/slots.md';
 
 # ion-fab

--- a/versioned_docs/version-v5/api/footer.md
+++ b/versioned_docs/version-v5/api/footer.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/footer/props.md';
 import Events from '@ionic-internal/component-api/v5/footer/events.md';
 import Methods from '@ionic-internal/component-api/v5/footer/methods.md';
 import Parts from '@ionic-internal/component-api/v5/footer/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/footer/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/footer/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/footer/slots.md';
 
 # ion-footer

--- a/versioned_docs/version-v5/api/grid.md
+++ b/versioned_docs/version-v5/api/grid.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/grid/props.md';
 import Events from '@ionic-internal/component-api/v5/grid/events.md';
 import Methods from '@ionic-internal/component-api/v5/grid/methods.md';
 import Parts from '@ionic-internal/component-api/v5/grid/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/grid/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/grid/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/grid/slots.md';
 
 # ion-grid

--- a/versioned_docs/version-v5/api/header.md
+++ b/versioned_docs/version-v5/api/header.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/header/props.md';
 import Events from '@ionic-internal/component-api/v5/header/events.md';
 import Methods from '@ionic-internal/component-api/v5/header/methods.md';
 import Parts from '@ionic-internal/component-api/v5/header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/header/slots.md';
 
 # ion-header

--- a/versioned_docs/version-v5/api/img.md
+++ b/versioned_docs/version-v5/api/img.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/img/props.md';
 import Events from '@ionic-internal/component-api/v5/img/events.md';
 import Methods from '@ionic-internal/component-api/v5/img/methods.md';
 import Parts from '@ionic-internal/component-api/v5/img/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/img/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/img/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/img/slots.md';
 
 # ion-img

--- a/versioned_docs/version-v5/api/infinite-scroll-content.md
+++ b/versioned_docs/version-v5/api/infinite-scroll-content.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/infinite-scroll-content/prop
 import Events from '@ionic-internal/component-api/v5/infinite-scroll-content/events.md';
 import Methods from '@ionic-internal/component-api/v5/infinite-scroll-content/methods.md';
 import Parts from '@ionic-internal/component-api/v5/infinite-scroll-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/infinite-scroll-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/infinite-scroll-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/infinite-scroll-content/slots.md';
 
 # ion-infinite-scroll-content

--- a/versioned_docs/version-v5/api/infinite-scroll.md
+++ b/versioned_docs/version-v5/api/infinite-scroll.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/infinite-scroll/props.md';
 import Events from '@ionic-internal/component-api/v5/infinite-scroll/events.md';
 import Methods from '@ionic-internal/component-api/v5/infinite-scroll/methods.md';
 import Parts from '@ionic-internal/component-api/v5/infinite-scroll/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/infinite-scroll/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/infinite-scroll/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/infinite-scroll/slots.md';
 
 # ion-infinite-scroll

--- a/versioned_docs/version-v5/api/input.md
+++ b/versioned_docs/version-v5/api/input.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/input/props.md';
 import Events from '@ionic-internal/component-api/v5/input/events.md';
 import Methods from '@ionic-internal/component-api/v5/input/methods.md';
 import Parts from '@ionic-internal/component-api/v5/input/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/input/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/input/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/input/slots.md';
 
 # ion-input

--- a/versioned_docs/version-v5/api/item-divider.md
+++ b/versioned_docs/version-v5/api/item-divider.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/item-divider/props.md';
 import Events from '@ionic-internal/component-api/v5/item-divider/events.md';
 import Methods from '@ionic-internal/component-api/v5/item-divider/methods.md';
 import Parts from '@ionic-internal/component-api/v5/item-divider/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/item-divider/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/item-divider/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/item-divider/slots.md';
 
 # ion-item-divider

--- a/versioned_docs/version-v5/api/item-group.md
+++ b/versioned_docs/version-v5/api/item-group.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/item-group/props.md';
 import Events from '@ionic-internal/component-api/v5/item-group/events.md';
 import Methods from '@ionic-internal/component-api/v5/item-group/methods.md';
 import Parts from '@ionic-internal/component-api/v5/item-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/item-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/item-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/item-group/slots.md';
 
 # ion-item-group

--- a/versioned_docs/version-v5/api/item-option.md
+++ b/versioned_docs/version-v5/api/item-option.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/item-option/props.md';
 import Events from '@ionic-internal/component-api/v5/item-option/events.md';
 import Methods from '@ionic-internal/component-api/v5/item-option/methods.md';
 import Parts from '@ionic-internal/component-api/v5/item-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/item-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/item-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/item-option/slots.md';
 
 # ion-item-option

--- a/versioned_docs/version-v5/api/item-options.md
+++ b/versioned_docs/version-v5/api/item-options.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/item-options/props.md';
 import Events from '@ionic-internal/component-api/v5/item-options/events.md';
 import Methods from '@ionic-internal/component-api/v5/item-options/methods.md';
 import Parts from '@ionic-internal/component-api/v5/item-options/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/item-options/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/item-options/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/item-options/slots.md';
 
 # ion-item-options

--- a/versioned_docs/version-v5/api/item-sliding.md
+++ b/versioned_docs/version-v5/api/item-sliding.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/item-sliding/props.md';
 import Events from '@ionic-internal/component-api/v5/item-sliding/events.md';
 import Methods from '@ionic-internal/component-api/v5/item-sliding/methods.md';
 import Parts from '@ionic-internal/component-api/v5/item-sliding/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/item-sliding/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/item-sliding/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/item-sliding/slots.md';
 
 # ion-item-sliding

--- a/versioned_docs/version-v5/api/item.md
+++ b/versioned_docs/version-v5/api/item.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/item/props.md';
 import Events from '@ionic-internal/component-api/v5/item/events.md';
 import Methods from '@ionic-internal/component-api/v5/item/methods.md';
 import Parts from '@ionic-internal/component-api/v5/item/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/item/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/item/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/item/slots.md';
 
 # ion-item

--- a/versioned_docs/version-v5/api/label.md
+++ b/versioned_docs/version-v5/api/label.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/label/props.md';
 import Events from '@ionic-internal/component-api/v5/label/events.md';
 import Methods from '@ionic-internal/component-api/v5/label/methods.md';
 import Parts from '@ionic-internal/component-api/v5/label/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/label/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/label/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/label/slots.md';
 
 # ion-label

--- a/versioned_docs/version-v5/api/list-header.md
+++ b/versioned_docs/version-v5/api/list-header.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/list-header/props.md';
 import Events from '@ionic-internal/component-api/v5/list-header/events.md';
 import Methods from '@ionic-internal/component-api/v5/list-header/methods.md';
 import Parts from '@ionic-internal/component-api/v5/list-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/list-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/list-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/list-header/slots.md';
 
 # ion-list-header

--- a/versioned_docs/version-v5/api/list.md
+++ b/versioned_docs/version-v5/api/list.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/list/props.md';
 import Events from '@ionic-internal/component-api/v5/list/events.md';
 import Methods from '@ionic-internal/component-api/v5/list/methods.md';
 import Parts from '@ionic-internal/component-api/v5/list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/list/slots.md';
 
 # ion-list

--- a/versioned_docs/version-v5/api/loading.md
+++ b/versioned_docs/version-v5/api/loading.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/loading/props.md';
 import Events from '@ionic-internal/component-api/v5/loading/events.md';
 import Methods from '@ionic-internal/component-api/v5/loading/methods.md';
 import Parts from '@ionic-internal/component-api/v5/loading/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/loading/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/loading/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/loading/slots.md';
 
 # ion-loading

--- a/versioned_docs/version-v5/api/menu-button.md
+++ b/versioned_docs/version-v5/api/menu-button.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/menu-button/props.md';
 import Events from '@ionic-internal/component-api/v5/menu-button/events.md';
 import Methods from '@ionic-internal/component-api/v5/menu-button/methods.md';
 import Parts from '@ionic-internal/component-api/v5/menu-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/menu-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/menu-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/menu-button/slots.md';
 
 # ion-menu-button

--- a/versioned_docs/version-v5/api/menu-toggle.md
+++ b/versioned_docs/version-v5/api/menu-toggle.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/menu-toggle/props.md';
 import Events from '@ionic-internal/component-api/v5/menu-toggle/events.md';
 import Methods from '@ionic-internal/component-api/v5/menu-toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v5/menu-toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/menu-toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/menu-toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/menu-toggle/slots.md';
 
 # ion-menu-toggle

--- a/versioned_docs/version-v5/api/menu.md
+++ b/versioned_docs/version-v5/api/menu.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/menu/props.md';
 import Events from '@ionic-internal/component-api/v5/menu/events.md';
 import Methods from '@ionic-internal/component-api/v5/menu/methods.md';
 import Parts from '@ionic-internal/component-api/v5/menu/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/menu/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/menu/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/menu/slots.md';
 
 # ion-menu

--- a/versioned_docs/version-v5/api/modal.md
+++ b/versioned_docs/version-v5/api/modal.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/modal/props.md';
 import Events from '@ionic-internal/component-api/v5/modal/events.md';
 import Methods from '@ionic-internal/component-api/v5/modal/methods.md';
 import Parts from '@ionic-internal/component-api/v5/modal/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/modal/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/modal/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/modal/slots.md';
 
 # ion-modal

--- a/versioned_docs/version-v5/api/nav-link.md
+++ b/versioned_docs/version-v5/api/nav-link.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/nav-link/props.md';
 import Events from '@ionic-internal/component-api/v5/nav-link/events.md';
 import Methods from '@ionic-internal/component-api/v5/nav-link/methods.md';
 import Parts from '@ionic-internal/component-api/v5/nav-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/nav-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/nav-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/nav-link/slots.md';
 
 # ion-nav-link

--- a/versioned_docs/version-v5/api/nav.md
+++ b/versioned_docs/version-v5/api/nav.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/nav/props.md';
 import Events from '@ionic-internal/component-api/v5/nav/events.md';
 import Methods from '@ionic-internal/component-api/v5/nav/methods.md';
 import Parts from '@ionic-internal/component-api/v5/nav/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/nav/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/nav/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/nav/slots.md';
 
 # ion-nav

--- a/versioned_docs/version-v5/api/note.md
+++ b/versioned_docs/version-v5/api/note.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/note/props.md';
 import Events from '@ionic-internal/component-api/v5/note/events.md';
 import Methods from '@ionic-internal/component-api/v5/note/methods.md';
 import Parts from '@ionic-internal/component-api/v5/note/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/note/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/note/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/note/slots.md';
 
 # ion-note

--- a/versioned_docs/version-v5/api/picker.md
+++ b/versioned_docs/version-v5/api/picker.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/picker/props.md';
 import Events from '@ionic-internal/component-api/v5/picker/events.md';
 import Methods from '@ionic-internal/component-api/v5/picker/methods.md';
 import Parts from '@ionic-internal/component-api/v5/picker/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/picker/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/picker/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/picker/slots.md';
 
 # ion-picker

--- a/versioned_docs/version-v5/api/popover.md
+++ b/versioned_docs/version-v5/api/popover.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/popover/props.md';
 import Events from '@ionic-internal/component-api/v5/popover/events.md';
 import Methods from '@ionic-internal/component-api/v5/popover/methods.md';
 import Parts from '@ionic-internal/component-api/v5/popover/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/popover/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/popover/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/popover/slots.md';
 
 # ion-popover

--- a/versioned_docs/version-v5/api/progress-bar.md
+++ b/versioned_docs/version-v5/api/progress-bar.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/progress-bar/props.md';
 import Events from '@ionic-internal/component-api/v5/progress-bar/events.md';
 import Methods from '@ionic-internal/component-api/v5/progress-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v5/progress-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/progress-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/progress-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/progress-bar/slots.md';
 
 # ion-progress-bar

--- a/versioned_docs/version-v5/api/radio-group.md
+++ b/versioned_docs/version-v5/api/radio-group.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/radio-group/props.md';
 import Events from '@ionic-internal/component-api/v5/radio-group/events.md';
 import Methods from '@ionic-internal/component-api/v5/radio-group/methods.md';
 import Parts from '@ionic-internal/component-api/v5/radio-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/radio-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/radio-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/radio-group/slots.md';
 
 # ion-radio-group

--- a/versioned_docs/version-v5/api/radio.md
+++ b/versioned_docs/version-v5/api/radio.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/radio/props.md';
 import Events from '@ionic-internal/component-api/v5/radio/events.md';
 import Methods from '@ionic-internal/component-api/v5/radio/methods.md';
 import Parts from '@ionic-internal/component-api/v5/radio/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/radio/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/radio/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/radio/slots.md';
 
 # ion-radio

--- a/versioned_docs/version-v5/api/range.md
+++ b/versioned_docs/version-v5/api/range.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/range/props.md';
 import Events from '@ionic-internal/component-api/v5/range/events.md';
 import Methods from '@ionic-internal/component-api/v5/range/methods.md';
 import Parts from '@ionic-internal/component-api/v5/range/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/range/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/range/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/range/slots.md';
 
 # ion-range

--- a/versioned_docs/version-v5/api/refresher-content.md
+++ b/versioned_docs/version-v5/api/refresher-content.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/refresher-content/props.md';
 import Events from '@ionic-internal/component-api/v5/refresher-content/events.md';
 import Methods from '@ionic-internal/component-api/v5/refresher-content/methods.md';
 import Parts from '@ionic-internal/component-api/v5/refresher-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/refresher-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/refresher-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/refresher-content/slots.md';
 
 # ion-refresher-content

--- a/versioned_docs/version-v5/api/refresher.md
+++ b/versioned_docs/version-v5/api/refresher.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/refresher/props.md';
 import Events from '@ionic-internal/component-api/v5/refresher/events.md';
 import Methods from '@ionic-internal/component-api/v5/refresher/methods.md';
 import Parts from '@ionic-internal/component-api/v5/refresher/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/refresher/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/refresher/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/refresher/slots.md';
 
 # ion-refresher

--- a/versioned_docs/version-v5/api/reorder-group.md
+++ b/versioned_docs/version-v5/api/reorder-group.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/reorder-group/props.md';
 import Events from '@ionic-internal/component-api/v5/reorder-group/events.md';
 import Methods from '@ionic-internal/component-api/v5/reorder-group/methods.md';
 import Parts from '@ionic-internal/component-api/v5/reorder-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/reorder-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/reorder-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/reorder-group/slots.md';
 
 # ion-reorder-group

--- a/versioned_docs/version-v5/api/reorder.md
+++ b/versioned_docs/version-v5/api/reorder.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/reorder/props.md';
 import Events from '@ionic-internal/component-api/v5/reorder/events.md';
 import Methods from '@ionic-internal/component-api/v5/reorder/methods.md';
 import Parts from '@ionic-internal/component-api/v5/reorder/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/reorder/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/reorder/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/reorder/slots.md';
 
 # ion-reorder

--- a/versioned_docs/version-v5/api/ripple-effect.md
+++ b/versioned_docs/version-v5/api/ripple-effect.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/ripple-effect/props.md';
 import Events from '@ionic-internal/component-api/v5/ripple-effect/events.md';
 import Methods from '@ionic-internal/component-api/v5/ripple-effect/methods.md';
 import Parts from '@ionic-internal/component-api/v5/ripple-effect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/ripple-effect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/ripple-effect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/ripple-effect/slots.md';
 
 # ion-ripple-effect

--- a/versioned_docs/version-v5/api/route-redirect.md
+++ b/versioned_docs/version-v5/api/route-redirect.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/route-redirect/props.md';
 import Events from '@ionic-internal/component-api/v5/route-redirect/events.md';
 import Methods from '@ionic-internal/component-api/v5/route-redirect/methods.md';
 import Parts from '@ionic-internal/component-api/v5/route-redirect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/route-redirect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/route-redirect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/route-redirect/slots.md';
 
 # ion-route-redirect

--- a/versioned_docs/version-v5/api/route.md
+++ b/versioned_docs/version-v5/api/route.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/route/props.md';
 import Events from '@ionic-internal/component-api/v5/route/events.md';
 import Methods from '@ionic-internal/component-api/v5/route/methods.md';
 import Parts from '@ionic-internal/component-api/v5/route/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/route/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/route/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/route/slots.md';
 
 # ion-route

--- a/versioned_docs/version-v5/api/router-link.md
+++ b/versioned_docs/version-v5/api/router-link.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/router-link/props.md';
 import Events from '@ionic-internal/component-api/v5/router-link/events.md';
 import Methods from '@ionic-internal/component-api/v5/router-link/methods.md';
 import Parts from '@ionic-internal/component-api/v5/router-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/router-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/router-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/router-link/slots.md';
 
 # ion-router-link

--- a/versioned_docs/version-v5/api/router-outlet.md
+++ b/versioned_docs/version-v5/api/router-outlet.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/router-outlet/props.md';
 import Events from '@ionic-internal/component-api/v5/router-outlet/events.md';
 import Methods from '@ionic-internal/component-api/v5/router-outlet/methods.md';
 import Parts from '@ionic-internal/component-api/v5/router-outlet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/router-outlet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/router-outlet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/router-outlet/slots.md';
 
 # ion-router-outlet

--- a/versioned_docs/version-v5/api/router.md
+++ b/versioned_docs/version-v5/api/router.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/router/props.md';
 import Events from '@ionic-internal/component-api/v5/router/events.md';
 import Methods from '@ionic-internal/component-api/v5/router/methods.md';
 import Parts from '@ionic-internal/component-api/v5/router/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/router/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/router/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/router/slots.md';
 
 # ion-router

--- a/versioned_docs/version-v5/api/row.md
+++ b/versioned_docs/version-v5/api/row.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/row/props.md';
 import Events from '@ionic-internal/component-api/v5/row/events.md';
 import Methods from '@ionic-internal/component-api/v5/row/methods.md';
 import Parts from '@ionic-internal/component-api/v5/row/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/row/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/row/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/row/slots.md';
 
 # ion-row

--- a/versioned_docs/version-v5/api/searchbar.md
+++ b/versioned_docs/version-v5/api/searchbar.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/searchbar/props.md';
 import Events from '@ionic-internal/component-api/v5/searchbar/events.md';
 import Methods from '@ionic-internal/component-api/v5/searchbar/methods.md';
 import Parts from '@ionic-internal/component-api/v5/searchbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/searchbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/searchbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/searchbar/slots.md';
 
 # ion-searchbar

--- a/versioned_docs/version-v5/api/segment-button.md
+++ b/versioned_docs/version-v5/api/segment-button.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/segment-button/props.md';
 import Events from '@ionic-internal/component-api/v5/segment-button/events.md';
 import Methods from '@ionic-internal/component-api/v5/segment-button/methods.md';
 import Parts from '@ionic-internal/component-api/v5/segment-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/segment-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/segment-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/segment-button/slots.md';
 
 # ion-segment-button

--- a/versioned_docs/version-v5/api/segment.md
+++ b/versioned_docs/version-v5/api/segment.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/segment/props.md';
 import Events from '@ionic-internal/component-api/v5/segment/events.md';
 import Methods from '@ionic-internal/component-api/v5/segment/methods.md';
 import Parts from '@ionic-internal/component-api/v5/segment/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/segment/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/segment/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/segment/slots.md';
 
 # ion-segment

--- a/versioned_docs/version-v5/api/select-option.md
+++ b/versioned_docs/version-v5/api/select-option.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/select-option/props.md';
 import Events from '@ionic-internal/component-api/v5/select-option/events.md';
 import Methods from '@ionic-internal/component-api/v5/select-option/methods.md';
 import Parts from '@ionic-internal/component-api/v5/select-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/select-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/select-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/select-option/slots.md';
 
 # ion-select-option

--- a/versioned_docs/version-v5/api/select.md
+++ b/versioned_docs/version-v5/api/select.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/select/props.md';
 import Events from '@ionic-internal/component-api/v5/select/events.md';
 import Methods from '@ionic-internal/component-api/v5/select/methods.md';
 import Parts from '@ionic-internal/component-api/v5/select/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/select/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/select/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/select/slots.md';
 
 # ion-select

--- a/versioned_docs/version-v5/api/skeleton-text.md
+++ b/versioned_docs/version-v5/api/skeleton-text.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/skeleton-text/props.md';
 import Events from '@ionic-internal/component-api/v5/skeleton-text/events.md';
 import Methods from '@ionic-internal/component-api/v5/skeleton-text/methods.md';
 import Parts from '@ionic-internal/component-api/v5/skeleton-text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/skeleton-text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/skeleton-text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/skeleton-text/slots.md';
 
 # ion-skeleton-text

--- a/versioned_docs/version-v5/api/slide.md
+++ b/versioned_docs/version-v5/api/slide.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/slide/props.md';
 import Events from '@ionic-internal/component-api/v5/slide/events.md';
 import Methods from '@ionic-internal/component-api/v5/slide/methods.md';
 import Parts from '@ionic-internal/component-api/v5/slide/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/slide/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/slide/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/slide/slots.md';
 
 # ion-slide

--- a/versioned_docs/version-v5/api/slides.md
+++ b/versioned_docs/version-v5/api/slides.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/slides/props.md';
 import Events from '@ionic-internal/component-api/v5/slides/events.md';
 import Methods from '@ionic-internal/component-api/v5/slides/methods.md';
 import Parts from '@ionic-internal/component-api/v5/slides/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/slides/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/slides/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/slides/slots.md';
 
 # ion-slides

--- a/versioned_docs/version-v5/api/spinner.md
+++ b/versioned_docs/version-v5/api/spinner.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/spinner/props.md';
 import Events from '@ionic-internal/component-api/v5/spinner/events.md';
 import Methods from '@ionic-internal/component-api/v5/spinner/methods.md';
 import Parts from '@ionic-internal/component-api/v5/spinner/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/spinner/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/spinner/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/spinner/slots.md';
 
 # ion-spinner

--- a/versioned_docs/version-v5/api/split-pane.md
+++ b/versioned_docs/version-v5/api/split-pane.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/split-pane/props.md';
 import Events from '@ionic-internal/component-api/v5/split-pane/events.md';
 import Methods from '@ionic-internal/component-api/v5/split-pane/methods.md';
 import Parts from '@ionic-internal/component-api/v5/split-pane/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/split-pane/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/split-pane/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/split-pane/slots.md';
 
 # ion-split-pane

--- a/versioned_docs/version-v5/api/tab-bar.md
+++ b/versioned_docs/version-v5/api/tab-bar.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/tab-bar/props.md';
 import Events from '@ionic-internal/component-api/v5/tab-bar/events.md';
 import Methods from '@ionic-internal/component-api/v5/tab-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v5/tab-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/tab-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/tab-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/tab-bar/slots.md';
 
 # ion-tab-bar

--- a/versioned_docs/version-v5/api/tab-button.md
+++ b/versioned_docs/version-v5/api/tab-button.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/tab-button/props.md';
 import Events from '@ionic-internal/component-api/v5/tab-button/events.md';
 import Methods from '@ionic-internal/component-api/v5/tab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v5/tab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/tab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/tab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/tab-button/slots.md';
 
 # ion-tab-button

--- a/versioned_docs/version-v5/api/tab.md
+++ b/versioned_docs/version-v5/api/tab.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/tab/props.md';
 import Events from '@ionic-internal/component-api/v5/tab/events.md';
 import Methods from '@ionic-internal/component-api/v5/tab/methods.md';
 import Parts from '@ionic-internal/component-api/v5/tab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/tab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/tab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/tab/slots.md';
 
 # ion-tab

--- a/versioned_docs/version-v5/api/tabs.md
+++ b/versioned_docs/version-v5/api/tabs.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/tabs/props.md';
 import Events from '@ionic-internal/component-api/v5/tabs/events.md';
 import Methods from '@ionic-internal/component-api/v5/tabs/methods.md';
 import Parts from '@ionic-internal/component-api/v5/tabs/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/tabs/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/tabs/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/tabs/slots.md';
 
 # ion-tabs

--- a/versioned_docs/version-v5/api/text.md
+++ b/versioned_docs/version-v5/api/text.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/text/props.md';
 import Events from '@ionic-internal/component-api/v5/text/events.md';
 import Methods from '@ionic-internal/component-api/v5/text/methods.md';
 import Parts from '@ionic-internal/component-api/v5/text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/text/slots.md';
 
 # ion-text

--- a/versioned_docs/version-v5/api/textarea.md
+++ b/versioned_docs/version-v5/api/textarea.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v5/textarea/props.md';
 import Events from '@ionic-internal/component-api/v5/textarea/events.md';
 import Methods from '@ionic-internal/component-api/v5/textarea/methods.md';
 import Parts from '@ionic-internal/component-api/v5/textarea/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/textarea/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/textarea/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/textarea/slots.md';
 
 # ion-textarea

--- a/versioned_docs/version-v5/api/thumbnail.md
+++ b/versioned_docs/version-v5/api/thumbnail.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/thumbnail/props.md';
 import Events from '@ionic-internal/component-api/v5/thumbnail/events.md';
 import Methods from '@ionic-internal/component-api/v5/thumbnail/methods.md';
 import Parts from '@ionic-internal/component-api/v5/thumbnail/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/thumbnail/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/thumbnail/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/thumbnail/slots.md';
 
 # ion-thumbnail

--- a/versioned_docs/version-v5/api/title.md
+++ b/versioned_docs/version-v5/api/title.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/title/props.md';
 import Events from '@ionic-internal/component-api/v5/title/events.md';
 import Methods from '@ionic-internal/component-api/v5/title/methods.md';
 import Parts from '@ionic-internal/component-api/v5/title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/title/slots.md';
 
 # ion-title

--- a/versioned_docs/version-v5/api/toast.md
+++ b/versioned_docs/version-v5/api/toast.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/toast/props.md';
 import Events from '@ionic-internal/component-api/v5/toast/events.md';
 import Methods from '@ionic-internal/component-api/v5/toast/methods.md';
 import Parts from '@ionic-internal/component-api/v5/toast/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/toast/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/toast/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/toast/slots.md';
 
 # ion-toast

--- a/versioned_docs/version-v5/api/toggle.md
+++ b/versioned_docs/version-v5/api/toggle.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/toggle/props.md';
 import Events from '@ionic-internal/component-api/v5/toggle/events.md';
 import Methods from '@ionic-internal/component-api/v5/toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v5/toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/toggle/slots.md';
 
 # ion-toggle

--- a/versioned_docs/version-v5/api/toolbar.md
+++ b/versioned_docs/version-v5/api/toolbar.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v5/toolbar/props.md';
 import Events from '@ionic-internal/component-api/v5/toolbar/events.md';
 import Methods from '@ionic-internal/component-api/v5/toolbar/methods.md';
 import Parts from '@ionic-internal/component-api/v5/toolbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/toolbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/toolbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/toolbar/slots.md';
 
 # ion-toolbar

--- a/versioned_docs/version-v5/api/virtual-scroll.md
+++ b/versioned_docs/version-v5/api/virtual-scroll.md
@@ -11,7 +11,7 @@ import Props from '@ionic-internal/component-api/v5/virtual-scroll/props.md';
 import Events from '@ionic-internal/component-api/v5/virtual-scroll/events.md';
 import Methods from '@ionic-internal/component-api/v5/virtual-scroll/methods.md';
 import Parts from '@ionic-internal/component-api/v5/virtual-scroll/parts.md';
-import CustomProps from '@ionic-internal/component-api/v5/virtual-scroll/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v5/virtual-scroll/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v5/virtual-scroll/slots.md';
 
 # ion-virtual-scroll

--- a/versioned_docs/version-v6/api/accordion-group.md
+++ b/versioned_docs/version-v6/api/accordion-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/accordion-group/props.md';
 import Events from '@ionic-internal/component-api/v6/accordion-group/events.md';
 import Methods from '@ionic-internal/component-api/v6/accordion-group/methods.md';
 import Parts from '@ionic-internal/component-api/v6/accordion-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/accordion-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/accordion-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/accordion-group/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/accordion.md
+++ b/versioned_docs/version-v6/api/accordion.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/accordion/props.md';
 import Events from '@ionic-internal/component-api/v6/accordion/events.md';
 import Methods from '@ionic-internal/component-api/v6/accordion/methods.md';
 import Parts from '@ionic-internal/component-api/v6/accordion/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/accordion/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/accordion/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/accordion/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/action-sheet.md
+++ b/versioned_docs/version-v6/api/action-sheet.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/action-sheet/props.md';
 import Events from '@ionic-internal/component-api/v6/action-sheet/events.md';
 import Methods from '@ionic-internal/component-api/v6/action-sheet/methods.md';
 import Parts from '@ionic-internal/component-api/v6/action-sheet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/action-sheet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/action-sheet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/action-sheet/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/alert.md
+++ b/versioned_docs/version-v6/api/alert.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v6/alert/props.md';
 import Events from '@ionic-internal/component-api/v6/alert/events.md';
 import Methods from '@ionic-internal/component-api/v6/alert/methods.md';
 import Parts from '@ionic-internal/component-api/v6/alert/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/alert/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/alert/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/alert/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/app.md
+++ b/versioned_docs/version-v6/api/app.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/app/props.md';
 import Events from '@ionic-internal/component-api/v6/app/events.md';
 import Methods from '@ionic-internal/component-api/v6/app/methods.md';
 import Parts from '@ionic-internal/component-api/v6/app/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/app/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/app/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/app/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/avatar.md
+++ b/versioned_docs/version-v6/api/avatar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/avatar/props.md';
 import Events from '@ionic-internal/component-api/v6/avatar/events.md';
 import Methods from '@ionic-internal/component-api/v6/avatar/methods.md';
 import Parts from '@ionic-internal/component-api/v6/avatar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/avatar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/avatar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/avatar/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/back-button.md
+++ b/versioned_docs/version-v6/api/back-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/back-button/props.md';
 import Events from '@ionic-internal/component-api/v6/back-button/events.md';
 import Methods from '@ionic-internal/component-api/v6/back-button/methods.md';
 import Parts from '@ionic-internal/component-api/v6/back-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/back-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/back-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/back-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/backdrop.md
+++ b/versioned_docs/version-v6/api/backdrop.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/backdrop/props.md';
 import Events from '@ionic-internal/component-api/v6/backdrop/events.md';
 import Methods from '@ionic-internal/component-api/v6/backdrop/methods.md';
 import Parts from '@ionic-internal/component-api/v6/backdrop/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/backdrop/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/backdrop/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/backdrop/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/badge.md
+++ b/versioned_docs/version-v6/api/badge.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/badge/props.md';
 import Events from '@ionic-internal/component-api/v6/badge/events.md';
 import Methods from '@ionic-internal/component-api/v6/badge/methods.md';
 import Parts from '@ionic-internal/component-api/v6/badge/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/badge/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/badge/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/badge/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/breadcrumb.md
+++ b/versioned_docs/version-v6/api/breadcrumb.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/breadcrumb/props.md';
 import Events from '@ionic-internal/component-api/v6/breadcrumb/events.md';
 import Methods from '@ionic-internal/component-api/v6/breadcrumb/methods.md';
 import Parts from '@ionic-internal/component-api/v6/breadcrumb/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/breadcrumb/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/breadcrumb/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/breadcrumb/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/breadcrumbs.md
+++ b/versioned_docs/version-v6/api/breadcrumbs.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/breadcrumbs/props.md';
 import Events from '@ionic-internal/component-api/v6/breadcrumbs/events.md';
 import Methods from '@ionic-internal/component-api/v6/breadcrumbs/methods.md';
 import Parts from '@ionic-internal/component-api/v6/breadcrumbs/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/breadcrumbs/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/breadcrumbs/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/breadcrumbs/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/button.md
+++ b/versioned_docs/version-v6/api/button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/button/props.md';
 import Events from '@ionic-internal/component-api/v6/button/events.md';
 import Methods from '@ionic-internal/component-api/v6/button/methods.md';
 import Parts from '@ionic-internal/component-api/v6/button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/button/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/buttons.md
+++ b/versioned_docs/version-v6/api/buttons.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/buttons/props.md';
 import Events from '@ionic-internal/component-api/v6/buttons/events.md';
 import Methods from '@ionic-internal/component-api/v6/buttons/methods.md';
 import Parts from '@ionic-internal/component-api/v6/buttons/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/buttons/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/buttons/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/buttons/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/card-content.md
+++ b/versioned_docs/version-v6/api/card-content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/card-content/props.md';
 import Events from '@ionic-internal/component-api/v6/card-content/events.md';
 import Methods from '@ionic-internal/component-api/v6/card-content/methods.md';
 import Parts from '@ionic-internal/component-api/v6/card-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/card-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/card-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/card-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/card-header.md
+++ b/versioned_docs/version-v6/api/card-header.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/card-header/props.md';
 import Events from '@ionic-internal/component-api/v6/card-header/events.md';
 import Methods from '@ionic-internal/component-api/v6/card-header/methods.md';
 import Parts from '@ionic-internal/component-api/v6/card-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/card-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/card-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/card-header/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/card-subtitle.md
+++ b/versioned_docs/version-v6/api/card-subtitle.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/card-subtitle/props.md';
 import Events from '@ionic-internal/component-api/v6/card-subtitle/events.md';
 import Methods from '@ionic-internal/component-api/v6/card-subtitle/methods.md';
 import Parts from '@ionic-internal/component-api/v6/card-subtitle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/card-subtitle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/card-subtitle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/card-subtitle/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/card-title.md
+++ b/versioned_docs/version-v6/api/card-title.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/card-title/props.md';
 import Events from '@ionic-internal/component-api/v6/card-title/events.md';
 import Methods from '@ionic-internal/component-api/v6/card-title/methods.md';
 import Parts from '@ionic-internal/component-api/v6/card-title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/card-title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/card-title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/card-title/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/card.md
+++ b/versioned_docs/version-v6/api/card.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/card/props.md';
 import Events from '@ionic-internal/component-api/v6/card/events.md';
 import Methods from '@ionic-internal/component-api/v6/card/methods.md';
 import Parts from '@ionic-internal/component-api/v6/card/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/card/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/card/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/card/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/checkbox.md
+++ b/versioned_docs/version-v6/api/checkbox.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/checkbox/props.md';
 import Events from '@ionic-internal/component-api/v6/checkbox/events.md';
 import Methods from '@ionic-internal/component-api/v6/checkbox/methods.md';
 import Parts from '@ionic-internal/component-api/v6/checkbox/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/checkbox/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/checkbox/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/checkbox/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/chip.md
+++ b/versioned_docs/version-v6/api/chip.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/chip/props.md';
 import Events from '@ionic-internal/component-api/v6/chip/events.md';
 import Methods from '@ionic-internal/component-api/v6/chip/methods.md';
 import Parts from '@ionic-internal/component-api/v6/chip/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/chip/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/chip/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/chip/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/col.md
+++ b/versioned_docs/version-v6/api/col.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/col/props.md';
 import Events from '@ionic-internal/component-api/v6/col/events.md';
 import Methods from '@ionic-internal/component-api/v6/col/methods.md';
 import Parts from '@ionic-internal/component-api/v6/col/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/col/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/col/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/col/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/content.md
+++ b/versioned_docs/version-v6/api/content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/content/props.md';
 import Events from '@ionic-internal/component-api/v6/content/events.md';
 import Methods from '@ionic-internal/component-api/v6/content/methods.md';
 import Parts from '@ionic-internal/component-api/v6/content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/content/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/datetime-button.md
+++ b/versioned_docs/version-v6/api/datetime-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/datetime-button/props.md';
 import Events from '@ionic-internal/component-api/v6/datetime-button/events.md';
 import Methods from '@ionic-internal/component-api/v6/datetime-button/methods.md';
 import Parts from '@ionic-internal/component-api/v6/datetime-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/datetime-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/datetime-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/datetime-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/datetime.md
+++ b/versioned_docs/version-v6/api/datetime.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/datetime/props.md';
 import Events from '@ionic-internal/component-api/v6/datetime/events.md';
 import Methods from '@ionic-internal/component-api/v6/datetime/methods.md';
 import Parts from '@ionic-internal/component-api/v6/datetime/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/datetime/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/datetime/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/datetime/slots.md';
 
 import Basic from '@site/static/usage/v6/datetime/basic/index.md';

--- a/versioned_docs/version-v6/api/fab-button.md
+++ b/versioned_docs/version-v6/api/fab-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/fab-button/props.md';
 import Events from '@ionic-internal/component-api/v6/fab-button/events.md';
 import Methods from '@ionic-internal/component-api/v6/fab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v6/fab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/fab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/fab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/fab-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/fab-list.md
+++ b/versioned_docs/version-v6/api/fab-list.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/fab-list/props.md';
 import Events from '@ionic-internal/component-api/v6/fab-list/events.md';
 import Methods from '@ionic-internal/component-api/v6/fab-list/methods.md';
 import Parts from '@ionic-internal/component-api/v6/fab-list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/fab-list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/fab-list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/fab-list/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/fab.md
+++ b/versioned_docs/version-v6/api/fab.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/fab/props.md';
 import Events from '@ionic-internal/component-api/v6/fab/events.md';
 import Methods from '@ionic-internal/component-api/v6/fab/methods.md';
 import Parts from '@ionic-internal/component-api/v6/fab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/fab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/fab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/fab/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/footer.md
+++ b/versioned_docs/version-v6/api/footer.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/footer/props.md';
 import Events from '@ionic-internal/component-api/v6/footer/events.md';
 import Methods from '@ionic-internal/component-api/v6/footer/methods.md';
 import Parts from '@ionic-internal/component-api/v6/footer/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/footer/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/footer/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/footer/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/grid.md
+++ b/versioned_docs/version-v6/api/grid.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/grid/props.md';
 import Events from '@ionic-internal/component-api/v6/grid/events.md';
 import Methods from '@ionic-internal/component-api/v6/grid/methods.md';
 import Parts from '@ionic-internal/component-api/v6/grid/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/grid/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/grid/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/grid/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/header.md
+++ b/versioned_docs/version-v6/api/header.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/header/props.md';
 import Events from '@ionic-internal/component-api/v6/header/events.md';
 import Methods from '@ionic-internal/component-api/v6/header/methods.md';
 import Parts from '@ionic-internal/component-api/v6/header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/header/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/img.md
+++ b/versioned_docs/version-v6/api/img.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/img/props.md';
 import Events from '@ionic-internal/component-api/v6/img/events.md';
 import Methods from '@ionic-internal/component-api/v6/img/methods.md';
 import Parts from '@ionic-internal/component-api/v6/img/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/img/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/img/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/img/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/infinite-scroll-content.md
+++ b/versioned_docs/version-v6/api/infinite-scroll-content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/infinite-scroll-content/prop
 import Events from '@ionic-internal/component-api/v6/infinite-scroll-content/events.md';
 import Methods from '@ionic-internal/component-api/v6/infinite-scroll-content/methods.md';
 import Parts from '@ionic-internal/component-api/v6/infinite-scroll-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/infinite-scroll-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/infinite-scroll-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/infinite-scroll-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/infinite-scroll.md
+++ b/versioned_docs/version-v6/api/infinite-scroll.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/infinite-scroll/props.md';
 import Events from '@ionic-internal/component-api/v6/infinite-scroll/events.md';
 import Methods from '@ionic-internal/component-api/v6/infinite-scroll/methods.md';
 import Parts from '@ionic-internal/component-api/v6/infinite-scroll/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/infinite-scroll/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/infinite-scroll/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/infinite-scroll/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/input.md
+++ b/versioned_docs/version-v6/api/input.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/input/props.md';
 import Events from '@ionic-internal/component-api/v6/input/events.md';
 import Methods from '@ionic-internal/component-api/v6/input/methods.md';
 import Parts from '@ionic-internal/component-api/v6/input/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/input/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/input/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/input/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/item-divider.md
+++ b/versioned_docs/version-v6/api/item-divider.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/item-divider/props.md';
 import Events from '@ionic-internal/component-api/v6/item-divider/events.md';
 import Methods from '@ionic-internal/component-api/v6/item-divider/methods.md';
 import Parts from '@ionic-internal/component-api/v6/item-divider/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/item-divider/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/item-divider/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/item-divider/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/item-group.md
+++ b/versioned_docs/version-v6/api/item-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/item-group/props.md';
 import Events from '@ionic-internal/component-api/v6/item-group/events.md';
 import Methods from '@ionic-internal/component-api/v6/item-group/methods.md';
 import Parts from '@ionic-internal/component-api/v6/item-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/item-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/item-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/item-group/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/item-option.md
+++ b/versioned_docs/version-v6/api/item-option.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/item-option/props.md';
 import Events from '@ionic-internal/component-api/v6/item-option/events.md';
 import Methods from '@ionic-internal/component-api/v6/item-option/methods.md';
 import Parts from '@ionic-internal/component-api/v6/item-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/item-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/item-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/item-option/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/item-options.md
+++ b/versioned_docs/version-v6/api/item-options.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/item-options/props.md';
 import Events from '@ionic-internal/component-api/v6/item-options/events.md';
 import Methods from '@ionic-internal/component-api/v6/item-options/methods.md';
 import Parts from '@ionic-internal/component-api/v6/item-options/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/item-options/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/item-options/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/item-options/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/item-sliding.md
+++ b/versioned_docs/version-v6/api/item-sliding.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/item-sliding/props.md';
 import Events from '@ionic-internal/component-api/v6/item-sliding/events.md';
 import Methods from '@ionic-internal/component-api/v6/item-sliding/methods.md';
 import Parts from '@ionic-internal/component-api/v6/item-sliding/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/item-sliding/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/item-sliding/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/item-sliding/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/item.md
+++ b/versioned_docs/version-v6/api/item.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/item/props.md';
 import Events from '@ionic-internal/component-api/v6/item/events.md';
 import Methods from '@ionic-internal/component-api/v6/item/methods.md';
 import Parts from '@ionic-internal/component-api/v6/item/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/item/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/item/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/item/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/label.md
+++ b/versioned_docs/version-v6/api/label.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/label/props.md';
 import Events from '@ionic-internal/component-api/v6/label/events.md';
 import Methods from '@ionic-internal/component-api/v6/label/methods.md';
 import Parts from '@ionic-internal/component-api/v6/label/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/label/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/label/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/label/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/list-header.md
+++ b/versioned_docs/version-v6/api/list-header.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/list-header/props.md';
 import Events from '@ionic-internal/component-api/v6/list-header/events.md';
 import Methods from '@ionic-internal/component-api/v6/list-header/methods.md';
 import Parts from '@ionic-internal/component-api/v6/list-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/list-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/list-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/list-header/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/list.md
+++ b/versioned_docs/version-v6/api/list.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/list/props.md';
 import Events from '@ionic-internal/component-api/v6/list/events.md';
 import Methods from '@ionic-internal/component-api/v6/list/methods.md';
 import Parts from '@ionic-internal/component-api/v6/list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/list/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/loading.md
+++ b/versioned_docs/version-v6/api/loading.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v6/loading/props.md';
 import Events from '@ionic-internal/component-api/v6/loading/events.md';
 import Methods from '@ionic-internal/component-api/v6/loading/methods.md';
 import Parts from '@ionic-internal/component-api/v6/loading/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/loading/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/loading/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/loading/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/menu-button.md
+++ b/versioned_docs/version-v6/api/menu-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/menu-button/props.md';
 import Events from '@ionic-internal/component-api/v6/menu-button/events.md';
 import Methods from '@ionic-internal/component-api/v6/menu-button/methods.md';
 import Parts from '@ionic-internal/component-api/v6/menu-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/menu-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/menu-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/menu-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/menu-toggle.md
+++ b/versioned_docs/version-v6/api/menu-toggle.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/menu-toggle/props.md';
 import Events from '@ionic-internal/component-api/v6/menu-toggle/events.md';
 import Methods from '@ionic-internal/component-api/v6/menu-toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v6/menu-toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/menu-toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/menu-toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/menu-toggle/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/menu.md
+++ b/versioned_docs/version-v6/api/menu.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/menu/props.md';
 import Events from '@ionic-internal/component-api/v6/menu/events.md';
 import Methods from '@ionic-internal/component-api/v6/menu/methods.md';
 import Parts from '@ionic-internal/component-api/v6/menu/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/menu/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/menu/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/menu/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/modal.md
+++ b/versioned_docs/version-v6/api/modal.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/modal/props.md';
 import Events from '@ionic-internal/component-api/v6/modal/events.md';
 import Methods from '@ionic-internal/component-api/v6/modal/methods.md';
 import Parts from '@ionic-internal/component-api/v6/modal/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/modal/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/modal/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/modal/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/nav-link.md
+++ b/versioned_docs/version-v6/api/nav-link.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/nav-link/props.md';
 import Events from '@ionic-internal/component-api/v6/nav-link/events.md';
 import Methods from '@ionic-internal/component-api/v6/nav-link/methods.md';
 import Parts from '@ionic-internal/component-api/v6/nav-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/nav-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/nav-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/nav-link/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/nav.md
+++ b/versioned_docs/version-v6/api/nav.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/nav/props.md';
 import Events from '@ionic-internal/component-api/v6/nav/events.md';
 import Methods from '@ionic-internal/component-api/v6/nav/methods.md';
 import Parts from '@ionic-internal/component-api/v6/nav/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/nav/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/nav/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/nav/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/note.md
+++ b/versioned_docs/version-v6/api/note.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/note/props.md';
 import Events from '@ionic-internal/component-api/v6/note/events.md';
 import Methods from '@ionic-internal/component-api/v6/note/methods.md';
 import Parts from '@ionic-internal/component-api/v6/note/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/note/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/note/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/note/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/picker.md
+++ b/versioned_docs/version-v6/api/picker.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/picker/props.md';
 import Events from '@ionic-internal/component-api/v6/picker/events.md';
 import Methods from '@ionic-internal/component-api/v6/picker/methods.md';
 import Parts from '@ionic-internal/component-api/v6/picker/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/picker/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/picker/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/picker/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/popover.md
+++ b/versioned_docs/version-v6/api/popover.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/popover/props.md';
 import Events from '@ionic-internal/component-api/v6/popover/events.md';
 import Methods from '@ionic-internal/component-api/v6/popover/methods.md';
 import Parts from '@ionic-internal/component-api/v6/popover/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/popover/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/popover/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/popover/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/progress-bar.md
+++ b/versioned_docs/version-v6/api/progress-bar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/progress-bar/props.md';
 import Events from '@ionic-internal/component-api/v6/progress-bar/events.md';
 import Methods from '@ionic-internal/component-api/v6/progress-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v6/progress-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/progress-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/progress-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/progress-bar/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/radio-group.md
+++ b/versioned_docs/version-v6/api/radio-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/radio-group/props.md';
 import Events from '@ionic-internal/component-api/v6/radio-group/events.md';
 import Methods from '@ionic-internal/component-api/v6/radio-group/methods.md';
 import Parts from '@ionic-internal/component-api/v6/radio-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/radio-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/radio-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/radio-group/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/radio.md
+++ b/versioned_docs/version-v6/api/radio.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/radio/props.md';
 import Events from '@ionic-internal/component-api/v6/radio/events.md';
 import Methods from '@ionic-internal/component-api/v6/radio/methods.md';
 import Parts from '@ionic-internal/component-api/v6/radio/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/radio/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/radio/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/radio/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/range.md
+++ b/versioned_docs/version-v6/api/range.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/range/props.md';
 import Events from '@ionic-internal/component-api/v6/range/events.md';
 import Methods from '@ionic-internal/component-api/v6/range/methods.md';
 import Parts from '@ionic-internal/component-api/v6/range/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/range/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/range/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/range/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/refresher-content.md
+++ b/versioned_docs/version-v6/api/refresher-content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/refresher-content/props.md';
 import Events from '@ionic-internal/component-api/v6/refresher-content/events.md';
 import Methods from '@ionic-internal/component-api/v6/refresher-content/methods.md';
 import Parts from '@ionic-internal/component-api/v6/refresher-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/refresher-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/refresher-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/refresher-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/refresher.md
+++ b/versioned_docs/version-v6/api/refresher.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/refresher/props.md';
 import Events from '@ionic-internal/component-api/v6/refresher/events.md';
 import Methods from '@ionic-internal/component-api/v6/refresher/methods.md';
 import Parts from '@ionic-internal/component-api/v6/refresher/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/refresher/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/refresher/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/refresher/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/reorder-group.md
+++ b/versioned_docs/version-v6/api/reorder-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/reorder-group/props.md';
 import Events from '@ionic-internal/component-api/v6/reorder-group/events.md';
 import Methods from '@ionic-internal/component-api/v6/reorder-group/methods.md';
 import Parts from '@ionic-internal/component-api/v6/reorder-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/reorder-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/reorder-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/reorder-group/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/reorder.md
+++ b/versioned_docs/version-v6/api/reorder.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/reorder/props.md';
 import Events from '@ionic-internal/component-api/v6/reorder/events.md';
 import Methods from '@ionic-internal/component-api/v6/reorder/methods.md';
 import Parts from '@ionic-internal/component-api/v6/reorder/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/reorder/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/reorder/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/reorder/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/ripple-effect.md
+++ b/versioned_docs/version-v6/api/ripple-effect.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/ripple-effect/props.md';
 import Events from '@ionic-internal/component-api/v6/ripple-effect/events.md';
 import Methods from '@ionic-internal/component-api/v6/ripple-effect/methods.md';
 import Parts from '@ionic-internal/component-api/v6/ripple-effect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/ripple-effect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/ripple-effect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/ripple-effect/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/route-redirect.md
+++ b/versioned_docs/version-v6/api/route-redirect.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/route-redirect/props.md';
 import Events from '@ionic-internal/component-api/v6/route-redirect/events.md';
 import Methods from '@ionic-internal/component-api/v6/route-redirect/methods.md';
 import Parts from '@ionic-internal/component-api/v6/route-redirect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/route-redirect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/route-redirect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/route-redirect/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/route.md
+++ b/versioned_docs/version-v6/api/route.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v6/route/props.md';
 import Events from '@ionic-internal/component-api/v6/route/events.md';
 import Methods from '@ionic-internal/component-api/v6/route/methods.md';
 import Parts from '@ionic-internal/component-api/v6/route/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/route/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/route/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/route/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/router-link.md
+++ b/versioned_docs/version-v6/api/router-link.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/router-link/props.md';
 import Events from '@ionic-internal/component-api/v6/router-link/events.md';
 import Methods from '@ionic-internal/component-api/v6/router-link/methods.md';
 import Parts from '@ionic-internal/component-api/v6/router-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/router-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/router-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/router-link/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/router-outlet.md
+++ b/versioned_docs/version-v6/api/router-outlet.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/router-outlet/props.md';
 import Events from '@ionic-internal/component-api/v6/router-outlet/events.md';
 import Methods from '@ionic-internal/component-api/v6/router-outlet/methods.md';
 import Parts from '@ionic-internal/component-api/v6/router-outlet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/router-outlet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/router-outlet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/router-outlet/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/router.md
+++ b/versioned_docs/version-v6/api/router.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/router/props.md';
 import Events from '@ionic-internal/component-api/v6/router/events.md';
 import Methods from '@ionic-internal/component-api/v6/router/methods.md';
 import Parts from '@ionic-internal/component-api/v6/router/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/router/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/router/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/router/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/row.md
+++ b/versioned_docs/version-v6/api/row.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/row/props.md';
 import Events from '@ionic-internal/component-api/v6/row/events.md';
 import Methods from '@ionic-internal/component-api/v6/row/methods.md';
 import Parts from '@ionic-internal/component-api/v6/row/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/row/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/row/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/row/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/searchbar.md
+++ b/versioned_docs/version-v6/api/searchbar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/searchbar/props.md';
 import Events from '@ionic-internal/component-api/v6/searchbar/events.md';
 import Methods from '@ionic-internal/component-api/v6/searchbar/methods.md';
 import Parts from '@ionic-internal/component-api/v6/searchbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/searchbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/searchbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/searchbar/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/segment-button.md
+++ b/versioned_docs/version-v6/api/segment-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/segment-button/props.md';
 import Events from '@ionic-internal/component-api/v6/segment-button/events.md';
 import Methods from '@ionic-internal/component-api/v6/segment-button/methods.md';
 import Parts from '@ionic-internal/component-api/v6/segment-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/segment-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/segment-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/segment-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/segment.md
+++ b/versioned_docs/version-v6/api/segment.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/segment/props.md';
 import Events from '@ionic-internal/component-api/v6/segment/events.md';
 import Methods from '@ionic-internal/component-api/v6/segment/methods.md';
 import Parts from '@ionic-internal/component-api/v6/segment/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/segment/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/segment/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/segment/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/select-option.md
+++ b/versioned_docs/version-v6/api/select-option.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/select-option/props.md';
 import Events from '@ionic-internal/component-api/v6/select-option/events.md';
 import Methods from '@ionic-internal/component-api/v6/select-option/methods.md';
 import Parts from '@ionic-internal/component-api/v6/select-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/select-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/select-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/select-option/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/select.md
+++ b/versioned_docs/version-v6/api/select.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/select/props.md';
 import Events from '@ionic-internal/component-api/v6/select/events.md';
 import Methods from '@ionic-internal/component-api/v6/select/methods.md';
 import Parts from '@ionic-internal/component-api/v6/select/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/select/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/select/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/select/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/skeleton-text.md
+++ b/versioned_docs/version-v6/api/skeleton-text.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/skeleton-text/props.md';
 import Events from '@ionic-internal/component-api/v6/skeleton-text/events.md';
 import Methods from '@ionic-internal/component-api/v6/skeleton-text/methods.md';
 import Parts from '@ionic-internal/component-api/v6/skeleton-text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/skeleton-text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/skeleton-text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/skeleton-text/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/slide.md
+++ b/versioned_docs/version-v6/api/slide.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/slide/props.md';
 import Events from '@ionic-internal/component-api/v6/slide/events.md';
 import Methods from '@ionic-internal/component-api/v6/slide/methods.md';
 import Parts from '@ionic-internal/component-api/v6/slide/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/slide/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/slide/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/slide/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/slides.md
+++ b/versioned_docs/version-v6/api/slides.md
@@ -13,7 +13,7 @@ import Props from '@ionic-internal/component-api/v6/slides/props.md';
 import Events from '@ionic-internal/component-api/v6/slides/events.md';
 import Methods from '@ionic-internal/component-api/v6/slides/methods.md';
 import Parts from '@ionic-internal/component-api/v6/slides/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/slides/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/slides/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/slides/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/spinner.md
+++ b/versioned_docs/version-v6/api/spinner.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/spinner/props.md';
 import Events from '@ionic-internal/component-api/v6/spinner/events.md';
 import Methods from '@ionic-internal/component-api/v6/spinner/methods.md';
 import Parts from '@ionic-internal/component-api/v6/spinner/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/spinner/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/spinner/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/spinner/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/split-pane.md
+++ b/versioned_docs/version-v6/api/split-pane.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/split-pane/props.md';
 import Events from '@ionic-internal/component-api/v6/split-pane/events.md';
 import Methods from '@ionic-internal/component-api/v6/split-pane/methods.md';
 import Parts from '@ionic-internal/component-api/v6/split-pane/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/split-pane/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/split-pane/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/split-pane/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/tab-bar.md
+++ b/versioned_docs/version-v6/api/tab-bar.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v6/tab-bar/props.md';
 import Events from '@ionic-internal/component-api/v6/tab-bar/events.md';
 import Methods from '@ionic-internal/component-api/v6/tab-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v6/tab-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/tab-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/tab-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/tab-bar/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/tab-button.md
+++ b/versioned_docs/version-v6/api/tab-button.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v6/tab-button/props.md';
 import Events from '@ionic-internal/component-api/v6/tab-button/events.md';
 import Methods from '@ionic-internal/component-api/v6/tab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v6/tab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/tab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/tab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/tab-button/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v6/api/tab.md
+++ b/versioned_docs/version-v6/api/tab.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/tab/props.md';
 import Events from '@ionic-internal/component-api/v6/tab/events.md';
 import Methods from '@ionic-internal/component-api/v6/tab/methods.md';
 import Parts from '@ionic-internal/component-api/v6/tab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/tab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/tab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/tab/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/tabs.md
+++ b/versioned_docs/version-v6/api/tabs.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/tabs/props.md';
 import Events from '@ionic-internal/component-api/v6/tabs/events.md';
 import Methods from '@ionic-internal/component-api/v6/tabs/methods.md';
 import Parts from '@ionic-internal/component-api/v6/tabs/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/tabs/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/tabs/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/tabs/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/text.md
+++ b/versioned_docs/version-v6/api/text.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/text/props.md';
 import Events from '@ionic-internal/component-api/v6/text/events.md';
 import Methods from '@ionic-internal/component-api/v6/text/methods.md';
 import Parts from '@ionic-internal/component-api/v6/text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/text/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/textarea.md
+++ b/versioned_docs/version-v6/api/textarea.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/textarea/props.md';
 import Events from '@ionic-internal/component-api/v6/textarea/events.md';
 import Methods from '@ionic-internal/component-api/v6/textarea/methods.md';
 import Parts from '@ionic-internal/component-api/v6/textarea/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/textarea/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/textarea/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/textarea/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/thumbnail.md
+++ b/versioned_docs/version-v6/api/thumbnail.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/thumbnail/props.md';
 import Events from '@ionic-internal/component-api/v6/thumbnail/events.md';
 import Methods from '@ionic-internal/component-api/v6/thumbnail/methods.md';
 import Parts from '@ionic-internal/component-api/v6/thumbnail/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/thumbnail/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/thumbnail/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/thumbnail/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/title.md
+++ b/versioned_docs/version-v6/api/title.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/title/props.md';
 import Events from '@ionic-internal/component-api/v6/title/events.md';
 import Methods from '@ionic-internal/component-api/v6/title/methods.md';
 import Parts from '@ionic-internal/component-api/v6/title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/title/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/toast.md
+++ b/versioned_docs/version-v6/api/toast.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v6/toast/props.md';
 import Events from '@ionic-internal/component-api/v6/toast/events.md';
 import Methods from '@ionic-internal/component-api/v6/toast/methods.md';
 import Parts from '@ionic-internal/component-api/v6/toast/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/toast/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/toast/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/toast/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/toggle.md
+++ b/versioned_docs/version-v6/api/toggle.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/toggle/props.md';
 import Events from '@ionic-internal/component-api/v6/toggle/events.md';
 import Methods from '@ionic-internal/component-api/v6/toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v6/toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/toggle/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/toolbar.md
+++ b/versioned_docs/version-v6/api/toolbar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/toolbar/props.md';
 import Events from '@ionic-internal/component-api/v6/toolbar/events.md';
 import Methods from '@ionic-internal/component-api/v6/toolbar/methods.md';
 import Parts from '@ionic-internal/component-api/v6/toolbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/toolbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/toolbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/toolbar/slots.md';
 
 <head>

--- a/versioned_docs/version-v6/api/virtual-scroll.md
+++ b/versioned_docs/version-v6/api/virtual-scroll.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v6/virtual-scroll/props.md';
 import Events from '@ionic-internal/component-api/v6/virtual-scroll/events.md';
 import Methods from '@ionic-internal/component-api/v6/virtual-scroll/methods.md';
 import Parts from '@ionic-internal/component-api/v6/virtual-scroll/parts.md';
-import CustomProps from '@ionic-internal/component-api/v6/virtual-scroll/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v6/virtual-scroll/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v6/virtual-scroll/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/accordion-group.md
+++ b/versioned_docs/version-v7/api/accordion-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/accordion-group/props.md';
 import Events from '@ionic-internal/component-api/v7/accordion-group/events.md';
 import Methods from '@ionic-internal/component-api/v7/accordion-group/methods.md';
 import Parts from '@ionic-internal/component-api/v7/accordion-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/accordion-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/accordion-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/accordion-group/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/accordion.md
+++ b/versioned_docs/version-v7/api/accordion.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/accordion/props.md';
 import Events from '@ionic-internal/component-api/v7/accordion/events.md';
 import Methods from '@ionic-internal/component-api/v7/accordion/methods.md';
 import Parts from '@ionic-internal/component-api/v7/accordion/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/accordion/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/accordion/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/accordion/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/action-sheet.md
+++ b/versioned_docs/version-v7/api/action-sheet.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v7/action-sheet/props.md';
 import Events from '@ionic-internal/component-api/v7/action-sheet/events.md';
 import Methods from '@ionic-internal/component-api/v7/action-sheet/methods.md';
 import Parts from '@ionic-internal/component-api/v7/action-sheet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/action-sheet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/action-sheet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/action-sheet/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/alert.md
+++ b/versioned_docs/version-v7/api/alert.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v7/alert/props.md';
 import Events from '@ionic-internal/component-api/v7/alert/events.md';
 import Methods from '@ionic-internal/component-api/v7/alert/methods.md';
 import Parts from '@ionic-internal/component-api/v7/alert/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/alert/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/alert/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/alert/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/app.md
+++ b/versioned_docs/version-v7/api/app.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/app/props.md';
 import Events from '@ionic-internal/component-api/v7/app/events.md';
 import Methods from '@ionic-internal/component-api/v7/app/methods.md';
 import Parts from '@ionic-internal/component-api/v7/app/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/app/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/app/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/app/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/avatar.md
+++ b/versioned_docs/version-v7/api/avatar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/avatar/props.md';
 import Events from '@ionic-internal/component-api/v7/avatar/events.md';
 import Methods from '@ionic-internal/component-api/v7/avatar/methods.md';
 import Parts from '@ionic-internal/component-api/v7/avatar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/avatar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/avatar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/avatar/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/back-button.md
+++ b/versioned_docs/version-v7/api/back-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/back-button/props.md';
 import Events from '@ionic-internal/component-api/v7/back-button/events.md';
 import Methods from '@ionic-internal/component-api/v7/back-button/methods.md';
 import Parts from '@ionic-internal/component-api/v7/back-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/back-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/back-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/back-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/backdrop.md
+++ b/versioned_docs/version-v7/api/backdrop.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/backdrop/props.md';
 import Events from '@ionic-internal/component-api/v7/backdrop/events.md';
 import Methods from '@ionic-internal/component-api/v7/backdrop/methods.md';
 import Parts from '@ionic-internal/component-api/v7/backdrop/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/backdrop/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/backdrop/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/backdrop/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/badge.md
+++ b/versioned_docs/version-v7/api/badge.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/badge/props.md';
 import Events from '@ionic-internal/component-api/v7/badge/events.md';
 import Methods from '@ionic-internal/component-api/v7/badge/methods.md';
 import Parts from '@ionic-internal/component-api/v7/badge/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/badge/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/badge/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/badge/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/breadcrumb.md
+++ b/versioned_docs/version-v7/api/breadcrumb.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/breadcrumb/props.md';
 import Events from '@ionic-internal/component-api/v7/breadcrumb/events.md';
 import Methods from '@ionic-internal/component-api/v7/breadcrumb/methods.md';
 import Parts from '@ionic-internal/component-api/v7/breadcrumb/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/breadcrumb/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/breadcrumb/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/breadcrumb/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/breadcrumbs.md
+++ b/versioned_docs/version-v7/api/breadcrumbs.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/breadcrumbs/props.md';
 import Events from '@ionic-internal/component-api/v7/breadcrumbs/events.md';
 import Methods from '@ionic-internal/component-api/v7/breadcrumbs/methods.md';
 import Parts from '@ionic-internal/component-api/v7/breadcrumbs/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/breadcrumbs/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/breadcrumbs/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/breadcrumbs/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/button.md
+++ b/versioned_docs/version-v7/api/button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/button/props.md';
 import Events from '@ionic-internal/component-api/v7/button/events.md';
 import Methods from '@ionic-internal/component-api/v7/button/methods.md';
 import Parts from '@ionic-internal/component-api/v7/button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/button/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/buttons.md
+++ b/versioned_docs/version-v7/api/buttons.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/buttons/props.md';
 import Events from '@ionic-internal/component-api/v7/buttons/events.md';
 import Methods from '@ionic-internal/component-api/v7/buttons/methods.md';
 import Parts from '@ionic-internal/component-api/v7/buttons/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/buttons/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/buttons/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/buttons/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/card-content.md
+++ b/versioned_docs/version-v7/api/card-content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/card-content/props.md';
 import Events from '@ionic-internal/component-api/v7/card-content/events.md';
 import Methods from '@ionic-internal/component-api/v7/card-content/methods.md';
 import Parts from '@ionic-internal/component-api/v7/card-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/card-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/card-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/card-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/card-header.md
+++ b/versioned_docs/version-v7/api/card-header.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/card-header/props.md';
 import Events from '@ionic-internal/component-api/v7/card-header/events.md';
 import Methods from '@ionic-internal/component-api/v7/card-header/methods.md';
 import Parts from '@ionic-internal/component-api/v7/card-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/card-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/card-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/card-header/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/card-subtitle.md
+++ b/versioned_docs/version-v7/api/card-subtitle.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/card-subtitle/props.md';
 import Events from '@ionic-internal/component-api/v7/card-subtitle/events.md';
 import Methods from '@ionic-internal/component-api/v7/card-subtitle/methods.md';
 import Parts from '@ionic-internal/component-api/v7/card-subtitle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/card-subtitle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/card-subtitle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/card-subtitle/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/card-title.md
+++ b/versioned_docs/version-v7/api/card-title.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/card-title/props.md';
 import Events from '@ionic-internal/component-api/v7/card-title/events.md';
 import Methods from '@ionic-internal/component-api/v7/card-title/methods.md';
 import Parts from '@ionic-internal/component-api/v7/card-title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/card-title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/card-title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/card-title/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/card.md
+++ b/versioned_docs/version-v7/api/card.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/card/props.md';
 import Events from '@ionic-internal/component-api/v7/card/events.md';
 import Methods from '@ionic-internal/component-api/v7/card/methods.md';
 import Parts from '@ionic-internal/component-api/v7/card/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/card/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/card/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/card/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/checkbox.md
+++ b/versioned_docs/version-v7/api/checkbox.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/checkbox/props.md';
 import Events from '@ionic-internal/component-api/v7/checkbox/events.md';
 import Methods from '@ionic-internal/component-api/v7/checkbox/methods.md';
 import Parts from '@ionic-internal/component-api/v7/checkbox/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/checkbox/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/checkbox/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/checkbox/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/chip.md
+++ b/versioned_docs/version-v7/api/chip.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/chip/props.md';
 import Events from '@ionic-internal/component-api/v7/chip/events.md';
 import Methods from '@ionic-internal/component-api/v7/chip/methods.md';
 import Parts from '@ionic-internal/component-api/v7/chip/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/chip/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/chip/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/chip/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/col.md
+++ b/versioned_docs/version-v7/api/col.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/col/props.md';
 import Events from '@ionic-internal/component-api/v7/col/events.md';
 import Methods from '@ionic-internal/component-api/v7/col/methods.md';
 import Parts from '@ionic-internal/component-api/v7/col/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/col/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/col/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/col/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/content.md
+++ b/versioned_docs/version-v7/api/content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/content/props.md';
 import Events from '@ionic-internal/component-api/v7/content/events.md';
 import Methods from '@ionic-internal/component-api/v7/content/methods.md';
 import Parts from '@ionic-internal/component-api/v7/content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/content/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/datetime-button.md
+++ b/versioned_docs/version-v7/api/datetime-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/datetime-button/props.md';
 import Events from '@ionic-internal/component-api/v7/datetime-button/events.md';
 import Methods from '@ionic-internal/component-api/v7/datetime-button/methods.md';
 import Parts from '@ionic-internal/component-api/v7/datetime-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/datetime-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/datetime-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/datetime-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/datetime.md
+++ b/versioned_docs/version-v7/api/datetime.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/datetime/props.md';
 import Events from '@ionic-internal/component-api/v7/datetime/events.md';
 import Methods from '@ionic-internal/component-api/v7/datetime/methods.md';
 import Parts from '@ionic-internal/component-api/v7/datetime/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/datetime/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/datetime/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/datetime/slots.md';
 
 import Basic from '@site/static/usage/v7/datetime/basic/index.md';

--- a/versioned_docs/version-v7/api/fab-button.md
+++ b/versioned_docs/version-v7/api/fab-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/fab-button/props.md';
 import Events from '@ionic-internal/component-api/v7/fab-button/events.md';
 import Methods from '@ionic-internal/component-api/v7/fab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v7/fab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/fab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/fab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/fab-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/fab-list.md
+++ b/versioned_docs/version-v7/api/fab-list.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/fab-list/props.md';
 import Events from '@ionic-internal/component-api/v7/fab-list/events.md';
 import Methods from '@ionic-internal/component-api/v7/fab-list/methods.md';
 import Parts from '@ionic-internal/component-api/v7/fab-list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/fab-list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/fab-list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/fab-list/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/fab.md
+++ b/versioned_docs/version-v7/api/fab.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/fab/props.md';
 import Events from '@ionic-internal/component-api/v7/fab/events.md';
 import Methods from '@ionic-internal/component-api/v7/fab/methods.md';
 import Parts from '@ionic-internal/component-api/v7/fab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/fab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/fab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/fab/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/footer.md
+++ b/versioned_docs/version-v7/api/footer.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/footer/props.md';
 import Events from '@ionic-internal/component-api/v7/footer/events.md';
 import Methods from '@ionic-internal/component-api/v7/footer/methods.md';
 import Parts from '@ionic-internal/component-api/v7/footer/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/footer/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/footer/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/footer/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/grid.md
+++ b/versioned_docs/version-v7/api/grid.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/grid/props.md';
 import Events from '@ionic-internal/component-api/v7/grid/events.md';
 import Methods from '@ionic-internal/component-api/v7/grid/methods.md';
 import Parts from '@ionic-internal/component-api/v7/grid/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/grid/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/grid/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/grid/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/header.md
+++ b/versioned_docs/version-v7/api/header.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/header/props.md';
 import Events from '@ionic-internal/component-api/v7/header/events.md';
 import Methods from '@ionic-internal/component-api/v7/header/methods.md';
 import Parts from '@ionic-internal/component-api/v7/header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/header/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/img.md
+++ b/versioned_docs/version-v7/api/img.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/img/props.md';
 import Events from '@ionic-internal/component-api/v7/img/events.md';
 import Methods from '@ionic-internal/component-api/v7/img/methods.md';
 import Parts from '@ionic-internal/component-api/v7/img/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/img/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/img/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/img/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/infinite-scroll-content.md
+++ b/versioned_docs/version-v7/api/infinite-scroll-content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/infinite-scroll-content/prop
 import Events from '@ionic-internal/component-api/v7/infinite-scroll-content/events.md';
 import Methods from '@ionic-internal/component-api/v7/infinite-scroll-content/methods.md';
 import Parts from '@ionic-internal/component-api/v7/infinite-scroll-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/infinite-scroll-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/infinite-scroll-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/infinite-scroll-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/infinite-scroll.md
+++ b/versioned_docs/version-v7/api/infinite-scroll.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/infinite-scroll/props.md';
 import Events from '@ionic-internal/component-api/v7/infinite-scroll/events.md';
 import Methods from '@ionic-internal/component-api/v7/infinite-scroll/methods.md';
 import Parts from '@ionic-internal/component-api/v7/infinite-scroll/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/infinite-scroll/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/infinite-scroll/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/infinite-scroll/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/input.md
+++ b/versioned_docs/version-v7/api/input.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/input/props.md';
 import Events from '@ionic-internal/component-api/v7/input/events.md';
 import Methods from '@ionic-internal/component-api/v7/input/methods.md';
 import Parts from '@ionic-internal/component-api/v7/input/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/input/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/input/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/input/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/item-divider.md
+++ b/versioned_docs/version-v7/api/item-divider.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/item-divider/props.md';
 import Events from '@ionic-internal/component-api/v7/item-divider/events.md';
 import Methods from '@ionic-internal/component-api/v7/item-divider/methods.md';
 import Parts from '@ionic-internal/component-api/v7/item-divider/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/item-divider/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/item-divider/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/item-divider/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/item-group.md
+++ b/versioned_docs/version-v7/api/item-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/item-group/props.md';
 import Events from '@ionic-internal/component-api/v7/item-group/events.md';
 import Methods from '@ionic-internal/component-api/v7/item-group/methods.md';
 import Parts from '@ionic-internal/component-api/v7/item-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/item-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/item-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/item-group/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/item-option.md
+++ b/versioned_docs/version-v7/api/item-option.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/item-option/props.md';
 import Events from '@ionic-internal/component-api/v7/item-option/events.md';
 import Methods from '@ionic-internal/component-api/v7/item-option/methods.md';
 import Parts from '@ionic-internal/component-api/v7/item-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/item-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/item-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/item-option/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/item-options.md
+++ b/versioned_docs/version-v7/api/item-options.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/item-options/props.md';
 import Events from '@ionic-internal/component-api/v7/item-options/events.md';
 import Methods from '@ionic-internal/component-api/v7/item-options/methods.md';
 import Parts from '@ionic-internal/component-api/v7/item-options/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/item-options/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/item-options/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/item-options/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/item-sliding.md
+++ b/versioned_docs/version-v7/api/item-sliding.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/item-sliding/props.md';
 import Events from '@ionic-internal/component-api/v7/item-sliding/events.md';
 import Methods from '@ionic-internal/component-api/v7/item-sliding/methods.md';
 import Parts from '@ionic-internal/component-api/v7/item-sliding/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/item-sliding/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/item-sliding/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/item-sliding/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/item.md
+++ b/versioned_docs/version-v7/api/item.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/item/props.md';
 import Events from '@ionic-internal/component-api/v7/item/events.md';
 import Methods from '@ionic-internal/component-api/v7/item/methods.md';
 import Parts from '@ionic-internal/component-api/v7/item/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/item/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/item/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/item/slots.md';
 
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/versioned_docs/version-v7/api/label.md
+++ b/versioned_docs/version-v7/api/label.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/label/props.md';
 import Events from '@ionic-internal/component-api/v7/label/events.md';
 import Methods from '@ionic-internal/component-api/v7/label/methods.md';
 import Parts from '@ionic-internal/component-api/v7/label/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/label/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/label/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/label/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/list-header.md
+++ b/versioned_docs/version-v7/api/list-header.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/list-header/props.md';
 import Events from '@ionic-internal/component-api/v7/list-header/events.md';
 import Methods from '@ionic-internal/component-api/v7/list-header/methods.md';
 import Parts from '@ionic-internal/component-api/v7/list-header/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/list-header/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/list-header/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/list-header/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/list.md
+++ b/versioned_docs/version-v7/api/list.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/list/props.md';
 import Events from '@ionic-internal/component-api/v7/list/events.md';
 import Methods from '@ionic-internal/component-api/v7/list/methods.md';
 import Parts from '@ionic-internal/component-api/v7/list/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/list/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/list/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/list/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/loading.md
+++ b/versioned_docs/version-v7/api/loading.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/loading/props.md';
 import Events from '@ionic-internal/component-api/v7/loading/events.md';
 import Methods from '@ionic-internal/component-api/v7/loading/methods.md';
 import Parts from '@ionic-internal/component-api/v7/loading/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/loading/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/loading/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/loading/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/menu-button.md
+++ b/versioned_docs/version-v7/api/menu-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/menu-button/props.md';
 import Events from '@ionic-internal/component-api/v7/menu-button/events.md';
 import Methods from '@ionic-internal/component-api/v7/menu-button/methods.md';
 import Parts from '@ionic-internal/component-api/v7/menu-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/menu-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/menu-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/menu-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/menu-toggle.md
+++ b/versioned_docs/version-v7/api/menu-toggle.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/menu-toggle/props.md';
 import Events from '@ionic-internal/component-api/v7/menu-toggle/events.md';
 import Methods from '@ionic-internal/component-api/v7/menu-toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v7/menu-toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/menu-toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/menu-toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/menu-toggle/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/menu.md
+++ b/versioned_docs/version-v7/api/menu.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/menu/props.md';
 import Events from '@ionic-internal/component-api/v7/menu/events.md';
 import Methods from '@ionic-internal/component-api/v7/menu/methods.md';
 import Parts from '@ionic-internal/component-api/v7/menu/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/menu/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/menu/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/menu/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/modal.md
+++ b/versioned_docs/version-v7/api/modal.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/modal/props.md';
 import Events from '@ionic-internal/component-api/v7/modal/events.md';
 import Methods from '@ionic-internal/component-api/v7/modal/methods.md';
 import Parts from '@ionic-internal/component-api/v7/modal/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/modal/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/modal/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/modal/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/nav-link.md
+++ b/versioned_docs/version-v7/api/nav-link.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/nav-link/props.md';
 import Events from '@ionic-internal/component-api/v7/nav-link/events.md';
 import Methods from '@ionic-internal/component-api/v7/nav-link/methods.md';
 import Parts from '@ionic-internal/component-api/v7/nav-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/nav-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/nav-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/nav-link/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/nav.md
+++ b/versioned_docs/version-v7/api/nav.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/nav/props.md';
 import Events from '@ionic-internal/component-api/v7/nav/events.md';
 import Methods from '@ionic-internal/component-api/v7/nav/methods.md';
 import Parts from '@ionic-internal/component-api/v7/nav/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/nav/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/nav/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/nav/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/note.md
+++ b/versioned_docs/version-v7/api/note.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/note/props.md';
 import Events from '@ionic-internal/component-api/v7/note/events.md';
 import Methods from '@ionic-internal/component-api/v7/note/methods.md';
 import Parts from '@ionic-internal/component-api/v7/note/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/note/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/note/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/note/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/picker.md
+++ b/versioned_docs/version-v7/api/picker.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/picker/props.md';
 import Events from '@ionic-internal/component-api/v7/picker/events.md';
 import Methods from '@ionic-internal/component-api/v7/picker/methods.md';
 import Parts from '@ionic-internal/component-api/v7/picker/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/picker/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/picker/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/picker/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/popover.md
+++ b/versioned_docs/version-v7/api/popover.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/popover/props.md';
 import Events from '@ionic-internal/component-api/v7/popover/events.md';
 import Methods from '@ionic-internal/component-api/v7/popover/methods.md';
 import Parts from '@ionic-internal/component-api/v7/popover/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/popover/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/popover/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/popover/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/progress-bar.md
+++ b/versioned_docs/version-v7/api/progress-bar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/progress-bar/props.md';
 import Events from '@ionic-internal/component-api/v7/progress-bar/events.md';
 import Methods from '@ionic-internal/component-api/v7/progress-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v7/progress-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/progress-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/progress-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/progress-bar/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/radio-group.md
+++ b/versioned_docs/version-v7/api/radio-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/radio-group/props.md';
 import Events from '@ionic-internal/component-api/v7/radio-group/events.md';
 import Methods from '@ionic-internal/component-api/v7/radio-group/methods.md';
 import Parts from '@ionic-internal/component-api/v7/radio-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/radio-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/radio-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/radio-group/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/radio.md
+++ b/versioned_docs/version-v7/api/radio.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/radio/props.md';
 import Events from '@ionic-internal/component-api/v7/radio/events.md';
 import Methods from '@ionic-internal/component-api/v7/radio/methods.md';
 import Parts from '@ionic-internal/component-api/v7/radio/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/radio/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/radio/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/radio/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/range.md
+++ b/versioned_docs/version-v7/api/range.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/range/props.md';
 import Events from '@ionic-internal/component-api/v7/range/events.md';
 import Methods from '@ionic-internal/component-api/v7/range/methods.md';
 import Parts from '@ionic-internal/component-api/v7/range/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/range/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/range/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/range/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/refresher-content.md
+++ b/versioned_docs/version-v7/api/refresher-content.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/refresher-content/props.md';
 import Events from '@ionic-internal/component-api/v7/refresher-content/events.md';
 import Methods from '@ionic-internal/component-api/v7/refresher-content/methods.md';
 import Parts from '@ionic-internal/component-api/v7/refresher-content/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/refresher-content/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/refresher-content/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/refresher-content/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/refresher.md
+++ b/versioned_docs/version-v7/api/refresher.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/refresher/props.md';
 import Events from '@ionic-internal/component-api/v7/refresher/events.md';
 import Methods from '@ionic-internal/component-api/v7/refresher/methods.md';
 import Parts from '@ionic-internal/component-api/v7/refresher/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/refresher/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/refresher/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/refresher/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/reorder-group.md
+++ b/versioned_docs/version-v7/api/reorder-group.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/reorder-group/props.md';
 import Events from '@ionic-internal/component-api/v7/reorder-group/events.md';
 import Methods from '@ionic-internal/component-api/v7/reorder-group/methods.md';
 import Parts from '@ionic-internal/component-api/v7/reorder-group/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/reorder-group/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/reorder-group/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/reorder-group/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/reorder.md
+++ b/versioned_docs/version-v7/api/reorder.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/reorder/props.md';
 import Events from '@ionic-internal/component-api/v7/reorder/events.md';
 import Methods from '@ionic-internal/component-api/v7/reorder/methods.md';
 import Parts from '@ionic-internal/component-api/v7/reorder/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/reorder/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/reorder/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/reorder/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/ripple-effect.md
+++ b/versioned_docs/version-v7/api/ripple-effect.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/ripple-effect/props.md';
 import Events from '@ionic-internal/component-api/v7/ripple-effect/events.md';
 import Methods from '@ionic-internal/component-api/v7/ripple-effect/methods.md';
 import Parts from '@ionic-internal/component-api/v7/ripple-effect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/ripple-effect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/ripple-effect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/ripple-effect/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/route-redirect.md
+++ b/versioned_docs/version-v7/api/route-redirect.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/route-redirect/props.md';
 import Events from '@ionic-internal/component-api/v7/route-redirect/events.md';
 import Methods from '@ionic-internal/component-api/v7/route-redirect/methods.md';
 import Parts from '@ionic-internal/component-api/v7/route-redirect/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/route-redirect/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/route-redirect/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/route-redirect/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/route.md
+++ b/versioned_docs/version-v7/api/route.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v7/route/props.md';
 import Events from '@ionic-internal/component-api/v7/route/events.md';
 import Methods from '@ionic-internal/component-api/v7/route/methods.md';
 import Parts from '@ionic-internal/component-api/v7/route/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/route/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/route/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/route/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/router-link.md
+++ b/versioned_docs/version-v7/api/router-link.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/router-link/props.md';
 import Events from '@ionic-internal/component-api/v7/router-link/events.md';
 import Methods from '@ionic-internal/component-api/v7/router-link/methods.md';
 import Parts from '@ionic-internal/component-api/v7/router-link/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/router-link/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/router-link/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/router-link/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/router-outlet.md
+++ b/versioned_docs/version-v7/api/router-outlet.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/router-outlet/props.md';
 import Events from '@ionic-internal/component-api/v7/router-outlet/events.md';
 import Methods from '@ionic-internal/component-api/v7/router-outlet/methods.md';
 import Parts from '@ionic-internal/component-api/v7/router-outlet/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/router-outlet/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/router-outlet/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/router-outlet/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/router.md
+++ b/versioned_docs/version-v7/api/router.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/router/props.md';
 import Events from '@ionic-internal/component-api/v7/router/events.md';
 import Methods from '@ionic-internal/component-api/v7/router/methods.md';
 import Parts from '@ionic-internal/component-api/v7/router/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/router/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/router/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/router/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/row.md
+++ b/versioned_docs/version-v7/api/row.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/row/props.md';
 import Events from '@ionic-internal/component-api/v7/row/events.md';
 import Methods from '@ionic-internal/component-api/v7/row/methods.md';
 import Parts from '@ionic-internal/component-api/v7/row/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/row/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/row/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/row/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/searchbar.md
+++ b/versioned_docs/version-v7/api/searchbar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/searchbar/props.md';
 import Events from '@ionic-internal/component-api/v7/searchbar/events.md';
 import Methods from '@ionic-internal/component-api/v7/searchbar/methods.md';
 import Parts from '@ionic-internal/component-api/v7/searchbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/searchbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/searchbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/searchbar/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/segment-button.md
+++ b/versioned_docs/version-v7/api/segment-button.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/segment-button/props.md';
 import Events from '@ionic-internal/component-api/v7/segment-button/events.md';
 import Methods from '@ionic-internal/component-api/v7/segment-button/methods.md';
 import Parts from '@ionic-internal/component-api/v7/segment-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/segment-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/segment-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/segment-button/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/segment.md
+++ b/versioned_docs/version-v7/api/segment.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/segment/props.md';
 import Events from '@ionic-internal/component-api/v7/segment/events.md';
 import Methods from '@ionic-internal/component-api/v7/segment/methods.md';
 import Parts from '@ionic-internal/component-api/v7/segment/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/segment/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/segment/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/segment/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/select-option.md
+++ b/versioned_docs/version-v7/api/select-option.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/select-option/props.md';
 import Events from '@ionic-internal/component-api/v7/select-option/events.md';
 import Methods from '@ionic-internal/component-api/v7/select-option/methods.md';
 import Parts from '@ionic-internal/component-api/v7/select-option/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/select-option/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/select-option/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/select-option/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/select.md
+++ b/versioned_docs/version-v7/api/select.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/select/props.md';
 import Events from '@ionic-internal/component-api/v7/select/events.md';
 import Methods from '@ionic-internal/component-api/v7/select/methods.md';
 import Parts from '@ionic-internal/component-api/v7/select/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/select/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/select/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/select/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/skeleton-text.md
+++ b/versioned_docs/version-v7/api/skeleton-text.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/skeleton-text/props.md';
 import Events from '@ionic-internal/component-api/v7/skeleton-text/events.md';
 import Methods from '@ionic-internal/component-api/v7/skeleton-text/methods.md';
 import Parts from '@ionic-internal/component-api/v7/skeleton-text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/skeleton-text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/skeleton-text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/skeleton-text/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/spinner.md
+++ b/versioned_docs/version-v7/api/spinner.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/spinner/props.md';
 import Events from '@ionic-internal/component-api/v7/spinner/events.md';
 import Methods from '@ionic-internal/component-api/v7/spinner/methods.md';
 import Parts from '@ionic-internal/component-api/v7/spinner/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/spinner/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/spinner/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/spinner/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/split-pane.md
+++ b/versioned_docs/version-v7/api/split-pane.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/split-pane/props.md';
 import Events from '@ionic-internal/component-api/v7/split-pane/events.md';
 import Methods from '@ionic-internal/component-api/v7/split-pane/methods.md';
 import Parts from '@ionic-internal/component-api/v7/split-pane/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/split-pane/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/split-pane/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/split-pane/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/tab-bar.md
+++ b/versioned_docs/version-v7/api/tab-bar.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v7/tab-bar/props.md';
 import Events from '@ionic-internal/component-api/v7/tab-bar/events.md';
 import Methods from '@ionic-internal/component-api/v7/tab-bar/methods.md';
 import Parts from '@ionic-internal/component-api/v7/tab-bar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/tab-bar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/tab-bar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/tab-bar/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/tab-button.md
+++ b/versioned_docs/version-v7/api/tab-button.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v7/tab-button/props.md';
 import Events from '@ionic-internal/component-api/v7/tab-button/events.md';
 import Methods from '@ionic-internal/component-api/v7/tab-button/methods.md';
 import Parts from '@ionic-internal/component-api/v7/tab-button/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/tab-button/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/tab-button/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/tab-button/slots.md';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';

--- a/versioned_docs/version-v7/api/tab.md
+++ b/versioned_docs/version-v7/api/tab.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/tab/props.md';
 import Events from '@ionic-internal/component-api/v7/tab/events.md';
 import Methods from '@ionic-internal/component-api/v7/tab/methods.md';
 import Parts from '@ionic-internal/component-api/v7/tab/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/tab/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/tab/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/tab/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/tabs.md
+++ b/versioned_docs/version-v7/api/tabs.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/tabs/props.md';
 import Events from '@ionic-internal/component-api/v7/tabs/events.md';
 import Methods from '@ionic-internal/component-api/v7/tabs/methods.md';
 import Parts from '@ionic-internal/component-api/v7/tabs/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/tabs/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/tabs/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/tabs/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/text.md
+++ b/versioned_docs/version-v7/api/text.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/text/props.md';
 import Events from '@ionic-internal/component-api/v7/text/events.md';
 import Methods from '@ionic-internal/component-api/v7/text/methods.md';
 import Parts from '@ionic-internal/component-api/v7/text/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/text/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/text/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/text/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/textarea.md
+++ b/versioned_docs/version-v7/api/textarea.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/textarea/props.md';
 import Events from '@ionic-internal/component-api/v7/textarea/events.md';
 import Methods from '@ionic-internal/component-api/v7/textarea/methods.md';
 import Parts from '@ionic-internal/component-api/v7/textarea/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/textarea/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/textarea/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/textarea/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/thumbnail.md
+++ b/versioned_docs/version-v7/api/thumbnail.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/thumbnail/props.md';
 import Events from '@ionic-internal/component-api/v7/thumbnail/events.md';
 import Methods from '@ionic-internal/component-api/v7/thumbnail/methods.md';
 import Parts from '@ionic-internal/component-api/v7/thumbnail/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/thumbnail/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/thumbnail/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/thumbnail/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/title.md
+++ b/versioned_docs/version-v7/api/title.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/title/props.md';
 import Events from '@ionic-internal/component-api/v7/title/events.md';
 import Methods from '@ionic-internal/component-api/v7/title/methods.md';
 import Parts from '@ionic-internal/component-api/v7/title/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/title/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/title/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/title/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/toast.md
+++ b/versioned_docs/version-v7/api/toast.md
@@ -9,7 +9,7 @@ import Props from '@ionic-internal/component-api/v7/toast/props.md';
 import Events from '@ionic-internal/component-api/v7/toast/events.md';
 import Methods from '@ionic-internal/component-api/v7/toast/methods.md';
 import Parts from '@ionic-internal/component-api/v7/toast/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/toast/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/toast/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/toast/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/toggle.md
+++ b/versioned_docs/version-v7/api/toggle.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/toggle/props.md';
 import Events from '@ionic-internal/component-api/v7/toggle/events.md';
 import Methods from '@ionic-internal/component-api/v7/toggle/methods.md';
 import Parts from '@ionic-internal/component-api/v7/toggle/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/toggle/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/toggle/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/toggle/slots.md';
 
 <head>

--- a/versioned_docs/version-v7/api/toolbar.md
+++ b/versioned_docs/version-v7/api/toolbar.md
@@ -6,7 +6,7 @@ import Props from '@ionic-internal/component-api/v7/toolbar/props.md';
 import Events from '@ionic-internal/component-api/v7/toolbar/events.md';
 import Methods from '@ionic-internal/component-api/v7/toolbar/methods.md';
 import Parts from '@ionic-internal/component-api/v7/toolbar/parts.md';
-import CustomProps from '@ionic-internal/component-api/v7/toolbar/custom-props.md';
+import CustomProps from '@ionic-internal/component-api/v7/toolbar/custom-props.mdx';
 import Slots from '@ionic-internal/component-api/v7/toolbar/slots.md';
 
 <head>


### PR DESCRIPTION
Resolves #3668

--------------------

Adds an iOS or MD tab if the component has css properties available for a specific mode, otherwise falls back to the existing UI.

This uses MDX features which required updating the generated imports for all components. 