### PR TITLE
docs(theming): replace charcoal variable with background since the property name is background

### DIFF
--- a/docs/theming/css-variables.md
+++ b/docs/theming/css-variables.md
@@ -84,7 +84,7 @@ The value of a CSS variable can be read in JavaScript using [getPropertyValue()]
 
 ```js
 const el = document.querySelector('.fancy-button');
-const color = el.style.getPropertyValue('--charcoal');
+const color = el.style.getPropertyValue('--background');
 ```
 
 ## Ionic Variables


### PR DESCRIPTION
The `getPropertyValue ` method incorrectly takes `--charcoal` as the input, it should be `--background`