### PR TITLE
docs(react): remove React protections link

### DIFF
--- a/docs/techniques/security.md
+++ b/docs/techniques/security.md
@@ -53,8 +53,6 @@ const element = <a href={userInput}>Click Me!</a>;
 
 If the developer needs to achieve more comprehensive sanitization, they can use the [sanitize-html](https://www.npmjs.com/package/sanitize-html) package.
 
-To learn more about the built-in protections that React and JSX provide, see the [React JSX Documentation](https://reactjs.org/docs/introducing-jsx.html#jsx-prevents-injection-attacks).
-
 ### Vue
 
 Vue does not provide any type of sanitizing methods built in. It is recommended that developers use a package such as [sanitize-html](https://www.npmjs.com/package/sanitize-html).


### PR DESCRIPTION
React no longer has a section regarding JSX preventing injection attacks. The link has been removed since it points to the legacy site and the current site doesn't mention it.