### PR TITLE
docs(support): add angular 18 support

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -44,7 +44,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v8     |           v16           |          v17.x          |   4.9.3+   |
+|    v8     |           v16           |        v18.x[^3]        |   4.9.3+   |
 |    v7     |           v14           |        v17.x[^2]        |    4.6+    |
 |    v6     |           v12           |        v15.x[^1]        |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |
@@ -53,6 +53,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 [^1]: Angular 14.x supported starting in Ionic v6.1.9. Angular 15.x supported starting in Ionic v6.3.6.
 [^2]: Angular 17.x supported starting in Ionic v7.5.4.
+[^3]: Angular 18.x supported starting in Ionic v8.2.0.
 
 **Angular 13+ Support On Older Versions of iOS**
 


### PR DESCRIPTION
This PR notes when Angular 18 support started in Ionic 8