### PR TITLE
docs(demos): update v8 playgrounds to use correct version

### DIFF
--- a/static/usage/v6/datetime/highlightedDates/array/index.md
+++ b/static/usage/v6/datetime/highlightedDates/array/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={6}
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v6/datetime/highlightedDates/callback/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={6}
+  version="6"
   code={{
     javascript,
     react,

--- a/static/usage/v6/icon/basic/index.md
+++ b/static/usage/v6/icon/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version={6} size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v6/icon/basic/demo.html" />
+<Playground version="6" size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v6/icon/basic/demo.html" />

--- a/static/usage/v6/tabs/router/index.md
+++ b/static/usage/v6/tabs/router/index.md
@@ -42,7 +42,7 @@ import react_library_page_tsx from './react/library_page_tsx.md';
 import react_search_page_tsx from './react/search_page_tsx.md';
 
 <Playground
-  version={6}
+  version="6"
   code={{
     javascript,
     angular: {

--- a/static/usage/v7/datetime/highlightedDates/array/index.md
+++ b/static/usage/v7/datetime/highlightedDates/array/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={7}
+  version="7"
   code={{
     javascript,
     react,

--- a/static/usage/v7/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v7/datetime/highlightedDates/callback/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={7}
+  version="7"
   code={{
     javascript,
     react,

--- a/static/usage/v7/icon/basic/index.md
+++ b/static/usage/v7/icon/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version={7} size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v7/icon/basic/demo.html" />
+<Playground version="7" size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v7/icon/basic/demo.html" />

--- a/static/usage/v7/tabs/router/index.md
+++ b/static/usage/v7/tabs/router/index.md
@@ -42,7 +42,7 @@ import react_library_page_tsx from './react/library_page_tsx.md';
 import react_search_page_tsx from './react/search_page_tsx.md';
 
 <Playground
-  version={7}
+  version="7"
   code={{
     javascript,
     angular: {

--- a/static/usage/v8/datetime/highlightedDates/array/index.md
+++ b/static/usage/v8/datetime/highlightedDates/array/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={7}
+  version={8}
   code={{
     javascript,
     react,

--- a/static/usage/v8/datetime/highlightedDates/array/index.md
+++ b/static/usage/v8/datetime/highlightedDates/array/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={8}
+  version="8"
   code={{
     javascript,
     react,

--- a/static/usage/v8/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v8/datetime/highlightedDates/callback/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={7}
+  version={8}
   code={{
     javascript,
     react,

--- a/static/usage/v8/datetime/highlightedDates/callback/index.md
+++ b/static/usage/v8/datetime/highlightedDates/callback/index.md
@@ -9,7 +9,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   size="medium"
-  version={8}
+  version="8"
   code={{
     javascript,
     react,

--- a/static/usage/v8/icon/basic/index.md
+++ b/static/usage/v8/icon/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version={8} size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v8/icon/basic/demo.html" />
+<Playground version="8" size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v8/icon/basic/demo.html" />

--- a/static/usage/v8/icon/basic/index.md
+++ b/static/usage/v8/icon/basic/index.md
@@ -5,4 +5,4 @@ import react from './react.md';
 import vue from './vue.md';
 import angular from './angular.md';
 
-<Playground version={7} size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v8/icon/basic/demo.html" />
+<Playground version={8} size="xsmall" code={{ javascript, react, vue, angular }} src="usage/v8/icon/basic/demo.html" />

--- a/static/usage/v8/tabs/router/index.md
+++ b/static/usage/v8/tabs/router/index.md
@@ -42,7 +42,7 @@ import react_library_page_tsx from './react/library_page_tsx.md';
 import react_search_page_tsx from './react/search_page_tsx.md';
 
 <Playground
-  version={8}
+  version="8"
   code={{
     javascript,
     angular: {

--- a/static/usage/v8/tabs/router/index.md
+++ b/static/usage/v8/tabs/router/index.md
@@ -42,7 +42,7 @@ import react_library_page_tsx from './react/library_page_tsx.md';
 import react_search_page_tsx from './react/search_page_tsx.md';
 
 <Playground
-  version={7}
+  version={8}
   code={{
     javascript,
     angular: {


### PR DESCRIPTION
This does two things:
1) Update the v8 playgrounds that were still using v7 to use the proper version
2) Update the syntax to use `""` instead of `{}` on the versions because these were skipped in a find & replace for that reason