### PR TITLE
docs(updating): set versions to force major number

### DIFF
--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -39,13 +39,13 @@ npm install @ionic/angular@latest @ionic/angular-server@latest @ionic/angular-to
 1. Ionic 8 supports React 17+. Update to the latest version of React:
 
 ```shell
-npm install react@latest react-dom@latest
+npm install react@17 react-dom@17
 ```
 
 2. Update to the latest version of Ionic 8:
 
 ```shell
-npm install @ionic/react@latest @ionic/react-router@latest
+npm install @ionic/react@8 @ionic/react-router@8
 ```
 
 ### Vue
@@ -53,13 +53,13 @@ npm install @ionic/react@latest @ionic/react-router@latest
 1. Ionic 7 supports Vue 3.0.6+. Update to the latest version of Vue:
 
 ```shell
-npm install vue@latest vue-router@latest
+npm install vue@^3.0.6 vue-router@^3.0.6
 ```
 
 2. Update to the latest version of Ionic 8:
 
 ```shell
-npm install @ionic/vue@latest @ionic/vue-router@latest
+npm install @ionic/vue@8 @ionic/vue-router@8
 ```
 
 ### Core
@@ -67,7 +67,7 @@ npm install @ionic/vue@latest @ionic/vue-router@latest
 1. Update to the latest version of Ionic 8:
 
 ```shell
-npm install @ionic/core@latest
+npm install @ionic/core@8
 ```
 
 ## Recommended Changes


### PR DESCRIPTION
With the advent of react 18 this documentation ages badly, forcing a major version number ensures this continues to work as specifies by the text above it