### PR TITLE
docs(angular): add tip for usage of IonRouterLink within navigation

### DIFF
--- a/docs/angular/navigation.md
+++ b/docs/angular/navigation.md
@@ -192,8 +192,7 @@ Developers can use the existing syntax for standalone component routing from Ang
 })
 export class AppRoutingModule {}
 ```
-
-To get started with standalone components [visit Angular's official docs](https://angular.io/guide/standalone-components).
+If you are using `routerLink`, `routerDirection`, or `routerAction` be sure to also import the `IonRouterLink` directive for Ionic components or the `IonRouterLinkWithHref` directive for <a> elements. To get started with standalone components [visit Angular's official docs](https://angular.io/guide/standalone-components).
 
 ## Live Example
 

--- a/docs/angular/navigation.md
+++ b/docs/angular/navigation.md
@@ -192,7 +192,12 @@ Developers can use the existing syntax for standalone component routing from Ang
 })
 export class AppRoutingModule {}
 ```
-If you are using `routerLink`, `routerDirection`, or `routerAction` be sure to also import the `IonRouterLink` directive for Ionic components or the `IonRouterLinkWithHref` directive for <a> elements. To get started with standalone components [visit Angular's official docs](https://angular.io/guide/standalone-components).
+
+:::tip
+If you are using `routerLink`, `routerDirection`, or `routerAction` be sure to also import the `IonRouterLink` directive for Ionic components or the `IonRouterLinkWithHref` directive for `<a>` elements. An example of this is available in the [Ionic Angular Build Options docs](./build-options.md#migrating-from-modules-to-standalone).
+:::
+
+To get started with standalone components [visit Angular's official docs](https://angular.io/guide/standalone-components).
 
 ## Live Example
 


### PR DESCRIPTION
Added mention of the need for`IonRouterLink` or  `IonRouterLinkWithHref` directives based on the info in step 9 of https://ionicframework.com/docs/angular/build-options#standalone-based-applications.