### PR TITLE
docs(api): add missing code to javascript demo index files

### DIFF
--- a/static/usage/v8/input/mask/javascript/index_ts.md
+++ b/static/usage/v8/input/mask/javascript/index_ts.md
@@ -19,6 +19,17 @@ import '@ionic/core/css/text-transformation.css';
 import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
+/**
+ * Ionic Dark Palette
+ * -----------------------------------------------------
+ * For more information, please see:
+ * https://ionicframework.com/docs/theming/dark-mode
+ */
+
+// import '@ionic/core/css/palettes/dark.always.css';
+// import '@ionic/core/css/palettes/dark.class.css';
+import '@ionic/core/css/palettes/dark.system.css';
+
 /* Theme variables */
 import './theme/variables.css';
 

--- a/static/usage/v8/modal/styling/animations/javascript/index_ts.md
+++ b/static/usage/v8/modal/styling/animations/javascript/index_ts.md
@@ -3,6 +3,36 @@ import { defineCustomElements } from '@ionic/core/loader';
 
 import { createAnimation } from '@ionic/core';
 
+/* Core CSS required for Ionic components to work properly */
+import '@ionic/core/css/core.css';
+
+/* Basic CSS for apps built with Ionic */
+import '@ionic/core/css/normalize.css';
+import '@ionic/core/css/structure.css';
+import '@ionic/core/css/typography.css';
+
+/* Optional CSS utils that can be commented out */
+import '@ionic/core/css/padding.css';
+import '@ionic/core/css/float-elements.css';
+import '@ionic/core/css/text-alignment.css';
+import '@ionic/core/css/text-transformation.css';
+import '@ionic/core/css/flex-utils.css';
+import '@ionic/core/css/display.css';
+
+/**
+ * Ionic Dark Palette
+ * -----------------------------------------------------
+ * For more information, please see:
+ * https://ionicframework.com/docs/theming/dark-mode
+ */
+
+// import '@ionic/core/css/palettes/dark.always.css';
+// import '@ionic/core/css/palettes/dark.class.css';
+import '@ionic/core/css/palettes/dark.system.css';
+
+/* Theme variables */
+import './theme/variables.css';
+
 defineCustomElements();
 
 (window as any).createAnimation = createAnimation;


### PR DESCRIPTION
## What is the current behavior?

When passing a custom `index.ts` file to the JavaScript StackBlitz demos, the dark palette files have to be included, otherwise the UI does not change to dark mode based on the system settings. This is apparent when opening a different framework alongside the JavaScript example while the system is set to "Dark". The following demos are broken:

[Input](https://ionicframework.com/docs/api/input#input-masking)
[Modal](https://ionicframework.com/docs/api/modal#animations)

## What is the new behavior?

I updated the `index.ts` files for the above demos to include the dark palettes and other missing boilerplate code. 

[Input](https://ionic-docs-git-docs-javascript-index-files-ionic1.vercel.app/docs/api/input#input-masking)
[Modal](https://ionic-docs-git-docs-javascript-index-files-ionic1.vercel.app/docs/api/modal#animations)

