### PR TITLE
docs(api): rename dark theme to palette

### DIFF
--- a/static/usage/v8/breadcrumbs/icons/custom-separators/javascript/index_ts.md
+++ b/static/usage/v8/breadcrumbs/icons/custom-separators/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/breadcrumbs/icons/icons-on-items/javascript/index_ts.md
+++ b/static/usage/v8/breadcrumbs/icons/icons-on-items/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/button/icons/javascript/index_ts.md
+++ b/static/usage/v8/button/icons/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/button/shape/javascript/index_ts.md
+++ b/static/usage/v8/button/shape/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/buttons/types/javascript/index_ts.md
+++ b/static/usage/v8/buttons/types/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/chip/slots/javascript/index_ts.md
+++ b/static/usage/v8/chip/slots/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/basic/javascript/index_ts.md
+++ b/static/usage/v8/fab/basic/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/before-content/javascript/index_ts.md
+++ b/static/usage/v8/fab/before-content/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/button-sizing/javascript/index_ts.md
+++ b/static/usage/v8/fab/button-sizing/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/list-side/javascript/index_ts.md
+++ b/static/usage/v8/fab/list-side/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/positioning/javascript/index_ts.md
+++ b/static/usage/v8/fab/positioning/javascript/index_ts.md
@@ -28,7 +28,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/safe-area/javascript/index_ts.md
+++ b/static/usage/v8/fab/safe-area/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/theming/colors/javascript/index_ts.md
+++ b/static/usage/v8/fab/theming/colors/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/theming/css-custom-properties/javascript/index_ts.md
+++ b/static/usage/v8/fab/theming/css-custom-properties/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/fab/theming/css-shadow-parts/javascript/index_ts.md
+++ b/static/usage/v8/fab/theming/css-shadow-parts/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/icon/basic/javascript/index_ts.md
+++ b/static/usage/v8/icon/basic/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/input/start-end-slots/javascript/index_ts.md
+++ b/static/usage/v8/input/start-end-slots/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/item-sliding/icons/javascript/index_ts.md
+++ b/static/usage/v8/item-sliding/icons/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/item/buttons/javascript/index_ts.md
+++ b/static/usage/v8/item/buttons/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/item/content-types/actions/javascript/index_ts.md
+++ b/static/usage/v8/item/content-types/actions/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/item/content-types/metadata/javascript/index_ts.md
+++ b/static/usage/v8/item/content-types/metadata/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/item/content-types/supporting-visuals/javascript/index_ts.md
+++ b/static/usage/v8/item/content-types/supporting-visuals/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/item/lines/javascript/index_ts.md
+++ b/static/usage/v8/item/lines/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/layout/dynamic-font-scaling/javascript/index_ts.md
+++ b/static/usage/v8/layout/dynamic-font-scaling/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/modal/custom-dialogs/javascript/index_ts.md
+++ b/static/usage/v8/modal/custom-dialogs/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/range/slots/javascript/index_ts.md
+++ b/static/usage/v8/range/slots/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/refresher/advanced/javascript/index_ts.md
+++ b/static/usage/v8/refresher/advanced/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/reorder/custom-icon/javascript/index_ts.md
+++ b/static/usage/v8/reorder/custom-icon/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/segment-button/layout/javascript/index_ts.md
+++ b/static/usage/v8/segment-button/layout/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/segment/scrollable/javascript/index_ts.md
+++ b/static/usage/v8/segment/scrollable/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/select/start-end-slots/javascript/index_ts.md
+++ b/static/usage/v8/select/start-end-slots/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/skeleton-text/basic/javascript/index_ts.md
+++ b/static/usage/v8/skeleton-text/basic/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/tabs/router/javascript/index_ts.md
+++ b/static/usage/v8/tabs/router/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/text/basic/javascript/index_ts.md
+++ b/static/usage/v8/text/basic/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/textarea/start-end-slots/javascript/index_ts.md
+++ b/static/usage/v8/textarea/start-end-slots/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode

--- a/static/usage/v8/toolbar/buttons/javascript/index_ts.md
+++ b/static/usage/v8/toolbar/buttons/javascript/index_ts.md
@@ -21,7 +21,7 @@ import '@ionic/core/css/flex-utils.css';
 import '@ionic/core/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Palette
  * -----------------------------------------------------
  * For more information, please see:
  * https://ionicframework.com/docs/theming/dark-mode


### PR DESCRIPTION
With the v8 release we started referring to the dark mode files as a `palette`, but some of the custom `index.ts` files have it commented as `theme` still. This updates the comment in those files. 