### PR TITLE
docs(api): pass ionicons dependency in the javascript and angular package file

### DIFF
--- a/static/code/stackblitz/v7/angular/package.json
+++ b/static/code/stackblitz/v7/angular/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@ionic/angular": "^7.0.0",
     "@ionic/core": "^7.0.0",
-    "@angular/platform-browser-dynamic": "18.0.5"
+    "@angular/platform-browser-dynamic": "18.0.5",
+    "ionicons": "7.4.0"
   }
 }

--- a/static/code/stackblitz/v7/html/package.json
+++ b/static/code/stackblitz/v7/html/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@ionic/core": "^7.0.0"
+    "@ionic/core": "^7.0.0",
+    "ionicons": "7.4.0"
   }
 }

--- a/static/code/stackblitz/v8/angular/package.json
+++ b/static/code/stackblitz/v8/angular/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@ionic/angular": "8.2.5",
     "@ionic/core": "8.2.5",
-    "@angular/platform-browser-dynamic": "18.0.5"
+    "@angular/platform-browser-dynamic": "18.0.5",
+    "ionicons": "7.4.0"
   }
 }

--- a/static/code/stackblitz/v8/html/package.json
+++ b/static/code/stackblitz/v8/html/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "@ionic/core": "8.2.5"
+    "@ionic/core": "8.2.5",
+    "ionicons": "7.4.0"
   }
 }

--- a/static/usage/v7/breadcrumbs/icons/custom-separators/index.md
+++ b/static/usage/v7/breadcrumbs/icons/custom-separators/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/breadcrumbs/icons/icons-on-items/index.md
+++ b/static/usage/v7/breadcrumbs/icons/icons-on-items/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/button/icons/index.md
+++ b/static/usage/v7/button/icons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/buttons/types/index.md
+++ b/static/usage/v7/buttons/types/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/chip/slots/index.md
+++ b/static/usage/v7/chip/slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/basic/index.md
+++ b/static/usage/v7/fab/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/button-sizing/index.md
+++ b/static/usage/v7/fab/button-sizing/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/list-side/index.md
+++ b/static/usage/v7/fab/list-side/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/positioning/index.md
+++ b/static/usage/v7/fab/positioning/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/safe-area/index.md
+++ b/static/usage/v7/fab/safe-area/index.md
@@ -21,9 +21,6 @@ import angular_global_css from './angular/global_css.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -38,9 +35,6 @@ import angular_global_css from './angular/global_css.md';
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/global.css': angular_global_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/theming/colors/index.md
+++ b/static/usage/v7/fab/theming/colors/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/theming/css-custom-properties/index.md
+++ b/static/usage/v7/fab/theming/css-custom-properties/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/fab/theming/css-shadow-parts/index.md
+++ b/static/usage/v7/fab/theming/css-shadow-parts/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/icon/basic/index.md
+++ b/static/usage/v7/icon/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/input/start-end-slots/index.md
+++ b/static/usage/v7/input/start-end-slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/item-sliding/icons/index.md
+++ b/static/usage/v7/item-sliding/icons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/item/buttons/index.md
+++ b/static/usage/v7/item/buttons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/item/content-types/actions/index.md
+++ b/static/usage/v7/item/content-types/actions/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/item/content-types/metadata/index.md
+++ b/static/usage/v7/item/content-types/metadata/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/item/content-types/supporting-visuals/index.md
+++ b/static/usage/v7/item/content-types/supporting-visuals/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/item/lines/index.md
+++ b/static/usage/v7/item/lines/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/layout/dynamic-font-scaling/index.md
+++ b/static/usage/v7/layout/dynamic-font-scaling/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/global.css': angular_global_css,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/modal/custom-dialogs/index.md
+++ b/static/usage/v7/modal/custom-dialogs/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     vue,
     react: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/global.css': angular_global_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/range/slots/index.md
+++ b/static/usage/v7/range/slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/refresher/advanced/index.md
+++ b/static/usage/v7/refresher/advanced/index.md
@@ -20,9 +20,6 @@ import angular_example_component_css from './angular/example_component_css.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_css from './angular/example_component_css.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/app/example.component.css': angular_example_component_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/reorder/custom-icon/index.md
+++ b/static/usage/v7/reorder/custom-icon/index.md
@@ -17,9 +17,6 @@ import angular_example_component_html from './angular/example_component_html.md'
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       files: {
         'src/app/example.component.ts': angular_example_component_ts,
         'src/app/example.component.html': angular_example_component_html,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/segment-button/layout/index.md
+++ b/static/usage/v7/segment-button/layout/index.md
@@ -17,9 +17,6 @@ import angular_example_component_html from './angular/example_component_html.md'
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       files: {
         'src/app/example.component.ts': angular_example_component_ts,
         'src/app/example.component.html': angular_example_component_html,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/segment/scrollable/index.md
+++ b/static/usage/v7/segment/scrollable/index.md
@@ -17,9 +17,6 @@ import angular_example_component_html from './angular/example_component_html.md'
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_html from './angular/example_component_html.md'
       files: {
         'src/app/example.component.ts': angular_example_component_ts,
         'src/app/example.component.html': angular_example_component_html,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/select/start-end-slots/index.md
+++ b/static/usage/v7/select/start-end-slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/skeleton-text/basic/index.md
+++ b/static/usage/v7/skeleton-text/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/tabs/router/index.md
+++ b/static/usage/v7/tabs/router/index.md
@@ -51,9 +51,6 @@ import react_search_page_tsx from './react/search_page_tsx.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     angular: {
       files: {
@@ -75,9 +72,6 @@ import react_search_page_tsx from './react/search_page_tsx.md';
         'src/app/app.module.ts': angular_app_module_ts,
         'src/app/app.component.html': angular_app_component_html,
         'src/app/app-routing.module.ts': angular_app_routing_module_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
     vue: {

--- a/static/usage/v7/text/basic/index.md
+++ b/static/usage/v7/text/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/textarea/start-end-slots/index.md
+++ b/static/usage/v7/textarea/start-end-slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/theming/automatic-dark-mode/index.md
+++ b/static/usage/v7/theming/automatic-dark-mode/index.md
@@ -23,9 +23,6 @@ import variables_css from './theme/variables_css.md';
         'index.ts': javascript_index_ts,
         'theme/variables.css': variables_css,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -46,9 +43,6 @@ import variables_css from './theme/variables_css.md';
         'src/app/example.component.ts': angular_example_component_ts,
         'src/global.css': angular_global_css,
         'src/theme/variables.css': variables_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/theming/manual-dark-mode/index.md
+++ b/static/usage/v7/theming/manual-dark-mode/index.md
@@ -23,9 +23,6 @@ import variables_css from './theme/variables_css.md';
         'index.ts': javascript_index_ts,
         'theme/variables.css': variables_css,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -46,9 +43,6 @@ import variables_css from './theme/variables_css.md';
         'src/app/example.component.ts': angular_example_component_ts,
         'src/global.css': angular_global_css,
         'src/theme/variables.css': variables_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v7/toolbar/buttons/index.md
+++ b/static/usage/v7/toolbar/buttons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/breadcrumbs/icons/custom-separators/index.md
+++ b/static/usage/v8/breadcrumbs/icons/custom-separators/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/breadcrumbs/icons/icons-on-items/index.md
+++ b/static/usage/v8/breadcrumbs/icons/icons-on-items/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/button/icons/index.md
+++ b/static/usage/v8/button/icons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/button/shape/index.md
+++ b/static/usage/v8/button/shape/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/buttons/types/index.md
+++ b/static/usage/v8/buttons/types/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/chip/slots/index.md
+++ b/static/usage/v8/chip/slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/basic/index.md
+++ b/static/usage/v8/fab/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/before-content/index.md
+++ b/static/usage/v8/fab/before-content/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/button-sizing/index.md
+++ b/static/usage/v8/fab/button-sizing/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/list-side/index.md
+++ b/static/usage/v8/fab/list-side/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/positioning/index.md
+++ b/static/usage/v8/fab/positioning/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/safe-area/index.md
+++ b/static/usage/v8/fab/safe-area/index.md
@@ -21,9 +21,6 @@ import angular_global_css from './angular/global_css.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -38,9 +35,6 @@ import angular_global_css from './angular/global_css.md';
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/global.css': angular_global_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/theming/colors/index.md
+++ b/static/usage/v8/fab/theming/colors/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/theming/css-custom-properties/index.md
+++ b/static/usage/v8/fab/theming/css-custom-properties/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/fab/theming/css-shadow-parts/index.md
+++ b/static/usage/v8/fab/theming/css-shadow-parts/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/icon/basic/index.md
+++ b/static/usage/v8/icon/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/input/start-end-slots/index.md
+++ b/static/usage/v8/input/start-end-slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/item-sliding/icons/index.md
+++ b/static/usage/v8/item-sliding/icons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/item/buttons/index.md
+++ b/static/usage/v8/item/buttons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/item/content-types/actions/index.md
+++ b/static/usage/v8/item/content-types/actions/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/item/content-types/metadata/index.md
+++ b/static/usage/v8/item/content-types/metadata/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/item/content-types/supporting-visuals/index.md
+++ b/static/usage/v8/item/content-types/supporting-visuals/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/item/lines/index.md
+++ b/static/usage/v8/item/lines/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/layout/dynamic-font-scaling/index.md
+++ b/static/usage/v8/layout/dynamic-font-scaling/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/modal/custom-dialogs/index.md
+++ b/static/usage/v8/modal/custom-dialogs/index.md
@@ -20,9 +20,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     vue,
     react: {
@@ -36,9 +33,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/global.css': angular_global_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/range/slots/index.md
+++ b/static/usage/v8/range/slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/refresher/advanced/index.md
+++ b/static/usage/v8/refresher/advanced/index.md
@@ -20,9 +20,6 @@ import angular_example_component_css from './angular/example_component_css.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -36,9 +33,6 @@ import angular_example_component_css from './angular/example_component_css.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/app/example.component.css': angular_example_component_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/reorder/custom-icon/index.md
+++ b/static/usage/v8/reorder/custom-icon/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/segment-button/layout/index.md
+++ b/static/usage/v8/segment-button/layout/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/segment/scrollable/index.md
+++ b/static/usage/v8/segment/scrollable/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/select/start-end-slots/index.md
+++ b/static/usage/v8/select/start-end-slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/skeleton-text/basic/index.md
+++ b/static/usage/v8/skeleton-text/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/tabs/router/index.md
+++ b/static/usage/v8/tabs/router/index.md
@@ -51,9 +51,6 @@ import react_search_page_tsx from './react/search_page_tsx.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     angular: {
       files: {
@@ -75,9 +72,6 @@ import react_search_page_tsx from './react/search_page_tsx.md';
         'src/app/app.module.ts': angular_app_module_ts,
         'src/app/app.component.html': angular_app_component_html,
         'src/app/app-routing.module.ts': angular_app_routing_module_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
     vue: {

--- a/static/usage/v8/text/basic/index.md
+++ b/static/usage/v8/text/basic/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/textarea/start-end-slots/index.md
+++ b/static/usage/v8/textarea/start-end-slots/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/theming/always-dark-mode/index.md
+++ b/static/usage/v8/theming/always-dark-mode/index.md
@@ -24,9 +24,6 @@ import variables_css from './theme/variables_css.md';
         'index.ts': javascript_index_ts,
         'theme/variables.css': variables_css,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -48,9 +45,6 @@ import variables_css from './theme/variables_css.md';
         'src/app/example.component.ts': angular_example_component_ts,
         'src/styles.css': angular_styles_css,
         'src/theme/variables.css': variables_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/theming/always-high-contrast-mode/index.md
+++ b/static/usage/v8/theming/always-high-contrast-mode/index.md
@@ -21,9 +21,6 @@ import vue_main_ts from './vue/main_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -42,9 +39,6 @@ import vue_main_ts from './vue/main_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/styles.css': angular_styles_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/theming/class-dark-mode/index.md
+++ b/static/usage/v8/theming/class-dark-mode/index.md
@@ -26,9 +26,6 @@ import variables_css from './theme/variables_css.md';
         'index.ts': javascript_index_ts,
         'theme/variables.css': variables_css,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -52,9 +49,6 @@ import variables_css from './theme/variables_css.md';
         'src/global.css': angular_global_css,
         'src/styles.css': angular_styles_css,
         'src/theme/variables.css': variables_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/theming/class-high-contrast-mode/index.md
+++ b/static/usage/v8/theming/class-high-contrast-mode/index.md
@@ -23,9 +23,6 @@ import vue_main_ts from './vue/main_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -46,9 +43,6 @@ import vue_main_ts from './vue/main_ts.md';
         'src/app/example.component.ts': angular_example_component_ts,
         'src/global.css': angular_global_css,
         'src/styles.css': angular_styles_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/theming/system-dark-mode/index.md
+++ b/static/usage/v8/theming/system-dark-mode/index.md
@@ -26,9 +26,6 @@ import variables_css from './theme/variables_css.md';
         'index.ts': javascript_index_ts,
         'theme/variables.css': variables_css,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -52,9 +49,6 @@ import variables_css from './theme/variables_css.md';
         'src/global.css': angular_global_css,
         'src/styles.css': angular_styles_css,
         'src/theme/variables.css': variables_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/theming/system-high-contrast-mode/index.md
+++ b/static/usage/v8/theming/system-high-contrast-mode/index.md
@@ -21,9 +21,6 @@ import vue_main_ts from './vue/main_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react: {
       files: {
@@ -42,9 +39,6 @@ import vue_main_ts from './vue/main_ts.md';
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
         'src/styles.css': angular_styles_css,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}

--- a/static/usage/v8/toolbar/buttons/index.md
+++ b/static/usage/v8/toolbar/buttons/index.md
@@ -17,9 +17,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
         'index.html': javascript_index_html,
         'index.ts': javascript_index_ts,
       },
-      dependencies: {
-        ionicons: '7.4.0',
-      },
     },
     react,
     vue,
@@ -27,9 +24,6 @@ import angular_example_component_ts from './angular/example_component_ts.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.ts': angular_example_component_ts,
-      },
-      dependencies: {
-        ionicons: '7.4.0',
       },
     },
   }}


### PR DESCRIPTION
This PR removes the `ionicons` dependency in Angular and Javascript from the individual demos and places it in their `package.json` files as a dependency instead. 

I realized after completing most of the `addIcon` usage demos that I should have done this in the first place but it was easier to wait until all of them were merged and change them all at once. 