### PR TITLE
Update 8-0.md - typo for the version number

### DIFF
--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -50,7 +50,7 @@ npm install @ionic/react@8 @ionic/react-router@8
 
 ### Vue
 
-1. Ionic 7 supports Vue 3.0.6+. Update to the latest version of Vue:
+1. Ionic 8 supports Vue 3.0.6+. Update to the latest version of Vue:
 
 ```shell
 npm install vue@^3.0.6 vue-router@^3.0.6


### PR DESCRIPTION
The start of the upgrade instructions for Vue referenced Ionic version 7 when it should be 8