### PR TITLE
docs(input, textarea): use a valid element for querySelector

### DIFF
--- a/static/usage/v7/input/helper-error/javascript.md
+++ b/static/usage/v7/input/helper-error/javascript.md
@@ -9,7 +9,7 @@
 ></ion-input>
 
 <script>
-  const input = input.querySelector('ion-input');
+  const input = document.querySelector('ion-input');
 
   input.addEventListener('ionInput', (ev) => validate(ev));
   input.addEventListener('ionBlur', () => markTouched());

--- a/static/usage/v7/textarea/helper-error/javascript.md
+++ b/static/usage/v7/textarea/helper-error/javascript.md
@@ -8,7 +8,7 @@
 ></ion-textarea>
 
 <script>
-  const textarea = textarea.querySelector('ion-textarea');
+  const textarea = document.querySelector('ion-textarea');
 
   textarea.addEventListener('ionInput', (ev) => validate(ev));
   textarea.addEventListener('ionBlur', () => markTouched());

--- a/static/usage/v7/textarea/helper-error/javascript.md
+++ b/static/usage/v7/textarea/helper-error/javascript.md
@@ -27,7 +27,7 @@
 
     if (value === '') return;
 
-    validateEmail(value) ? textarea.classList.add('ion-valid') : input.classList.add('ion-invalid');
+    validateEmail(value) ? textarea.classList.add('ion-valid') : textarea.classList.add('ion-invalid');
   };
 
   const markTouched = () => {

--- a/static/usage/v8/input/helper-error/javascript.md
+++ b/static/usage/v8/input/helper-error/javascript.md
@@ -9,7 +9,7 @@
 ></ion-input>
 
 <script>
-  const input = input.querySelector('ion-input');
+  const input = document.querySelector('ion-input');
 
   input.addEventListener('ionInput', (ev) => validate(ev));
   input.addEventListener('ionBlur', () => markTouched());

--- a/static/usage/v8/textarea/helper-error/javascript.md
+++ b/static/usage/v8/textarea/helper-error/javascript.md
@@ -8,7 +8,7 @@
 ></ion-textarea>
 
 <script>
-  const textarea = textarea.querySelector('ion-textarea');
+  const textarea = document.querySelector('ion-textarea');
 
   textarea.addEventListener('ionInput', (ev) => validate(ev));
   textarea.addEventListener('ionBlur', () => markTouched());

--- a/static/usage/v8/textarea/helper-error/javascript.md
+++ b/static/usage/v8/textarea/helper-error/javascript.md
@@ -27,7 +27,7 @@
 
     if (value === '') return;
 
-    validateEmail(value) ? textarea.classList.add('ion-valid') : input.classList.add('ion-invalid');
+    validateEmail(value) ? textarea.classList.add('ion-valid') : textarea.classList.add('ion-invalid');
   };
 
   const markTouched = () => {


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

When viewing the StackBlitz demo for helper and error text for `ion-input` and `ion-textarea` on JavaScript, it does not fire the events needed for the helper and error text to update.


## What is the new behavior?

- Used the correct element for the `querySelector`


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

1. Navigate to [Helper and Error text](https://ionicframework.com/docs/api/input#helper--error-text) on `ion-input`
2. Open StackBlitz - JavaScript
3. Verify that the text is updated when the input value is valid or not
4. Navigate to [Helper and Error text](https://ionicframework.com/docs/api/textarea#helper--error-text) on `ion-textarea`
5. Open StackBlitz - JavaScript
6. Verify that the text is updated when the textarea value is valid or not
