### PR TITLE
Remove incorrect information about ion-tab-bar being optional

### DIFF
--- a/docs/api/tabs.md
+++ b/docs/api/tabs.md
@@ -22,8 +22,6 @@ The component is a container of individual [Tab](tab.md) components.
 
 The `ion-tabs` component does not have any styling and works as a router outlet in order to handle navigation. It does not provide any UI feedback or mechanism to switch between tabs. In order to do so, an `ion-tab-bar` should be provided as a direct child of `ion-tabs`.
 
-Both `ion-tabs` and `ion-tab-bar` can be used as standalone elements. They don’t depend on each other to work, but they are usually used together in order to implement a tab-based navigation that behaves like a native app.
-
 The `ion-tab-bar` needs a slot defined in order to be projected to the right place in an `ion-tabs` component.
 
 :::note Framework Support


### PR DESCRIPTION
Attempting to use an ion-tabs without an ion-tab-bar results in an uncaught exception:

![image](https://github.com/user-attachments/assets/a41e6795-88e6-4662-ad52-96a28d43dacd)
