### PR TITLE
fix(input): vue counter example uses maxlength as a number

### DIFF
--- a/static/usage/v7/input/counter/vue.md
+++ b/static/usage/v7/input/counter/vue.md
@@ -1,13 +1,13 @@
 ```html
 <template>
-  <ion-input label="Default counter" label-placement="floating" :counter="true" maxlength="20"></ion-input>
+  <ion-input label="Default counter" label-placement="floating" :counter="true" :maxlength="20"></ion-input>
 
   <ion-input
     id="custom-input"
     label="Custom Counter Format"
     label-placement="floating"
     :counter="true"
-    maxlength="20"
+    :maxlength="20"
     :counter-formatter="customFormatter"
   ></ion-input>
 </template>

--- a/static/usage/v8/input/counter/vue.md
+++ b/static/usage/v8/input/counter/vue.md
@@ -1,13 +1,13 @@
 ```html
 <template>
-  <ion-input label="Default counter" label-placement="floating" :counter="true" maxlength="20"></ion-input>
+  <ion-input label="Default counter" label-placement="floating" :counter="true" :maxlength="20"></ion-input>
 
   <ion-input
     id="custom-input"
     label="Custom Counter Format"
     label-placement="floating"
     :counter="true"
-    maxlength="20"
+    :maxlength="20"
     :counter-formatter="customFormatter"
   ></ion-input>
 </template>


### PR DESCRIPTION
Resolves: #3796

Updates the Vue examples for the `ion-input` counter example to bind the `maxlength property as a number instead of a string. 