### PR TITLE
docs(datetime): remove non-existent value from presentation

### DIFF
--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -204,7 +204,7 @@ Some use cases may call for only date selection or only time selection. The `pre
 
 ### Month and Year Selection
 
-Month and year selection is available by passing `month-year`, `year-month`, `month`, or `year` to the `presentation` property.
+Month and year selection is available by passing `month-year`, `month`, or `year` to the `presentation` property.
 
 This example shows a datetime with the `month-year` configuration.
 

--- a/versioned_docs/version-v7/api/datetime.md
+++ b/versioned_docs/version-v7/api/datetime.md
@@ -207,7 +207,7 @@ Some use cases may call for only date selection or only time selection. The `pre
 
 ### Month and Year Selection
 
-Month and year selection is available by passing `month-year`, `year-month`, `month`, or `year` to the `presentation` property.
+Month and year selection is available by passing `month-year`, `month`, or `year` to the `presentation` property.
 
 This example shows a datetime with the `month-year` configuration.
 


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

The `presentation` section in `ion-datetime` mentions that `year-month` can be used as a value. That's not an actual option.

## What is the new behavior?

- Removed any instances of `year-month`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

[Preview](https://ionic-docs-git-minor-fixes-ionic1.vercel.app/docs/api/datetime#month-and-year-selection)
