### PR TITLE
docs(vue): streamline usage examples with script setup syntax

### DIFF
--- a/static/usage/v8/input/basic/vue.md
+++ b/static/usage/v8/input/basic/vue.md
@@ -23,12 +23,7 @@
   </ion-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput, IonItem, IonList } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput, IonItem, IonList },
-  });
 </script>
 ```

--- a/static/usage/v8/input/clear/vue.md
+++ b/static/usage/v8/input/clear/vue.md
@@ -34,12 +34,7 @@
   </ion-list>
 </template>
 
-<script lang="ts">
-  import { IonInput, IonItem, IonList } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput, IonItem, IonList },
-  });
+<script setup lang="ts">
+  import { IonInput, IonItem, IonList } from '@ionic/vue';  
 </script>
 ```

--- a/static/usage/v8/input/fill/vue.md
+++ b/static/usage/v8/input/fill/vue.md
@@ -7,12 +7,7 @@
   <ion-input label="Outline input" label-placement="floating" fill="outline" placeholder="Enter text"></ion-input>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput },
-  });
 </script>
 ```

--- a/static/usage/v8/input/filtering/vue.md
+++ b/static/usage/v8/input/filtering/vue.md
@@ -12,35 +12,28 @@
   </ion-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput, IonItem, IonList } from '@ionic/vue';
-  import { defineComponent, ref } from 'vue';
+  
+  const ionInputEl = ref();
+  const inputModel = ref('');
+  
+  const onInput = (ev) => {
+    const value = ev.target!.value;
 
-  export default defineComponent({
-    components: { IonInput, IonItem, IonList },
-    setup() {
-      const ionInputEl = ref();
-      const inputModel = ref('');
-      const onInput = (ev) => {
-        const value = ev.target!.value;
+    // Removes non alphanumeric characters
+    const filteredValue = value.replace(/[^a-zA-Z0-9]+/g, '');
 
-        // Removes non alphanumeric characters
-        const filteredValue = value.replace(/[^a-zA-Z0-9]+/g, '');
+    /**
+     * Update both the state variable and
+     * the component to keep them in sync.
+     */
+    inputModel.value = filteredValue;
 
-        /**
-         * Update both the state variable and
-         * the component to keep them in sync.
-         */
-        inputModel.value = filteredValue;
-
-        const inputCmp = ionInputEl.value;
-        if (inputCmp !== undefined) {
-          inputCmp.$el.value = filteredValue;
-        }
-      };
-
-      return { ionInputEl, inputModel, onInput };
-    },
-  });
+    const inputCmp = ionInputEl.value;
+    if (inputCmp !== undefined) {
+      inputCmp.$el.value = filteredValue;
+    }
+  };
 </script>
 ```

--- a/static/usage/v8/input/helper-error/vue.md
+++ b/static/usage/v8/input/helper-error/vue.md
@@ -13,36 +13,41 @@
   ></ion-input>
 </template>
 
-<script lang="ts">
-  import { IonInput } from '@ionic/vue';
-  import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
+import { IonInput } from '@ionic/vue';
 
-  export default defineComponent({
-    components: { IonInput },
-    methods: {
-      validateEmail(email) {
-        return email.match(
-          /^(?=.{1,254}$)(?=.{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
-        );
-      },
+const intput = ref<HTMLElement | null>(null);
 
-      validate(ev) {
-        const value = ev.target.value;
+function validateEmail(email: string) {
+  return email.match(
+    /^(?=.{1,254}$)(?=.{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+  ) !== null;
+}
 
-        this.$refs.input.$el.classList.remove('ion-valid');
-        this.$refs.input.$el.classList.remove('ion-invalid');
+function validate(ev: Event) {
+  const target = ev.target as HTMLInputElement;
+  const value = target.value;
 
-        if (value === '') return;
+  if (!intput.value) return;
 
-        this.validateEmail(value)
-          ? this.$refs.input.$el.classList.add('ion-valid')
-          : this.$refs.input.$el.classList.add('ion-invalid');
-      },
+  const inputElement = intput.value;
 
-      markTouched() {
-        this.$refs.input.$el.classList.add('ion-touched');
-      },
-    },
-  });
+  inputElement.classList.remove('ion-valid');
+  inputElement.classList.remove('ion-invalid');
+
+  if (value === '') return;
+
+  if (validateEmail(value)) {
+    inputElement.classList.add('ion-valid');
+  } else {
+    inputElement.classList.add('ion-invalid');
+  }
+}
+
+function markTouched() {
+  if (!intput.value) return;
+  intput.value.classList.add('ion-touched');
+}
 </script>
 ```

--- a/static/usage/v8/input/label-placement/vue.md
+++ b/static/usage/v8/input/label-placement/vue.md
@@ -19,12 +19,7 @@
   </ion-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput, IonItem, IonList } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput, IonItem, IonList },
-  });
 </script>
 ```

--- a/static/usage/v8/input/label-slot/vue.md
+++ b/static/usage/v8/input/label-slot/vue.md
@@ -9,12 +9,7 @@
   </ion-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput, IonItem, IonList, IonText } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput, IonItem, IonList, IonText },
-  });
 </script>
 ```

--- a/static/usage/v8/input/no-visible-label/vue.md
+++ b/static/usage/v8/input/no-visible-label/vue.md
@@ -7,12 +7,7 @@
   </ion-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput, IonItem, IonList } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput, IonItem, IonList },
-  });
 </script>
 ```

--- a/static/usage/v8/input/start-end-slots/vue.md
+++ b/static/usage/v8/input/start-end-slots/vue.md
@@ -12,22 +12,8 @@
   </ion-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonButton, IonIcon, IonInput, IonItem, IonList } from '@ionic/vue';
   import { eye, lockClosed } from 'ionicons/icons';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: {
-      IonButton,
-      IonIcon,
-      IonInput,
-      IonItem,
-      IonList,
-    },
-    setup() {
-      return { eye, lockClosed };
-    },
-  });
 </script>
 ```

--- a/static/usage/v8/input/theming/colors/vue.md
+++ b/static/usage/v8/input/theming/colors/vue.md
@@ -11,12 +11,7 @@
   <ion-input aria-label="Dark input" color="dark" placeholder="Dark input"></ion-input>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput },
-  });
 </script>
 ```

--- a/static/usage/v8/input/theming/css-properties/vue.md
+++ b/static/usage/v8/input/theming/css-properties/vue.md
@@ -10,13 +10,8 @@
   ></ion-input>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonInput } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonInput },
-  });
 </script>
 
 <style>

--- a/static/usage/v8/item-divider/basic/vue.md
+++ b/static/usage/v8/item-divider/basic/vue.md
@@ -35,12 +35,7 @@
   </ion-list>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonItem, IonItemDivider, IonItemGroup, IonLabel, IonList } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonItem, IonItemDivider, IonItemGroup, IonLabel, IonList },
-  });
 </script>
 ```

--- a/static/usage/v8/item-divider/theming/colors/vue.md
+++ b/static/usage/v8/item-divider/theming/colors/vue.md
@@ -32,12 +32,7 @@
   </ion-item-divider>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonItemDivider, IonLabel } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonItemDivider, IonLabel },
-  });
 </script>
 ```

--- a/static/usage/v8/item-divider/theming/css-properties/vue.md
+++ b/static/usage/v8/item-divider/theming/css-properties/vue.md
@@ -5,13 +5,8 @@
   </ion-item-divider>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
   import { IonItemDivider } from '@ionic/vue';
-  import { defineComponent } from 'vue';
-
-  export default defineComponent({
-    components: { IonItemDivider },
-  });
 </script>
 
 <style scoped>


### PR DESCRIPTION
**Problem:**
Many Vue usage examples in the current docs use an outdated syntax containing unnecessary bloat.

**Solution:**
This PR streamlines code snippets by using [Vue's officially recommended](https://vuejs.org/api/sfc-script-setup.html) <script setup> syntax, making usage examples more digestible.