### PR TITLE
docs(action-sheet): update angular to standalone

### DIFF
--- a/static/usage/v7/action-sheet/controller/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/controller/angular/example_component_ts.md
@@ -7,6 +7,7 @@ import { ActionSheetController } from '@ionic/angular';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/action-sheet/controller/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/controller/angular/example_component_ts.md
@@ -1,11 +1,13 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonButton } from '@ionic/angular/standalone';
 
 import { ActionSheetController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonButton],
 })
 export class ExampleComponent {
   constructor(private actionSheetCtrl: ActionSheetController) {}

--- a/static/usage/v7/action-sheet/controller/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/controller/angular/example_component_ts.md
@@ -1,8 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
-
-import { ActionSheetController } from '@ionic/angular';
+import { ActionSheetController, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v7/action-sheet/inline/isOpen/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/inline/isOpen/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/action-sheet/inline/isOpen/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/inline/isOpen/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   isActionSheetOpen = false;

--- a/static/usage/v7/action-sheet/inline/trigger/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/inline/trigger/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/action-sheet/inline/trigger/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/inline/trigger/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [

--- a/static/usage/v7/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [

--- a/static/usage/v7/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
+import type { OverlayEventDetail } from '@ionic/core';
 
 @Component({
   selector: 'app-example',
@@ -34,7 +35,8 @@ export class ExampleComponent {
 
   constructor() {}
 
-  logResult(ev) {
+  logResult(event: Event) {
+    const ev = event as CustomEvent<OverlayEventDetail<string>>;
     console.log(JSON.stringify(ev.detail, null, 2));
   }
 }

--- a/static/usage/v7/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
@@ -35,9 +35,8 @@ export class ExampleComponent {
 
   constructor() {}
 
-  logResult(event: Event) {
-    const ev = event as CustomEvent<OverlayEventDetail<string>>;
-    console.log(JSON.stringify(ev.detail, null, 2));
+  logResult(event: CustomEvent<OverlayEventDetail<string>>) {
+    console.log(JSON.stringify(event.detail, null, 2));
   }
 }
 ```

--- a/static/usage/v7/action-sheet/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/theming/css-properties/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [

--- a/static/usage/v7/action-sheet/theming/styling/angular/example_component_ts.md
+++ b/static/usage/v7/action-sheet/theming/styling/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [

--- a/static/usage/v8/action-sheet/controller/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/controller/angular/example_component_ts.md
@@ -7,6 +7,7 @@ import { ActionSheetController } from '@ionic/angular';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/action-sheet/controller/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/controller/angular/example_component_ts.md
@@ -1,11 +1,13 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonButton } from '@ionic/angular/standalone';
 
 import { ActionSheetController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonButton],
 })
 export class ExampleComponent {
   constructor(private actionSheetCtrl: ActionSheetController) {}

--- a/static/usage/v8/action-sheet/controller/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/controller/angular/example_component_ts.md
@@ -1,8 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
-
-import { ActionSheetController } from '@ionic/angular';
+import { ActionSheetController, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v8/action-sheet/inline/isOpen/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/inline/isOpen/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/action-sheet/inline/isOpen/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/inline/isOpen/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   isActionSheetOpen = false;

--- a/static/usage/v8/action-sheet/inline/trigger/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/inline/trigger/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/action-sheet/inline/trigger/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/inline/trigger/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [

--- a/static/usage/v8/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [

--- a/static/usage/v8/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
+import type { OverlayEventDetail } from '@ionic/core';
 
 @Component({
   selector: 'app-example',
@@ -34,7 +35,8 @@ export class ExampleComponent {
 
   constructor() {}
 
-  logResult(ev) {
+  logResult(event: Event) {
+    const ev = event as CustomEvent<OverlayEventDetail<string>>;
     console.log(JSON.stringify(ev.detail, null, 2));
   }
 }

--- a/static/usage/v8/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
@@ -35,9 +35,8 @@ export class ExampleComponent {
 
   constructor() {}
 
-  logResult(event: Event) {
-    const ev = event as CustomEvent<OverlayEventDetail<string>>;
-    console.log(JSON.stringify(ev.detail, null, 2));
+  logResult(event: CustomEvent<OverlayEventDetail<string>>) {
+    console.log(JSON.stringify(event.detail, null, 2));
   }
 }
 ```

--- a/static/usage/v8/action-sheet/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/theming/css-properties/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [

--- a/static/usage/v8/action-sheet/theming/styling/angular/example_component_ts.md
+++ b/static/usage/v8/action-sheet/theming/styling/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonActionSheet, IonButton],
 })
 export class ExampleComponent {
   public actionSheetButtons = [


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-action-sheet-ionic1.vercel.app/docs/api/action-sheet)