### PR TITLE
docs(alert): update angular to standalone

### DIFF
--- a/static/usage/v7/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v7/alert/buttons/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import type { OverlayEventDetail } from '@ionic/core';
 
 @Component({
   selector: 'app-example',
@@ -25,7 +26,8 @@ export class ExampleComponent {
     },
   ];
 
-  setResult(ev) {
+  setResult(event: Event) {
+    const ev = event as CustomEvent<OverlayEventDetail<string>>;
     console.log(`Dismissed with role: ${ev.detail.role}`);
   }
 }

--- a/static/usage/v7/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v7/alert/buttons/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = [

--- a/static/usage/v7/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v7/alert/buttons/angular/example_component_ts.md
@@ -6,6 +6,7 @@ import type { OverlayEventDetail } from '@ionic/core';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/alert/customization/angular/example_component_ts.md
+++ b/static/usage/v7/alert/customization/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/alert/customization/angular/example_component_ts.md
+++ b/static/usage/v7/alert/customization/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = [

--- a/static/usage/v7/alert/inputs/radios/angular/example_component_ts.md
+++ b/static/usage/v7/alert/inputs/radios/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/alert/inputs/radios/angular/example_component_ts.md
+++ b/static/usage/v7/alert/inputs/radios/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = ['OK'];

--- a/static/usage/v7/alert/inputs/text-inputs/angular/example_component_ts.md
+++ b/static/usage/v7/alert/inputs/text-inputs/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/alert/inputs/text-inputs/angular/example_component_ts.md
+++ b/static/usage/v7/alert/inputs/text-inputs/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = ['OK'];

--- a/static/usage/v7/alert/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/controller/angular/example_component_ts.md
@@ -6,6 +6,7 @@ import { AlertController } from '@ionic/angular';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/alert/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/controller/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonButton } from '@ionic/angular/standalone';
 import { AlertController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonButton],
 })
 export class ExampleComponent {
   constructor(private alertController: AlertController) {}

--- a/static/usage/v7/alert/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/controller/angular/example_component_ts.md
@@ -1,7 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
-import { AlertController } from '@ionic/angular';
+import { AlertController, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v7/alert/presenting/isOpen/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/isOpen/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   isAlertOpen = false;

--- a/static/usage/v7/alert/presenting/isOpen/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/isOpen/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v7/alert/presenting/trigger/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/trigger/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   alertButtons = ['Action'];

--- a/static/usage/v7/alert/presenting/trigger/angular/example_component_ts.md
+++ b/static/usage/v7/alert/presenting/trigger/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v8/alert/buttons/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import type { OverlayEventDetail } from '@ionic/core';
 
 @Component({
   selector: 'app-example',
@@ -25,7 +26,8 @@ export class ExampleComponent {
     },
   ];
 
-  setResult(ev) {
+  setResult(event: Event) {
+    const ev = event as CustomEvent<OverlayEventDetail<string>>;
     console.log(`Dismissed with role: ${ev.detail.role}`);
   }
 }

--- a/static/usage/v8/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v8/alert/buttons/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = [

--- a/static/usage/v8/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v8/alert/buttons/angular/example_component_ts.md
@@ -6,6 +6,7 @@ import type { OverlayEventDetail } from '@ionic/core';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/alert/customization/angular/example_component_ts.md
+++ b/static/usage/v8/alert/customization/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/alert/customization/angular/example_component_ts.md
+++ b/static/usage/v8/alert/customization/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = [

--- a/static/usage/v8/alert/inputs/radios/angular/example_component_ts.md
+++ b/static/usage/v8/alert/inputs/radios/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/alert/inputs/radios/angular/example_component_ts.md
+++ b/static/usage/v8/alert/inputs/radios/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = ['OK'];

--- a/static/usage/v8/alert/inputs/text-inputs/angular/example_component_ts.md
+++ b/static/usage/v8/alert/inputs/text-inputs/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/alert/inputs/text-inputs/angular/example_component_ts.md
+++ b/static/usage/v8/alert/inputs/text-inputs/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   public alertButtons = ['OK'];

--- a/static/usage/v8/alert/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v8/alert/presenting/controller/angular/example_component_ts.md
@@ -6,6 +6,7 @@ import { AlertController } from '@ionic/angular';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/alert/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v8/alert/presenting/controller/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonButton } from '@ionic/angular/standalone';
 import { AlertController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonButton],
 })
 export class ExampleComponent {
   constructor(private alertController: AlertController) {}

--- a/static/usage/v8/alert/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v8/alert/presenting/controller/angular/example_component_ts.md
@@ -1,7 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
-import { AlertController } from '@ionic/angular';
+import { AlertController, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v8/alert/presenting/isOpen/angular/example_component_ts.md
+++ b/static/usage/v8/alert/presenting/isOpen/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   isAlertOpen = false;

--- a/static/usage/v8/alert/presenting/isOpen/angular/example_component_ts.md
+++ b/static/usage/v8/alert/presenting/isOpen/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {

--- a/static/usage/v8/alert/presenting/trigger/angular/example_component_ts.md
+++ b/static/usage/v8/alert/presenting/trigger/angular/example_component_ts.md
@@ -1,9 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonAlert, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {
   alertButtons = ['Action'];

--- a/static/usage/v8/alert/presenting/trigger/angular/example_component_ts.md
+++ b/static/usage/v8/alert/presenting/trigger/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonAlert, IonButton } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonAlert, IonButton],
 })
 export class ExampleComponent {


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-alert-ionic1.vercel.app/docs/api/alert)