### PR TITLE
docs(app): update angular to standalone

### DIFF
--- a/static/usage/v8/app/set-focus/angular/example_component_ts.md
+++ b/static/usage/v8/app/set-focus/angular/example_component_ts.md
@@ -1,10 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonButton, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonButton, IonRadio, IonRadioGroup]
 })
 export class ExampleComponent {
   focusElement(id: string) {

--- a/static/usage/v8/app/set-focus/angular/example_component_ts.md
+++ b/static/usage/v8/app/set-focus/angular/example_component_ts.md
@@ -6,7 +6,7 @@ import { IonButton, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
-  imports: [IonButton, IonRadio, IonRadioGroup]
+  imports: [IonButton, IonRadio, IonRadioGroup],
 })
 export class ExampleComponent {
   focusElement(id: string) {


### PR DESCRIPTION
Migrates v8 Angular playgrounds to standalone (playground did not exist on v7)

[Preview](https://ionic-docs-git-rou-11416-app-ionic1.vercel.app/docs/api/app)