### PR TITLE
docs(backdrop): update angular to standalone

### DIFF
--- a/static/usage/v7/backdrop/basic/angular/example_component_ts.md
+++ b/static/usage/v7/backdrop/basic/angular/example_component_ts.md
@@ -1,12 +1,21 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import {
+  IonBackdrop,
+  IonButton,
+  IonCheckbox,
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
-  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar]
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar],
 })
-export class ExampleComponent { }
+export class ExampleComponent {}
 ```

--- a/static/usage/v7/backdrop/basic/angular/example_component_ts.md
+++ b/static/usage/v7/backdrop/basic/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar]
+})
+export class ExampleComponent { }
+```

--- a/static/usage/v7/backdrop/basic/index.md
+++ b/static/usage/v7/backdrop/basic/index.md
@@ -7,8 +7,9 @@ import react_main_css from './react/main_css.md';
 
 import vue from './vue.md';
 
-import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/backdrop/styling/angular/example_component_ts.md
+++ b/static/usage/v7/backdrop/styling/angular/example_component_ts.md
@@ -1,12 +1,20 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import {
+  IonBackdrop,
+  IonButton,
+  IonCheckbox,
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
-  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar]
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar],
 })
-export class ExampleComponent { }
+export class ExampleComponent {}
 ```

--- a/static/usage/v7/backdrop/styling/angular/example_component_ts.md
+++ b/static/usage/v7/backdrop/styling/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar]
+})
+export class ExampleComponent { }
+```

--- a/static/usage/v7/backdrop/styling/index.md
+++ b/static/usage/v7/backdrop/styling/index.md
@@ -7,8 +7,9 @@ import react_main_css from './react/main_css.md';
 
 import vue from './vue.md';
 
-import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -23,8 +24,9 @@ import angular_example_component_html from './angular/example_component_html.md'
     vue,
     angular: {
       files: {
-        'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/backdrop/basic/angular/example_component_ts.md
+++ b/static/usage/v8/backdrop/basic/angular/example_component_ts.md
@@ -1,12 +1,21 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import {
+  IonBackdrop,
+  IonButton,
+  IonCheckbox,
+  IonContent,
+  IonHeader,
+  IonItem,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
-  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar]
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar],
 })
-export class ExampleComponent { }
+export class ExampleComponent {}
 ```

--- a/static/usage/v8/backdrop/basic/angular/example_component_ts.md
+++ b/static/usage/v8/backdrop/basic/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonItem, IonTitle, IonToolbar]
+})
+export class ExampleComponent { }
+```

--- a/static/usage/v8/backdrop/basic/index.md
+++ b/static/usage/v8/backdrop/basic/index.md
@@ -7,8 +7,9 @@ import react_main_css from './react/main_css.md';
 
 import vue from './vue.md';
 
-import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_html from './angular/example_component_html.md'
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/backdrop/styling/angular/example_component_ts.md
+++ b/static/usage/v8/backdrop/styling/angular/example_component_ts.md
@@ -1,12 +1,20 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import {
+  IonBackdrop,
+  IonButton,
+  IonCheckbox,
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
-  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar]
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar],
 })
-export class ExampleComponent { }
+export class ExampleComponent {}
 ```

--- a/static/usage/v8/backdrop/styling/angular/example_component_ts.md
+++ b/static/usage/v8/backdrop/styling/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar]
+})
+export class ExampleComponent { }
+```

--- a/static/usage/v8/backdrop/styling/index.md
+++ b/static/usage/v8/backdrop/styling/index.md
@@ -7,8 +7,9 @@ import react_main_css from './react/main_css.md';
 
 import vue from './vue.md';
 
-import angular_example_component_css from './angular/example_component_css.md';
 import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -23,8 +24,9 @@ import angular_example_component_html from './angular/example_component_html.md'
     vue,
     angular: {
       files: {
-        'src/app/example.component.css': angular_example_component_css,
         'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-backdrop-ionic1.vercel.app/docs/api/backdrop)