### PR TITLE
docs(fab): update angular to standalone

### DIFF
--- a/static/usage/v7/fab/basic/angular/example_component_ts.md
+++ b/static/usage/v7/fab/basic/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v7/fab/button-sizing/angular/example_component_ts.md
+++ b/static/usage/v7/fab/button-sizing/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, colorPalette, document, globe } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v7/fab/list-side/angular/example_component_ts.md
+++ b/static/usage/v7/fab/list-side/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionico
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v7/fab/positioning/angular/example_component_ts.md
+++ b/static/usage/v7/fab/positioning/angular/example_component_ts.md
@@ -1,5 +1,15 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonContent,
+  IonFab,
+  IonFabButton,
+  IonFabList,
+  IonHeader,
+  IonIcon,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import {
@@ -15,6 +25,7 @@ import {
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonContent, IonFab, IonFabButton, IonFabList, IonHeader, IonIcon, IonTitle, IonToolbar],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v7/fab/safe-area/angular/example_component_ts.md
+++ b/static/usage/v7/fab/safe-area/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v7/fab/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v7/fab/theming/colors/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionico
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v7/fab/theming/css-custom-properties/angular/example_component_ts.md
+++ b/static/usage/v7/fab/theming/css-custom-properties/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, colorPalette, document, globe } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v7/fab/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v7/fab/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, colorPalette, document, globe } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/basic/angular/example_component_ts.md
+++ b/static/usage/v8/fab/basic/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/before-content/angular/example_component_html.md
+++ b/static/usage/v8/fab/before-content/angular/example_component_html.md
@@ -6,12 +6,14 @@
     </ion-fab-button>
   </ion-fab>
   <ion-list>
-    <ion-item [button]="true" *ngFor="let item of items; let index">
+    @for (item of items; track item; let index = $index) {
+    <ion-item button>
       <ion-avatar slot="start">
         <img [src]="'https://picsum.photos/80/80?random=' + index" alt="avatar" />
       </ion-avatar>
       <ion-label>{{ item }}</ion-label>
     </ion-item>
+    }
   </ion-list>
   <ion-infinite-scroll (ionInfinite)="onIonInfinite($event)">
     <ion-infinite-scroll-content></ion-infinite-scroll-content>

--- a/static/usage/v8/fab/before-content/angular/example_component_ts.md
+++ b/static/usage/v8/fab/before-content/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
 import {
+  InfiniteScrollCustomEvent,
   IonAvatar,
   IonContent,
   IonFab,
@@ -12,8 +13,6 @@ import {
   IonLabel,
   IonList,
 } from '@ionic/angular/standalone';
-
-import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';

--- a/static/usage/v8/fab/before-content/angular/example_component_ts.md
+++ b/static/usage/v8/fab/before-content/angular/example_component_ts.md
@@ -21,6 +21,7 @@ import { add } from 'ionicons/icons';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [
     IonAvatar,
     IonContent,

--- a/static/usage/v8/fab/before-content/angular/example_component_ts.md
+++ b/static/usage/v8/fab/before-content/angular/example_component_ts.md
@@ -1,5 +1,17 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
+import {
+  IonAvatar,
+  IonContent,
+  IonFab,
+  IonFabButton,
+  IonIcon,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
 
 import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
@@ -9,6 +21,18 @@ import { add } from 'ionicons/icons';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  imports: [
+    IonAvatar,
+    IonContent,
+    IonFab,
+    IonFabButton,
+    IonIcon,
+    IonInfiniteScroll,
+    IonInfiniteScrollContent,
+    IonItem,
+    IonLabel,
+    IonList,
+  ],
 })
 export class ExampleComponent implements OnInit {
   items = [];

--- a/static/usage/v8/fab/before-content/angular/example_component_ts.md
+++ b/static/usage/v8/fab/before-content/angular/example_component_ts.md
@@ -36,7 +36,7 @@ import { add } from 'ionicons/icons';
   ],
 })
 export class ExampleComponent implements OnInit {
-  items = [];
+  items: string[] = [];
 
   constructor() {
     /**
@@ -58,10 +58,10 @@ export class ExampleComponent implements OnInit {
     }
   }
 
-  onIonInfinite(ev) {
+  onIonInfinite(ev: InfiniteScrollCustomEvent) {
     this.generateItems();
     setTimeout(() => {
-      (ev as InfiniteScrollCustomEvent).target.complete();
+      ev.target.complete();
     }, 500);
   }
 }

--- a/static/usage/v8/fab/button-sizing/angular/example_component_ts.md
+++ b/static/usage/v8/fab/button-sizing/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, colorPalette, document, globe } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/list-side/angular/example_component_ts.md
+++ b/static/usage/v8/fab/list-side/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionico
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/positioning/angular/example_component_ts.md
+++ b/static/usage/v8/fab/positioning/angular/example_component_ts.md
@@ -1,5 +1,15 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonContent,
+  IonFab,
+  IonFabButton,
+  IonFabList,
+  IonHeader,
+  IonIcon,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import {
@@ -15,6 +25,7 @@ import {
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonContent, IonFab, IonFabButton, IonFabList, IonHeader, IonIcon, IonTitle, IonToolbar],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/safe-area/angular/example_component_ts.md
+++ b/static/usage/v8/fab/safe-area/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v8/fab/theming/colors/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionico
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/theming/css-custom-properties/angular/example_component_ts.md
+++ b/static/usage/v8/fab/theming/css-custom-properties/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, colorPalette, document, globe } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/fab/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v8/fab/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { add, colorPalette, document, globe } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonFab, IonFabButton, IonFabList, IonIcon],
 })
 export class ExampleComponent {
   constructor() {


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-fab-ionic1.vercel.app/docs/api/fab)