### PR TITLE
docs(gestures): update angular to standalone

### DIFF
--- a/static/usage/v7/gestures/basic/angular/example_component_ts.md
+++ b/static/usage/v7/gestures/basic/angular/example_component_ts.md
@@ -2,7 +2,7 @@
 import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
 import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
 import type { GestureDetail } from '@ionic/angular';
-import { GestureController, IonCard } from '@ionic/angular';
+import { GestureController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
@@ -11,8 +11,8 @@ import { GestureController, IonCard } from '@ionic/angular';
   imports: [IonCard, IonCardContent, IonCardHeader, IonCardSubtitle],
 })
 export class ExampleComponent {
-  @ViewChild(IonCard, { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;
-  @ViewChild('debug', { read: ElementRef }) debug: ElementRef<HTMLParagraphElement>;
+  @ViewChild(IonCard, { read: ElementRef }) card!: ElementRef<HTMLIonCardElement>;
+  @ViewChild('debug', { read: ElementRef }) debug!: ElementRef<HTMLParagraphElement>;
 
   isCardActive = false;
 

--- a/static/usage/v7/gestures/basic/angular/example_component_ts.md
+++ b/static/usage/v7/gestures/basic/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
+import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
 import type { GestureDetail } from '@ionic/angular';
 import { GestureController, IonCard } from '@ionic/angular';
 
@@ -7,6 +8,7 @@ import { GestureController, IonCard } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonCard, IonCardContent, IonCardHeader, IonCardSubtitle],
 })
 export class ExampleComponent {
   @ViewChild(IonCard, { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;

--- a/static/usage/v7/gestures/basic/angular/example_component_ts.md
+++ b/static/usage/v7/gestures/basic/angular/example_component_ts.md
@@ -1,8 +1,7 @@
 ```ts
 import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
-import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
-import type { GestureDetail } from '@ionic/angular';
-import { GestureController } from '@ionic/angular';
+import { GestureController, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
+import type { GestureDetail } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v7/gestures/double-click/angular/example_component_ts.md
+++ b/static/usage/v7/gestures/double-click/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { IonCard, IonCardContent } from '@ionic/angular/standalone';
-import { GestureController, IonCard } from '@ionic/angular';
+import { GestureController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
@@ -10,7 +10,7 @@ import { GestureController, IonCard } from '@ionic/angular';
   imports: [IonCard, IonCardContent],
 })
 export class ExampleComponent {
-  @ViewChild('card', { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;
+  @ViewChild('card', { read: ElementRef }) card!: ElementRef<HTMLIonCardElement>;
 
   private currentOffset: number = 0;
   private lastOnStart: number = 0;

--- a/static/usage/v7/gestures/double-click/angular/example_component_ts.md
+++ b/static/usage/v7/gestures/double-click/angular/example_component_ts.md
@@ -1,7 +1,6 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { IonCard, IonCardContent } from '@ionic/angular/standalone';
-import { GestureController } from '@ionic/angular';
+import { GestureController, IonCard, IonCardContent } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v7/gestures/double-click/angular/example_component_ts.md
+++ b/static/usage/v7/gestures/double-click/angular/example_component_ts.md
@@ -1,11 +1,13 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
+import { IonCard, IonCardContent } from '@ionic/angular/standalone';
 import { GestureController, IonCard } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonCard, IonCardContent],
 })
 export class ExampleComponent {
   @ViewChild('card', { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;

--- a/static/usage/v8/gestures/basic/angular/example_component_ts.md
+++ b/static/usage/v8/gestures/basic/angular/example_component_ts.md
@@ -2,7 +2,7 @@
 import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
 import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
 import type { GestureDetail } from '@ionic/angular';
-import { GestureController, IonCard } from '@ionic/angular';
+import { GestureController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
@@ -11,8 +11,8 @@ import { GestureController, IonCard } from '@ionic/angular';
   imports: [IonCard, IonCardContent, IonCardHeader, IonCardSubtitle],
 })
 export class ExampleComponent {
-  @ViewChild(IonCard, { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;
-  @ViewChild('debug', { read: ElementRef }) debug: ElementRef<HTMLParagraphElement>;
+  @ViewChild(IonCard, { read: ElementRef }) card!: ElementRef<HTMLIonCardElement>;
+  @ViewChild('debug', { read: ElementRef }) debug!: ElementRef<HTMLParagraphElement>;
 
   isCardActive = false;
 

--- a/static/usage/v8/gestures/basic/angular/example_component_ts.md
+++ b/static/usage/v8/gestures/basic/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
+import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
 import type { GestureDetail } from '@ionic/angular';
 import { GestureController, IonCard } from '@ionic/angular';
 
@@ -7,6 +8,7 @@ import { GestureController, IonCard } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonCard, IonCardContent, IonCardHeader, IonCardSubtitle],
 })
 export class ExampleComponent {
   @ViewChild(IonCard, { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;

--- a/static/usage/v8/gestures/basic/angular/example_component_ts.md
+++ b/static/usage/v8/gestures/basic/angular/example_component_ts.md
@@ -1,8 +1,7 @@
 ```ts
 import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
-import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
-import type { GestureDetail } from '@ionic/angular';
-import { GestureController } from '@ionic/angular';
+import { GestureController, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
+import type { GestureDetail } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v8/gestures/double-click/angular/example_component_ts.md
+++ b/static/usage/v8/gestures/double-click/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { IonCard, IonCardContent } from '@ionic/angular/standalone';
-import { GestureController, IonCard } from '@ionic/angular';
+import { GestureController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
@@ -10,7 +10,7 @@ import { GestureController, IonCard } from '@ionic/angular';
   imports: [IonCard, IonCardContent],
 })
 export class ExampleComponent {
-  @ViewChild('card', { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;
+  @ViewChild('card', { read: ElementRef }) card!: ElementRef<HTMLIonCardElement>;
 
   private currentOffset: number = 0;
   private lastOnStart: number = 0;

--- a/static/usage/v8/gestures/double-click/angular/example_component_ts.md
+++ b/static/usage/v8/gestures/double-click/angular/example_component_ts.md
@@ -1,7 +1,6 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { IonCard, IonCardContent } from '@ionic/angular/standalone';
-import { GestureController } from '@ionic/angular';
+import { GestureController, IonCard, IonCardContent } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v8/gestures/double-click/angular/example_component_ts.md
+++ b/static/usage/v8/gestures/double-click/angular/example_component_ts.md
@@ -1,11 +1,13 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
+import { IonCard, IonCardContent } from '@ionic/angular/standalone';
 import { GestureController, IonCard } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['./example.component.css'],
+  imports: [IonCard, IonCardContent],
 })
 export class ExampleComponent {
   @ViewChild('card', { read: ElementRef }) card: ElementRef<HTMLIonCardElement>;


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-gestures-ionic1.vercel.app/docs/utilities/gestures)