### PR TITLE
docs(grid): update angular to standalone

### DIFF
--- a/static/usage/v7/grid/basic/angular/example_component_ts.md
+++ b/static/usage/v7/grid/basic/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/basic/index.md
+++ b/static/usage/v7/grid/basic/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/customizing/column-number/angular/example_component_ts.md
+++ b/static/usage/v7/grid/customizing/column-number/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/customizing/column-number/index.md
+++ b/static/usage/v7/grid/customizing/column-number/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/customizing/padding/angular/example_component_ts.md
+++ b/static/usage/v7/grid/customizing/padding/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/customizing/padding/index.md
+++ b/static/usage/v7/grid/customizing/padding/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/customizing/width/angular/example_component_ts.md
+++ b/static/usage/v7/grid/customizing/width/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/customizing/width/index.md
+++ b/static/usage/v7/grid/customizing/width/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/fixed/angular/example_component_ts.md
+++ b/static/usage/v7/grid/fixed/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/fixed/index.md
+++ b/static/usage/v7/grid/fixed/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/horizontal-alignment/angular/example_component_ts.md
+++ b/static/usage/v7/grid/horizontal-alignment/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/horizontal-alignment/index.md
+++ b/static/usage/v7/grid/horizontal-alignment/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/offset-responsive/angular/example_component_ts.md
+++ b/static/usage/v7/grid/offset-responsive/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/offset-responsive/index.md
+++ b/static/usage/v7/grid/offset-responsive/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/offset/angular/example_component_ts.md
+++ b/static/usage/v7/grid/offset/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/offset/index.md
+++ b/static/usage/v7/grid/offset/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/push-pull-responsive/angular/example_component_ts.md
+++ b/static/usage/v7/grid/push-pull-responsive/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/push-pull-responsive/index.md
+++ b/static/usage/v7/grid/push-pull-responsive/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/push-pull/angular/example_component_ts.md
+++ b/static/usage/v7/grid/push-pull/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/push-pull/index.md
+++ b/static/usage/v7/grid/push-pull/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/size-auto/angular/example_component_ts.md
+++ b/static/usage/v7/grid/size-auto/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/size-auto/angular/example_component_ts.md
+++ b/static/usage/v7/grid/size-auto/angular/example_component_ts.md
@@ -1,12 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonInput, IonRow } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
-  imports: [IonCol, IonGrid, IonRow],
+  imports: [IonCol, IonGrid, IonInput, IonRow],
 })
 export class ExampleComponent {}
 ```

--- a/static/usage/v7/grid/size-auto/index.md
+++ b/static/usage/v7/grid/size-auto/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/size-responsive/angular/example_component_ts.md
+++ b/static/usage/v7/grid/size-responsive/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/size-responsive/index.md
+++ b/static/usage/v7/grid/size-responsive/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/size/angular/example_component_ts.md
+++ b/static/usage/v7/grid/size/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/size/index.md
+++ b/static/usage/v7/grid/size/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/grid/vertical-alignment/angular/example_component_ts.md
+++ b/static/usage/v7/grid/vertical-alignment/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/grid/vertical-alignment/index.md
+++ b/static/usage/v7/grid/vertical-alignment/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/basic/angular/example_component_ts.md
+++ b/static/usage/v8/grid/basic/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/basic/index.md
+++ b/static/usage/v8/grid/basic/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/customizing/column-number/angular/example_component_ts.md
+++ b/static/usage/v8/grid/customizing/column-number/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/customizing/column-number/index.md
+++ b/static/usage/v8/grid/customizing/column-number/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/customizing/padding/angular/example_component_ts.md
+++ b/static/usage/v8/grid/customizing/padding/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/customizing/padding/index.md
+++ b/static/usage/v8/grid/customizing/padding/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/customizing/width/angular/example_component_ts.md
+++ b/static/usage/v8/grid/customizing/width/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/customizing/width/index.md
+++ b/static/usage/v8/grid/customizing/width/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/fixed/angular/example_component_ts.md
+++ b/static/usage/v8/grid/fixed/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/fixed/index.md
+++ b/static/usage/v8/grid/fixed/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/horizontal-alignment/angular/example_component_ts.md
+++ b/static/usage/v8/grid/horizontal-alignment/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/horizontal-alignment/index.md
+++ b/static/usage/v8/grid/horizontal-alignment/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/offset-responsive/angular/example_component_ts.md
+++ b/static/usage/v8/grid/offset-responsive/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/offset-responsive/index.md
+++ b/static/usage/v8/grid/offset-responsive/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/offset/angular/example_component_ts.md
+++ b/static/usage/v8/grid/offset/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/offset/index.md
+++ b/static/usage/v8/grid/offset/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/push-pull-responsive/angular/example_component_ts.md
+++ b/static/usage/v8/grid/push-pull-responsive/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/push-pull-responsive/index.md
+++ b/static/usage/v8/grid/push-pull-responsive/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/push-pull/angular/example_component_ts.md
+++ b/static/usage/v8/grid/push-pull/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/push-pull/index.md
+++ b/static/usage/v8/grid/push-pull/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/size-auto/angular/example_component_ts.md
+++ b/static/usage/v8/grid/size-auto/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/size-auto/angular/example_component_ts.md
+++ b/static/usage/v8/grid/size-auto/angular/example_component_ts.md
@@ -1,12 +1,12 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonInput, IonRow } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
-  imports: [IonCol, IonGrid, IonRow],
+  imports: [IonCol, IonGrid, IonInput, IonRow],
 })
 export class ExampleComponent {}
 ```

--- a/static/usage/v8/grid/size-auto/index.md
+++ b/static/usage/v8/grid/size-auto/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/size-responsive/angular/example_component_ts.md
+++ b/static/usage/v8/grid/size-responsive/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/size-responsive/index.md
+++ b/static/usage/v8/grid/size-responsive/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/size/angular/example_component_ts.md
+++ b/static/usage/v8/grid/size/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/size/index.md
+++ b/static/usage/v8/grid/size/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/grid/vertical-alignment/angular/example_component_ts.md
+++ b/static/usage/v8/grid/vertical-alignment/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonCol, IonGrid, IonRow],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/grid/vertical-alignment/index.md
+++ b/static/usage/v8/grid/vertical-alignment/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-grid-ionic1.vercel.app/docs/api/grid)