### PR TITLE
docs(icon): update angular to standalone

### DIFF
--- a/static/usage/v7/icon/basic/angular/example_component_ts.md
+++ b/static/usage/v7/icon/basic/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonIcon } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { logoIonic } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { logoIonic } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonIcon],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/icon/basic/angular.md
+++ b/static/usage/v8/icon/basic/angular.md
@@ -1,6 +1,0 @@
-```html
-<ion-icon name="logo-ionic"></ion-icon>
-<ion-icon name="logo-ionic" size="large"></ion-icon>
-<ion-icon name="logo-ionic" color="primary"></ion-icon>
-<ion-icon name="logo-ionic" size="large" color="primary"></ion-icon>
-```

--- a/static/usage/v8/icon/basic/angular/example_component_ts.md
+++ b/static/usage/v8/icon/basic/angular/example_component_ts.md
@@ -2,11 +2,23 @@
 import { Component } from '@angular/core';
 import { IonIcon } from '@ionic/angular/standalone';
 
+import { addIcons } from 'ionicons';
+import { logoIonic } from 'ionicons/icons';
+
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
   imports: [IonIcon],
 })
-export class ExampleComponent {}
+export class ExampleComponent {
+  constructor() {
+    /**
+     * Any icons you want to use in your application
+     * can be registered in app.component.ts and then
+     * referenced by name anywhere in your application.
+     */
+    addIcons({ logoIonic });
+  }
+}
 ```

--- a/static/usage/v8/icon/basic/angular/example_component_ts.md
+++ b/static/usage/v8/icon/basic/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonIcon } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonIcon],
 })
 export class ExampleComponent {}

--- a/static/usage/v8/icon/basic/angular/example_component_ts.md
+++ b/static/usage/v8/icon/basic/angular/example_component_ts.md
@@ -1,22 +1,11 @@
 ```ts
 import { Component } from '@angular/core';
-
-import { addIcons } from 'ionicons';
-import { logoIonic } from 'ionicons/icons';
+import { IonIcon } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  styleUrls: ['example.component.css'],
+  imports: [IonIcon],
 })
-export class ExampleComponent {
-  constructor() {
-    /**
-     * Any icons you want to use in your application
-     * can be registered in app.component.ts and then
-     * referenced by name anywhere in your application.
-     */
-    addIcons({ logoIonic });
-  }
-}
+export class ExampleComponent {}
 ```

--- a/static/usage/v8/icon/basic/index.md
+++ b/static/usage/v8/icon/basic/index.md
@@ -12,12 +12,7 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 <Playground
   version="8"
   code={{
-    javascript: {
-      files: {
-        'index.html': javascript_index_html,
-        'index.ts': javascript_index_ts,
-      },
-    },
+    javascript,
     react,
     vue,
     angular: {

--- a/static/usage/v8/icon/basic/index.md
+++ b/static/usage/v8/icon/basic/index.md
@@ -12,7 +12,12 @@ import angular_example_component_ts from './angular/example_component_ts.md';
 <Playground
   version="8"
   code={{
-    javascript,
+    javascript: {
+      files: {
+        'index.html': javascript_index_html,
+        'index.ts': javascript_index_ts,
+      },
+    },
     react,
     vue,
     angular: {


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-icon-ionic1.vercel.app/docs/api/icon)