### PR TITLE
docs(infinite-scroll): update angular to standalone

### DIFF
--- a/docs/api/infinite-scroll.md
+++ b/docs/api/infinite-scroll.md
@@ -21,6 +21,8 @@ The Infinite Scroll component calls an action to be performed when the user scro
 
 The expression assigned to the `ionInfinite` event is called when the user reaches that defined distance. When this expression has finished any and all tasks, it should call the `complete()` method on the infinite scroll instance.
 
+## Basic Usage
+
 import Basic from '@site/static/usage/v8/infinite-scroll/basic/index.md';
 
 <Basic />

--- a/static/usage/v7/infinite-scroll/basic/angular/example_component_html.md
+++ b/static/usage/v7/infinite-scroll/basic/angular/example_component_html.md
@@ -1,12 +1,14 @@
 ```html
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let item of items; let index">
+    @for (item of items; track item; let index = $index) {
+    <ion-item>
       <ion-avatar slot="start">
         <img [src]="'https://picsum.photos/80/80?random=' + index" alt="avatar" />
       </ion-avatar>
       <ion-label>{{ item }}</ion-label>
     </ion-item>
+    }
   </ion-list>
   <ion-infinite-scroll (ionInfinite)="onIonInfinite($event)">
     <ion-infinite-scroll-content></ion-infinite-scroll-content>

--- a/static/usage/v7/infinite-scroll/basic/angular/example_component_ts.md
+++ b/static/usage/v7/infinite-scroll/basic/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
 import {
+  InfiniteScrollCustomEvent,
   IonAvatar,
   IonContent,
   IonInfiniteScroll,
@@ -9,8 +10,6 @@ import {
   IonLabel,
   IonList,
 } from '@ionic/angular/standalone';
-
-import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v7/infinite-scroll/basic/angular/example_component_ts.md
+++ b/static/usage/v7/infinite-scroll/basic/angular/example_component_ts.md
@@ -1,5 +1,14 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
+import {
+  IonAvatar,
+  IonContent,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
 
 import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
@@ -7,6 +16,7 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.scss'],
+  imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
   items = [];

--- a/static/usage/v7/infinite-scroll/basic/angular/example_component_ts.md
+++ b/static/usage/v7/infinite-scroll/basic/angular/example_component_ts.md
@@ -15,11 +15,11 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  styleUrls: ['example.component.scss'],
+  styleUrls: ['example.component.css'],
   imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
-  items = [];
+  items: string[] = [];
 
   ngOnInit() {
     this.generateItems();
@@ -32,10 +32,10 @@ export class ExampleComponent implements OnInit {
     }
   }
 
-  onIonInfinite(ev) {
+  onIonInfinite(ev: InfiniteScrollCustomEvent) {
     this.generateItems();
     setTimeout(() => {
-      (ev as InfiniteScrollCustomEvent).target.complete();
+      ev.target.complete();
     }, 500);
   }
 }

--- a/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/angular/example_component_html.md
+++ b/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/angular/example_component_html.md
@@ -1,12 +1,14 @@
 ```html
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let item of items; let index">
+    @for (item of items; track item; let index = $index) {
+    <ion-item>
       <ion-avatar slot="start">
         <img [src]="'https://picsum.photos/80/80?random=' + index" alt="avatar" />
       </ion-avatar>
       <ion-label>{{ item }}</ion-label>
     </ion-item>
+    }
   </ion-list>
   <ion-infinite-scroll>
     <div class="infinite-scroll-content">

--- a/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
+import { IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
 
 import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
@@ -7,6 +8,7 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.scss'],
+  imports: [IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
   items = [];

--- a/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
@@ -2,16 +2,14 @@
 import { Component, OnInit } from '@angular/core';
 import { IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
 
-import { InfiniteScrollCustomEvent } from '@ionic/angular';
-
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  styleUrls: ['example.component.scss'],
+  styleUrls: ['example.component.css'],
   imports: [IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
-  items = [];
+  items: string[] = [];
 
   ngOnInit() {
     for (let i = 1; i < 51; i++) {

--- a/static/usage/v7/infinite-scroll/infinite-scroll-content/angular/example_component_html.md
+++ b/static/usage/v7/infinite-scroll/infinite-scroll-content/angular/example_component_html.md
@@ -1,12 +1,14 @@
 ```html
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let item of items; let index">
+    @for (item of items; track item; let index = $index) {
+    <ion-item>
       <ion-avatar slot="start">
         <img [src]="'https://picsum.photos/80/80?random=' + index" alt="avatar" />
       </ion-avatar>
       <ion-label>{{ item }}</ion-label>
     </ion-item>
+    }
   </ion-list>
   <ion-infinite-scroll>
     <ion-infinite-scroll-content loadingText="Please wait..." loadingSpinner="bubbles"></ion-infinite-scroll-content>

--- a/static/usage/v7/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v7/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
@@ -1,5 +1,14 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
+import {
+  IonAvatar,
+  IonContent,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
 
 import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
@@ -7,6 +16,7 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.scss'],
+  imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
   items = [];

--- a/static/usage/v7/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v7/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
@@ -10,16 +10,14 @@ import {
   IonList,
 } from '@ionic/angular/standalone';
 
-import { InfiniteScrollCustomEvent } from '@ionic/angular';
-
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  styleUrls: ['example.component.scss'],
+  styleUrls: ['example.component.css'],
   imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
-  items = [];
+  items: string[] = [];
 
   ngOnInit() {
     for (let i = 1; i < 51; i++) {

--- a/static/usage/v8/infinite-scroll/basic/angular/example_component_html.md
+++ b/static/usage/v8/infinite-scroll/basic/angular/example_component_html.md
@@ -1,12 +1,14 @@
 ```html
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let item of items; let index">
+    @for (item of items; track item; let index = $index) {
+    <ion-item>
       <ion-avatar slot="start">
         <img [src]="'https://picsum.photos/80/80?random=' + index" alt="avatar" />
       </ion-avatar>
       <ion-label>{{ item }}</ion-label>
     </ion-item>
+    }
   </ion-list>
   <ion-infinite-scroll (ionInfinite)="onIonInfinite($event)">
     <ion-infinite-scroll-content></ion-infinite-scroll-content>

--- a/static/usage/v8/infinite-scroll/basic/angular/example_component_ts.md
+++ b/static/usage/v8/infinite-scroll/basic/angular/example_component_ts.md
@@ -1,6 +1,7 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
 import {
+  InfiniteScrollCustomEvent,
   IonAvatar,
   IonContent,
   IonInfiniteScroll,
@@ -9,8 +10,6 @@ import {
   IonLabel,
   IonList,
 } from '@ionic/angular/standalone';
-
-import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v8/infinite-scroll/basic/angular/example_component_ts.md
+++ b/static/usage/v8/infinite-scroll/basic/angular/example_component_ts.md
@@ -1,5 +1,14 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
+import {
+  IonAvatar,
+  IonContent,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
 
 import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
@@ -7,6 +16,7 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.scss'],
+  imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
   items = [];

--- a/static/usage/v8/infinite-scroll/basic/angular/example_component_ts.md
+++ b/static/usage/v8/infinite-scroll/basic/angular/example_component_ts.md
@@ -15,11 +15,11 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  styleUrls: ['example.component.scss'],
+  styleUrls: ['example.component.css'],
   imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
-  items = [];
+  items: string[] = [];
 
   ngOnInit() {
     this.generateItems();
@@ -32,10 +32,10 @@ export class ExampleComponent implements OnInit {
     }
   }
 
-  onIonInfinite(ev) {
+  onIonInfinite(ev: InfiniteScrollCustomEvent) {
     this.generateItems();
     setTimeout(() => {
-      (ev as InfiniteScrollCustomEvent).target.complete();
+      ev.target.complete();
     }, 500);
   }
 }

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/angular/example_component_html.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/angular/example_component_html.md
@@ -1,12 +1,14 @@
 ```html
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let item of items; let index">
+    @for (item of items; track item; let index = $index) {
+    <ion-item>
       <ion-avatar slot="start">
         <img [src]="'https://picsum.photos/80/80?random=' + index" alt="avatar" />
       </ion-avatar>
       <ion-label>{{ item }}</ion-label>
     </ion-item>
+    }
   </ion-list>
   <ion-infinite-scroll>
     <div class="infinite-scroll-content">

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
+import { IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
 
 import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
@@ -7,6 +8,7 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.scss'],
+  imports: [IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
   items = [];

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
@@ -2,16 +2,14 @@
 import { Component, OnInit } from '@angular/core';
 import { IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
 
-import { InfiniteScrollCustomEvent } from '@ionic/angular';
-
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  styleUrls: ['example.component.scss'],
+  styleUrls: ['example.component.css'],
   imports: [IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
-  items = [];
+  items: string[] = [];
 
   ngOnInit() {
     for (let i = 1; i < 51; i++) {

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/angular/example_component_html.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/angular/example_component_html.md
@@ -1,12 +1,14 @@
 ```html
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let item of items; let index">
+    @for (item of items; track item; let index = $index) {
+    <ion-item>
       <ion-avatar slot="start">
         <img [src]="'https://picsum.photos/80/80?random=' + index" alt="avatar" />
       </ion-avatar>
       <ion-label>{{ item }}</ion-label>
     </ion-item>
+    }
   </ion-list>
   <ion-infinite-scroll>
     <ion-infinite-scroll-content loadingText="Please wait..." loadingSpinner="bubbles"></ion-infinite-scroll-content>

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
@@ -1,5 +1,14 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
+import {
+  IonAvatar,
+  IonContent,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
+  IonItem,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
 
 import { InfiniteScrollCustomEvent } from '@ionic/angular';
 
@@ -7,6 +16,7 @@ import { InfiniteScrollCustomEvent } from '@ionic/angular';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.scss'],
+  imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
   items = [];

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
@@ -10,16 +10,14 @@ import {
   IonList,
 } from '@ionic/angular/standalone';
 
-import { InfiniteScrollCustomEvent } from '@ionic/angular';
-
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  styleUrls: ['example.component.scss'],
+  styleUrls: ['example.component.css'],
   imports: [IonAvatar, IonContent, IonInfiniteScroll, IonInfiniteScrollContent, IonItem, IonLabel, IonList],
 })
 export class ExampleComponent implements OnInit {
-  items = [];
+  items: string[] = [];
 
   ngOnInit() {
     for (let i = 1; i < 51; i++) {

--- a/versioned_docs/version-v7/api/infinite-scroll.md
+++ b/versioned_docs/version-v7/api/infinite-scroll.md
@@ -23,6 +23,8 @@ The Infinite Scroll component calls an action to be performed when the user scro
 
 The expression assigned to the `ionInfinite` event is called when the user reaches that defined distance. When this expression has finished any and all tasks, it should call the `complete()` method on the infinite scroll instance.
 
+## Basic Usage
+
 import Basic from '@site/static/usage/v7/infinite-scroll/basic/index.md';
 
 <Basic />


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-infinite-scroll-ionic1.vercel.app/docs/api/infinite-scroll)