### PR TITLE
docs(item-sliding): update angular to standalone

### DIFF
--- a/static/usage/v7/item-sliding/basic/angular/example_component_html.md
+++ b/static/usage/v7/item-sliding/basic/angular/example_component_html.md
@@ -1,0 +1,39 @@
+```html
+<ion-list>
+  <ion-item-sliding>
+    <ion-item>
+      <ion-label>Sliding Item with End Options</ion-label>
+    </ion-item>
+
+    <ion-item-options>
+      <ion-item-option>Favorite</ion-item-option>
+      <ion-item-option color="danger">Delete</ion-item-option>
+    </ion-item-options>
+  </ion-item-sliding>
+
+  <ion-item-sliding>
+    <ion-item-options side="start">
+      <ion-item-option color="success">Archive</ion-item-option>
+    </ion-item-options>
+
+    <ion-item>
+      <ion-label>Sliding Item with Start Options</ion-label>
+    </ion-item>
+  </ion-item-sliding>
+
+  <ion-item-sliding>
+    <ion-item-options side="start">
+      <ion-item-option color="success">Archive</ion-item-option>
+    </ion-item-options>
+
+    <ion-item>
+      <ion-label>Sliding Item with Options on Both Sides</ion-label>
+    </ion-item>
+
+    <ion-item-options side="end">
+      <ion-item-option>Favorite</ion-item-option>
+      <ion-item-option color="danger">Delete</ion-item-option>
+    </ion-item-options>
+  </ion-item-sliding>
+</ion-list>
+```

--- a/static/usage/v7/item-sliding/basic/angular/example_component_ts.md
+++ b/static/usage/v7/item-sliding/basic/angular/example_component_ts.md
@@ -1,0 +1,11 @@
+```ts
+import { Component } from '@angular/core';
+import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/item-sliding/basic/angular/example_component_ts.md
+++ b/static/usage/v7/item-sliding/basic/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonLi
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
 })
 export class ExampleComponent {}

--- a/static/usage/v7/item-sliding/basic/index.md
+++ b/static/usage/v7/item-sliding/basic/index.md
@@ -3,6 +3,22 @@ import Playground from '@site/src/components/global/Playground';
 import javascript from './javascript.md';
 import react from './react.md';
 import vue from './vue.md';
-import angular from './angular.md';
 
-<Playground version="7" code={{ javascript, react, vue, angular }} src="usage/v7/item-sliding/basic/demo.html" />
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="7"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v7/item-sliding/basic/demo.html"
+/>

--- a/static/usage/v7/item-sliding/expandable/angular/example_component_html.md
+++ b/static/usage/v7/item-sliding/expandable/angular/example_component_html.md
@@ -1,0 +1,18 @@
+```html
+<ion-list>
+  <ion-item-sliding>
+    <ion-item-options side="start">
+      <ion-item-option color="success" expandable>Archive</ion-item-option>
+    </ion-item-options>
+
+    <ion-item>
+      <ion-label>Sliding Item with Expandable Options</ion-label>
+    </ion-item>
+
+    <ion-item-options side="end">
+      <ion-item-option>Favorite</ion-item-option>
+      <ion-item-option color="danger" expandable>Delete</ion-item-option>
+    </ion-item-options>
+  </ion-item-sliding>
+</ion-list>
+```

--- a/static/usage/v7/item-sliding/expandable/angular/example_component_ts.md
+++ b/static/usage/v7/item-sliding/expandable/angular/example_component_ts.md
@@ -1,0 +1,11 @@
+```ts
+import { Component } from '@angular/core';
+import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/item-sliding/expandable/angular/example_component_ts.md
+++ b/static/usage/v7/item-sliding/expandable/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonLi
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
 })
 export class ExampleComponent {}

--- a/static/usage/v7/item-sliding/expandable/index.md
+++ b/static/usage/v7/item-sliding/expandable/index.md
@@ -3,11 +3,23 @@ import Playground from '@site/src/components/global/Playground';
 import javascript from './javascript.md';
 import react from './react.md';
 import vue from './vue.md';
-import angular from './angular.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
-  code={{ javascript, react, vue, angular }}
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
   src="usage/v7/item-sliding/expandable/demo.html"
   size="100px"
 />

--- a/static/usage/v7/item-sliding/icons/angular/example_component_ts.md
+++ b/static/usage/v7/item-sliding/icons/angular/example_component_ts.md
@@ -1,5 +1,14 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonIcon,
+  IonItem,
+  IonItemOption,
+  IonItemOptions,
+  IonItemSliding,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { archive, heart, trash } from 'ionicons/icons';
@@ -8,6 +17,7 @@ import { archive, heart, trash } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/item-sliding/basic/angular/example_component_html.md
+++ b/static/usage/v8/item-sliding/basic/angular/example_component_html.md
@@ -1,0 +1,39 @@
+```html
+<ion-list>
+  <ion-item-sliding>
+    <ion-item>
+      <ion-label>Sliding Item with End Options</ion-label>
+    </ion-item>
+
+    <ion-item-options>
+      <ion-item-option>Favorite</ion-item-option>
+      <ion-item-option color="danger">Delete</ion-item-option>
+    </ion-item-options>
+  </ion-item-sliding>
+
+  <ion-item-sliding>
+    <ion-item-options side="start">
+      <ion-item-option color="success">Archive</ion-item-option>
+    </ion-item-options>
+
+    <ion-item>
+      <ion-label>Sliding Item with Start Options</ion-label>
+    </ion-item>
+  </ion-item-sliding>
+
+  <ion-item-sliding>
+    <ion-item-options side="start">
+      <ion-item-option color="success">Archive</ion-item-option>
+    </ion-item-options>
+
+    <ion-item>
+      <ion-label>Sliding Item with Options on Both Sides</ion-label>
+    </ion-item>
+
+    <ion-item-options side="end">
+      <ion-item-option>Favorite</ion-item-option>
+      <ion-item-option color="danger">Delete</ion-item-option>
+    </ion-item-options>
+  </ion-item-sliding>
+</ion-list>
+```

--- a/static/usage/v8/item-sliding/basic/angular/example_component_ts.md
+++ b/static/usage/v8/item-sliding/basic/angular/example_component_ts.md
@@ -1,0 +1,11 @@
+```ts
+import { Component } from '@angular/core';
+import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/item-sliding/basic/angular/example_component_ts.md
+++ b/static/usage/v8/item-sliding/basic/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonLi
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
 })
 export class ExampleComponent {}

--- a/static/usage/v8/item-sliding/basic/index.md
+++ b/static/usage/v8/item-sliding/basic/index.md
@@ -3,6 +3,22 @@ import Playground from '@site/src/components/global/Playground';
 import javascript from './javascript.md';
 import react from './react.md';
 import vue from './vue.md';
-import angular from './angular.md';
 
-<Playground version="8" code={{ javascript, react, vue, angular }} src="usage/v8/item-sliding/basic/demo.html" />
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="8"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v8/item-sliding/basic/demo.html"
+/>

--- a/static/usage/v8/item-sliding/expandable/angular/example_component_html.md
+++ b/static/usage/v8/item-sliding/expandable/angular/example_component_html.md
@@ -1,0 +1,18 @@
+```html
+<ion-list>
+  <ion-item-sliding>
+    <ion-item-options side="start">
+      <ion-item-option color="success" expandable>Archive</ion-item-option>
+    </ion-item-options>
+
+    <ion-item>
+      <ion-label>Sliding Item with Expandable Options</ion-label>
+    </ion-item>
+
+    <ion-item-options side="end">
+      <ion-item-option>Favorite</ion-item-option>
+      <ion-item-option color="danger" expandable>Delete</ion-item-option>
+    </ion-item-options>
+  </ion-item-sliding>
+</ion-list>
+```

--- a/static/usage/v8/item-sliding/expandable/angular/example_component_ts.md
+++ b/static/usage/v8/item-sliding/expandable/angular/example_component_ts.md
@@ -1,0 +1,11 @@
+```ts
+import { Component } from '@angular/core';
+import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/item-sliding/expandable/angular/example_component_ts.md
+++ b/static/usage/v8/item-sliding/expandable/angular/example_component_ts.md
@@ -5,6 +5,7 @@ import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonLi
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
   imports: [IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
 })
 export class ExampleComponent {}

--- a/static/usage/v8/item-sliding/expandable/index.md
+++ b/static/usage/v8/item-sliding/expandable/index.md
@@ -3,11 +3,23 @@ import Playground from '@site/src/components/global/Playground';
 import javascript from './javascript.md';
 import react from './react.md';
 import vue from './vue.md';
-import angular from './angular.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
-  code={{ javascript, react, vue, angular }}
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
   src="usage/v8/item-sliding/expandable/demo.html"
   size="100px"
 />

--- a/static/usage/v8/item-sliding/icons/angular/example_component_ts.md
+++ b/static/usage/v8/item-sliding/icons/angular/example_component_ts.md
@@ -1,5 +1,14 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonIcon,
+  IonItem,
+  IonItemOption,
+  IonItemOptions,
+  IonItemSliding,
+  IonLabel,
+  IonList,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { archive, heart, trash } from 'ionicons/icons';
@@ -8,6 +17,7 @@ import { archive, heart, trash } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList],
 })
 export class ExampleComponent {
   constructor() {


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-item-sliding-ionic1.vercel.app/docs/api/item-sliding)