### PR TITLE
docs(layout): update angular to standalone

### DIFF
--- a/static/usage/v7/layout/dynamic-font-scaling/angular/example_component_ts.md
+++ b/static/usage/v7/layout/dynamic-font-scaling/angular/example_component_ts.md
@@ -1,5 +1,22 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonCheckbox,
+  IonContent,
+  IonFooter,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonTitle,
+  IonToggle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { create } from 'ionicons/icons';
@@ -8,6 +25,23 @@ import { create } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [
+    IonBackButton,
+    IonButton,
+    IonButtons,
+    IonCheckbox,
+    IonContent,
+    IonFooter,
+    IonHeader,
+    IonIcon,
+    IonInput,
+    IonItem,
+    IonLabel,
+    IonList,
+    IonTitle,
+    IonToggle,
+    IonToolbar,
+  ],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/layout/dynamic-font-scaling/angular/example_component_ts.md
+++ b/static/usage/v8/layout/dynamic-font-scaling/angular/example_component_ts.md
@@ -1,5 +1,22 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonCheckbox,
+  IonContent,
+  IonFooter,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonTitle,
+  IonToggle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { create } from 'ionicons/icons';
@@ -8,6 +25,23 @@ import { create } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [
+    IonBackButton,
+    IonButton,
+    IonButtons,
+    IonCheckbox,
+    IonContent,
+    IonFooter,
+    IonHeader,
+    IonIcon,
+    IonInput,
+    IonItem,
+    IonLabel,
+    IonList,
+    IonTitle,
+    IonToggle,
+    IonToolbar,
+  ],
 })
 export class ExampleComponent {
   constructor() {


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-layout-ionic1.vercel.app/docs/layout/dynamic-font-scaling)
