### PR TITLE
docs(ripple-effect): update angular to standalone

### DIFF
--- a/static/usage/v7/ripple-effect/basic/angular/example_component_ts.md
+++ b/static/usage/v7/ripple-effect/basic/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonRippleEffect } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonRippleEffect],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/ripple-effect/basic/index.md
+++ b/static/usage/v7/ripple-effect/basic/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/ripple-effect/customizing/angular/example_component_ts.md
+++ b/static/usage/v7/ripple-effect/customizing/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonRippleEffect } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonRippleEffect],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/ripple-effect/customizing/index.md
+++ b/static/usage/v7/ripple-effect/customizing/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v7/ripple-effect/type/angular/example_component_ts.md
+++ b/static/usage/v7/ripple-effect/type/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonRippleEffect } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonRippleEffect],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/ripple-effect/type/index.md
+++ b/static/usage/v7/ripple-effect/type/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/ripple-effect/basic/angular/example_component_ts.md
+++ b/static/usage/v8/ripple-effect/basic/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonRippleEffect } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonRippleEffect],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/ripple-effect/basic/index.md
+++ b/static/usage/v8/ripple-effect/basic/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/ripple-effect/customizing/angular/example_component_ts.md
+++ b/static/usage/v8/ripple-effect/customizing/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonRippleEffect } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonRippleEffect],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/ripple-effect/customizing/index.md
+++ b/static/usage/v8/ripple-effect/customizing/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/ripple-effect/type/angular/example_component_ts.md
+++ b/static/usage/v8/ripple-effect/type/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonRippleEffect } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonRippleEffect],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/ripple-effect/type/index.md
+++ b/static/usage/v8/ripple-effect/type/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-ripple-effect-ionic1.vercel.app/docs/api/ripple-effect)