### PR TITLE
docs(skeleton-text): update angular to standalone

### DIFF
--- a/static/usage/v7/skeleton-text/basic/angular/example_component_html.md
+++ b/static/usage/v7/skeleton-text/basic/angular/example_component_html.md
@@ -1,5 +1,6 @@
 ```html
-<ion-list *ngIf="loaded">
+@if (loaded) {
+<ion-list>
   <ion-list-header>Albums</ion-list-header>
   <ion-item>
     <ion-thumbnail slot="start">
@@ -12,8 +13,8 @@
     </ion-label>
   </ion-item>
 </ion-list>
-
-<ion-list *ngIf="!loaded">
+} @else {
+<ion-list>
   <ion-list-header>
     <ion-skeleton-text [animated]="true" style="width: 80px"></ion-skeleton-text>
   </ion-list-header>
@@ -34,6 +35,7 @@
     </ion-label>
   </ion-item>
 </ion-list>
+}
 
 <ion-button (click)="loaded = !loaded">Toggle</ion-button>
 ```

--- a/static/usage/v7/skeleton-text/basic/angular/example_component_ts.md
+++ b/static/usage/v7/skeleton-text/basic/angular/example_component_ts.md
@@ -1,5 +1,15 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonListHeader,
+  IonSkeletonText,
+  IonThumbnail,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { musicalNotes } from 'ionicons/icons';
@@ -8,6 +18,7 @@ import { musicalNotes } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonButton, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail],
 })
 export class ExampleComponent {
   public loaded = false;

--- a/static/usage/v7/skeleton-text/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v7/skeleton-text/theming/css-properties/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v7/skeleton-text/theming/css-properties/index.md
+++ b/static/usage/v7/skeleton-text/theming/css-properties/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="7"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}

--- a/static/usage/v8/skeleton-text/basic/angular/example_component_html.md
+++ b/static/usage/v8/skeleton-text/basic/angular/example_component_html.md
@@ -1,5 +1,6 @@
 ```html
-<ion-list *ngIf="loaded">
+@if (loaded) {
+<ion-list>
   <ion-list-header>Albums</ion-list-header>
   <ion-item>
     <ion-thumbnail slot="start">
@@ -12,8 +13,8 @@
     </ion-label>
   </ion-item>
 </ion-list>
-
-<ion-list *ngIf="!loaded">
+} @else {
+<ion-list>
   <ion-list-header>
     <ion-skeleton-text [animated]="true" style="width: 80px"></ion-skeleton-text>
   </ion-list-header>
@@ -34,6 +35,7 @@
     </ion-label>
   </ion-item>
 </ion-list>
+}
 
 <ion-button (click)="loaded = !loaded">Toggle</ion-button>
 ```

--- a/static/usage/v8/skeleton-text/basic/angular/example_component_ts.md
+++ b/static/usage/v8/skeleton-text/basic/angular/example_component_ts.md
@@ -1,5 +1,15 @@
 ```ts
 import { Component } from '@angular/core';
+import {
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonListHeader,
+  IonSkeletonText,
+  IonThumbnail,
+} from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { musicalNotes } from 'ionicons/icons';
@@ -8,6 +18,7 @@ import { musicalNotes } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonButton, IonIcon, IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail],
 })
 export class ExampleComponent {
   public loaded = false;

--- a/static/usage/v8/skeleton-text/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v8/skeleton-text/theming/css-properties/angular/example_component_ts.md
@@ -1,0 +1,12 @@
+```ts
+import { Component } from '@angular/core';
+import { IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['example.component.css'],
+  imports: [IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail],
+})
+export class ExampleComponent {}
+```

--- a/static/usage/v8/skeleton-text/theming/css-properties/index.md
+++ b/static/usage/v8/skeleton-text/theming/css-properties/index.md
@@ -9,6 +9,7 @@ import vue from './vue.md';
 
 import angular_example_component_html from './angular/example_component_html.md';
 import angular_example_component_css from './angular/example_component_css.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
 
 <Playground
   version="8"
@@ -25,6 +26,7 @@ import angular_example_component_css from './angular/example_component_css.md';
       files: {
         'src/app/example.component.html': angular_example_component_html,
         'src/app/example.component.css': angular_example_component_css,
+        'src/app/example.component.ts': angular_example_component_ts,
       },
     },
   }}


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-skeleton-text-ionic1.vercel.app/docs/api/skeleton-text)