### PR TITLE
docs(text): update angular to standalone

### DIFF
--- a/static/usage/v7/text/basic/angular/example_component_ts.md
+++ b/static/usage/v7/text/basic/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonIcon, IonText } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { warning } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { warning } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonIcon, IonText],
 })
 export class ExampleComponent {
   constructor() {

--- a/static/usage/v8/text/basic/angular/example_component_ts.md
+++ b/static/usage/v8/text/basic/angular/example_component_ts.md
@@ -1,5 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
+import { IonIcon, IonText } from '@ionic/angular/standalone';
 
 import { addIcons } from 'ionicons';
 import { warning } from 'ionicons/icons';
@@ -8,6 +9,7 @@ import { warning } from 'ionicons/icons';
   selector: 'app-example',
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
+  imports: [IonIcon, IonText],
 })
 export class ExampleComponent {
   constructor() {


### PR DESCRIPTION
Migrates v7 & v8 Angular playgrounds to standalone

[Preview](https://ionic-docs-git-rou-11416-text-ionic1.vercel.app/docs/api/text)