### PR TITLE
docs(input): add missing imports for maskito in React

### DIFF
--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -209,7 +209,6 @@ const openReactEditor = async (code: string, options?: EditorOptions) => {
     'package.json': JSON.stringify(package_json, null, 2),
     'package-lock.json': defaultFiles[5],
     ...options?.files,
-    ...options?.dependencies,
     '.stackblitzrc': `{
   "startCommand": "yarn run start"
 }`,

--- a/static/usage/v7/input/mask/react.md
+++ b/static/usage/v7/input/mask/react.md
@@ -1,8 +1,9 @@
 ```tsx
 import { useState } from 'react';
 import { IonInput, IonItem, IonList } from '@ionic/react';
-import { useMaskito } from '@maskito/react';
+
 import { MaskitoOptions, maskitoTransform } from '@maskito/core';
+import { useMaskito } from '@maskito/react';
 
 function Example() {
   const cardMask = useMaskito({

--- a/static/usage/v8/input/mask/react.md
+++ b/static/usage/v8/input/mask/react.md
@@ -1,6 +1,8 @@
 ```tsx
-import React from 'react';
+import { useState } from 'react';
 import { IonInput, IonItem, IonList } from '@ionic/react';
+
+import { MaskitoOptions, maskitoTransform } from '@maskito/core';
 import { useMaskito } from '@maskito/react';
 
 function Example() {


### PR DESCRIPTION
## Current Behavior

The input mask demo is not working in StackBlitz for React. Additionally, it incorrectly passes dependencies as files.

1. Navigate to [Input Masking](https://ionicframework.com/docs/api/input#input-masking).
2. Select `React` and then `Open in StackBlitz`.
3. Observe that a folder named `@maskito` is present, containing two files (`core` and `react`) which only contain dependency versions.
4. Note that the demo does not display correctly, resulting in a white screen where the demo should appear.

 ## New Behavior

The dependencies are no longer passed as files, and the missing imports are added, allowing the React demo to function correctly.

1. Navigate to [Input Masking](https://ionic-docs-git-docs-react-stackblitz-input-mask-ionic1.vercel.app/docs/api/input#input-masking).
2. Select `React` and then `Open in StackBlitz`.
3. Confirm that the `@maskito` folder is no longer there and the demo displays as expected.