### PR TITLE
docs(input-password-toggle): update title to correct component name

### DIFF
--- a/docs/api/input-password-toggle.md
+++ b/docs/api/input-password-toggle.md
@@ -1,5 +1,5 @@
 ---
-title: "ion-password-toggle"
+title: "ion-input-password-toggle"
 ---
 import Props from '@ionic-internal/component-api/v8/input-password-toggle/props.md';
 import Events from '@ionic-internal/component-api/v8/input-password-toggle/events.md';


### PR DESCRIPTION
The title is incorrectly displayed as [`ion-password-toggle`](https://ionicframework.com/docs/api/input-password-toggle). It should be [`ion-input-password-toggle`](https://ionic-docs-git-docs-input-password-toggle-title-ionic1.vercel.app/docs/api/input-password-toggle) to match the component name.

This component does not exist on v7 and therefore does not need to be updated in the versioned docs. 