### PR TITLE
docs(glossary): update formatting to remove line breaks around links

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ docs/api
 docs/native
 versioned_docs/version-v*/native
 docs/cli/commands
+docs/reference/glossary.md
 
 static/code/stackblitz
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -17,12 +17,7 @@ title: Glossary
     <h3>Accessibility</h3>
   </a>
   <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility" target="_blank">
-      Accessibility
-    </a>{' '}
-    (a11y) is the practice of enabling as many people as possible to use the content, even if people have limited
-    abilities. This includes people with disabilities, those using mobile devices, and those with slow network
-    connections. Content should be developed to be as accessible as technology allows.
+    <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility" target="_blank">Accessibility</a> (a11y) is the practice of enabling as many people as possible to use the content, even if people have limited abilities. This include people with disabilities, those using mobile devices, and those with slow network connections. Content should be developed to be as accessible as technology allows.
   </p>
 </section>
 
@@ -31,12 +26,7 @@ title: Glossary
     <h3>Android SDK</h3>
   </a>
   <p>
-    The{' '}
-    <a href="http://developer.android.com/sdk/index.html" target="_blank">
-      Android SDK
-    </a>{' '}
-    is a software development kit built for developers building for Google's Android Platform. It includes tools for
-    building, testing, and debugging Android applications.
+    The <a href="http://developer.android.com/sdk/index.html" target="_blank">Android SDK</a> is a software development kit built for developers building for Google's Android Platform. It includes tools for building, testing, and debugging Android applications.
   </p>
 </section>
 
@@ -45,10 +35,8 @@ title: Glossary
     <h3>Android Studio</h3>
   </a>
   <p>
-    <a href="https://developer.android.com/studio/" target="_blank">
-      Android Studio
-    </a>{' '}
-    is the official Integrated Development Environment (IDE) for Native Android app development.
+    <a href="https://developer.android.com/studio/" target="_blank">Android Studio</a> is the official
+    Integrated Development Environment (IDE) for Native Android app development.
   </p>
 </section>
 
@@ -57,10 +45,8 @@ title: Glossary
     <h3>Autoprefixer</h3>
   </a>
   <p>
-    <a href="https://github.com/postcss/autoprefixer" target="_blank">
-      Autoprefixer
-    </a>{' '}
-    is a tool that adds vendor-specific-prefixes to hand-written Sass/CSS code. This ensures that standardized CSS rules
+    <a href="https://github.com/postcss/autoprefixer" target="_blank">Autoprefixer</a> is a tool that adds
+    vendor-specific-prefixes to hand-written Sass/CSS code. This ensures that standardized CSS rules
     you write will be applied across all supporting browsers. For example, instead of having to know every flexbox
     syntax used by various browsers, autoprefixer allows you to just write <code>display: flex;</code> and it'll
     automatically plug in the correct CSS.
@@ -82,13 +68,10 @@ title: Glossary
     <h3>Capacitor</h3>
   </a>
   <p>
-    <a href="https://capacitorjs.com/" target="_blank">
-      Capacitor
-    </a>{' '}
-    is an open source cross-platform app runtime that allows web-based apps to run natively on iOS, Android, Electron,
-    and the web. It's helpful to refer to these apps "Native Progressive Web Apps" and they represent the next evolution
-    beyond the traditional Hybrid app mentality. Capacitor was created and is actively developed/supported by Ionic, the
-    company.
+    <a href="https://capacitorjs.com/" target="_blank">Capacitor</a> is an open source cross-platform app runtime
+    that allows web-based apps to run natively on iOS, Android, Electron, and the web. It's helpful to refer to these
+    apps "Native Progressive Web Apps" and they represent the next evolution beyond the traditional Hybrid app mentality.
+    Capacitor was created and is actively developed/supported by Ionic, the company.
   </p>
 </section>
 
@@ -101,13 +84,10 @@ title: Glossary
   <p>
     A CLI, or <strong>C</strong>ommand-<strong>L</strong>ine <strong>I</strong>nterface, is a text-based interface for
     interacting with a program. The common command-line app for a Mac user is the Terminal app, and Windows users often
-    use Command Prompt. The Ionic community often uses this term to refer to{' '}
+    use Command Prompt. The Ionic community often uses this term to refer to
     <a href="https://ionicframework.com/docs/cli">Ionic's CLI</a>. Ionic's CLI can be used for a number of things, such
-    as creating production builds of an app, running the development server, and accessing{' '}
-    <a href="https://ionic.io/appflow" target="_blank">
-      Ionic commercial services
-    </a>
-    .
+    as creating production builds of an app, running the development server, and accessing
+    <a href="https://ionic.io/appflow" target="_blank">Ionic commercial services</a>.
   </p>
 </section>
 
@@ -118,11 +98,8 @@ title: Glossary
     <h3>CommonJS</h3>
   </a>
   <p>
-    <a href="https://webpack.github.io/docs/commonjs.html" target="_blank">
-      CommonJS
-    </a>{' '}
-    is a group that defines standard formats for JavaScript APIs. They have defined standards for JavaScript modules and
-    packages.
+    <a href="https://webpack.github.io/docs/commonjs.html" target="_blank">CommonJS</a> is a group that defines
+    standard formats for JavaScript APIs. They have defined standards for JavaScript modules and packages.
   </p>
 </section>
 
@@ -131,12 +108,10 @@ title: Glossary
     <h3>Cordova</h3>
   </a>
   <p>
-    <a href="https://cordova.apache.org" target="_blank">
-      Apache Cordova
-    </a>{' '}
-    is an open source mobile application development framework that transforms standard HTML/CSS/JS into full-fledged
-    native apps. It provides a JavaScript API for accessing native device functionality, such as the camera or
-    accelerometer. Cordova contains the necessary build tools for packaging webapps for iOS, Android, and Windows Phone.
+    <a href="https://cordova.apache.org" target="_blank">Apache Cordova</a> is an open source mobile application
+    development framework that transforms standard HTML/CSS/JS into full-fledged native apps. It provides a JavaScript
+    API for accessing native device functionality, such as the camera or accelerometer. Cordova contains the necessary
+    build tools for packaging webapps for iOS, Android, and Windows Phone.
   </p>
 </section>
 
@@ -145,10 +120,8 @@ title: Glossary
     <h3>CORS</h3>
   </a>
   <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">
-      CORS
-    </a>{' '}
-    (Cross-Origin Resource Sharing) is a mechanism for servers to control client access to web assets. See the{' '}
+    <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">CORS</a>
+    (Cross-Origin Resource Sharing) is a mechanism for servers to control client access to web assets. See the
     <a href="../troubleshooting/cors">CORS FAQs</a> for more information.
   </p>
 </section>
@@ -158,10 +131,8 @@ title: Glossary
     <h3>CSS Variables</h3>
   </a>
   <p>
-    You may be familiar with variables from Sass.{' '}
-    <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">
-      CSS Variables
-    </a>{' '}
+    You may be familiar with variables from Sass.
+    <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">CSS Variables</a>
     enable the same functionality but are built into the browser. CSS Variables are available in all evergreen browsers.
   </p>
 </section>
@@ -172,7 +143,7 @@ title: Glossary
   </a>
   <p>
     Decorators are expressions that return a function. They allow you to take an existing function, and extend its
-    behavior. With TypeScript, you can also decorate <i>classes</i> and <i>parameters</i>. When you decorate a{' '}
+    behavior. With TypeScript, you can also decorate <i>classes</i> and <i>parameters</i>. When you decorate a
     <strong>class</strong>, you are wrapping and extending the behavior of its constructor. In other words, the
     decorator will add some functionality when the constructor is called, and will then return the original constructor.
     When you decorate a <strong>parameter</strong>, you are wrapping the argument that gets passed in for that
@@ -240,11 +211,8 @@ title: Glossary
     <h3>Git</h3>
   </a>
   <p>
-    <a href="https://git-scm.com/" target="_blank">
-      Git
-    </a>{' '}
-    is a distributed version control system for managing code. It allows development teams to contribute code to the
-    same project without causing code conflicts.
+    <a href="https://git-scm.com/" target="_blank">Git</a> is a distributed version control system for managing code.
+    It allows development teams to contribute code to the same project without causing code conflicts.
   </p>
 </section>
 
@@ -253,12 +221,9 @@ title: Glossary
     <h3>Gulp</h3>
   </a>
   <p>
-    <a href="http://gulpjs.com/" target="_blank">
-      Gulp
-    </a>{' '}
-    is a tool for running tasks which can be used to build your app. Common build tasks include transpiling{' '}
-    <a href="#es2015-es6">ES6</a> to <a href="#es5">ES5</a>, turning <a href="#sass">Sass</a> into CSS, minifying code,
-    and concatenating files.
+    <a href="http://gulpjs.com/" target="_blank">Gulp</a> is a tool for running tasks which can be used to build your app.
+    Common build tasks include transpiling <a href="#es2015-es6">ES6</a> to <a href="#es5">ES5</a>, turning
+    <a href="#sass">Sass</a> into CSS, minifying code, and concatenating files.
   </p>
 </section>
 
@@ -267,9 +232,7 @@ title: Glossary
     <h3>ES Modules</h3>
   </a>
   <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import" target="_blank">
-      ES Modules
-    </a>{' '}
+    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import" target="_blank">ES Modules</a>
     brings the concept of modules natively to JavaScript. With modules, classes and variables are no longer in the
     global scope and have to be explicitly imported into your project to be used. This makes it much easier to
     understand where your code is coming from and increases modularity and compartmentalization of functionality.
@@ -281,12 +244,9 @@ title: Glossary
     <h3>Ionicons</h3>
   </a>
   <p>
-    <a href="https://ionic.io/ionicons/" target="_blank">
-      Ionicons
-    </a>{' '}
-    is an open-source icon set used and created by Ionic. It includes 1:1 iOS and Material Design icons, as well as
-    commonly used social/application icons. Ionicons is included by default in Ionic distributions, but they can also be
-    used in any project.
+    <a href="https://ionic.io/ionicons/" target="_blank">Ionicons</a> is an open-source icon set used and created
+    by Ionic. It includes 1:1 iOS and Material Design icons, as well as commonly used social/application icons.
+    Ionicons is included by default in Ionic distributions, but they can also be used in any project.
   </p>
 </section>
 
@@ -295,11 +255,9 @@ title: Glossary
     <h3>Karma</h3>
   </a>
   <p>
-    <a href="https://karma-runner.github.io/latest/index.html" target="_blank">
-      Karma
-    </a>{' '}
-    is a test runner that will run an app's test inside a real browser. It executes test cases, written in any testing
-    framework, in a real browser. Karma was originally written for use with Angular 1.
+    <a href="https://karma-runner.github.io/latest/index.html" target="_blank">Karma</a> is a test runner that
+    will run an app's test inside a real browser. It executes test cases, written in any testing framework, in
+    a real browser. Karma was originally written for use with Angular 1.
   </p>
 </section>
 
@@ -328,9 +286,9 @@ title: Glossary
     <h3>Live Reload</h3>
   </a>
   <p>
-    <strong>Live Reload</strong> (or <strong>live-reload</strong>) is a tool that automatically reloads the browser or{' '}
+    <strong>Live Reload</strong> (or <strong>live-reload</strong>) is a tool that automatically reloads the browser or
     <a href="../core-concepts/webview">Web View</a> when it detects changes in your app. In some cases, it can replace
-    parts of your app without having to reload the entire window. See the{' '}
+    parts of your app without having to reload the entire window. See the
     <a href="../cli/livereload">Live Reload docs</a> for more information.
   </p>
 </section>
@@ -340,11 +298,9 @@ title: Glossary
     <h3>Node</h3>
   </a>
   <p>
-    <a href="https://nodejs.org/" target="_blank">
-      Node
-    </a>{' '}
-    is a runtime environment that allows JavaScript to be written on the server-side. In addition to being used for web
-    services, node is often used to build developer tools, such as the <a href="#cli">Ionic CLI</a>.
+    <a href="https://nodejs.org/" target="_blank">Node</a> is a runtime environment that allows JavaScript to be
+    written on the server-side. In addition to being used for web services, node is often used to build developer
+    tools, such as the <a href="#cli">Ionic CLI</a>.
   </p>
 </section>
 
@@ -353,11 +309,9 @@ title: Glossary
     <h3>npm</h3>
   </a>
   <p>
-    <a href="https://www.npmjs.com/" target="_blank">
-      npm
-    </a>{' '}
-    is the package manager for <a href="#node">node</a>. It allows developers to install, share, and package node
-    modules. Ionic can be installed with npm, along with a number of its dependencies.
+    <a href="https://www.npmjs.com/" target="_blank">npm</a> is the package manager for <a href="#node">node</a>.
+    It allows developers to install, share, and package node modules. Ionic can be installed with npm, along with
+    a number of its dependencies.
   </p>
 </section>
 
@@ -377,13 +331,9 @@ title: Glossary
     <h3>Package ID</h3>
   </a>
   <p>
-    Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the{' '}
+    Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the
     <strong>Package ID</strong> is used for identifying apps published to the App Store/Play Store. It is a string
-    formatted in{' '}
-    <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">
-      reverse-DNS notation
-    </a>
-    .
+    formatted in <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">reverse-DNS notation</a>.
   </p>
 </section>
 
@@ -392,12 +342,9 @@ title: Glossary
     <h3>Polyfill</h3>
   </a>
   <p>
-    A{' '}
-    <a href="https://remysharp.com/2010/10/08/what-is-a-polyfill" target="_blank">
-      polyfill
-    </a>{' '}
-    is a bit of code that adds functionality to the browser and normalizes browser differences. This is similar to a{' '}
-    <a href="#shim">shim</a>, but where a shim has it's own API, a polyfill let's the expect API of the browser be used.
+    A <a href="https://remysharp.com/2010/10/08/what-is-a-polyfill" target="_blank">polyfill</a> is a bit of code that
+    adds functionality to the browser and normalizes browser differences. This is similar to a <a href="#shim">shim</a>,
+    but where a shim has it's own API, a polyfill let's the expect API of the browser be used.
   </p>
 </section>
 
@@ -406,11 +353,9 @@ title: Glossary
     <h3>Protractor</h3>
   </a>
   <p>
-    <a href="https://angular.github.io/protractor/#/" target="_blank">
-      Protractor
-    </a>{' '}
-    is a testing framework written for and by the Angular team. Protractor can be used with test runners, like Karma,
-    for end-to-end testing. Test runners allow you to quickly and programmatically verify code quality.
+    <a href="https://angular.github.io/protractor/#/" target="_blank">Protractor</a> is a testing framework written for
+    and by the Angular team. Protractor can be used with test runners, like Karma, for end-to-end testing. Test runners
+    allow you to quickly and programmatically verify code quality.
   </p>
 </section>
 
@@ -420,15 +365,9 @@ title: Glossary
   </a>
   <p>
     Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features
-    such as{' '}
-    <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">
-      variables
-    </a>
-    , <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">
-      mixins
-    </a>, and <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">
-      loops
-    </a>.
+    such as <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">variables</a>,
+    <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">mixins</a>, and
+    <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">loops</a>.
   </p>
 </section>
 
@@ -438,15 +377,10 @@ title: Glossary
   </a>
   <p>
     A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a
-    data attribute at run time. Overriding scoped selectors in CSS requires a{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">
-      higher specificity
-    </a>{' '}
-    selector. Scoped components can also be styled using{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">
-      CSS Custom Properties
-    </a>
-    .
+    data attribute at run time. Overriding scoped selectors in CSS requires a
+    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a>
+    selector. Scoped components can also be styled using
+    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>.
   </p>
 </section>
 
@@ -455,19 +389,11 @@ title: Glossary
     <h3>Shadow DOM</h3>
   </a>
   <p>
-    <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">
-      Shadow DOM
-    </a>{' '}
+    <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a>
     is a native browser solution for DOM and style encapsulation of a component. It shields the component from its
-    surrounding environment. To externally style internal elements of a Shadow DOM component you must use{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">
-      CSS Custom Properties
-    </a>{' '}
-    or{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">
-      CSS Shadow Parts
-    </a>
-    .
+    surrounding environment. To externally style internal elements of a Shadow DOM component you must use
+    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>
+    or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a>.
   </p>
 </section>
 
@@ -487,9 +413,9 @@ title: Glossary
   </a>
   <p>
     Transpilation is the process of converting code from one language to another language prior to execution. Typically,
-    a transpiler will convert a high-level language to another high-level language. The most common type of{' '}
-    <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a> (
-    <a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
+    a transpiler will convert a high-level language to another high-level language. The most common type of
+    <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a>
+    (<a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
   </p>
 </section>
 
@@ -498,18 +424,11 @@ title: Glossary
     <h3>TypeScript</h3>
   </a>
   <p>
-    <a href="http://www.typescriptlang.org" target="_blank">
-      TypeScript
-    </a>{' '}
-    is a superset of JavaScript, which means it gives you JavaScript, along with a number of extra features such as{' '}
-    <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">
-      type declarations
-    </a>{' '}
-    and{' '}
-    <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">
-      interfaces
-    </a>
-    . Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
+    <a href="http://www.typescriptlang.org" target="_blank">TypeScript</a> is a superset of JavaScript,
+    which means it gives you JavaScript, along with a number of extra features such as
+    <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">type declarations</a>
+    and <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">interfaces</a>.
+    Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
   </p>
 </section>
 
@@ -528,12 +447,9 @@ title: Glossary
     <h3>Webpack</h3>
   </a>
   <p>
-    <a href="https://webpack.github.io/" target="_blank">
-      Webpack
-    </a>{' '}
-    bundles together JavaScript modules and other assets. It can be used to create single or multiple "chunks" that are
-    only loaded when needed. Webpack can be used to take many files and dependencies and bundle them into one file, or
-    other types.
+    <a href="https://webpack.github.io/" target="_blank">Webpack</a> bundles together JavaScript modules and other assets.
+    It can be used to create single or multiple "chunks" that are only loaded when needed. Webpack can be used to take
+    many files and dependencies and bundle them into one file, or other types.
   </p>
 </section>
 
@@ -542,15 +458,10 @@ title: Glossary
     <h3>Web Standards</h3>
   </a>
   <p>
-    The{' '}
-    <a href="https://www.w3.org/" target="_blank">
-      World Wide Web Consortium
-    </a>{' '}
-    (W3C) is the standards organization for the Web. Together, industry leaders and the public work together to develop{' '}
-    <a href="https://www.w3.org/standards/" target="_blank">
-      web standards
-    </a>
-    , which are a set of protocols, specifications, and technologies that define the Web Platform.
+    The <a href="https://www.w3.org/" target="_blank">World Wide Web Consortium</a> (W3C) is the standards organization
+    for the Web. Together, industry leaders and the public work together to develop
+    <a href="https://www.w3.org/standards/" target="_blank">web standards</a>, which are a set of protocols, specifications,
+    and technologies that define the Web Platform.
   </p>
 </section>
 
@@ -559,11 +470,9 @@ title: Glossary
     <h3>Xcode</h3>
   </a>
   <p>
-    <a href="https://developer.apple.com/xcode/" target="_blank">
-      Xcode
-    </a>{' '}
-    is an Apple IDE (integrated development environment) for software development on Apple operating systems (macOS,
-    iOS, watchOS and tvOS), with extensions available for other languages and platforms.
+    <a href="https://developer.apple.com/xcode/" target="_blank">Xcode</a> is an Apple IDE (integrated development
+    environment) for software development on Apple operating systems (macOS, iOS, watchOS and tvOS), with extensions
+    available for other languages and platforms.
   </p>
 </section>
 


### PR DESCRIPTION
## Current Behavior

Links in the [Glossary](https://ionicframework.com/docs/reference/glossary) contain unnecessary line breaks.

## New Behavior

Exclude the glossary file from Prettier formatting to prevent the addition of line breaks and `{' '}` around links and fixes the formatting. [Preview](https://ionic-docs-git-docs-glossary-link-line-breaks-ionic1.vercel.app/docs/reference/glossary)