### PR TITLE
docs(developing): remove Atom from list of recommended editors

### DIFF
--- a/docs/developing/tips.md
+++ b/docs/developing/tips.md
@@ -96,7 +96,6 @@ It is recommended that packages get updated through the CLI since npm will now r
 There are a lot of code editors to choose from. Here are some of our favorites:
 
 - [Visual Studio Code](https://code.visualstudio.com): a popular and free text editor made by Microsoft
-- [Atom](https://atom.io): a hackable text editor made by GitHub
 - [WebStorm](https://www.jetbrains.com/webstorm/): a powerful non-free editor by JetBrains
 
 ## Using a Debugger

--- a/versioned_docs/version-v7/developing/tips.md
+++ b/versioned_docs/version-v7/developing/tips.md
@@ -96,7 +96,6 @@ It is recommended that packages get updated through the CLI since npm will now r
 There are a lot of code editors to choose from. Here are some of our favorites:
 
 - [Visual Studio Code](https://code.visualstudio.com): a popular and free text editor made by Microsoft
-- [Atom](https://atom.io): a hackable text editor made by GitHub
 - [WebStorm](https://www.jetbrains.com/webstorm/): a powerful non-free editor by JetBrains
 
 ## Using a Debugger


### PR DESCRIPTION
Since Atom is deprecated, I have removed it from the recommendation list.



