### PR TITLE
docs(ios, android): update v6 links

### DIFF
--- a/docs/developing/android.md
+++ b/docs/developing/android.md
@@ -16,7 +16,7 @@ import DocsCards from '@components/global/DocsCards';
 
 :::info Looking for the legacy Android guide?
 
-The Developing for Android guide has officially migrated to the [Capacitor documentation for Android](https://capacitorjs.com/docs/android). If you need to access the legacy documentation, you can find it under the [legacy developing for Android guide](/docs/v6/developing/android).
+The Developing for Android guide has officially migrated to the [Capacitor documentation for Android](https://capacitorjs.com/docs/android). If you need to access the legacy documentation, you can find it under the [legacy developing for Android guide](https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/android).
 
 :::
 
@@ -30,7 +30,7 @@ The Developing for Android guide has officially migrated to the [Capacitor docum
   </DocsCard>
   <DocsCard
     header="Developing for Android with Cordova (Legacy)"
-    href="/docs/v6/developing/android"
+    href="https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/android"
     icon="/icons/native-cordova-bot.png"
   >
     <p>Learn the fundamentals you need to know to start building Android apps with Ionic Framework and Cordova.</p>

--- a/docs/developing/ios.md
+++ b/docs/developing/ios.md
@@ -14,8 +14,6 @@ skipIntros: true
 
 import DocsCard from '@components/global/DocsCard';
 import DocsCards from '@components/global/DocsCards';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Link from '@docusaurus/Link';
 
 :::info Looking for the legacy iOS guide?
 

--- a/docs/developing/ios.md
+++ b/docs/developing/ios.md
@@ -14,10 +14,12 @@ skipIntros: true
 
 import DocsCard from '@components/global/DocsCard';
 import DocsCards from '@components/global/DocsCards';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
 
 :::info Looking for the legacy iOS guide?
 
-The Developing for iOS guide has officially migrated to the [Capacitor documentation for iOS](https://capacitorjs.com/docs/ios). If you need to access the legacy documentation, you can find it under the [legacy developing for iOS guide](/docs/v6/developing/ios).
+The Developing for iOS guide has officially migrated to the [Capacitor documentation for iOS](https://capacitorjs.com/docs/ios). If you need to access the legacy documentation, you can find it under the [legacy developing for iOS guide](https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/ios).
 
 :::
 
@@ -31,7 +33,7 @@ The Developing for iOS guide has officially migrated to the [Capacitor documenta
   </DocsCard>
   <DocsCard
     header="Developing for iOS with Cordova (Legacy)"
-    href="/docs/v6/developing/ios"
+    href="https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/ios"
     icon="/icons/native-cordova-bot.png"
   >
     <p>Learn the fundamentals you need to know to start building iOS apps with Ionic Framework and Cordova.</p>

--- a/versioned_docs/version-v7/developing/android.md
+++ b/versioned_docs/version-v7/developing/android.md
@@ -16,7 +16,7 @@ import DocsCards from '@components/global/DocsCards';
 
 :::info Looking for the legacy Android guide?
 
-The Developing for Android guide has officially migrated to the [Capacitor documentation for Android](https://capacitorjs.com/docs/android). If you need to access the legacy documentation, you can find it under the [legacy developing for Android guide](/docs/v6/developing/android).
+The Developing for Android guide has officially migrated to the [Capacitor documentation for Android](https://capacitorjs.com/docs/android). If you need to access the legacy documentation, you can find it under the [legacy developing for Android guide](https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/android).
 
 :::
 
@@ -30,7 +30,7 @@ The Developing for Android guide has officially migrated to the [Capacitor docum
   </DocsCard>
   <DocsCard
     header="Developing for Android with Cordova (Legacy)"
-    href="/docs/v6/developing/android"
+    href="https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/android"
     icon="/icons/native-cordova-bot.png"
   >
     <p>Learn the fundamentals you need to know to start building Android apps with Ionic Framework and Cordova.</p>

--- a/versioned_docs/version-v7/developing/ios.md
+++ b/versioned_docs/version-v7/developing/ios.md
@@ -17,7 +17,7 @@ import DocsCards from '@components/global/DocsCards';
 
 :::info Looking for the legacy iOS guide?
 
-The Developing for iOS guide has officially migrated to the [Capacitor documentation for iOS](https://capacitorjs.com/docs/ios). If you need to access the legacy documentation, you can find it under the [legacy developing for iOS guide](/docs/v6/developing/ios).
+The Developing for iOS guide has officially migrated to the [Capacitor documentation for iOS](https://capacitorjs.com/docs/ios). If you need to access the legacy documentation, you can find it under the [legacy developing for iOS guide](https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/ios).
 
 :::
 
@@ -31,7 +31,7 @@ The Developing for iOS guide has officially migrated to the [Capacitor documenta
   </DocsCard>
   <DocsCard
     header="Developing for iOS with Cordova (Legacy)"
-    href="/docs/v6/developing/ios"
+    href="https://ionic-docs-o31kiyk8l-ionic1.vercel.app/docs/v6/developing/ios"
     icon="/icons/native-cordova-bot.png"
   >
     <p>Learn the fundamentals you need to know to start building iOS apps with Ionic Framework and Cordova.</p>


### PR DESCRIPTION
Issue URL: resolves https://github.com/ionic-team/ionic-docs/issues/3838


## What is the current behavior?

Links that are pointing to v6 in the following structure are no longer redirecting correctly: `/docs/v6`. This is due to that version being archived, which causes the domain to change.


## What is the new behavior?

Updated the links to the correct domain. I checked for other locations but this is only happening within two pages.

I considered making a global variable through the Docusaurus config but decided against it since it would only be used for 4 pages. We might also end up removing the reference in the next version.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

[Preview - iOS v8](https://ionic-docs-git-rou-11505-ionic1.vercel.app/docs/developing/ios)
[Preview - Android v8](https://ionic-docs-git-rou-11505-ionic1.vercel.app/docs/developing/android)
[Preview - iOS v7](https://ionic-docs-git-rou-11505-ionic1.vercel.app/docs/v7/developing/ios)
[Preview - Android v7](https://ionic-docs-git-rou-11505-ionic1.vercel.app/docs/v7/developing/android)