### PR TITLE
docs(select): add helperText and errorText section

### DIFF
--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -253,6 +253,16 @@ import TypeaheadExample from '@site/static/usage/v8/select/typeahead/index.md';
 
 <TypeaheadExample />
 
+## Helper & Error Text
+
+Helper and error text can be used inside of a select with the `helperText` and `errorText` property. The error text will not be displayed unless the `ion-invalid` and `ion-touched` classes are added to the `ion-select`. This ensures errors are not shown before the user has a chance to enter data.
+
+In Angular, this is done automatically through form validation. In JavaScript, React and Vue, the class needs to be manually added based on your own validation.
+
+import HelperError from '@site/static/usage/v8/select/helper-error/index.md';
+
+<HelperError />
+
 ## Interfaces
 
 ### SelectChangeEventDetail

--- a/static/usage/v8/select/helper-error/angular/example_component_html.md
+++ b/static/usage/v8/select/helper-error/angular/example_component_html.md
@@ -1,0 +1,19 @@
+```html
+<form [formGroup]="myForm" (ngSubmit)="onSubmit()">
+  <ion-select
+    formControlName="favFruit"
+    label="Default label"
+    placeholder="Favorite Fruit"
+    helperText="Select your favorite fruit"
+    errorText="This field is required"
+  >
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+
+  <br />
+
+  <ion-button type="submit" size="small">Submit</ion-button>
+</form>
+```

--- a/static/usage/v8/select/helper-error/angular/example_component_ts.md
+++ b/static/usage/v8/select/helper-error/angular/example_component_ts.md
@@ -1,0 +1,29 @@
+```ts
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { IonSelect, IonButton } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  standalone: true,
+  imports: [IonSelect, IonButton, ReactiveFormsModule],
+  templateUrl: './example.component.html',
+  styleUrl: './example.component.css',
+})
+export class ExampleComponent {
+  myForm: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.myForm = this.fb.group({
+      favFruit: [false, Validators.required],
+    });
+  }
+
+  onSubmit() {
+    // Mark the control as touched to trigger the error message.
+    // This is needed if the user submits the form without interacting
+    // with the checkbox.
+    this.myForm.get('favFruit')!.markAsTouched();
+  }
+}
+```

--- a/static/usage/v8/select/helper-error/demo.html
+++ b/static/usage/v8/select/helper-error/demo.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Input</title>
+    <link rel="stylesheet" href="../../common.css" />
+    <script src="../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+  </head>
+
+  <body>
+    <div class="container">
+      <form id="my-form">
+        <ion-select
+          label="Default label"
+          placeholder="Favorite Fruit"
+          helper-text="Select your favorite fruit"
+          error-text="This field is required"
+        >
+          <ion-select-option value="apple">Apple</ion-select-option>
+          <ion-select-option value="banana">Banana</ion-select-option>
+          <ion-select-option value="orange">Orange</ion-select-option>
+        </ion-select>
+
+        <br />
+
+        <ion-button type="submit" size="small">Submit</ion-button>
+      </form>
+    </div>
+
+    <script>
+      const form = document.getElementById('my-form');
+      const favFruit = form.querySelector('ion-select');
+
+      form.addEventListener('submit', (event) => submit(event));
+      favFruit.addEventListener('ionChange', (event) => validateSelect(event));
+
+      const validateSelect = (event) => {
+        favFruit.classList.add('ion-touched');
+
+        if (!event.detail.value) {
+          favFruit.classList.add('ion-invalid');
+          favFruit.classList.remove('ion-valid');
+        } else {
+          favFruit.classList.remove('ion-invalid');
+          favFruit.classList.add('ion-valid');
+        }
+      };
+
+      const submit = (event) => {
+        event.preventDefault();
+
+        validateSelect({ detail: { value: favFruit.value } });
+      };
+    </script>
+  </body>
+</html>

--- a/static/usage/v8/select/helper-error/index.md
+++ b/static/usage/v8/select/helper-error/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="8"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v8/select/helper-error/demo.html"
+/>

--- a/static/usage/v8/select/helper-error/javascript.md
+++ b/static/usage/v8/select/helper-error/javascript.md
@@ -1,0 +1,44 @@
+```html
+<form id="my-form">
+  <ion-select
+    label="Default label"
+    placeholder="Favorite Fruit"
+    helper-text="Select your favorite fruit"
+    error-text="This field is required"
+  >
+    <ion-select-option value="apple">Apple</ion-select-option>
+    <ion-select-option value="banana">Banana</ion-select-option>
+    <ion-select-option value="orange">Orange</ion-select-option>
+  </ion-select>
+
+  <br />
+
+  <ion-button type="submit" size="small">Submit</ion-button>
+</form>
+
+<script>
+  const form = document.getElementById('my-form');
+  const favFruit = form.querySelector('ion-select');
+
+  form.addEventListener('submit', (event) => submit(event));
+  favFruit.addEventListener('ionChange', (event) => validateSelect(event));
+
+  const validateSelect = (event) => {
+    favFruit.classList.add('ion-touched');
+
+    if (!event.detail.value) {
+      favFruit.classList.add('ion-invalid');
+      favFruit.classList.remove('ion-valid');
+    } else {
+      favFruit.classList.remove('ion-invalid');
+      favFruit.classList.add('ion-valid');
+    }
+  };
+
+  const submit = (event) => {
+    event.preventDefault();
+
+    validateSelect({ detail: { value: favFruit.value } });
+  };
+</script>
+```

--- a/static/usage/v8/select/helper-error/react.md
+++ b/static/usage/v8/select/helper-error/react.md
@@ -1,0 +1,54 @@
+```tsx
+import React, { useRef, useState } from 'react';
+import { IonSelect, IonSelectOption, IonButton, SelectCustomEvent } from '@ionic/react';
+
+function Example() {
+  const [isTouched, setIsTouched] = useState<boolean>(false);
+  const [isValid, setIsValid] = useState<boolean | undefined>();
+
+  const favFruitRef = useRef<HTMLIonSelectElement>(null);
+
+  const validateSelect = (event: SelectCustomEvent<{ value: string }>) => {
+    setIsTouched(true);
+    setIsValid(event.detail.value);
+  };
+
+  const submit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (favFruitRef.current) {
+      validateSelect({ detail: { value: favFruitRef.current.value } } as SelectCustomEvent<{
+        value: string;
+      }>);
+    }
+  };
+
+  return (
+    <>
+      <form onSubmit={submit}>
+        <IonSelect
+          ref={favFruitRef}
+          className={`${isValid ? 'ion-valid' : ''} ${isValid === false ? 'ion-invalid' : ''} ${
+            isTouched ? 'ion-touched' : ''
+          }`}
+          helperText="Select your favorite fruit"
+          errorText="This field is required"
+          onIonChange={(event) => validateSelect(event)}
+        >
+          <IonSelectOption value="apple">Apple</IonSelectOption>
+          <IonSelectOption value="banana">Banana</IonSelectOption>
+          <IonSelectOption value="orange">Orange</IonSelectOption>
+        </IonSelect>
+
+        <br />
+
+        <IonButton type="submit" size="small">
+          Submit
+        </IonButton>
+      </form>
+    </>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/v8/select/helper-error/vue.md
+++ b/static/usage/v8/select/helper-error/vue.md
@@ -1,0 +1,56 @@
+```html
+<template>
+  <form @submit.prevent="submit">
+    <ion-select
+      v-model="favFruit"
+      helper-text="Select your favorite frui"
+      error-text="This field is required"
+      @ionChange="validateSelect"
+      :class="{ 'ion-valid': isValid, 'ion-invalid': isValid === false, 'ion-touched': isTouched }"
+    >
+      <ion-select-option value="apple">Apple</ion-select-option>
+      <ion-select-option value="banana">Banana</ion-select-option>
+      <ion-select-option value="orange">Orange</ion-select-option>
+    </ion-select>
+
+    <br />
+
+    <ion-button type="submit" size="small">Submit</ion-button>
+  </form>
+</template>
+
+<script lang="ts">
+  import { defineComponent, ref } from 'vue';
+  import { IonSelect, IonSelectOption, IonButton, SelectCustomEvent } from '@ionic/vue';
+
+  export default defineComponent({
+    components: {
+      IonSelect,
+      IonSelectOption,
+      IonButton,
+    },
+    setup() {
+      const favFruit = ref(false);
+      const isTouched = ref(false);
+      const isValid = ref<boolean | undefined>();
+
+      const validateSelect = (event: SelectCustomEvent<{ value: string }>) => {
+        isTouched.value = true;
+        isValid.value = event.detail.value;
+      };
+
+      const submit = () => {
+        validateSelect({ detail: { value: favFruit.value } } as SelectCustomEvent<{ value: string }>);
+      };
+
+      return {
+        favFruit,
+        isTouched,
+        isValid,
+        validateSelect,
+        submit,
+      };
+    },
+  });
+</script>
+```


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ PR uses a dev build, this [commit]() must be reverted before merging.

Issue URL: internal


## What is the current behavior?

Select does not have `helperText` or `errorText` props.

## What is the new behavior?

A new section has been created for the supporting text on how to use them along with playgrounds for each framework.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

There's a bug right now for Vue `ionChange` that doesn't cause it to fire. A [fix](https://github.com/ionic-team/ionic-framework/pull/30227) is coming. The Vue playground is not broken.

[Preview]()