### PR TITLE
docs(toggle): add helperText and errorText section

### DIFF
--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -73,6 +73,16 @@ import Justify from '@site/static/usage/v8/toggle/justify/index.md';
 
 <Justify />
 
+## Helper & Error Text
+
+Helper and error text can be used inside of a toggle with the `helperText` and `errorText` property. The error text will not be displayed unless the `ion-invalid` and `ion-touched` classes are added to the `ion-toggle`. This ensures errors are not shown before the user has a chance to enter data.
+
+In Angular, this is done automatically through form validation. In JavaScript, React and Vue, the class needs to be manually added based on your own validation.
+
+import HelperError from '@site/static/usage/v8/toggle/helper-error/index.md';
+
+<HelperError />
+
 ## Theming
 
 ### Colors

--- a/static/usage/v8/toggle/helper-error/angular/example_component_html.md
+++ b/static/usage/v8/toggle/helper-error/angular/example_component_html.md
@@ -1,0 +1,11 @@
+```html
+<form [formGroup]="myForm" (ngSubmit)="onSubmit()">
+  <ion-toggle formControlName="wifi" helperText="This needs to be enabled" errorText="This field is required">
+    Wi-Fi
+  </ion-toggle>
+
+  <br />
+
+  <ion-button type="submit" size="small">Submit</ion-button>
+</form>
+```

--- a/static/usage/v8/toggle/helper-error/angular/example_component_ts.md
+++ b/static/usage/v8/toggle/helper-error/angular/example_component_ts.md
@@ -1,0 +1,29 @@
+```ts
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { IonToggle, IonButton } from '@ionic/angular/standalone';
+
+@Component({
+  selector: 'app-example',
+  standalone: true,
+  imports: [IonToggle, IonButton, ReactiveFormsModule],
+  templateUrl: './example.component.html',
+  styleUrl: './example.component.css',
+})
+export class ExampleComponent {
+  myForm: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.myForm = this.fb.group({
+      wifi: [false, Validators.requiredTrue],
+    });
+  }
+
+  onSubmit() {
+    // Mark the control as touched to trigger the error message.
+    // This is needed if the user submits the form without interacting
+    // with the toggle.
+    this.myForm.get('wifi')!.markAsTouched();
+  }
+}
+```

--- a/static/usage/v8/toggle/helper-error/demo.html
+++ b/static/usage/v8/toggle/helper-error/demo.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Input</title>
+    <link rel="stylesheet" href="../../common.css" />
+    <script src="../../common.js"></script>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css"
+    />
+  </head>
+
+  <body>
+    <div class="container">
+      <form id="my-form">
+        <ion-toggle helper-text="This needs to be enabled" error-text="This field is required">
+          Wi-Fi
+        </ion-toggle>
+
+        <br />
+
+        <ion-button type="submit" size="small">Submit</ion-button>
+      </form>
+    </div>
+
+    <script>
+      const form = document.getElementById('my-form');
+      const wifi = form.querySelector('ion-toggle');
+
+      form.addEventListener('submit', (event) => submit(event));
+      wifi.addEventListener('ionChange', (event) => validateToggle(event));
+
+      const validateToggle = (event) => {
+        wifi.classList.add('ion-touched');
+
+        if (!event.detail.checked) {
+          wifi.classList.add('ion-invalid');
+          wifi.classList.remove('ion-valid');
+        } else {
+          wifi.classList.remove('ion-invalid');
+          wifi.classList.add('ion-valid');
+        }
+      };
+
+      const submit = (event) => {
+        event.preventDefault();
+
+        validateToggle({ detail: { checked: wifi.checked } });
+      };
+    </script>
+  </body>
+</html>

--- a/static/usage/v8/toggle/helper-error/index.md
+++ b/static/usage/v8/toggle/helper-error/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="8"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v8/toggle/helper-error/demo.html"
+/>

--- a/static/usage/v8/toggle/helper-error/javascript.md
+++ b/static/usage/v8/toggle/helper-error/javascript.md
@@ -1,0 +1,37 @@
+```html
+<form id="my-form">
+  <ion-toggle helper-text="This needs to be enabled" error-text="This field is required">
+    Wi-Fi
+  </ion-toggle>
+
+  <br />
+
+  <ion-button type="submit" size="small">Submit</ion-button>
+</form>
+
+<script>
+  const form = document.getElementById('my-form');
+  const wifi = form.querySelector('ion-toggle');
+
+  form.addEventListener('submit', (event) => submit(event));
+  wifi.addEventListener('ionChange', (event) => validateToggle(event));
+
+  const validateToggle = (event) => {
+    wifi.classList.add('ion-touched');
+
+    if (!event.detail.checked) {
+      wifi.classList.add('ion-invalid');
+      wifi.classList.remove('ion-valid');
+    } else {
+      wifi.classList.remove('ion-invalid');
+      wifi.classList.add('ion-valid');
+    }
+  };
+
+  const submit = (event) => {
+    event.preventDefault();
+
+    validateToggle({ detail: { checked: wifi.checked } });
+  };
+</script>
+```

--- a/static/usage/v8/toggle/helper-error/react.md
+++ b/static/usage/v8/toggle/helper-error/react.md
@@ -1,0 +1,52 @@
+```tsx
+import React, { useRef, useState } from 'react';
+import { IonToggle, IonButton, ToggleCustomEvent } from '@ionic/react';
+
+function Example() {
+  const [isTouched, setIsTouched] = useState<boolean>(false);
+  const [isValid, setIsValid] = useState<boolean | undefined>();
+
+  const wifiRef = useRef<HTMLIonToggleElement>(null);
+
+  const validateToggle = (event: ToggleCustomEvent<{ checked: boolean }>) => {
+    setIsTouched(true);
+    setIsValid(event.detail.checked);
+  };
+
+  const submit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (wifiRef.current) {
+      validateToggle({ detail: { checked: wifiRef.current.checked } } as ToggleCustomEvent<{
+        checked: boolean;
+      }>);
+    }
+  };
+
+  return (
+    <>
+      <form onSubmit={submit}>
+        <IonToggle
+          ref={wifiRef}
+          className={`${isValid ? 'ion-valid' : ''} ${isValid === false ? 'ion-invalid' : ''} ${
+            isTouched ? 'ion-touched' : ''
+          }`}
+          helperText="This needs to be enabled"
+          errorText="This field is required"
+          onIonChange={(event) => validateToggle(event)}
+        >
+          I agree to the terms and conditions
+        </IonToggle>
+
+        <br />
+
+        <IonButton type="submit" size="small">
+          Submit
+        </IonButton>
+      </form>
+    </>
+  );
+}
+
+export default Example;
+```

--- a/static/usage/v8/toggle/helper-error/vue.md
+++ b/static/usage/v8/toggle/helper-error/vue.md
@@ -1,0 +1,53 @@
+```html
+<template>
+  <form @submit.prevent="submit">
+    <ion-toggle
+      v-model="wifi"
+      helper-text="This needs to be enabled"
+      error-text="This field is required"
+      @ionChange="validateToggle"
+      :class="{ 'ion-valid': isValid, 'ion-invalid': isValid === false, 'ion-touched': isTouched }"
+    >
+      Wi-Fi
+    </ion-toggle>
+
+    <br />
+
+    <ion-button type="submit" size="small">Submit</ion-button>
+  </form>
+</template>
+
+<script lang="ts">
+  import { defineComponent, ref } from 'vue';
+  import { IonToggle, IonButton, ToggleCustomEvent } from '@ionic/vue';
+
+  export default defineComponent({
+    components: {
+      IonToggle,
+      IonButton,
+    },
+    setup() {
+      const wifi = ref(false);
+      const isTouched = ref(false);
+      const isValid = ref<boolean | undefined>();
+
+      const validateToggle = (event: ToggleCustomEvent<{ checked: boolean }>) => {
+        isTouched.value = true;
+        isValid.value = event.detail.checked;
+      };
+
+      const submit = () => {
+        validateToggle({ detail: { checked: wifi.value } } as ToggleCustomEvent<{ checked: boolean }>);
+      };
+
+      return {
+        wifi,
+        isTouched,
+        isValid,
+        validateToggle,
+        submit,
+      };
+    },
+  });
+</script>
+```


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ PR uses a dev build, this [commit]() must be reverted before merging.

Issue URL: internal


## What is the current behavior?

Toggle does not have `helperText` or `errorText` props.

## What is the new behavior?

A new section has been created for the supporting text on how to use them along with playgrounds for each framework.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

There's a bug right now for Vue `ionChange` that doesn't cause it to fire. A [fix](https://github.com/ionic-team/ionic-framework/pull/30227) is coming. The Vue playground is not broken.

[Preview]()