### PR TITLE
docs(badge, tab-bar): add playground to show usage of badges in tab-bar

### DIFF
--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -27,7 +27,7 @@ import Basic from '@site/static/usage/v8/badge/basic/index.md';
 
 ## Inside Tab Bar
 
-Badges can be added to a tab button, commonly used to indicate notifications or additional items linked to the element.
+Badges can be added inside a tab button, often used to indicate notifications or highlight additional items associated with the element.
 
 :::info
 Empty badges are only available for `md` mode.

--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -25,6 +25,18 @@ import Basic from '@site/static/usage/v8/badge/basic/index.md';
 
 <Basic />
 
+## Inside Tab Bar
+
+Badges can be added to a tab button, commonly used to indicate notifications or additional items linked to the element.
+
+:::info
+Empty badges are only available for `md` mode.
+:::
+
+import InsideTabBar from '@site/static/usage/v8/badge/inside-tab-bar/index.md';
+
+<InsideTabBar />
+
 ## Theming
 
 ### Colors

--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -25,7 +25,7 @@ import Basic from '@site/static/usage/v8/badge/basic/index.md';
 
 <Basic />
 
-## Inside Tab Bar
+## Badges in Tab Buttons
 
 Badges can be added inside a tab button, often used to indicate notifications or highlight additional items associated with the element.
 

--- a/docs/api/tab-bar.md
+++ b/docs/api/tab-bar.md
@@ -148,6 +148,18 @@ export default defineComponent({
 
 </Tabs>
 
+## With Badges
+
+Badges can be added to a tab button, commonly used to indicate notifications or additional items linked to the element.
+
+:::info
+Empty badges are only available for `md` mode.
+:::
+
+import InsideTabBar from '@site/static/usage/v8/badge/inside-tab-bar/index.md';
+
+<InsideTabBar />
+
 ## Properties
 <Props />
 

--- a/docs/api/tab-bar.md
+++ b/docs/api/tab-bar.md
@@ -150,7 +150,7 @@ export default defineComponent({
 
 ## Badges in Tab Buttons
 
-Badges can be added to a tab button, commonly used to indicate notifications or additional items linked to the element.
+Badges can be added inside a tab button, often used to indicate notifications or highlight additional items associated with the element.
 
 :::info
 Empty badges are only available for `md` mode.

--- a/docs/api/tab-bar.md
+++ b/docs/api/tab-bar.md
@@ -148,7 +148,7 @@ export default defineComponent({
 
 </Tabs>
 
-## With Badges
+## Badges in Tab Buttons
 
 Badges can be added to a tab button, commonly used to indicate notifications or additional items linked to the element.
 

--- a/static/usage/v8/badge/inside-tab-bar/angular/example_component_html.md
+++ b/static/usage/v8/badge/inside-tab-bar/angular/example_component_html.md
@@ -8,10 +8,12 @@
 
   <ion-tab-button tab="2">
     <ion-icon name="musical-note"></ion-icon>
+    <ion-label>Music</ion-label>
   </ion-tab-button>
 
   <ion-tab-button tab="3">
     <ion-icon name="calendar"></ion-icon>
+    <ion-label>Calendar</ion-label>
     <ion-badge color="danger">47</ion-badge>
   </ion-tab-button>
 </ion-tab-bar>

--- a/static/usage/v8/badge/inside-tab-bar/angular/example_component_html.md
+++ b/static/usage/v8/badge/inside-tab-bar/angular/example_component_html.md
@@ -7,6 +7,10 @@
   </ion-tab-button>
 
   <ion-tab-button tab="2">
+    <ion-icon name="musical-note"></ion-icon>
+  </ion-tab-button>
+
+  <ion-tab-button tab="3">
     <ion-icon name="calendar"></ion-icon>
     <ion-badge color="danger">47</ion-badge>
   </ion-tab-button>

--- a/static/usage/v8/badge/inside-tab-bar/angular/example_component_html.md
+++ b/static/usage/v8/badge/inside-tab-bar/angular/example_component_html.md
@@ -1,0 +1,14 @@
+```html
+<ion-tab-bar color="light">
+  <ion-tab-button tab="1">
+    <ion-icon name="heart"></ion-icon>
+    <ion-label>Favorites</ion-label>
+    <ion-badge color="danger"></ion-badge>
+  </ion-tab-button>
+
+  <ion-tab-button tab="2">
+    <ion-icon name="calendar"></ion-icon>
+    <ion-badge color="danger">47</ion-badge>
+  </ion-tab-button>
+</ion-tab-bar>
+```

--- a/static/usage/v8/badge/inside-tab-bar/angular/example_component_ts.md
+++ b/static/usage/v8/badge/inside-tab-bar/angular/example_component_ts.md
@@ -2,7 +2,7 @@
 import { Component } from '@angular/core';
 import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { heart, calendar } from 'ionicons/icons';
+import { heart, calendar, musicalNote } from 'ionicons/icons';
 
 @Component({
   selector: 'app-example',
@@ -17,7 +17,7 @@ export class ExampleComponent {
      * can be registered in app.component.ts and then
      * referenced by name anywhere in your application.
      */
-    addIcons({ heart, calendar });
+    addIcons({ heart, calendar, musicalNote });
   }
 }
 ```

--- a/static/usage/v8/badge/inside-tab-bar/angular/example_component_ts.md
+++ b/static/usage/v8/badge/inside-tab-bar/angular/example_component_ts.md
@@ -1,0 +1,23 @@
+```ts
+import { Component } from '@angular/core';
+import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import { heart, calendar } from 'ionicons/icons';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: 'example.component.html',
+  styleUrls: ['./example.component.css'],
+  imports: [IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel],
+})
+export class ExampleComponent {
+  constructor() {
+    /**
+     * Any icons you want to use in your application
+     * can be registered in app.component.ts and then
+     * referenced by name anywhere in your application.
+     */
+    addIcons({ heart, calendar });
+  }
+}
+```

--- a/static/usage/v8/badge/inside-tab-bar/demo.html
+++ b/static/usage/v8/badge/inside-tab-bar/demo.html
@@ -29,10 +29,12 @@
 
             <ion-tab-button tab="2">
               <ion-icon name="musical-note"></ion-icon>
+              <ion-label>Music</ion-label>
             </ion-tab-button>
 
             <ion-tab-button tab="3">
               <ion-icon name="calendar"></ion-icon>
+              <ion-label>Calendar</ion-label>
               <ion-badge color="danger">47</ion-badge>
             </ion-tab-button>
           </ion-tab-bar>

--- a/static/usage/v8/badge/inside-tab-bar/demo.html
+++ b/static/usage/v8/badge/inside-tab-bar/demo.html
@@ -28,6 +28,10 @@
             </ion-tab-button>
 
             <ion-tab-button tab="2">
+              <ion-icon name="musical-note"></ion-icon>
+            </ion-tab-button>
+
+            <ion-tab-button tab="3">
               <ion-icon name="calendar"></ion-icon>
               <ion-badge color="danger">47</ion-badge>
             </ion-tab-button>

--- a/static/usage/v8/badge/inside-tab-bar/demo.html
+++ b/static/usage/v8/badge/inside-tab-bar/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Badge</title>
+    <link rel="stylesheet" href="../../common.css" />
+    <script src="../../common.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-tab-bar {
+        flex: 1;
+      }
+    </style>
+  </head>
+
+  <body>
+    <ion-app>
+      <ion-content>
+        <div class="container">
+          <ion-tab-bar color="light">
+            <ion-tab-button tab="1">
+              <ion-icon name="heart"></ion-icon>
+              <ion-label>Favorites</ion-label>
+              <ion-badge color="danger"></ion-badge>
+            </ion-tab-button>
+
+            <ion-tab-button tab="2">
+              <ion-icon name="calendar"></ion-icon>
+              <ion-badge color="danger">47</ion-badge>
+            </ion-tab-button>
+          </ion-tab-bar>
+        </div>
+      </ion-content>
+    </ion-app>
+  </body>
+</html>

--- a/static/usage/v8/badge/inside-tab-bar/index.md
+++ b/static/usage/v8/badge/inside-tab-bar/index.md
@@ -1,0 +1,24 @@
+import Playground from '@site/src/components/global/Playground';
+
+import javascript from './javascript.md';
+import react from './react.md';
+import vue from './vue.md';
+
+import angular_example_component_html from './angular/example_component_html.md';
+import angular_example_component_ts from './angular/example_component_ts.md';
+
+<Playground
+  version="8"
+  code={{
+    javascript,
+    react,
+    vue,
+    angular: {
+      files: {
+        'src/app/example.component.html': angular_example_component_html,
+        'src/app/example.component.ts': angular_example_component_ts,
+      },
+    },
+  }}
+  src="usage/v8/badge/inside-tab-bar/demo.html"
+/>

--- a/static/usage/v8/badge/inside-tab-bar/javascript.md
+++ b/static/usage/v8/badge/inside-tab-bar/javascript.md
@@ -8,10 +8,12 @@
 
   <ion-tab-button tab="2">
     <ion-icon name="musical-note"></ion-icon>
+    <ion-label>Music</ion-label>
   </ion-tab-button>
 
   <ion-tab-button tab="3">
     <ion-icon name="calendar"></ion-icon>
+    <ion-label>Calendar</ion-label>
     <ion-badge color="danger">47</ion-badge>
   </ion-tab-button>
 </ion-tab-bar>

--- a/static/usage/v8/badge/inside-tab-bar/javascript.md
+++ b/static/usage/v8/badge/inside-tab-bar/javascript.md
@@ -7,6 +7,10 @@
   </ion-tab-button>
 
   <ion-tab-button tab="2">
+    <ion-icon name="musical-note"></ion-icon>
+  </ion-tab-button>
+
+  <ion-tab-button tab="3">
     <ion-icon name="calendar"></ion-icon>
     <ion-badge color="danger">47</ion-badge>
   </ion-tab-button>

--- a/static/usage/v8/badge/inside-tab-bar/javascript.md
+++ b/static/usage/v8/badge/inside-tab-bar/javascript.md
@@ -1,0 +1,14 @@
+```html
+<ion-tab-bar color="light">
+  <ion-tab-button tab="1">
+    <ion-icon name="heart"></ion-icon>
+    <ion-label>Favorites</ion-label>
+    <ion-badge color="danger"></ion-badge>
+  </ion-tab-button>
+
+  <ion-tab-button tab="2">
+    <ion-icon name="calendar"></ion-icon>
+    <ion-badge color="danger">47</ion-badge>
+  </ion-tab-button>
+</ion-tab-bar>
+```

--- a/static/usage/v8/badge/inside-tab-bar/react.md
+++ b/static/usage/v8/badge/inside-tab-bar/react.md
@@ -1,7 +1,7 @@
 ```tsx
 import React from 'react';
 import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/react';
-import { heart, calendar } from 'ionicons/icons';
+import { heart, calendar, musicalNote } from 'ionicons/icons';
 
 function Example() {
   return (
@@ -13,6 +13,9 @@ function Example() {
           <IonBadge color="danger"></IonBadge>
         </IonTabButton>
         <IonTabButton tab="tab2">
+          <IonIcon icon={musicalNote} />
+        </IonTabButton>
+        <IonTabButton tab="tab3">
           <IonIcon icon={calendar} />
           <IonBadge color="danger">47</IonBadge>
         </IonTabButton>

--- a/static/usage/v8/badge/inside-tab-bar/react.md
+++ b/static/usage/v8/badge/inside-tab-bar/react.md
@@ -14,9 +14,11 @@ function Example() {
         </IonTabButton>
         <IonTabButton tab="tab2">
           <IonIcon icon={musicalNote} />
+          <IonLabel>Music</IonLabel>
         </IonTabButton>
         <IonTabButton tab="tab3">
           <IonIcon icon={calendar} />
+          <IonLabel>Calendar</IonLabel>
           <IonBadge color="danger">47</IonBadge>
         </IonTabButton>
       </IonTabBar>

--- a/static/usage/v8/badge/inside-tab-bar/react.md
+++ b/static/usage/v8/badge/inside-tab-bar/react.md
@@ -1,0 +1,24 @@
+```tsx
+import React from 'react';
+import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/react';
+import { heart, calendar } from 'ionicons/icons';
+
+function Example() {
+  return (
+    <>
+      <IonTabBar color="light">
+        <IonTabButton tab="tab1">
+          <IonIcon icon={heart} />
+          <IonLabel>Favorites</IonLabel>
+          <IonBadge color="danger"></IonBadge>
+        </IonTabButton>
+        <IonTabButton tab="tab2">
+          <IonIcon icon={calendar} />
+          <IonBadge color="danger">47</IonBadge>
+        </IonTabButton>
+      </IonTabBar>
+    </>
+  );
+}
+export default Example;
+```

--- a/static/usage/v8/badge/inside-tab-bar/vue.md
+++ b/static/usage/v8/badge/inside-tab-bar/vue.md
@@ -1,0 +1,35 @@
+```html
+<template>
+  <ion-tab-bar color="light">
+    <ion-tab-button tab="1">
+      <ion-icon :icon="heart" />
+      <ion-label>Favorites</ion-label>
+      <ion-badge color="danger"></ion-badge>
+    </ion-tab-button>
+
+    <ion-tab-button tab="2">
+      <ion-icon :icon="calendar" />
+      <ion-badge color="danger">47</ion-badge>
+    </ion-tab-button>
+  </ion-tab-bar>
+</template>
+
+<script lang="ts">
+  import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/vue';
+  import { heart, calendar } from 'ionicons/icons';
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({
+    components: {
+      IonBadge,
+      IonTabBar,
+      IonTabButton,
+      IonIcon,
+      IonLabel,
+    },
+    setup() {
+      return { heart, calendar };
+    },
+  });
+</script>
+```

--- a/static/usage/v8/badge/inside-tab-bar/vue.md
+++ b/static/usage/v8/badge/inside-tab-bar/vue.md
@@ -8,6 +8,10 @@
     </ion-tab-button>
 
     <ion-tab-button tab="2">
+      <ion-icon :icon="musicalNote" />
+    </ion-tab-button>
+
+    <ion-tab-button tab="3">
       <ion-icon :icon="calendar" />
       <ion-badge color="danger">47</ion-badge>
     </ion-tab-button>
@@ -16,7 +20,7 @@
 
 <script lang="ts">
   import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/vue';
-  import { heart, calendar } from 'ionicons/icons';
+  import { heart, calendar, musicalNote } from 'ionicons/icons';
   import { defineComponent } from 'vue';
 
   export default defineComponent({
@@ -28,7 +32,7 @@
       IonLabel,
     },
     setup() {
-      return { heart, calendar };
+      return { heart, calendar, musicalNote };
     },
   });
 </script>

--- a/static/usage/v8/badge/inside-tab-bar/vue.md
+++ b/static/usage/v8/badge/inside-tab-bar/vue.md
@@ -9,10 +9,12 @@
 
     <ion-tab-button tab="2">
       <ion-icon :icon="musicalNote" />
+      <ion-label>Music</ion-label>
     </ion-tab-button>
 
     <ion-tab-button tab="3">
       <ion-icon :icon="calendar" />
+      <ion-label>Calendar</ion-label>
       <ion-badge color="danger">47</ion-badge>
     </ion-tab-button>
   </ion-tab-bar>


### PR DESCRIPTION
Issue URL: resolves #4039 


## What is the current behavior?

There are no docs that show how badges can be used within a tab bar.

## What is the new behavior?

Added playgrounds to show this use case.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

[Badge preview](https://ionic-docs-git-fw-6378-ionic1.vercel.app/docs/api/badge#badges-in-tab-buttons)
[Tab bar preview](https://ionic-docs-git-fw-6378-ionic1.vercel.app/docs/api/tab-bar#badges-in-tab-buttons)