### PR TITLE
refactor(stackblitz): move html playgrounds to node and vite

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,13 @@
       "groupName": "react"
     },
     {
+      "matchPackageNames": ["vite", "vite-plugin-static-copy"],
+      "groupName": "vite-html",
+      "matchFileNames": [
+        "static/code/stackblitz/**/html/package.json"
+      ]
+    },
+    {
       "matchPackageNames": ["vite", "@vitejs/plugin-react"],
       "groupName": "vite-react",
       "matchFileNames": [

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -54,19 +54,24 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
       options?.includeIonContent ? 'html/index.withContent.html' : 'html/index.html',
       'html/variables.css',
       'html/package.json',
+      'html/tsconfig.json',
+      'html/vite.config.ts',
     ],
     options.version
   );
 
+  const package_json = JSON.parse(defaultFiles[3]);
+
   const indexHtml = 'index.html';
   const files = {
-    'index.ts': defaultFiles[0],
+    'package.json': JSON.stringify(package_json, null, 2),
+    'src/index.ts': defaultFiles[0],
     [indexHtml]: defaultFiles[1],
-    'theme/variables.css': defaultFiles[2],
+    'src/theme/variables.css': defaultFiles[2],
+    'tsconfig.json': defaultFiles[4],
+    'vite.config.ts': defaultFiles[5],
     ...options?.files,
   };
-
-  const package_json = defaultFiles[3];
 
   files[indexHtml] = defaultFiles[1].replace(/{{ TEMPLATE }}/g, code).replace(
     '</head>',
@@ -82,23 +87,18 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
 `
   );
 
-  let dependencies = {};
-  try {
-    dependencies = {
-      ...dependencies,
-      ...JSON.parse(package_json).dependencies,
-      ...options?.dependencies,
+  if (options?.dependencies) {
+    package_json.dependencies = {
+      ...package_json.dependencies,
+      ...options.dependencies,
     };
-  } catch (e) {
-    console.error('Failed to parse package.json contents', e);
   }
 
   sdk.openProject({
-    template: 'typescript',
+    template: 'node',
     title: options?.title ?? DEFAULT_EDITOR_TITLE,
     description: options?.description ?? DEFAULT_EDITOR_DESCRIPTION,
     files,
-    dependencies,
   });
 };
 

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -62,6 +62,13 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
 
   const package_json = JSON.parse(defaultFiles[3]);
 
+  if (options?.dependencies) {
+    package_json.dependencies = {
+      ...package_json.dependencies,
+      ...options.dependencies,
+    };
+  }
+
   const indexHtml = 'index.html';
   const files = {
     'package.json': JSON.stringify(package_json, null, 2),
@@ -86,13 +93,6 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
 </head>
 `
   );
-
-  if (options?.dependencies) {
-    package_json.dependencies = {
-      ...package_json.dependencies,
-      ...options.dependencies,
-    };
-  }
 
   sdk.openProject({
     template: 'node',

--- a/src/components/global/Playground/stackblitz.utils.ts
+++ b/src/components/global/Playground/stackblitz.utils.ts
@@ -65,9 +65,9 @@ const openHtmlEditor = async (code: string, options?: EditorOptions) => {
   const indexHtml = 'index.html';
   const files = {
     'package.json': JSON.stringify(package_json, null, 2),
-    'src/index.ts': defaultFiles[0],
+    'index.ts': defaultFiles[0],
     [indexHtml]: defaultFiles[1],
-    'src/theme/variables.css': defaultFiles[2],
+    'theme/variables.css': defaultFiles[2],
     'tsconfig.json': defaultFiles[4],
     'vite.config.ts': defaultFiles[5],
     ...options?.files,

--- a/static/code/stackblitz/v7/html/index.html
+++ b/static/code/stackblitz/v7/html/index.html
@@ -13,7 +13,7 @@
     {{ TEMPLATE }}
   </ion-app>
 
-  <script type="module" src="./src/index.ts"></script>
+  <script type="module" src="./index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v7/html/index.html
+++ b/static/code/stackblitz/v7/html/index.html
@@ -1,14 +1,19 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/core.css" />
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/ionic.bundle.css" />
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ionic App</title>
 </head>
 
 <body>
   <ion-app>
     {{ TEMPLATE }}
   </ion-app>
+
+  <script type="module" src="./src/index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v7/html/index.withContent.html
+++ b/static/code/stackblitz/v7/html/index.withContent.html
@@ -1,8 +1,11 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/core.css" />
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@7/css/ionic.bundle.css" />
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ionic App</title>
 </head>
 
 <body>
@@ -11,6 +14,8 @@
       {{ TEMPLATE }}
     </ion-content>
   </ion-app>
+
+  <script type="module" src="./src/index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v7/html/index.withContent.html
+++ b/static/code/stackblitz/v7/html/index.withContent.html
@@ -15,7 +15,7 @@
     </ion-content>
   </ion-app>
 
-  <script type="module" src="./src/index.ts"></script>
+  <script type="module" src="./index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v7/html/package.json
+++ b/static/code/stackblitz/v7/html/package.json
@@ -1,6 +1,17 @@
 {
+  "name": "html-starter",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview"
+  },
   "dependencies": {
     "@ionic/core": "^7.0.0",
-    "ionicons": "8.0.8"
+    "ionicons": "8.0.8",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
   }
 }

--- a/static/code/stackblitz/v7/html/package.json
+++ b/static/code/stackblitz/v7/html/package.json
@@ -12,6 +12,9 @@
     "@ionic/core": "^7.0.0",
     "ionicons": "8.0.8",
     "typescript": "^5.0.0",
-    "vite": "^4.0.0"
+    "vite": "^6.0.0"
+  },
+  "devDependencies": {
+    "vite-plugin-static-copy": "^3.1.0"
   }
 }

--- a/static/code/stackblitz/v7/html/package.json
+++ b/static/code/stackblitz/v7/html/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "@ionic/core": "^7.0.0",
-    "ionicons": "8.0.8",
-    "typescript": "^5.0.0",
-    "vite": "^6.0.0"
+    "ionicons": "8.0.8"
   },
   "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0",
     "vite-plugin-static-copy": "^3.1.0"
   }
 }

--- a/static/code/stackblitz/v7/html/tsconfig.json
+++ b/static/code/stackblitz/v7/html/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["esnext", "dom"],
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/static/code/stackblitz/v7/html/vite.config.ts
+++ b/static/code/stackblitz/v7/html/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ['@ionic/core'],
+  },
+});

--- a/static/code/stackblitz/v7/html/vite.config.ts
+++ b/static/code/stackblitz/v7/html/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default defineConfig({
   optimizeDeps: {
     exclude: ['@ionic/core'],
   },
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'node_modules/ionicons/dist/svg/*',
+          dest: 'svg'
+        }
+      ]
+    })
+  ]
 });

--- a/static/code/stackblitz/v8/html/index.html
+++ b/static/code/stackblitz/v8/html/index.html
@@ -1,14 +1,11 @@
 <html>
 
-<head>
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@8/css/core.css" />
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@8/css/ionic.bundle.css" />
-</head>
-
 <body>
   <ion-app>
     {{ TEMPLATE }}
   </ion-app>
+
+  <script type="module" src="./src/index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v8/html/index.html
+++ b/static/code/stackblitz/v8/html/index.html
@@ -13,7 +13,7 @@
     {{ TEMPLATE }}
   </ion-app>
 
-  <script type="module" src="./src/index.ts"></script>
+  <script type="module" src="./index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v8/html/index.html
+++ b/static/code/stackblitz/v8/html/index.html
@@ -1,4 +1,12 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ionic App</title>
+</head>
 
 <body>
   <ion-app>

--- a/static/code/stackblitz/v8/html/index.withContent.html
+++ b/static/code/stackblitz/v8/html/index.withContent.html
@@ -15,7 +15,7 @@
     </ion-content>
   </ion-app>
 
-  <script type="module" src="./src/index.ts"></script>
+  <script type="module" src="./index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v8/html/index.withContent.html
+++ b/static/code/stackblitz/v8/html/index.withContent.html
@@ -1,16 +1,13 @@
 <html>
 
-<head>
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@8/css/core.css" />
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@8/css/ionic.bundle.css" />
-</head>
-
 <body>
   <ion-app>
     <ion-content class="ion-padding">
       {{ TEMPLATE }}
     </ion-content>
   </ion-app>
+
+  <script type="module" src="./src/index.ts"></script>
 </body>
 
 </html>

--- a/static/code/stackblitz/v8/html/index.withContent.html
+++ b/static/code/stackblitz/v8/html/index.withContent.html
@@ -1,4 +1,12 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ionic App</title>
+</head>
 
 <body>
   <ion-app>

--- a/static/code/stackblitz/v8/html/package.json
+++ b/static/code/stackblitz/v8/html/package.json
@@ -10,11 +10,12 @@
   },
   "dependencies": {
     "@ionic/core": "8.6.0",
-    "ionicons": "8.0.8",
-    "typescript": "^5.0.0",
-    "vite": "^6.0.0"
+    "ionicons": "8.0.8"
+
   },
   "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0",
     "vite-plugin-static-copy": "^3.1.0"
   }
 }

--- a/static/code/stackblitz/v8/html/package.json
+++ b/static/code/stackblitz/v8/html/package.json
@@ -12,6 +12,9 @@
     "@ionic/core": "8.6.0",
     "ionicons": "8.0.8",
     "typescript": "^5.0.0",
-    "vite": "^4.0.0"
+    "vite": "^6.0.0"
+  },
+  "devDependencies": {
+    "vite-plugin-static-copy": "^3.1.0"
   }
 }

--- a/static/code/stackblitz/v8/html/package.json
+++ b/static/code/stackblitz/v8/html/package.json
@@ -1,6 +1,17 @@
 {
+  "name": "html-starter",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "start": "vite preview"
+  },
   "dependencies": {
     "@ionic/core": "8.6.0",
-    "ionicons": "8.0.8"
+    "ionicons": "8.0.8",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
   }
 }

--- a/static/code/stackblitz/v8/html/tsconfig.json
+++ b/static/code/stackblitz/v8/html/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["esnext", "dom"],
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/static/code/stackblitz/v8/html/vite.config.ts
+++ b/static/code/stackblitz/v8/html/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: ['@ionic/core'],
+  },
+});

--- a/static/code/stackblitz/v8/html/vite.config.ts
+++ b/static/code/stackblitz/v8/html/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default defineConfig({
   optimizeDeps: {
     exclude: ['@ionic/core'],
   },
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        {
+          src: 'node_modules/ionicons/dist/svg/*',
+          dest: 'svg'
+        }
+      ]
+    })
+  ]
 });


### PR DESCRIPTION
This PR migrates the JavaScript playgrounds to use Node and Vite.

Playgrounds I suggest testing:
- [Alert: Controller](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/api/alert#controller-alerts) - example of overlay
- [Badge: Custom CSS Properties](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/api/badge#css-properties) - example of custom styles
- [Buttons: Icons](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/api/button#icons) - example of using Ionicons
- [Input: Mask](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/api/input#input-masking) - example of using a custom dependency
- [Ripple Effect: Basic](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/api/ripple-effect#basic-usage) - example of ripple effect
- [Modal: Inline](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/api/modal#inline-modals-recommended) - example of modal
- [Tabs: Basic](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/api/tabs#basic-usage) - example of tabs
- [Theming: Dark Mode: Always](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/theming/dark-mode#always) - example of custom index file
- [Theming: Dark Mode: Manual](https://ionic-docs-git-fw-6238-ionic1.vercel.app/docs/v7/theming/dark-mode#manually-toggle-dark-mode) - example of custom index file