### PR TITLE
Specified current major version

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ The Ionic command-line interface ([CLI](/docs/reference/glossary#cli)) is the go
 
 ## Installation
 
-The Ionic CLI can be installed globally with npm:
+The Ionic CLI 7 can be installed globally with npm:
 
 ```shell
 npm install -g @ionic/cli


### PR DESCRIPTION
Docs v8 says it will install v8 but it installs v7 as v8 cli was never released.