### PR TITLE
docs(navigation): correct routerDirection values

### DIFF
--- a/docs/react/navigation.md
+++ b/docs/react/navigation.md
@@ -197,7 +197,7 @@ const UsersListPage: React.FC = () => {
 
 Other components that have the `routerLink` prop are `IonButton`, `IonCard`, `IonRouterLink`, `IonFabButton`, and `IonItemOption`.
 
-Each of these components also have a `routerDirection` prop to explicitly set the type of page transition to use ("back", "forward", or "none").
+Each of these components also have a `routerDirection` prop to explicitly set the type of page transition to use (`"forward"`, `"back"`, or `"root"`).
 
 Outside of these components that have the `routerLink` prop, you can also use React Routers [`Link`](https://v5.reactrouter.com/web/api/Link) component to navigate between views:
 

--- a/docs/vue/navigation.md
+++ b/docs/vue/navigation.md
@@ -138,7 +138,7 @@ Both options provide the same navigation mechanism, just fitting different use c
 
 The `router-link` attribute can be set on any Ionic Vue component, and the router will navigate to the route specified when the component is clicked. The `router-link` attribute accepts string values as well as named routes, just like `router.push` from Vue Router. For additional control, the `router-direction` and `router-animation` attributes can be set as well.
 
-The `router-direction` attribute accepts values of `forward`, `back`, or `none` and is used to control the direction of the page transition.
+The `router-direction` attribute accepts values of `"forward"`, `"back"`, or `"root"` and is used to control the direction of the page transition.
 
 The `router-animation` attribute accepts an `AnimationBuilder` function and is used to provide a custom page transition that is only used when clicking the component it is provided on. The `AnimationBuilder` type is a function that returns an Ionic Animation instance. See the [Animations documentation](../utilities/animations) for more information on using animations in Ionic Vue.
 

--- a/docs/vue/utility-functions.md
+++ b/docs/vue/utility-functions.md
@@ -72,7 +72,7 @@ interface UseIonRouterResult {
   forward: (routerAnimation?: AnimationBuilder) => void;
   navigate: (
     location: string | Location,
-    routerDirection?: 'forward' | 'back' | 'root' | 'none',
+    routerDirection?: 'forward' | 'back' | 'root',
     routerAction?: 'push' | 'pop' | 'replace',
     routerAnimation?: AnimationBuilder
   ) => void;

--- a/versioned_docs/version-v7/react/navigation.md
+++ b/versioned_docs/version-v7/react/navigation.md
@@ -197,7 +197,7 @@ const UsersListPage: React.FC = () => {
 
 Other components that have the `routerLink` prop are `IonButton`, `IonCard`, `IonRouterLink`, `IonFabButton`, and `IonItemOption`.
 
-Each of these components also have a `routerDirection` prop to explicitly set the type of page transition to use ("back", "forward", or "none").
+Each of these components also have a `routerDirection` prop to explicitly set the type of page transition to use (`"forward"`, `"back"`, or `"root"`).
 
 Outside of these components that have the `routerLink` prop, you can also use React Routers [`Link`](https://v5.reactrouter.com/web/api/Link) component to navigate between views:
 

--- a/versioned_docs/version-v7/vue/navigation.md
+++ b/versioned_docs/version-v7/vue/navigation.md
@@ -138,7 +138,7 @@ Both options provide the same navigation mechanism, just fitting different use c
 
 The `router-link` attribute can be set on any Ionic Vue component, and the router will navigate to the route specified when the component is clicked. The `router-link` attribute accepts string values as well as named routes, just like `router.push` from Vue Router. For additional control, the `router-direction` and `router-animation` attributes can be set as well.
 
-The `router-direction` attribute accepts values of `forward`, `back`, or `none` and is used to control the direction of the page transition.
+The `router-direction` attribute accepts values of `"forward"`, `"back"`, or `"root"` and is used to control the direction of the page transition.
 
 The `router-animation` attribute accepts an `AnimationBuilder` function and is used to provide a custom page transition that is only used when clicking the component it is provided on. The `AnimationBuilder` type is a function that returns an Ionic Animation instance. See the [Animations documentation](../utilities/animations) for more information on using animations in Ionic Vue.
 

--- a/versioned_docs/version-v7/vue/utility-functions.md
+++ b/versioned_docs/version-v7/vue/utility-functions.md
@@ -72,7 +72,7 @@ interface UseIonRouterResult {
   forward: (routerAnimation?: AnimationBuilder) => void;
   navigate: (
     location: string | Location,
-    routerDirection?: 'forward' | 'back' | 'root' | 'none',
+    routerDirection?: 'forward' | 'back' | 'root',
     routerAction?: 'push' | 'pop' | 'replace',
     routerAnimation?: AnimationBuilder
   ) => void;


### PR DESCRIPTION
RouterDirection does not contain `none`: https://github.com/ionic-team/ionic-framework/blob/8dd566b5c1241022e26cc91c0f415de20c0d0f34/core/src/components/router/utils/interface.ts#L66

When using with Vue it gives this error:

```
Type '"none"' is not assignable to type 'RouterDirection | undefined'
```

While it might work for React, I think this is incorrect: https://github.com/ionic-team/ionic-framework/blob/8dd566b5c1241022e26cc91c0f415de20c0d0f34/packages/react/src/models/RouterDirection.ts#L1