### PR TITLE
docs(support-page): update v7 status

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -20,16 +20,16 @@ Given the reality of time and resource constraints as well as the desire to keep
 
 The current status of each Ionic Framework version is:
 
-| Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
-| :-----: | :--------------: | :----------: | :--------------: | :---------------: |
-|   V8    |    **Active**    | Apr 17, 2024 |       TBD        |        TBD        |
-|   V7    | Extended Support | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
-|   V6    |  End of Support  | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
-|   V5    |  End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
-|   V4    |  End of Support  | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
-|   V3    |  End of Support  | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
-|   V2    |  End of Support  | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
-|   V1    |  End of Support  | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
+| Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
+| :-----: | :------------: | :----------: | :--------------: | :---------------: |
+|   V8    |   **Active**   | Apr 17, 2024 |       TBD        |        TBD        |
+|   V7    | End of Support | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
+|   V6    | End of Support | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
+|   V5    | End of Support | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
+|   V4    | End of Support | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
+|   V3    | End of Support | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
+|   V2    | End of Support | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
+|   V1    | End of Support | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
 - **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).

--- a/versioned_docs/version-v7/reference/support.md
+++ b/versioned_docs/version-v7/reference/support.md
@@ -20,15 +20,15 @@ Given the reality of time and resource constraints as well as the desire to keep
 
 The current status of each Ionic Framework version is:
 
-| Version |        Status        |   Released   | Maintenance Ends | Ext. Support Ends |
-| :-----: | :------------------: | :----------: | :--------------: | :---------------: |
-|   V7    | **Extended Support** | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
-|   V6    |    End of Support    | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
-|   V5    |    End of Support    | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
-|   V4    |    End of Support    | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
-|   V3    |    End of Support    | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
-|   V2    |    End of Support    | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
-|   V1    |    End of Support    | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
+| Version |       Status       |   Released   | Maintenance Ends | Ext. Support Ends |
+| :-----: | :----------------: | :----------: | :--------------: | :---------------: |
+|   V7    | **End of Support** | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
+|   V6    |   End of Support   | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
+|   V5    |   End of Support   | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
+|   V4    |   End of Support   | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
+|   V3    |   End of Support   | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
+|   V2    |   End of Support   | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
+|   V1    |   End of Support   | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
 - **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

As of April 17, v7 is no longer supported at any level. This makes the support page out of date.

## What is the new behavior?

Update the support page to reflect the correct status for v7,

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

- [v8 Preview](https://ionic-docs-git-support-page-ionic1.vercel.app/docs/reference/support#framework-maintenance-and-support-status)
- [v7 Preview](https://ionic-docs-git-support-page-ionic1.vercel.app/docs/v7/reference/support#framework-maintenance-and-support-status)