### PR TITLE
docs(playgrounds): fix cdn imports to target v8

### DIFF
--- a/static/code/stackblitz/v8/html/index.withContent.html
+++ b/static/code/stackblitz/v8/html/index.withContent.html
@@ -1,8 +1,8 @@
 <html>
 
 <head>
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@next/css/core.css" />
-  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@next/css/ionic.bundle.css" />
+  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@8/css/core.css" />
+  <link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/@ionic/core@8/css/ionic.bundle.css" />
 </head>
 
 <body>

--- a/static/usage/v8/common.js
+++ b/static/usage/v8/common.js
@@ -1,7 +1,7 @@
 const linkElement = document.createElement('link');
 
 linkElement.rel = 'stylesheet';
-linkElement.href = 'https://cdn.jsdelivr.net/npm/@ionic/core@next/css/palettes/dark.class.css';
+linkElement.href = 'https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/dark.class.css';
 
 document.head.appendChild(linkElement);
 

--- a/static/usage/v8/fab/before-content/demo.html
+++ b/static/usage/v8/fab/before-content/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@next/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@next/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
   </head>
 
   <body>


### PR DESCRIPTION
There are a few paths targeting `core@next` which should be `core@8`. See the differences here:

[static/code/stackblitz/v8/html/index.withContent.html](https://github.com/ionic-team/ionic-docs/blob/fee8fa0c3a0a39f984b62f3775672bfdeb16d56c/static/code/stackblitz/v8/html/index.withContent.html#L4-L5)
[static/code/stackblitz/v8/html/index.html](https://github.com/ionic-team/ionic-docs/blob/fee8fa0c3a0a39f984b62f3775672bfdeb16d56c/static/code/stackblitz/v8/html/index.html#L4-L5)

The files above are both used by the JavaScript StackBlitz examples but target different npm tags for `core`.