### PR TITLE
docs(infinite-scroll): remove duplicate and unused imports

### DIFF
--- a/static/usage/v7/infinite-scroll/basic/vue.md
+++ b/static/usage/v7/infinite-scroll/basic/vue.md
@@ -23,7 +23,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -37,7 +36,6 @@
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v7/infinite-scroll/basic/vue.md
+++ b/static/usage/v7/infinite-scroll/basic/vue.md
@@ -32,7 +32,6 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,

--- a/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/vue.md
+++ b/static/usage/v7/infinite-scroll/custom-infinite-scroll-content/vue.md
@@ -89,7 +89,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -98,13 +97,11 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v7/infinite-scroll/infinite-scroll-content/vue.md
+++ b/static/usage/v7/infinite-scroll/infinite-scroll-content/vue.md
@@ -26,7 +26,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -35,13 +34,11 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v8/infinite-scroll/basic/vue.md
+++ b/static/usage/v8/infinite-scroll/basic/vue.md
@@ -23,7 +23,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -37,7 +36,6 @@
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v8/infinite-scroll/basic/vue.md
+++ b/static/usage/v8/infinite-scroll/basic/vue.md
@@ -32,7 +32,6 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
@@ -98,7 +98,6 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,

--- a/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/custom-infinite-scroll-content/vue.md
@@ -89,7 +89,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -103,7 +102,6 @@
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
@@ -26,7 +26,6 @@
     IonList,
     IonItem,
     IonAvatar,
-    IonImg,
     IonLabel,
     InfiniteScrollCustomEvent,
   } from '@ionic/vue';
@@ -40,7 +39,6 @@
       IonList,
       IonItem,
       IonAvatar,
-      IonImg,
       IonLabel,
     },
     setup() {

--- a/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
+++ b/static/usage/v8/infinite-scroll/infinite-scroll-content/vue.md
@@ -35,7 +35,6 @@
   export default defineComponent({
     components: {
       IonContent,
-      IonContent,
       IonInfiniteScroll,
       IonInfiniteScrollContent,
       IonList,


### PR DESCRIPTION
Resolves #4095

**Changelog**
- Removed duplicate IonContent imports in Vue displays
- Removed import and export of unused IonImg components in Vue displays
- Demoed changes of modified components, all remain functional
- Compiled and previewed modified docs site with changes, all remain functional