### PR TITLE
docs(docusaurus): Ionic method parameters are missing descriptions (#634)

### DIFF
--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -173,6 +173,25 @@ function renderEvents({ events }) {
 ${events.map((event) => `| \`${event.event}\` | ${formatMultiline(event.docs)} | \`${event.bubbles}\` |`).join('\n')}`;
 }
 
+/**
+ * Formats method parameters for the optional Parameters row of each method table
+ * @param {*} paramsArr Array of method parameters
+ * @returns formatted parameters for methods table
+ */
+function renderParameters(paramsArr) {
+  if (!paramsArr.some((param) => param.docs)) {
+    return '';
+  }
+
+  const documentedParams = paramsArr.filter((param) => param.docs);
+  const formattedParams = documentedParams
+    .map((param) => {
+      return `**${param.name}**: ${formatMultiline(param.docs)}`;
+    })
+    .join('<br/>');
+  return `| **Parameters** | ${formattedParams} |`;
+}
+
 function renderMethods({ methods }) {
   if (methods.length === 0) {
     return 'No public methods available for this component.';
@@ -189,6 +208,7 @@ ${methods
 | --- | --- |
 | **Description** | ${formatMultiline(method.docs)} |
 | **Signature** | \`${method.signature.replace(/\|/g, '\uff5c')}\` |
+${method.parameters.length !== 0 ? renderParameters(method.parameters) : ''}
 `
   )
   .join('\n')}


### PR DESCRIPTION
Resolves #634 

Created renderParameters function in docusaurus script to include optional row for method parameter definitions if present. Called in renderMethods function.