### PR TITLE
docs(accordion): update demos to always set accordion to 300px wide

### DIFF
--- a/static/usage/v7/accordion/accessibility/animations/demo.html
+++ b/static/usage/v7/accordion/accessibility/animations/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/basic/demo.html
+++ b/static/usage/v7/accordion/basic/demo.html
@@ -8,6 +8,12 @@
     <script src="../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/customization/advanced-expansion-styles/demo.html
+++ b/static/usage/v7/accordion/customization/advanced-expansion-styles/demo.html
@@ -32,13 +32,8 @@
         --color: var(--ion-color-primary-contrast);
       }
 
-      .container {
-        width: 300px;
-        margin: 0 auto;
-      }
-
       ion-accordion-group {
-        width: 100%;
+        width: 300px;
       }
     </style>
   </head>

--- a/static/usage/v7/accordion/customization/expansion-styles/demo.html
+++ b/static/usage/v7/accordion/customization/expansion-styles/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/customization/icons/demo.html
+++ b/static/usage/v7/accordion/customization/icons/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/customization/theming/demo.html
+++ b/static/usage/v7/accordion/customization/theming/demo.html
@@ -30,6 +30,10 @@
       div[slot='content'] {
         background: rgba(var(--ion-color-rose-rgb), 0.25);
       }
+
+      ion-accordion-group {
+        width: 300px;
+      }
     </style>
   </head>
 

--- a/static/usage/v7/accordion/disable/group/demo.html
+++ b/static/usage/v7/accordion/disable/group/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/disable/individual/demo.html
+++ b/static/usage/v7/accordion/disable/individual/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/listen-changes/demo.html
+++ b/static/usage/v7/accordion/listen-changes/demo.html
@@ -8,6 +8,12 @@
     <script src="../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/multiple/demo.html
+++ b/static/usage/v7/accordion/multiple/demo.html
@@ -8,6 +8,12 @@
     <script src="../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/readonly/group/demo.html
+++ b/static/usage/v7/accordion/readonly/group/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/readonly/individual/demo.html
+++ b/static/usage/v7/accordion/readonly/individual/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@7/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@7/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v7/accordion/toggle/demo.html
+++ b/static/usage/v7/accordion/toggle/demo.html
@@ -12,6 +12,10 @@
       .container {
         flex-direction: column;
       }
+
+      ion-accordion-group {
+        width: 300px;
+      }
     </style>
   </head>
 

--- a/static/usage/v8/accordion/accessibility/animations/demo.html
+++ b/static/usage/v8/accordion/accessibility/animations/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/basic/demo.html
+++ b/static/usage/v8/accordion/basic/demo.html
@@ -8,6 +8,12 @@
     <script src="../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/customization/advanced-expansion-styles/demo.html
+++ b/static/usage/v8/accordion/customization/advanced-expansion-styles/demo.html
@@ -32,13 +32,8 @@
         --color: var(--ion-color-primary-contrast);
       }
 
-      .container {
-        width: 300px;
-        margin: 0 auto;
-      }
-
       ion-accordion-group {
-        width: 100%;
+        width: 300px;
       }
     </style>
   </head>

--- a/static/usage/v8/accordion/customization/expansion-styles/demo.html
+++ b/static/usage/v8/accordion/customization/expansion-styles/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/customization/icons/demo.html
+++ b/static/usage/v8/accordion/customization/icons/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/customization/theming/demo.html
+++ b/static/usage/v8/accordion/customization/theming/demo.html
@@ -30,6 +30,10 @@
       div[slot='content'] {
         background: rgba(var(--ion-color-rose-rgb), 0.25);
       }
+
+      ion-accordion-group {
+        width: 300px;
+      }
     </style>
   </head>
 

--- a/static/usage/v8/accordion/disable/group/demo.html
+++ b/static/usage/v8/accordion/disable/group/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/disable/individual/demo.html
+++ b/static/usage/v8/accordion/disable/individual/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/listen-changes/demo.html
+++ b/static/usage/v8/accordion/listen-changes/demo.html
@@ -8,6 +8,12 @@
     <script src="../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/multiple/demo.html
+++ b/static/usage/v8/accordion/multiple/demo.html
@@ -8,6 +8,12 @@
     <script src="../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/readonly/group/demo.html
+++ b/static/usage/v8/accordion/readonly/group/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/readonly/individual/demo.html
+++ b/static/usage/v8/accordion/readonly/individual/demo.html
@@ -8,6 +8,12 @@
     <script src="../../../common.js"></script>
     <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+
+    <style>
+      ion-accordion-group {
+        width: 300px;
+      }
+    </style>
   </head>
 
   <body>

--- a/static/usage/v8/accordion/toggle/demo.html
+++ b/static/usage/v8/accordion/toggle/demo.html
@@ -12,6 +12,10 @@
       .container {
         flex-direction: column;
       }
+
+      ion-accordion-group {
+        width: 300px;
+      }
     </style>
   </head>
 


### PR DESCRIPTION
I noticed that the [Accordion: Expansion Styles](https://ionicframework.com/docs/api/accordion#advanced-expansion-styles) demo is the only one that shows the accordion a bit wider. This looks better in my opinion, so I updated all of the demos to add this style.

| Before | After |
| ---| ---|
| ![before](https://github.com/user-attachments/assets/75b3cefa-c7ae-473a-ba7c-33814c3e9bde) | ![after](https://github.com/user-attachments/assets/b0db0922-1190-45c8-880a-64ca8f7cd450) |

[Preview](https://ionic-docs-git-docs-accordion-demos-ionic1.vercel.app/docs/api/accordion)