### PR TITLE
fix(docusaurus): support diff code blocks #4156

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -324,7 +324,7 @@ module.exports = {
     prism: {
       theme: { plain: {}, styles: [] },
       // https://github.com/FormidableLabs/prism-react-renderer/blob/e6d323332b0363a633407fabab47b608088e3a4d/packages/generate-prism-languages/index.ts#L9-L25
-      additionalLanguages: ['shell-session', 'http'],
+      additionalLanguages: ['shell-session', 'http', 'diff'],
     },
     algolia: {
       appId: 'O9QSL985BS',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -323,7 +323,8 @@ module.exports = {
     },
     prism: {
       theme: { plain: {}, styles: [] },
-      // https://github.com/FormidableLabs/prism-react-renderer/blob/e6d323332b0363a633407fabab47b608088e3a4d/packages/generate-prism-languages/index.ts#L9-L25
+      // Prism provides a [default list of languages](https://github.com/FormidableLabs/prism-react-renderer/blob/e1c83a468b05df7f452b3ad7e4ae5ab874574d4e/packages/generate-prism-languages/index.ts#L9-L26).
+      // A list of [additional languages](https://prismjs.com/#supported-languages) that are supported can be found at their website.
       additionalLanguages: ['shell-session', 'http', 'diff'],
     },
     algolia: {

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -175,6 +175,7 @@ pre[class*='language-'] {
   cursor: help;
 }
 
+// Code removals (indicated by a leading '-') within a diff.
 .token.deleted {
   color: red;
 }

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -149,6 +149,7 @@ pre[class*='language-'] {
 .language-css .token.string,
 .style .token.string,
 .token.variable,
+// Code additions (indicated by a leading '+') within a diff.
 .token.inserted {
   color: #42b983;
 }

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -175,6 +175,13 @@ pre[class*='language-'] {
   cursor: help;
 }
 
-.token.deleted {
-  color: red;
+// diff code block highlighting
+.language-diff .token.deleted {
+  color: rgb(50, 0, 0);
+  background-color: rgba(255, 0, 0, 0.05);
+}
+
+.language-diff .token.inserted {
+  color: darkgreen;
+  background-color: rgba(0, 255, 0, 0.05);
 }

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -175,6 +175,10 @@ pre[class*='language-'] {
   cursor: help;
 }
 
+.token.deleted {
+  color: red;
+}
+
 // diff code block highlighting
 .language-diff .token.deleted {
   color: rgb(50, 0, 0);

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -137,8 +137,7 @@ pre[class*='language-'] {
 .token.selector,
 .token.char,
 .token.function,
-.token.builtin,
-.token.inserted {
+.token.builtin {
   color: #ff6810;
 }
 
@@ -150,7 +149,7 @@ pre[class*='language-'] {
 .language-css .token.string,
 .style .token.string,
 .token.variable,
-.language-diff .token.inserted {
+.token.inserted {
   color: #42b983;
 }
 
@@ -160,8 +159,7 @@ pre[class*='language-'] {
 
 .token.regex,
 .token.keyword,
-.token.important,
-.language-diff .token.deleted {
+.token.important {
   color: #f55073;
 }
 

--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -149,7 +149,8 @@ pre[class*='language-'] {
 .token.attr-value,
 .language-css .token.string,
 .style .token.string,
-.token.variable {
+.token.variable,
+.language-diff .token.inserted {
   color: #42b983;
 }
 
@@ -159,7 +160,8 @@ pre[class*='language-'] {
 
 .token.regex,
 .token.keyword,
-.token.important {
+.token.important,
+.language-diff .token.deleted {
   color: #f55073;
 }
 
@@ -177,15 +179,4 @@ pre[class*='language-'] {
 
 .token.deleted {
   color: red;
-}
-
-// diff code block highlighting
-.language-diff .token.deleted {
-  color: rgb(50, 0, 0);
-  background-color: rgba(255, 0, 0, 0.05);
-}
-
-.language-diff .token.inserted {
-  color: darkgreen;
-  background-color: rgba(0, 255, 0, 0.05);
 }


### PR DESCRIPTION
resolves #4156

# Changes

- Add 'diff' to list of additionalLanguages in docusaurus.config.js
- Move `.token.inserted` selector to greenish #42b983 block after verifying `.token.inserted` and `.token.deleted` will only select lines in diff blocks
## Screenshot

<img width="489" alt="diffBugScreenshot" src="https://github.com/user-attachments/assets/8dac808a-d757-4d52-b799-1fad6a52d3fa" />

Screenshot from docs/angular/build-options