### PR TITLE
docs(support): add Angular 20 support

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -44,7 +44,7 @@ The Ionic team has compiled a set of recommendations for using the Ionic Framewo
 
 | Framework | Minimum Angular Version | Maximum Angular Version | TypeScript |
 | :-------: | :---------------------: | :---------------------: | :--------: |
-|    v8     |           v16           |        v19.x[^3]        |   4.9.3+   |
+|    v8     |           v16           |        v20.x[^3]        |   4.9.3+   |
 |    v7     |           v14           |        v17.x[^2]        |    4.6+    |
 |    v6     |           v12           |        v15.x[^1]        |    4.0+    |
 |    v5     |          v8.2           |          v12.x          |    3.5+    |


### PR DESCRIPTION
Issue URL: internal


## What is the current behavior?

The support page displays that Angular 19 is the maximum version.


## What is the new behavior?

Updated the support page to display Angular 20 to be the maximum version.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

[Preview](https://ionic-docs-b74ljiu5s-ionic1.vercel.app/docs/reference/support#ionic-angular)
