### PR TITLE
chore(renovate): bundle @angular-devkit with @angular

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "schedule": ["every weekday before 11am"]
     },
     {
-      "matchPackagePatterns": ["@angular/"],
+      "matchPackagePatterns": ["@angular/",  "@angular-devkit/"],
       "groupName": "angular",
       "schedule": ["on the first day of the month"]
     },


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

`@angular-devkit` does not upgrade with `@angular` packages.

## What is the new behavior?

`@angular-devkit` has been grouped under `angular`. This will allow `@angular-devkit` and `@angular` packages to be upgraded in the same PR.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A