### PR TITLE
fix(sidebar): scroll to the active item after navigating

### DIFF
--- a/src/theme/DocSidebar/index.tsx
+++ b/src/theme/DocSidebar/index.tsx
@@ -3,15 +3,28 @@
  *
  * Reason for modifying:
  * - Add a logo to the top of the sidebar
+ * - Scroll to the active item in the sidebar
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useLocation } from '@docusaurus/router';
 import DocSidebar from '@theme-original/DocSidebar';
 import type { Props } from '@theme/DocSidebar';
 
 import Logo from '@theme-original/Logo';
 
 export default function DocSidebarWrapper(props: Props): JSX.Element {
+  const location = useLocation();
+
+  useEffect(() => {
+    setTimeout(() => {
+      const activeItem = document.querySelector('.menu__link--active');
+      if (activeItem && activeItem.scrollIntoView) {
+        activeItem.scrollIntoView({ block: 'center', behavior: 'auto' });
+      }
+    }, 100);
+  }, [location.pathname]);
+
   return (
     <>
       <Logo />


### PR DESCRIPTION
**Problem:**
When navigating the docs site, the sidebar does not update to reflect the active item.

**Solution:**
This PR updates the sidebar to scroll the active item into view when a new page is selected.

**Test steps:**
1. Visit https://ionicframework.com/docs/components
2. Scroll down and select "Popover"
3. Notice that the sidebar remains at the top (starting at "Accordion") and "Popover" is not visible
4. Visit https://ionic-docs-git-fix-sidebar-scroll-ionic1.vercel.app/docs/components
5. Repeat step 2
6. Confirm that the sidebar now scrolls to and highlights "Popover"

**Repeat the test steps above for a "Guide" page:**
1. Go to https://ionicframework.com/docs/
2. Click on the "Theming" card
3. Notice the sidebar remains at the top
4. Repeat for https://ionic-docs-git-fix-sidebar-scroll-ionic1.vercel.app/docs/