### PR TITLE
docs(radio): point to correct v7 usage for comparewith

### DIFF
--- a/static/usage/v7/radio/using-comparewith/angular/example_component_ts.md
+++ b/static/usage/v7/radio/using-comparewith/angular/example_component_ts.md
@@ -13,7 +13,7 @@ interface Food {
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
   imports: [IonItem, IonList, IonRadio, IonRadioGroup],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class ExampleComponent {
   foods: Food[] = [

--- a/static/usage/v7/radio/using-comparewith/angular/example_component_ts.md
+++ b/static/usage/v7/radio/using-comparewith/angular/example_component_ts.md
@@ -1,5 +1,5 @@
 ```ts
-import { Component } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
 
 interface Food {
@@ -13,6 +13,7 @@ interface Food {
   templateUrl: 'example.component.html',
   styleUrls: ['example.component.css'],
   imports: [IonItem, IonList, IonRadio, IonRadioGroup],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class ExampleComponent {
   foods: Food[] = [

--- a/versioned_docs/version-v7/api/radio.md
+++ b/versioned_docs/version-v7/api/radio.md
@@ -43,7 +43,7 @@ import LabelPlacement from '@site/static/usage/v7/radio/label-placement/index.md
 
 By default, the radio group uses strict equality (`===`) to determine if an option is selected. This can be overridden by providing a property name or a function to the `compareWith` property.
 
-import UsingComparewith from '@site/static/usage/v8/radio/using-comparewith/index.md';
+import UsingComparewith from '@site/static/usage/v7/radio/using-comparewith/index.md';
 
 <UsingComparewith />
 


### PR DESCRIPTION
The v7 version of the [Radio API docs](https://ionic-docs-git-docs-radio-v7-usage-ionic1.vercel.app/docs/v7/api/radio#object-value-references) was pointing to the v8 playground example for comparewith. 