### PR TITLE
docs(vue): update v7 stackblitz templates

### DIFF
--- a/static/code/stackblitz/v7/vue/App.vue
+++ b/static/code/stackblitz/v7/vue/App.vue
@@ -4,15 +4,7 @@
   </ion-app>
 </template>
 
-<script lang="ts">
-import { IonApp } from '@ionic/vue';
-
-import { defineComponent } from 'vue';
-
-import Example from './components/Example.vue';
-
-export default defineComponent({
-  name: 'App',
-  components: { IonApp, Example },
-});
+<script setup lang="ts">
+  import { IonApp } from '@ionic/vue';
+  import Example from './components/Example.vue';
 </script>

--- a/static/code/stackblitz/v7/vue/App.withContent.vue
+++ b/static/code/stackblitz/v7/vue/App.withContent.vue
@@ -6,15 +6,7 @@
   </ion-app>
 </template>
 
-<script lang="ts">
-import { IonApp, IonContent } from '@ionic/vue';
-
-import { defineComponent } from 'vue';
-
-import Example from './components/Example.vue';
-
-export default defineComponent({
-  name: 'App',
-  components: { IonApp, IonContent, Example },
-});
+<script setup lang="ts">
+  import { IonApp, IonContent } from '@ionic/vue';
+  import Example from './components/Example.vue';
 </script>

--- a/static/code/stackblitz/v7/vue/env.d.ts
+++ b/static/code/stackblitz/v7/vue/env.d.ts
@@ -1,8 +1,0 @@
-/// <reference types="vite/client" />
-
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-  const component: DefineComponent<{}, {}, any>
-  export default component
-}


### PR DESCRIPTION
- [#4242](https://github.com/ionic-team/ionic-docs/pull/4242) - Updates all v8 playgrounds to use `script setup` syntax
- **This PR** - Updates all v7 playgrounds to use `script setup` syntax
- [#4243](https://github.com/ionic-team/ionic-docs/pull/4243) - Updates all references to Vue code in the guide & API docs to use `script setup` syntax