### PR TITLE
feat(styles): add background to code block title

### DIFF
--- a/src/styles/components/_code.scss
+++ b/src/styles/components/_code.scss
@@ -51,12 +51,9 @@ code {
 // Overrides
 #__docusaurus {
   [class*='codeBlockContainer_'] {
-    box-shadow: none;
-  }
+    --prism-background-color: var(--code-block-bg-c);
 
-  // Code block title
-  [class*='codeBlockTitle_'] {
-    background: var(--code-block-bg-c);
+    box-shadow: none;
   }
 }
 
@@ -68,7 +65,6 @@ code {
 
 code[class*='language-'],
 pre[class*='language-'] {
-  background: var(--code-block-bg-c);
   white-space: pre;
   word-spacing: normal;
   word-break: normal;


### PR DESCRIPTION
Updated the background for the code block title to match the code background. Inspired by the [Docusaurus examples](https://docusaurus.io/docs/markdown-features/code-blocks).

You can see an example of `title` being used on the React: Add to Existing guide ([Before](https://ionicframework.com/docs/react/adding-ionic-react-to-an-existing-react-project#using-individual-ionic-components) | [After](https://ionic-docs-git-feat-code-block-title-ionic1.vercel.app/docs/react/adding-ionic-react-to-an-existing-react-project#using-individual-ionic-components)).

| Before | After |
| --- | --- |
| ![Before: Light Mode](https://github.com/user-attachments/assets/1a9e050d-854e-44ee-8c96-25ef366b9892) | ![After: Light Mode](https://github.com/user-attachments/assets/900e126f-b6a4-4775-b2a7-480edf9d405b) |
| ![Before: Dark Mode](https://github.com/user-attachments/assets/a16bcac4-c8e0-411e-b67e-6a0c0af51c3b) | ![After: Dark Mode](https://github.com/user-attachments/assets/6a0c914b-823d-480b-b34d-b84939152617) |