### PR TITLE
chore(react): remove old files that are no longer used

### DIFF
--- a/docs/react/adding-ionic-react-to-an-existing-react-project.md
+++ b/docs/react/adding-ionic-react-to-an-existing-react-project.md
@@ -1,6 +1,0 @@
----
-title: Add to Existing React Project
-sidebar_label: Add to Existing
----
-
-This page has moved. Go to [Add to Existing](/docs/react/add-to-existing).

--- a/versioned_docs/version-v7/react/adding-ionic-react-to-an-existing-react-project.md
+++ b/versioned_docs/version-v7/react/adding-ionic-react-to-an-existing-react-project.md
@@ -1,6 +1,0 @@
----
-title: Add to Existing React Project
-sidebar_label: Add to Existing
----
-
-This page has moved. Go to [Add to Existing](/docs/react/add-to-existing).


### PR DESCRIPTION
These React guides were renamed in https://github.com/ionic-team/ionic-docs/pull/4286 but not deleted because we need to update the JP docs before we can delete them. These files should not be reachable due to redirects so they are safe to delete.

⚠️ This PR should not be merged until https://github.com/ionic-team/ionic-docs/pull/4334 is merged. ⚠️ 