### PR TITLE
fix(styles): stretch single card to full width on smaller screens

### DIFF
--- a/src/components/global/DocsCards/cards.css
+++ b/src/components/global/DocsCards/cards.css
@@ -9,7 +9,7 @@ docs-cards {
  * This prevents a single card from stretching the full width by
  * adding an invisible pseudo-element as a second grid item. This
  * creates a 2-column layout on larger screens (card takes 1 column)
- * and collapses to full width on smaller screens. Used on the
+ * and collapses to full width on smaller screens. This is used on the
  * Packages & CDN page by the JavaScript section.
  */
 docs-cards:has(docs-card:only-child)::after {


### PR DESCRIPTION
When viewing on mobile I realized the JavaScript card was still only taking up 50% of the available width. This PR updates the styles to fake a grid item to allow it it to grow to 100% width on smaller screens but only 1 column width on larger ones.

| Before | After |
| --- | --- |
| ![before-small](https://github.com/user-attachments/assets/b4b88164-06a9-4ac1-a5a3-5ce597b09c75) | ![after-small](https://github.com/user-attachments/assets/939da66c-c6e8-4b51-8c12-16feaccc11d5) |
| ![before-large](https://github.com/user-attachments/assets/7c789437-de1b-44ec-8bbe-3179f3619882) | ![after-large](https://github.com/user-attachments/assets/f04e0dbf-ada7-4f3a-aac1-1d849ddebec4) |

## Previews

This was done to fix the Packages & CDN guide but I've included some other guides that use cards to verify their behavior hasn't changed:
- [Packages & CDN Preview](https://ionic-docs-git-fix-card-styles-ionic1.vercel.app/docs/intro/cdn)
- [Quickstart](https://ionic-docs-git-fix-card-styles-ionic1.vercel.app/docs/javascript/quickstart#explore-more)
- [Components](https://ionic-docs-git-fix-card-styles-ionic1.vercel.app/docs/components)