### PR TITLE
docs(item): document required react version for ionic v9

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -65,6 +65,7 @@ Note that later versions of Ionic do not support iOS 13; see [mobile support tab
 
 | Framework | Required React Version | TypeScript |
 | :-------: | :--------------------: | :--------: |
+|    v9     |          v18+          |    3.7+    |
 |    v8     |          v17+          |    3.7+    |
 |    v7     |          v17+          |    3.7+    |
 |    v6     |          v17+          |    3.7+    |


### PR DESCRIPTION
## Description
Document v9 support for React 18+ in docs/reference/support.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [X] Documentation

## Rationale / Problems Fixed
Support for React 17 is dropped in https://github.com/ionic-team/ionic-framework/pull/31063.