### PR TITLE
fix(api): do not render a code block for unnamed slots

### DIFF
--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -331,7 +331,12 @@ function renderSlots({ slots }) {
   return `
 | Name | Description |
 | --- | --- |
-${slots.map((slot) => `| \`${slot.name}\` | ${formatMultiline(slot.docs)} |`).join('\n')}
-
+${slots
+  .map((slot) => {
+    const slotName = slot.name?.trim();
+    const displayedSlotName = slotName ? `\`${slotName}\`` : '';
+    return `| ${displayedSlotName} | ${formatMultiline(slot.docs)} |`;
+  })
+  .join('\n')}
 `;
 }


### PR DESCRIPTION
When the slots table renders a slot with no name, it shows up as backticks only. See [item](https://ionicframework.com/docs/api/item#slots):

<img width="1070" height="453" alt="before" src="https://github.com/user-attachments/assets/2f6cfd07-5dab-4752-9f22-3302ba8f5e5c" />

This PR updates it to [not render anything](https://ionic-docs-git-fix-slots-render-ionic1.vercel.app/docs/api/item#slots):

<img width="1070" height="453" alt="after" src="https://github.com/user-attachments/assets/0880fbab-a251-4282-b111-ba43020bc3e7" />
