### PR TITLE
chore(playground): use vue code fence in Vue playground template

### DIFF
--- a/_templates/playground/new/vue.md.ejs.t
+++ b/_templates/playground/new/vue.md.ejs.t
@@ -2,7 +2,7 @@
 arbitrary: <% pascalComponent = h.changeCase.pascal(component) %>
 to: "<%= `static/usage/v${version}/${name}/${path}/vue.md` %>"
 ---
-```html
+```vue
 <template>
   <<%= component %>></<%= component %>>
 </template>


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

The Vue playground template uses a ` ```html ` code fence, which doesn't provide accurate syntax highlighting for `.vue` single-file components.

## What is the new behavior?

The code fence is updated to ` ```vue `, enabling proper Vue syntax highlighting for the generated playground files.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Docs now supports `vue` as a [valid syntax highlighting language](https://github.com/ionic-team/ionic-docs/pull/4311), making this change viable. Since playground files are generated from this template via `npm run playground:new`, all newly generated Vue examples will benefit from accurate highlighting going forward.