### PR TITLE
fix(api): prefix the property and method headings to avoid duplicates

### DIFF
--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -132,6 +132,38 @@ function formatMultiline(str) {
   return str.split('\n\n').join('<br /><br />').split('\n').join(' ');
 }
 
+/**
+ * Kebab-case slug for API identifiers (camelCase props, method names).
+ */
+function apiIdentifierSlug(name) {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/_/g, '-')
+    .toLowerCase();
+}
+
+/**
+ * Heading id for Properties subheadings.
+ * Prefixes IDs with `prop-` so they never collide with narrative sections on the same
+ * doc page that use headings like "Shape", "Fill", or "Size".
+ *
+ * Anchors become `#prop-${slug}` rather than `#${slug}`.
+ */
+function propertyHeadingId(propName) {
+  return `prop-${apiIdentifierSlug(propName)}`;
+}
+
+/**
+ * Heading id for Methods subheadings.
+ * Prefixes IDs with `method-` so they never collide with narrative sections on the same
+ * doc page that use headings like "Dismiss", "Present", or "Close".
+ *
+ * Anchors become `#method-${slug}` rather than `#${slug}`.
+ */
+function methodHeadingId(methodName) {
+  return `method-${apiIdentifierSlug(methodName)}`;
+}
+
 function formatType(attr, type) {
   if (attr === 'color') {
     /**
@@ -181,7 +213,7 @@ ${properties
     }
 
     return `
-### ${prop.name} ${isDeprecated ? '(deprecated)' : ''}
+### ${prop.name} ${isDeprecated ? '(deprecated)' : ''} {#${propertyHeadingId(prop.name)}}
 
 | | |
 | --- | --- |
@@ -243,7 +275,7 @@ function renderMethods({ methods }) {
 ${methods
   .map(
     (method) => `
-### ${method.name}
+### ${method.name} {#${methodHeadingId(method.name)}}
 
 | | |
 | --- | --- |


### PR DESCRIPTION
On certain component API pages the sections containing playground demos are sometimes named the same as a property name. When you click on one of the property names, it will link you to the top section instead of the property. 

### Reproduction

To reproduce:

1. Go to the button api page here: https://ionicframework.com/docs/api/button
2. Click on any of the highlighted links under `Properties` below:
    <img width="300" alt="CleanShot 2026-05-13 at 11 00 24@2x" src="https://github.com/user-attachments/assets/10520553-3fba-4865-a1c5-0b587cf316c9" />
3. See that the associated section in the first highlighted box is navigated to.

This can be reproduced on the following components:
- [Button](https://ionicframework.com/docs/api/button) (see above)
- [Input OTP](https://ionicframework.com/docs/api/input-otp) (type, shape, fill, size, separators, pattern)
- [Segment Button](https://ionicframework.com/docs/api/segment-button) (layout)
- [Toast](https://ionicframework.com/docs/api/toast) (layout)
- [Ripple Effect](https://ionicframework.com/docs/api/ripple-effect) (type)
- Potentially others

### Solution

I updated both the properties and methods to prefix the headings with `#prop-` and `#method-`, respectively. While I didn't find any examples of collisions with the method headings, I wanted to avoid future collisions with names like `dismiss`, `close`, etc.

I did not modify Events, CSS Shadow Parts, CSS Custom Properties or Slots because those render tables.

I also updated the slug so that camelCase properties and methods will render as kebab case. For example, `contentId` on Segment Button was [`#contentid`](https://ionicframework.com/docs/api/segment-button#contentid). and is now [`#prop-content-id`](https://ionic-docs-git-fix-heading-anchors-ionic1.vercel.app/docs/api/segment-button#prop-content-id). The Refresher method `getProgress` was [`#getprogress`](https://ionicframework.com/docs/api/refresher#getprogress) and is now [`#method-get-progress`](https://ionic-docs-git-fix-heading-anchors-ionic1.vercel.app/docs/api/refresher#method-get-progress). I can revert this if we do not want the url slugs to use kebab case.

You can see my fix on any of the above components: [Preview](https://ionic-docs-git-fix-heading-anchors-ionic1.vercel.app/docs/components)

---

### Alternative solution:

If we don't like changing all of the property links we could change the playground section heading ids like this:

```diff
-## Size
+## Size {#button-size}
```

Which would change the link from `#size` to `#button-size`. However, we would have to remember to do this each time we add a new section heading that is the same as a property or method name.