### PR TITLE
docs(deployment): update Play Store deployment instructions

### DIFF
--- a/docs/deployment/play-store.mdx
+++ b/docs/deployment/play-store.mdx
@@ -23,7 +23,7 @@ If you are using Capacitor, you can additionally refer to the Capacitor document
 To generate a release build for Android, build your web app and then run the following cli command:
 
 ```shell
-npx cap copy && npx cap sync
+npx cap sync
 ```
 
 This will copy all web assets and sync any plugin changes.

--- a/versioned_docs/version-v6/deployment/play-store.mdx
+++ b/versioned_docs/version-v6/deployment/play-store.mdx
@@ -23,7 +23,7 @@ If you are using Capacitor, you can additionally refer to the Capacitor document
 To generate a release build for Android, build your web app and then run the following cli command:
 
 ```shell
-npx cap copy && npx cap sync
+npx cap sync
 ```
 
 This will copy all web assets and sync any plugin changes.

--- a/versioned_docs/version-v7/deployment/play-store.mdx
+++ b/versioned_docs/version-v7/deployment/play-store.mdx
@@ -23,7 +23,7 @@ If you are using Capacitor, you can additionally refer to the Capacitor document
 To generate a release build for Android, build your web app and then run the following cli command:
 
 ```shell
-npx cap copy && npx cap sync
+npx cap sync
 ```
 
 This will copy all web assets and sync any plugin changes.


### PR DESCRIPTION
Was confusing me because during dev I only ever used `cap sync` and wondered why I suddenly need `cap copy` for play store.

`cap --help` says

> sync [options] [platform]         copy + update

## Description
<!--- Describe your changes in detail -->

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation
- [ ] Other (CI, chores, etc.)
