### PR TITLE
docs(updating): document @ionic/core package exports field in v9 upgrade guide

### DIFF
--- a/cspell-wordlist.txt
+++ b/cspell-wordlist.txt
@@ -62,6 +62,8 @@ runtimes
 scroller
 subcomponent
 subcomponents
+subpath
+subpaths
 swipeable
 templating
 transpiling

--- a/docs/updating/9-0.md
+++ b/docs/updating/9-0.md
@@ -300,6 +300,23 @@ For more information on migrating from Vue Router v4 to v5, refer to the [Vue Ro
 npm install @ionic/core@latest
 ```
 
+#### Package Exports
+
+`@ionic/core`'s `package.json` now declares an `exports` field. This fixes subpaths like `@ionic/core/components` and `@ionic/core/loader` failing under Node ESM with `ERR_UNSUPPORTED_DIR_IMPORT`. The strict ESM resolver doesn't read the nested `package.json` files the package previously relied on, and the `exports` field replaces them. This affects toolchains such as Angular 21's default Vitest builder and raw Node.
+
+The `exports` field defines the supported public entry points, and imports of paths it doesn't cover will fail. If your app uses Node ESM, webpack 5, or TypeScript `moduleResolution: "bundler"`, `"node16"`, or `"nodenext"` and imports from an unsupported path, switch to one of the subpaths below:
+
+| Subpath                           | Use                                              |
+| --------------------------------- | ------------------------------------------------ |
+| `@ionic/core`                     | Root entry, controllers, animation builders      |
+| `@ionic/core/components`          | Custom-element constructors and shared utilities |
+| `@ionic/core/components/ion-*.js` | Single-component custom-element constructor      |
+| `@ionic/core/loader`              | `defineCustomElements` lazy loader               |
+| `@ionic/core/hydrate`             | SSR hydration entry                              |
+| `@ionic/core/css/*.css`           | Global stylesheets and palettes                  |
+
+Apps on `moduleResolution: "node"` (classic) and webpack 4 keep resolving through the legacy fields and need no changes.
+
 ### Legacy Picker
 
 1. Remove any usages of the `ion-picker-legacy` and `ion-picker-legacy-column` components. These components have been removed in Ionic 9. The recommended path forward is to use `ion-picker` inside a modal. Review the [Picker in Modal documentation](../api/picker.md#picker-in-modal) for more information.


### PR DESCRIPTION
Adds a "Package Exports" subsection to the Ionic 9 upgrade guide, related to this PR: https://github.com/ionic-team/ionic-framework/pull/31180
