### PR TITLE
docs(datetime): fix a spelling mistake in the API documentation

### DIFF
--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -364,7 +364,7 @@ The selected date will not render if `preferWheel` is set to `true`.
 
 <DatetimeHeaderStyling />
 
-### Calender Header
+### Calendar Header
 
 The calendar header manages the date navigation controls (month/year picker and prev/next buttons) and the days of the week when using a grid style layout.
 

--- a/versioned_docs/version-v7/api/datetime.md
+++ b/versioned_docs/version-v7/api/datetime.md
@@ -342,7 +342,7 @@ The benefit of this approach is that every component, not just `ion-datetime`, c
 
 <GlobalTheming />
 
-### Calender Header
+### Calendar Header
 
 The calendar header manages the date navigation controls (month/year picker and prev/next buttons) and the days of the week when using a grid style layout.
 


### PR DESCRIPTION
## Description
Fixed a typo in the Datetime API documentation. Changed the heading "Calender Header" to "Calendar Header" to correct the spelling.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
There was a spelling mistake in the title of the calendar header datetime API. This minor correction improves the Ionic documentation.

## Tests or Reproductions
Since this is just a simple text change in the documentation, there is no need to perform code testing or set up test projects. Here is the URL for the error:
https://ionicframework.com/docs/api/datetime#calender-header

## Platforms Affected
- [ ] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
Just a simple typo fix to improve the docs. Thank you!
