### PR TITLE
docs(gallery): add a note about supporting css variables in gap

### DIFF
--- a/docs/api/gallery.md
+++ b/docs/api/gallery.md
@@ -107,6 +107,11 @@ import Columns from '@site/static/usage/v9/gallery/columns/index.md';
 
 Gap can be configured with the `gap` property using either a single value for a fixed gap, or a breakpoint map to change gap across screen sizes.
 
+Whether provided as a single value or as a value inside a breakpoint map, each gap value can be either a **string** or a **number**:
+
+- A **string** can be any valid CSS [length-percentage](https://developer.mozilla.org/en-US/docs/Web/CSS/length-percentage) (such as `16px`, `1rem`, or `20%`), a math function (such as `calc(1rem + 8px)`), or a CSS variable (such as `var(--app-gallery-gap)`).
+- A **number** is treated as a pixel value, so `16` is equivalent to `"16px"`.
+
 If no value is provided, or if an invalid value is used, the gallery falls back to its default gap value. The default value is `16px`.
 
 import Gap from '@site/static/usage/v9/gallery/gap/index.md';

--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -57,7 +57,7 @@ module.exports = function (context, options) {
       // TODO(FW-7097): Replace this with `latest` when v9 is released.
       // Dev build based on the `next` branch of `ionic-framework`.
       // This must be used to build the docs with the new components.
-      let npmTag = '8.8.7-dev.11779221548.1d38f927';
+      let npmTag = '8.8.9-dev.11780493108.1d8e1a89';
       if (currentVersion.banner === 'unreleased') {
         npmTag = 'next';
       } else if (currentVersion.path !== undefined) {


### PR DESCRIPTION
[Preview](https://ionic-docs-git-fw-7299-ionic1.vercel.app/docs/api/gallery#gap)

Note: You must install the dev build if you want the demos to work.

Dev build: `8.8.9-dev.11780493108.1d8e1a89`