### PR TITLE
docs(support): update support tables for v9 and enterprise

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -22,7 +22,8 @@ The current status of each Ionic Framework version is:
 
 | Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :------------: | :----------: | :--------------: | :---------------: |
-|   V8    |   **Active**   | Apr 17, 2024 |       TBD        |        TBD        |
+|   V9    |   **Active**   |     TBD      |       TBD        |        TBD        |
+|   V8    |   Maintenance  | Apr 17, 2024 |       TBD        |        TBD        |
 |   V7    | End of Support | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
 |   V6    | End of Support | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
 |   V5    | End of Support | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
@@ -32,7 +33,7 @@ The current status of each Ionic Framework version is:
 |   V1    | End of Support | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
-- **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).
+- **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available.
 
 ## Compatibility Recommendations
 

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -23,7 +23,7 @@ The current status of each Ionic Framework version is:
 | Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :------------: | :----------: | :--------------: | :---------------: |
 |   V9    |   **Active**   |     TBD      |       TBD        |        TBD        |
-|   V8    |   Maintenance  | Apr 17, 2024 |       TBD        |        TBD        |
+|   V8    |  Maintenance   | Apr 17, 2024 |       TBD        |        TBD        |
 |   V7    | End of Support | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
 |   V6    | End of Support | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
 |   V5    | End of Support | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |

--- a/versioned_docs/version-v5/reference/support.md
+++ b/versioned_docs/version-v5/reference/support.md
@@ -19,7 +19,7 @@ The current status of each Ionic Framework version is:
 |   V1    | End of Support | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
-- **Extended Support**: For teams and organizations that require additional long term support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).
+- **Extended Support**: For teams and organizations that require additional long term support, Ionic has extended support options available.
 
 ## Compatibility Recommendations
 

--- a/versioned_docs/version-v6/reference/support.md
+++ b/versioned_docs/version-v6/reference/support.md
@@ -30,7 +30,7 @@ The current status of each Ionic Framework version is:
 |   V1    |  End of Support  | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
-- **Extended Support**: For teams and organizations that require additional long term support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).
+- **Extended Support**: For teams and organizations that require additional long term support, Ionic has extended support options available.
 
 ## Compatibility Recommendations
 

--- a/versioned_docs/version-v7/reference/support.md
+++ b/versioned_docs/version-v7/reference/support.md
@@ -31,7 +31,7 @@ The current status of each Ionic Framework version is:
 |   V1    |   End of Support   | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
-- **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).
+- **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available.
 
 ## Compatibility Recommendations
 

--- a/versioned_docs/version-v8/reference/support.md
+++ b/versioned_docs/version-v8/reference/support.md
@@ -20,16 +20,16 @@ Given the reality of time and resource constraints as well as the desire to keep
 
 The current status of each Ionic Framework version is:
 
-| Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
-| :-----: | :--------------: | :----------: | :--------------: | :---------------: |
-|   V8    | **Maintenance**  | Apr 17, 2024 |       TBD        |        TBD        |
-|   V7    |  End of Support  | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
-|   V6    |  End of Support  | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
-|   V5    |  End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
-|   V4    |  End of Support  | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
-|   V3    |  End of Support  | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
-|   V2    |  End of Support  | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
-|   V1    |  End of Support  | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
+| Version |     Status      |   Released   | Maintenance Ends | Ext. Support Ends |
+| :-----: | :-------------: | :----------: | :--------------: | :---------------: |
+|   V8    | **Maintenance** | Apr 17, 2024 |       TBD        |        TBD        |
+|   V7    | End of Support  | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
+|   V6    | End of Support  | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
+|   V5    | End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
+|   V4    | End of Support  | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
+|   V3    | End of Support  | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
+|   V2    | End of Support  | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
+|   V1    | End of Support  | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
 - **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available.

--- a/versioned_docs/version-v8/reference/support.md
+++ b/versioned_docs/version-v8/reference/support.md
@@ -20,19 +20,19 @@ Given the reality of time and resource constraints as well as the desire to keep
 
 The current status of each Ionic Framework version is:
 
-| Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
-| :-----: | :------------: | :----------: | :--------------: | :---------------: |
-|   V8    |   **Active**   | Apr 17, 2024 |       TBD        |        TBD        |
-|   V7    | End of Support | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
-|   V6    | End of Support | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
-|   V5    | End of Support | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
-|   V4    | End of Support | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
-|   V3    | End of Support | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
-|   V2    | End of Support | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
-|   V1    | End of Support | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
+| Version |      Status      |   Released   | Maintenance Ends | Ext. Support Ends |
+| :-----: | :--------------: | :----------: | :--------------: | :---------------: |
+|   V8    | **Maintenance**  | Apr 17, 2024 |       TBD        |        TBD        |
+|   V7    |  End of Support  | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
+|   V6    |  End of Support  | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
+|   V5    |  End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |
+|   V4    |  End of Support  | Jan 23, 2019 |   Aug 11, 2020   |   Sept 30, 2022   |
+|   V3    |  End of Support  | Apr 5, 2017  |   Oct 30, 2019   |   Aug 11, 2020    |
+|   V2    |  End of Support  | Jan 25, 2017 |   Apr 5, 2017    |    Apr 5, 2017    |
+|   V1    |  End of Support  | May 12, 2015 |   Jan 25, 2017   |   Jan 25, 2017    |
 
 - **Maintenance**: Only critical bug and security fixes. No major feature improvements.
-- **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available. To learn more, see our [Enterprise offerings](https://ionicframework.com/enterprise).
+- **Extended Support**: For teams and organizations that require additional long term maintenance support, Ionic has extended support options available.
 
 ## Compatibility Recommendations
 


### PR DESCRIPTION
Updates the support guide to add v9 and mark v8 as maintenance, plus removes the old enterprise links.