### PR TITLE
docs(angular): update standalone import paths in v9 static assets

### DIFF
--- a/static/code/stackblitz/v9/angular/app.component.ts
+++ b/static/code/stackblitz/v9/angular/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonApp } from '@ionic/angular/standalone';
+import { IonApp } from '@ionic/angular';
 import { ExampleComponent } from './example.component';
 
 @Component({

--- a/static/code/stackblitz/v9/angular/app.component.withContent.ts
+++ b/static/code/stackblitz/v9/angular/app.component.withContent.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonApp, IonContent } from '@ionic/angular/standalone';
+import { IonApp, IonContent } from '@ionic/angular';
 import { ExampleComponent } from './example.component';
 
 @Component({

--- a/static/code/stackblitz/v9/angular/main.ts
+++ b/static/code/stackblitz/v9/angular/main.ts
@@ -1,7 +1,7 @@
 import { provideZoneChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
-import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';

--- a/static/usage/v9/accordion/accessibility/animations/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/accessibility/animations/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/basic/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/customization/advanced-expansion-styles/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/customization/advanced-expansion-styles/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/customization/expansion-styles/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/customization/expansion-styles/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/customization/icons/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/customization/icons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { caretDownCircle } from 'ionicons/icons';
 

--- a/static/usage/v9/accordion/customization/theming/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/customization/theming/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/disable/group/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/disable/group/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/disable/individual/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/disable/individual/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/listen-changes/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/listen-changes/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/multiple/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/multiple/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/readonly/group/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/readonly/group/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/readonly/individual/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/readonly/individual/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/accordion/toggle/angular/example_component_ts.md
+++ b/static/usage/v9/accordion/toggle/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import { IonAccordion, IonAccordionGroup, IonButton, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAccordion, IonAccordionGroup, IonButton, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/action-sheet/controller/angular/example_component_ts.md
+++ b/static/usage/v9/action-sheet/controller/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { ActionSheetController, IonButton } from '@ionic/angular/standalone';
+import { ActionSheetController, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/action-sheet/inline/isOpen/angular/example_component_ts.md
+++ b/static/usage/v9/action-sheet/inline/isOpen/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
+import { IonActionSheet, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/action-sheet/inline/trigger/angular/example_component_ts.md
+++ b/static/usage/v9/action-sheet/inline/trigger/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
+import { IonActionSheet, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
+++ b/static/usage/v9/action-sheet/role-info-on-dismiss/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
+import { IonActionSheet, IonButton } from '@ionic/angular';
 import type { OverlayEventDetail } from '@ionic/core';
 
 @Component({

--- a/static/usage/v9/action-sheet/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/action-sheet/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
+import { IonActionSheet, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/action-sheet/theming/styling/angular/example_component_ts.md
+++ b/static/usage/v9/action-sheet/theming/styling/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonActionSheet, IonButton } from '@ionic/angular/standalone';
+import { IonActionSheet, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/alert/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/alert/buttons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import { IonAlert, IonButton } from '@ionic/angular';
 import type { OverlayEventDetail } from '@ionic/core';
 
 @Component({

--- a/static/usage/v9/alert/customization/angular/example_component_ts.md
+++ b/static/usage/v9/alert/customization/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import { IonAlert, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/alert/inputs/radios/angular/example_component_ts.md
+++ b/static/usage/v9/alert/inputs/radios/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import { IonAlert, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/alert/inputs/text-inputs/angular/example_component_ts.md
+++ b/static/usage/v9/alert/inputs/text-inputs/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import { IonAlert, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/alert/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v9/alert/presenting/controller/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { AlertController, IonButton } from '@ionic/angular/standalone';
+import { AlertController, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/alert/presenting/isOpen/angular/example_component_ts.md
+++ b/static/usage/v9/alert/presenting/isOpen/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import { IonAlert, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/alert/presenting/trigger/angular/example_component_ts.md
+++ b/static/usage/v9/alert/presenting/trigger/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAlert, IonButton } from '@ionic/angular/standalone';
+import { IonAlert, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/basic/angular/example_component_ts.md
+++ b/static/usage/v9/animations/basic/angular/example_component_ts.md
@@ -1,8 +1,8 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { IonButton, IonCard, IonCardContent } from '@ionic/angular/standalone';
-import type { Animation } from '@ionic/angular/standalone';
-import { AnimationController } from '@ionic/angular/standalone';
+import { IonButton, IonCard, IonCardContent } from '@ionic/angular';
+import type { Animation } from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/before-and-after-hooks/angular/example_component_ts.md
+++ b/static/usage/v9/animations/before-and-after-hooks/angular/example_component_ts.md
@@ -1,9 +1,9 @@
 ```ts
 import { Component, ElementRef, ViewChildren } from '@angular/core';
-import { IonButton, IonCard, IonCardContent } from '@ionic/angular/standalone';
+import { IonButton, IonCard, IonCardContent } from '@ionic/angular';
 import type { QueryList } from '@angular/core';
-import type { Animation } from '@ionic/angular/standalone';
-import { AnimationController } from '@ionic/angular/standalone';
+import type { Animation } from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/chain/angular/example_component_ts.md
+++ b/static/usage/v9/animations/chain/angular/example_component_ts.md
@@ -1,9 +1,9 @@
 ```ts
 import { Component, ElementRef, ViewChildren } from '@angular/core';
-import { IonButton, IonCard, IonCardContent } from '@ionic/angular/standalone';
+import { IonButton, IonCard, IonCardContent } from '@ionic/angular';
 import type { QueryList } from '@angular/core';
-import type { Animation } from '@ionic/angular/standalone';
-import { AnimationController } from '@ionic/angular/standalone';
+import type { Animation } from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/gesture/angular/example_component_ts.md
+++ b/static/usage/v9/animations/gesture/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { AnimationController, GestureController, IonCard, IonCardContent } from '@ionic/angular/standalone';
-import type { Animation, Gesture, GestureDetail } from '@ionic/angular/standalone';
+import { AnimationController, GestureController, IonCard, IonCardContent } from '@ionic/angular';
+import type { Animation, Gesture, GestureDetail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/group/angular/example_component_ts.md
+++ b/static/usage/v9/animations/group/angular/example_component_ts.md
@@ -1,9 +1,9 @@
 ```ts
 import { Component, ElementRef, ViewChildren } from '@angular/core';
-import { IonButton, IonCard, IonCardContent } from '@ionic/angular/standalone';
+import { IonButton, IonCard, IonCardContent } from '@ionic/angular';
 import type { QueryList } from '@angular/core';
-import type { Animation } from '@ionic/angular/standalone';
-import { AnimationController } from '@ionic/angular/standalone';
+import type { Animation } from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/keyframes/angular/example_component_ts.md
+++ b/static/usage/v9/animations/keyframes/angular/example_component_ts.md
@@ -1,8 +1,8 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { IonButton, IonCard, IonCardContent } from '@ionic/angular/standalone';
-import type { Animation } from '@ionic/angular/standalone';
-import { AnimationController } from '@ionic/angular/standalone';
+import { IonButton, IonCard, IonCardContent } from '@ionic/angular';
+import type { Animation } from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/modal-override/angular/example_component_ts.md
+++ b/static/usage/v9/animations/modal-override/angular/example_component_ts.md
@@ -8,8 +8,8 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
-import { AnimationController } from '@ionic/angular/standalone';
+} from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/animations/modal-override/angular/example_component_ts.md
+++ b/static/usage/v9/animations/modal-override/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import {
-  IonButton,
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonModal,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButton, IonButtons, IonContent, IonHeader, IonModal, IonTitle, IonToolbar } from '@ionic/angular';
 import { AnimationController } from '@ionic/angular';
 
 @Component({

--- a/static/usage/v9/animations/preference-based/angular/example_component_ts.md
+++ b/static/usage/v9/animations/preference-based/angular/example_component_ts.md
@@ -1,8 +1,8 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { IonButton, IonCard, IonCardContent } from '@ionic/angular/standalone';
-import type { Animation } from '@ionic/angular/standalone';
-import { AnimationController } from '@ionic/angular/standalone';
+import { IonButton, IonCard, IonCardContent } from '@ionic/angular';
+import type { Animation } from '@ionic/angular';
+import { AnimationController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/app/set-focus/angular/example_component_ts.md
+++ b/static/usage/v9/app/set-focus/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonButton, IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/avatar/basic/angular/example_component_ts.md
+++ b/static/usage/v9/avatar/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAvatar } from '@ionic/angular/standalone';
+import { IonAvatar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/avatar/chip/angular/example_component_ts.md
+++ b/static/usage/v9/avatar/chip/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAvatar, IonChip, IonLabel } from '@ionic/angular/standalone';
+import { IonAvatar, IonChip, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/avatar/item/angular/example_component_ts.md
+++ b/static/usage/v9/avatar/item/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAvatar, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonAvatar, IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/avatar/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/avatar/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAvatar } from '@ionic/angular/standalone';
+import { IonAvatar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/back-button/basic/angular/example_component_ts.md
+++ b/static/usage/v9/back-button/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonNav } from '@ionic/angular/standalone';
+import { IonNav } from '@ionic/angular';
 
 import { PageOneComponent } from './page-one.component';
 

--- a/static/usage/v9/back-button/basic/angular/page_one_component_ts.md
+++ b/static/usage/v9/back-button/basic/angular/page_one_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonHeader, IonNavLink, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonNavLink, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { PageTwoComponent } from './page-two.component';
 

--- a/static/usage/v9/back-button/basic/angular/page_two_component_ts.md
+++ b/static/usage/v9/back-button/basic/angular/page_two_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-page-two',

--- a/static/usage/v9/back-button/custom/angular/example_component_ts.md
+++ b/static/usage/v9/back-button/custom/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonNav } from '@ionic/angular/standalone';
+import { IonNav } from '@ionic/angular';
 
 import { PageOneComponent } from './page-one.component';
 

--- a/static/usage/v9/back-button/custom/angular/page_one_component_ts.md
+++ b/static/usage/v9/back-button/custom/angular/page_one_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonHeader, IonNavLink, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonNavLink, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { PageTwoComponent } from './page-two.component';
 

--- a/static/usage/v9/back-button/custom/angular/page_two_component_ts.md
+++ b/static/usage/v9/back-button/custom/angular/page_two_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { caretBack } from 'ionicons/icons';

--- a/static/usage/v9/backdrop/basic/angular/example_component_ts.md
+++ b/static/usage/v9/backdrop/basic/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonItem,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/backdrop/styling/angular/example_component_ts.md
+++ b/static/usage/v9/backdrop/styling/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonHeader,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/backdrop/styling/angular/example_component_ts.md
+++ b/static/usage/v9/backdrop/styling/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonBackdrop,
-  IonButton,
-  IonCheckbox,
-  IonContent,
-  IonHeader,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonBackdrop, IonButton, IonCheckbox, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/badge/basic/angular/example_component_ts.md
+++ b/static/usage/v9/badge/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBadge, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonBadge, IonItem, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/badge/inside-tab-bar/angular/example_component_ts.md
+++ b/static/usage/v9/badge/inside-tab-bar/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular/standalone';
+import { IonBadge, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { heart, calendar, musicalNote } from 'ionicons/icons';
 

--- a/static/usage/v9/badge/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/badge/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBadge, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonBadge, IonItem, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/badge/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/badge/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBadge, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonBadge, IonItem, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/basic/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/collapsing-items/expand-on-click/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/collapsing-items/expand-on-click/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/collapsing-items/items-before-after/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/collapsing-items/items-before-after/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/collapsing-items/max-items/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/collapsing-items/max-items/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/collapsing-items/popover-on-click/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/collapsing-items/popover-on-click/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import {
-  IonBreadcrumb,
-  IonBreadcrumbs,
-  IonContent,
-  IonItem,
-  IonLabel,
-  IonList,
-  IonPopover,
-} from '@ionic/angular';
+import { IonBreadcrumb, IonBreadcrumbs, IonContent, IonItem, IonLabel, IonList, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/collapsing-items/popover-on-click/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/collapsing-items/popover-on-click/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonLabel,
   IonList,
   IonPopover,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/icons/custom-separators/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/icons/custom-separators/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs, IonIcon } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { arrowForwardCircle } from 'ionicons/icons';

--- a/static/usage/v9/breadcrumbs/icons/icons-on-items/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/icons/icons-on-items/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs, IonIcon, IonLabel } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs, IonIcon, IonLabel } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { camera, film, flash, home } from 'ionicons/icons';

--- a/static/usage/v9/breadcrumbs/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/breadcrumbs/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/breadcrumbs/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular/standalone';
+import { IonBreadcrumb, IonBreadcrumbs } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/button/basic/angular/example_component_ts.md
+++ b/static/usage/v9/button/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/button/expand/angular/example_component_ts.md
+++ b/static/usage/v9/button/expand/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/button/fill/angular/example_component_ts.md
+++ b/static/usage/v9/button/fill/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/button/icons/angular/example_component_ts.md
+++ b/static/usage/v9/button/icons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonIcon } from '@ionic/angular/standalone';
+import { IonButton, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { heart, logoApple, settingsSharp, star } from 'ionicons/icons';

--- a/static/usage/v9/button/shape/angular/example_component_ts.md
+++ b/static/usage/v9/button/shape/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonIcon } from '@ionic/angular/standalone';
+import { IonButton, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { heart } from 'ionicons/icons';

--- a/static/usage/v9/button/size/angular/example_component_ts.md
+++ b/static/usage/v9/button/size/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/button/text-wrapping/angular/example_component_ts.md
+++ b/static/usage/v9/button/text-wrapping/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/button/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/button/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/button/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/button/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton } from '@ionic/angular/standalone';
+import { IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/buttons/basic/angular/example_component_ts.md
+++ b/static/usage/v9/buttons/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonButtons, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonButtons, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/buttons/placement/angular/example_component_ts.md
+++ b/static/usage/v9/buttons/placement/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonButtons, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonButtons, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/buttons/types/angular/example_component_ts.md
+++ b/static/usage/v9/buttons/types/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonBackButton,
-  IonButton,
-  IonButtons,
-  IonIcon,
-  IonMenuButton,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonBackButton, IonButton, IonButtons, IonIcon, IonMenuButton, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { create, ellipsisHorizontal, ellipsisVertical, helpCircle, personCircle, search, star } from 'ionicons/icons';

--- a/static/usage/v9/buttons/types/angular/example_component_ts.md
+++ b/static/usage/v9/buttons/types/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonMenuButton,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { create, ellipsisHorizontal, ellipsisVertical, helpCircle, personCircle, search, star } from 'ionicons/icons';

--- a/static/usage/v9/card/basic/angular/example_component_ts.md
+++ b/static/usage/v9/card/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular/standalone';
+import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/card/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/card/buttons/angular/example_component_ts.md
@@ -7,7 +7,7 @@ import {
   IonCardHeader,
   IonCardSubtitle,
   IonCardTitle,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/card/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/card/buttons/angular/example_component_ts.md
@@ -1,13 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButton,
-  IonCard,
-  IonCardContent,
-  IonCardHeader,
-  IonCardSubtitle,
-  IonCardTitle,
-} from '@ionic/angular';
+import { IonButton, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/card/list/angular/example_component_ts.md
+++ b/static/usage/v9/card/list/angular/example_component_ts.md
@@ -10,7 +10,7 @@ import {
   IonLabel,
   IonList,
   IonThumbnail,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/card/media/angular/example_component_ts.md
+++ b/static/usage/v9/card/media/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular/standalone';
+import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/card/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/card/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular/standalone';
+import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/card/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/card/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular/standalone';
+import { IonCard, IonCardContent, IonCardHeader, IonCardSubtitle, IonCardTitle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/alignment/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/alignment/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonCheckbox, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/basic/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox } from '@ionic/angular/standalone';
+import { IonCheckbox } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/helper-error/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { IonCheckbox, IonButton } from '@ionic/angular/standalone';
+import { IonCheckbox, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/indeterminate/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/indeterminate/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox } from '@ionic/angular/standalone';
+import { IonCheckbox } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/justify/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/justify/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonCheckbox, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/label-link/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/label-link/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox } from '@ionic/angular/standalone';
+import { IonCheckbox } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/label-placement/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/label-placement/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox } from '@ionic/angular/standalone';
+import { IonCheckbox } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/checkbox/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox } from '@ionic/angular/standalone';
+import { IonCheckbox } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/chip/basic/angular/example_component_ts.md
+++ b/static/usage/v9/chip/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonChip } from '@ionic/angular/standalone';
+import { IonChip } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/chip/slots/angular/example_component_ts.md
+++ b/static/usage/v9/chip/slots/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAvatar, IonChip, IonIcon, IonLabel } from '@ionic/angular/standalone';
+import { IonAvatar, IonChip, IonIcon, IonLabel } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { close, closeCircle, pin } from 'ionicons/icons';

--- a/static/usage/v9/chip/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/chip/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonChip } from '@ionic/angular/standalone';
+import { IonChip } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/chip/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/chip/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonChip } from '@ionic/angular/standalone';
+import { IonChip } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/config/mode/angular/example_component_ts.md
+++ b/static/usage/v9/config/mode/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { Config, IonButton } from '@ionic/angular/standalone';
+import { Config, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/basic/angular/example_component_ts.md
+++ b/static/usage/v9/content/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent } from '@ionic/angular/standalone';
+import { IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/fixed/angular/example_component_ts.md
+++ b/static/usage/v9/content/fixed/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent } from '@ionic/angular/standalone';
+import { IonButton, IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/fullscreen/angular/example_component_ts.md
+++ b/static/usage/v9/content/fullscreen/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonFooter, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonFooter, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/header-footer/angular/example_component_ts.md
+++ b/static/usage/v9/content/header-footer/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonFooter, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonFooter, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/scroll-events/angular/example_component_ts.md
+++ b/static/usage/v9/content/scroll-events/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, ScrollDetail } from '@ionic/angular/standalone';
+import { IonContent, ScrollDetail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/scroll-methods/angular/example_component_ts.md
+++ b/static/usage/v9/content/scroll-methods/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import { IonButton, IonContent } from '@ionic/angular/standalone';
+import { IonButton, IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/content/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent } from '@ionic/angular/standalone';
+import { IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/content/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent } from '@ionic/angular/standalone';
+import { IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/content/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent } from '@ionic/angular/standalone';
+import { IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/content/theming/safe-area/angular/example_component_ts.md
+++ b/static/usage/v9/content/theming/safe-area/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent } from '@ionic/angular/standalone';
+import { IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime-button/basic/angular/example_component_ts.md
+++ b/static/usage/v9/datetime-button/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime, IonDatetimeButton, IonModal } from '@ionic/angular/standalone';
+import { IonDatetime, IonDatetimeButton, IonModal } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime-button/format-options/angular/example_component_ts.md
+++ b/static/usage/v9/datetime-button/format-options/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime, IonDatetimeButton, IonModal } from '@ionic/angular/standalone';
+import { IonDatetime, IonDatetimeButton, IonModal } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/basic/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/buttons/customizing-button-texts/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/buttons/customizing-button-texts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/buttons/customizing-buttons/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/buttons/customizing-buttons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonButtons, IonDatetime } from '@ionic/angular/standalone';
+import { IonButton, IonButtons, IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/buttons/showing-confirmation-buttons/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/buttons/showing-confirmation-buttons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/date-constraints/advanced/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/date-constraints/advanced/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/date-constraints/max-min/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/date-constraints/max-min/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/date-constraints/values/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/date-constraints/values/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/format-options/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/format-options/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/highlightedDates/array/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/highlightedDates/array/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/highlightedDates/callback/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/highlightedDates/callback/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/localization/custom-locale/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/localization/custom-locale/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/localization/first-day-of-week/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/localization/first-day-of-week/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/localization/hour-cycle/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/localization/hour-cycle/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/localization/locale-extension-tags/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/localization/locale-extension-tags/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/localization/time-label/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/localization/time-label/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/multiple/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/multiple/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/presentation/date/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/presentation/date/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/presentation/month-and-year/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/presentation/month-and-year/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/presentation/time/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/presentation/time/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/presentation/wheel/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/presentation/wheel/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/show-adjacent-days/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/show-adjacent-days/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/styling/calendar-days/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/styling/calendar-days/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 import { FormsModule } from '@angular/forms';
 
 // ViewEncapsulation is turned off for this demo due to

--- a/static/usage/v9/datetime/styling/global-theming/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/styling/global-theming/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/styling/wheel-styling/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/styling/wheel-styling/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, ViewEncapsulation } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 // ViewEncapsulation is turned off for this demo due to
 // a lack of support for styling multiple css shadow parts

--- a/static/usage/v9/datetime/title/customizing-title/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/title/customizing-title/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/datetime/title/showing-default-title/angular/example_component_ts.md
+++ b/static/usage/v9/datetime/title/showing-default-title/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonDatetime } from '@ionic/angular/standalone';
+import { IonDatetime } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/fab/basic/angular/example_component_ts.md
+++ b/static/usage/v9/fab/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFab, IonFabButton, IonIcon } from '@ionic/angular/standalone';
+import { IonFab, IonFabButton, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';

--- a/static/usage/v9/fab/before-content/angular/example_component_ts.md
+++ b/static/usage/v9/fab/before-content/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonItem,
   IonLabel,
   IonList,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';

--- a/static/usage/v9/fab/button-sizing/angular/example_component_ts.md
+++ b/static/usage/v9/fab/button-sizing/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';

--- a/static/usage/v9/fab/list-side/angular/example_component_ts.md
+++ b/static/usage/v9/fab/list-side/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionicons/icons';

--- a/static/usage/v9/fab/positioning/angular/example_component_ts.md
+++ b/static/usage/v9/fab/positioning/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonIcon,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import {

--- a/static/usage/v9/fab/positioning/angular/example_component_ts.md
+++ b/static/usage/v9/fab/positioning/angular/example_component_ts.md
@@ -1,15 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonContent,
-  IonFab,
-  IonFabButton,
-  IonFabList,
-  IonHeader,
-  IonIcon,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonContent, IonFab, IonFabButton, IonFabList, IonHeader, IonIcon, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import {

--- a/static/usage/v9/fab/safe-area/angular/example_component_ts.md
+++ b/static/usage/v9/fab/safe-area/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFab, IonFabButton, IonIcon } from '@ionic/angular/standalone';
+import { IonFab, IonFabButton, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add } from 'ionicons/icons';

--- a/static/usage/v9/fab/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/fab/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add, chevronBack, chevronDown, chevronForward, chevronUp } from 'ionicons/icons';

--- a/static/usage/v9/fab/theming/css-custom-properties/angular/example_component_ts.md
+++ b/static/usage/v9/fab/theming/css-custom-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';

--- a/static/usage/v9/fab/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/fab/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular/standalone';
+import { IonFab, IonFabButton, IonFabList, IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add, colorPalette, document, globe } from 'ionicons/icons';

--- a/static/usage/v9/footer/basic/angular/example_component_ts.md
+++ b/static/usage/v9/footer/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/footer/custom-scroll-target/angular/example_component_ts.md
+++ b/static/usage/v9/footer/custom-scroll-target/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/footer/fade/angular/example_component_ts.md
+++ b/static/usage/v9/footer/fade/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/footer/no-border/angular/example_component_ts.md
+++ b/static/usage/v9/footer/no-border/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/footer/translucent/angular/example_component_ts.md
+++ b/static/usage/v9/footer/translucent/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonFooter, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gallery/basic/angular/example_component_ts.md
+++ b/static/usage/v9/gallery/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonGallery, IonGalleryItem, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonGallery, IonGalleryItem, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gallery/columns/angular/example_component_ts.md
+++ b/static/usage/v9/gallery/columns/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonGallery, IonGalleryItem } from '@ionic/angular/standalone';
+import { IonGallery, IonGalleryItem } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gallery/gap/angular/example_component_ts.md
+++ b/static/usage/v9/gallery/gap/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonGallery, IonGalleryItem } from '@ionic/angular/standalone';
+import { IonGallery, IonGalleryItem } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gallery/images/angular/example_component_ts.md
+++ b/static/usage/v9/gallery/images/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonGallery, IonGalleryItem, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonGallery, IonGalleryItem, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gallery/masonry-best-fit/angular/example_component_ts.md
+++ b/static/usage/v9/gallery/masonry-best-fit/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonGallery, IonGalleryItem } from '@ionic/angular/standalone';
+import { IonGallery, IonGalleryItem } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gallery/masonry-sequential/angular/example_component_ts.md
+++ b/static/usage/v9/gallery/masonry-sequential/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonGallery, IonGalleryItem } from '@ionic/angular/standalone';
+import { IonGallery, IonGalleryItem } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gallery/uniform/angular/example_component_ts.md
+++ b/static/usage/v9/gallery/uniform/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonGallery, IonGalleryItem } from '@ionic/angular/standalone';
+import { IonGallery, IonGalleryItem } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gestures/basic/angular/example_component_ts.md
+++ b/static/usage/v9/gestures/basic/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { ChangeDetectorRef, Component, ElementRef, ViewChild } from '@angular/core';
-import { GestureController, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular/standalone';
-import type { GestureDetail } from '@ionic/angular/standalone';
+import { GestureController, IonCard, IonCardContent, IonCardHeader, IonCardSubtitle } from '@ionic/angular';
+import type { GestureDetail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/gestures/double-click/angular/example_component_ts.md
+++ b/static/usage/v9/gestures/double-click/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, ElementRef, ViewChild } from '@angular/core';
-import { GestureController, IonCard, IonCardContent } from '@ionic/angular/standalone';
+import { GestureController, IonCard, IonCardContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/basic/angular/example_component_ts.md
+++ b/static/usage/v9/grid/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/customizing/column-number/angular/example_component_ts.md
+++ b/static/usage/v9/grid/customizing/column-number/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/customizing/padding/angular/example_component_ts.md
+++ b/static/usage/v9/grid/customizing/padding/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/customizing/width/angular/example_component_ts.md
+++ b/static/usage/v9/grid/customizing/width/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/fixed/angular/example_component_ts.md
+++ b/static/usage/v9/grid/fixed/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/horizontal-alignment/angular/example_component_ts.md
+++ b/static/usage/v9/grid/horizontal-alignment/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/offset-responsive/angular/example_component_ts.md
+++ b/static/usage/v9/grid/offset-responsive/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/offset/angular/example_component_ts.md
+++ b/static/usage/v9/grid/offset/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/push-pull-responsive/angular/example_component_ts.md
+++ b/static/usage/v9/grid/push-pull-responsive/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/push-pull/angular/example_component_ts.md
+++ b/static/usage/v9/grid/push-pull/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/size-auto/angular/example_component_ts.md
+++ b/static/usage/v9/grid/size-auto/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonInput, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonInput, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/size-responsive/angular/example_component_ts.md
+++ b/static/usage/v9/grid/size-responsive/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/size/angular/example_component_ts.md
+++ b/static/usage/v9/grid/size/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/grid/vertical-alignment/angular/example_component_ts.md
+++ b/static/usage/v9/grid/vertical-alignment/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCol, IonGrid, IonRow } from '@ionic/angular/standalone';
+import { IonCol, IonGrid, IonRow } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/header/basic/angular/example_component_ts.md
+++ b/static/usage/v9/header/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/header/condense/angular/example_component_ts.md
+++ b/static/usage/v9/header/condense/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/header/custom-scroll-target/angular/example_component_ts.md
+++ b/static/usage/v9/header/custom-scroll-target/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/header/fade/angular/example_component_ts.md
+++ b/static/usage/v9/header/fade/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/header/no-border/angular/example_component_ts.md
+++ b/static/usage/v9/header/no-border/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/header/translucent/angular/example_component_ts.md
+++ b/static/usage/v9/header/translucent/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/icon/basic/angular/example_component_ts.md
+++ b/static/usage/v9/icon/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon } from '@ionic/angular/standalone';
+import { IonIcon } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { logoIonic } from 'ionicons/icons';

--- a/static/usage/v9/img/basic/angular/example_component_ts.md
+++ b/static/usage/v9/img/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonImg } from '@ionic/angular/standalone';
+import { IonImg } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/infinite-scroll/basic/angular/example_component_ts.md
+++ b/static/usage/v9/infinite-scroll/basic/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonItem,
   IonLabel,
   IonList,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v9/infinite-scroll/custom-infinite-scroll-content/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```tsx
 import { Component, OnInit } from '@angular/core';
-import { IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonAvatar, IonContent, IonInfiniteScroll, IonItem, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
+++ b/static/usage/v9/infinite-scroll/infinite-scroll-content/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonItem,
   IonLabel,
   IonList,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/basic/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/fill/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/fill/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/pattern/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/pattern/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/separators/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/separators/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/shape/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/shape/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/size/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/size/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/states/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/states/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   AbstractControl,
   ValidationErrors,
 } from '@angular/forms';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 function otpRequiredLength(length: number) {
   return (control: AbstractControl): ValidationErrors | null => {

--- a/static/usage/v9/input-otp/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-otp/type/angular/example_component_ts.md
+++ b/static/usage/v9/input-otp/type/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInputOtp } from '@ionic/angular/standalone';
+import { IonInputOtp } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input-password-toggle/basic/angular/example_component_ts.md
+++ b/static/usage/v9/input-password-toggle/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonInputPasswordToggle } from '@ionic/angular/standalone';
+import { IonInput, IonInputPasswordToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/basic/angular/example_component_ts.md
+++ b/static/usage/v9/input/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/clear/angular/example_component_ts.md
+++ b/static/usage/v9/input/clear/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/counter-alignment/angular/example_component_ts.md
+++ b/static/usage/v9/input/counter-alignment/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/counter/angular/example_component_ts.md
+++ b/static/usage/v9/input/counter/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput } from '@ionic/angular/standalone';
+import { IonInput } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/fill/angular/example_component_ts.md
+++ b/static/usage/v9/input/fill/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput } from '@ionic/angular/standalone';
+import { IonInput } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/filtering/angular/example_component_ts.md
+++ b/static/usage/v9/input/filtering/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/input/helper-error/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput } from '@ionic/angular/standalone';
+import { IonInput } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/label-placement/angular/example_component_ts.md
+++ b/static/usage/v9/input/label-placement/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/label-slot/angular/example_component_ts.md
+++ b/static/usage/v9/input/label-slot/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList, IonText } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList, IonText } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/mask/angular/example_component_ts.md
+++ b/static/usage/v9/input/mask/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 import { FormsModule } from '@angular/forms';
 
 import { MaskitoOptions, MaskitoElementPredicate, maskitoTransform } from '@maskito/core';

--- a/static/usage/v9/input/no-visible-label/angular/example_component_ts.md
+++ b/static/usage/v9/input/no-visible-label/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/set-focus/angular/example_component_ts.md
+++ b/static/usage/v9/input/set-focus/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonButton, IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/start-end-slots/angular/example_component_ts.md
+++ b/static/usage/v9/input/start-end-slots/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonIcon, IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonButton, IonIcon, IonInput, IonItem, IonList } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { eye, lockClosed } from 'ionicons/icons';

--- a/static/usage/v9/input/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/input/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput } from '@ionic/angular/standalone';
+import { IonInput } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/input/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput } from '@ionic/angular/standalone';
+import { IonInput } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/input/types/angular/example_component_ts.md
+++ b/static/usage/v9/input/types/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-divider/basic/angular/example_component_ts.md
+++ b/static/usage/v9/item-divider/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonItemDivider, IonItemGroup, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonItem, IonItemDivider, IonItemGroup, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-divider/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/item-divider/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItemDivider, IonLabel } from '@ionic/angular/standalone';
+import { IonItemDivider, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-divider/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/item-divider/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItemDivider, IonLabel } from '@ionic/angular/standalone';
+import { IonItemDivider, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-group/basic/angular/example_component_ts.md
+++ b/static/usage/v9/item-group/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonItemDivider, IonItemGroup, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonItemDivider, IonItemGroup, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-group/sliding-items/angular/example_component_ts.md
+++ b/static/usage/v9/item-group/sliding-items/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonItemOptions,
   IonItemSliding,
   IonLabel,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-sliding/basic/angular/example_component_ts.md
+++ b/static/usage/v9/item-sliding/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-sliding/expandable/angular/example_component_ts.md
+++ b/static/usage/v9/item-sliding/expandable/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item-sliding/icons/angular/example_component_ts.md
+++ b/static/usage/v9/item-sliding/icons/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonIcon,
-  IonItem,
-  IonItemOption,
-  IonItemOptions,
-  IonItemSliding,
-  IonLabel,
-  IonList,
-} from '@ionic/angular';
+import { IonIcon, IonItem, IonItemOption, IonItemOptions, IonItemSliding, IonLabel, IonList } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { archive, heart, trash } from 'ionicons/icons';

--- a/static/usage/v9/item-sliding/icons/angular/example_component_ts.md
+++ b/static/usage/v9/item-sliding/icons/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonItemSliding,
   IonLabel,
   IonList,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { archive, heart, trash } from 'ionicons/icons';

--- a/static/usage/v9/item/basic/angular/example_component_ts.md
+++ b/static/usage/v9/item/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/item/buttons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonIcon, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonButton, IonIcon, IonItem, IonLabel } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { home, navigate, star } from 'ionicons/icons';

--- a/static/usage/v9/item/clickable/angular/example_component_ts.md
+++ b/static/usage/v9/item/clickable/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/content-types/actions/angular/example_component_ts.md
+++ b/static/usage/v9/item/content-types/actions/angular/example_component_ts.md
@@ -13,7 +13,7 @@ import {
   IonList,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { pin, share, trash } from 'ionicons/icons';

--- a/static/usage/v9/item/content-types/controls/angular/example_component_ts.md
+++ b/static/usage/v9/item/content-types/controls/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonList,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/content-types/controls/angular/example_component_ts.md
+++ b/static/usage/v9/item/content-types/controls/angular/example_component_ts.md
@@ -1,15 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonCheckbox,
-  IonContent,
-  IonHeader,
-  IonInput,
-  IonItem,
-  IonList,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonCheckbox, IonContent, IonHeader, IonInput, IonItem, IonList, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/content-types/metadata/angular/example_component_ts.md
+++ b/static/usage/v9/item/content-types/metadata/angular/example_component_ts.md
@@ -11,7 +11,7 @@ import {
   IonText,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { chevronForward, listCircle } from 'ionicons/icons';

--- a/static/usage/v9/item/content-types/supporting-visuals/angular/example_component_ts.md
+++ b/static/usage/v9/item/content-types/supporting-visuals/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAvatar, IonIcon, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonAvatar, IonIcon, IonItem, IonLabel, IonList } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { airplane, bluetooth, call, wifi } from 'ionicons/icons';

--- a/static/usage/v9/item/content-types/text/angular/example_component_ts.md
+++ b/static/usage/v9/item/content-types/text/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/detail-arrows/angular/example_component_ts.md
+++ b/static/usage/v9/item/detail-arrows/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/inputs/angular/example_component_ts.md
+++ b/static/usage/v9/item/inputs/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonSelect,
   IonSelectOption,
   IonToggle,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/inputs/angular/example_component_ts.md
+++ b/static/usage/v9/item/inputs/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonCheckbox,
-  IonInput,
-  IonItem,
-  IonRange,
-  IonSelect,
-  IonSelectOption,
-  IonToggle,
-} from '@ionic/angular';
+import { IonCheckbox, IonInput, IonItem, IonRange, IonSelect, IonSelectOption, IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/lines/angular/example_component_ts.md
+++ b/static/usage/v9/item/lines/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon, IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonIcon, IonItem, IonLabel } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { informationCircle, star } from 'ionicons/icons';

--- a/static/usage/v9/item/media/angular/example_component_ts.md
+++ b/static/usage/v9/item/media/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonAvatar, IonItem, IonLabel, IonThumbnail } from '@ionic/angular/standalone';
+import { IonAvatar, IonItem, IonLabel, IonThumbnail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/item/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/item/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/item/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/item/theming/input-highlight/angular/example_component_ts.md
+++ b/static/usage/v9/item/theming/input-highlight/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/keyboard/enterkeyhint/angular/example_component_ts.md
+++ b/static/usage/v9/keyboard/enterkeyhint/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/keyboard/inputmode/angular/example_component_ts.md
+++ b/static/usage/v9/keyboard/inputmode/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonInput, IonItem, IonList } from '@ionic/angular/standalone';
+import { IonInput, IonItem, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/label/basic/angular/example_component_ts.md
+++ b/static/usage/v9/label/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel } from '@ionic/angular/standalone';
+import { IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/label/input/angular/example_component_ts.md
+++ b/static/usage/v9/label/input/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonCheckbox, IonInput, IonItem, IonLabel, IonToggle } from '@ionic/angular/standalone';
+import { IonCheckbox, IonInput, IonItem, IonLabel, IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/label/item/angular/example_component_ts.md
+++ b/static/usage/v9/label/item/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel } from '@ionic/angular/standalone';
+import { IonItem, IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/label/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/label/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel } from '@ionic/angular/standalone';
+import { IonLabel } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/layout/dynamic-font-scaling/angular/example_component_ts.md
+++ b/static/usage/v9/layout/dynamic-font-scaling/angular/example_component_ts.md
@@ -16,7 +16,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { create } from 'ionicons/icons';

--- a/static/usage/v9/list-header/basic/angular/example_component_ts.md
+++ b/static/usage/v9/list-header/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/list-header/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/list-header/buttons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonItem, IonLabel, IonList, IonListHeader } from '@ionic/angular/standalone';
+import { IonButton, IonItem, IonLabel, IonList, IonListHeader } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/list-header/lines/angular/example_component_ts.md
+++ b/static/usage/v9/list-header/lines/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonList, IonListHeader } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/list-header/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/list-header/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonListHeader } from '@ionic/angular/standalone';
+import { IonLabel, IonListHeader } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/list-header/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/list-header/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonListHeader } from '@ionic/angular/standalone';
+import { IonLabel, IonListHeader } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/list/basic/angular/example_component_ts.md
+++ b/static/usage/v9/list/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/list/inset/angular/example_component_ts.md
+++ b/static/usage/v9/list/inset/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonContent, IonItem, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/list/lines/angular/example_component_ts.md
+++ b/static/usage/v9/list/lines/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonList } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonList } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/loading/controller/angular/example_component_ts.md
+++ b/static/usage/v9/loading/controller/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, LoadingController } from '@ionic/angular/standalone';
+import { IonButton, LoadingController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/loading/inline/angular/example_component_ts.md
+++ b/static/usage/v9/loading/inline/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonLoading } from '@ionic/angular/standalone';
+import { IonButton, IonLoading } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/loading/spinners/angular/example_component_ts.md
+++ b/static/usage/v9/loading/spinners/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonLoading } from '@ionic/angular/standalone';
+import { IonButton, IonLoading } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/loading/theming/angular/example_component_ts.md
+++ b/static/usage/v9/loading/theming/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonLoading } from '@ionic/angular/standalone';
+import { IonButton, IonLoading } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/basic/angular/example_component_ts.md
+++ b/static/usage/v9/menu/basic/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonMenu,
-  IonMenuButton,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButtons, IonContent, IonHeader, IonMenu, IonMenuButton, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/basic/angular/example_component_ts.md
+++ b/static/usage/v9/menu/basic/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonMenuButton,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/multiple/angular/example_component_ts.md
+++ b/static/usage/v9/menu/multiple/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonTitle,
   IonToolbar,
   MenuController,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/multiple/angular/example_component_ts.md
+++ b/static/usage/v9/menu/multiple/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButton,
-  IonContent,
-  IonHeader,
-  IonMenu,
-  IonTitle,
-  IonToolbar,
-  MenuController,
-} from '@ionic/angular';
+import { IonButton, IonContent, IonHeader, IonMenu, IonTitle, IonToolbar, MenuController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/sides/angular/example_component_ts.md
+++ b/static/usage/v9/menu/sides/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonMenu,
-  IonMenuButton,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButtons, IonContent, IonHeader, IonMenu, IonMenuButton, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/sides/angular/example_component_ts.md
+++ b/static/usage/v9/menu/sides/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonMenuButton,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/theming/angular/example_component_ts.md
+++ b/static/usage/v9/menu/theming/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonMenuButton,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/toggle/angular/example_component_ts.md
+++ b/static/usage/v9/menu/toggle/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButton,
-  IonContent,
-  IonHeader,
-  IonMenu,
-  IonMenuToggle,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButton, IonContent, IonHeader, IonMenu, IonMenuToggle, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/toggle/angular/example_component_ts.md
+++ b/static/usage/v9/menu/toggle/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonMenuToggle,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/menu/type/angular/example_component_ts.md
+++ b/static/usage/v9/menu/type/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonRadioGroup,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/can-dismiss/boolean/angular/example_component_ts.md
+++ b/static/usage/v9/modal/can-dismiss/boolean/angular/example_component_ts.md
@@ -11,7 +11,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/can-dismiss/child-state/angular/child_component_ts.md
+++ b/static/usage/v9/modal/can-dismiss/child-state/angular/child_component_ts.md
@@ -14,7 +14,7 @@ import {
   IonNote,
   IonToolbar,
   IonTitle,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-child',

--- a/static/usage/v9/modal/can-dismiss/child-state/angular/example_component_ts.md
+++ b/static/usage/v9/modal/can-dismiss/child-state/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { ChildComponent } from './child.component';
 

--- a/static/usage/v9/modal/can-dismiss/function/angular/example_component_ts.md
+++ b/static/usage/v9/modal/can-dismiss/function/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/can-dismiss/prevent-swipe-to-close/angular/example_component_ts.md
+++ b/static/usage/v9/modal/can-dismiss/prevent-swipe-to-close/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/can-dismiss/prevent-swipe-to-close/angular/example_component_ts.md
+++ b/static/usage/v9/modal/can-dismiss/prevent-swipe-to-close/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButton,
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonModal,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButton, IonButtons, IonContent, IonHeader, IonModal, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/card/basic/angular/example_component_ts.md
+++ b/static/usage/v9/modal/card/basic/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/controller/angular/example_component_ts.md
+++ b/static/usage/v9/modal/controller/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { IonButton, IonContent, IonHeader, IonTitle, IonToolbar, ModalController } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonTitle, IonToolbar, ModalController } from '@ionic/angular';
 
 import { ModalExampleComponent } from './modal-example.component';
 

--- a/static/usage/v9/modal/controller/angular/modal-example_component_ts.md
+++ b/static/usage/v9/modal/controller/angular/modal-example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonTitle,
   IonToolbar,
   ModalController,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-modal-example',

--- a/static/usage/v9/modal/custom-dialogs/angular/example_component_ts.md
+++ b/static/usage/v9/modal/custom-dialogs/angular/example_component_ts.md
@@ -11,7 +11,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { personCircle } from 'ionicons/icons';

--- a/static/usage/v9/modal/inline/basic/angular/example_component_ts.md
+++ b/static/usage/v9/modal/inline/basic/angular/example_component_ts.md
@@ -11,7 +11,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 import { OverlayEventDetail } from '@ionic/core/components';
 
 @Component({

--- a/static/usage/v9/modal/inline/is-open/angular/example_component_ts.md
+++ b/static/usage/v9/modal/inline/is-open/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/inline/is-open/angular/example_component_ts.md
+++ b/static/usage/v9/modal/inline/is-open/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButton,
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonModal,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButton, IonButtons, IonContent, IonHeader, IonModal, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/performance/mount/angular/example_component_ts.md
+++ b/static/usage/v9/modal/performance/mount/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/performance/mount/angular/example_component_ts.md
+++ b/static/usage/v9/modal/performance/mount/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButton,
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonModal,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButton, IonButtons, IonContent, IonHeader, IonModal, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/sheet/auto-height/angular/example_component_ts.md
+++ b/static/usage/v9/modal/sheet/auto-height/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonHeader, IonModal, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonModal, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/sheet/background-content/angular/example_component_ts.md
+++ b/static/usage/v9/modal/sheet/background-content/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonSearchbar,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/sheet/basic/angular/example_component_ts.md
+++ b/static/usage/v9/modal/sheet/basic/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonSearchbar,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/sheet/expand-to-scroll/angular/example_component_ts.md
+++ b/static/usage/v9/modal/sheet/expand-to-scroll/angular/example_component_ts.md
@@ -11,7 +11,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/sheet/handle-behavior/angular/example_component_ts.md
+++ b/static/usage/v9/modal/sheet/handle-behavior/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonHeader, IonLabel, IonModal, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonLabel, IonModal, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/styling/animations/angular/example_component_ts.md
+++ b/static/usage/v9/modal/styling/animations/angular/example_component_ts.md
@@ -13,7 +13,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/modal/styling/theming/angular/example_component_ts.md
+++ b/static/usage/v9/modal/styling/theming/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonModal,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/nav/modal-navigation/angular/example_component_ts.md
+++ b/static/usage/v9/nav/modal-navigation/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonNav,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { PageOneComponent } from './page-one.component';
 

--- a/static/usage/v9/nav/modal-navigation/angular/example_component_ts.md
+++ b/static/usage/v9/nav/modal-navigation/angular/example_component_ts.md
@@ -1,15 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import {
-  IonButton,
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonModal,
-  IonNav,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButton, IonButtons, IonContent, IonHeader, IonModal, IonNav, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { PageOneComponent } from './page-one.component';
 

--- a/static/usage/v9/nav/modal-navigation/angular/page_one_component_ts.md
+++ b/static/usage/v9/nav/modal-navigation/angular/page_one_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonNav } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonNav } from '@ionic/angular';
 
 import { PageTwoComponent } from './page-two.component';
 

--- a/static/usage/v9/nav/modal-navigation/angular/page_three_component_ts.md
+++ b/static/usage/v9/nav/modal-navigation/angular/page_three_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonNav } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonNav } from '@ionic/angular';
 
 @Component({
   selector: 'app-page-one',

--- a/static/usage/v9/nav/modal-navigation/angular/page_two_component_ts.md
+++ b/static/usage/v9/nav/modal-navigation/angular/page_two_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonNav } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonNav } from '@ionic/angular';
 
 import { PageThreeComponent } from './page-three.component';
 

--- a/static/usage/v9/nav/nav-link/angular/example_component_ts.md
+++ b/static/usage/v9/nav/nav-link/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonNav } from '@ionic/angular/standalone';
+import { IonNav } from '@ionic/angular';
 
 import { PageOneComponent } from './page-one.component';
 

--- a/static/usage/v9/nav/nav-link/angular/page_one_component_ts.md
+++ b/static/usage/v9/nav/nav-link/angular/page_one_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonHeader, IonNavLink, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonNavLink, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { PageTwoComponent } from './page-two.component';
 

--- a/static/usage/v9/nav/nav-link/angular/page_three_component_ts.md
+++ b/static/usage/v9/nav/nav-link/angular/page_three_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-page-one',

--- a/static/usage/v9/nav/nav-link/angular/page_two_component_ts.md
+++ b/static/usage/v9/nav/nav-link/angular/page_two_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonNavLink,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { PageThreeComponent } from './page-three.component';
 

--- a/static/usage/v9/navigation/angular/app_component_ts.md
+++ b/static/usage/v9/navigation/angular/app_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { IonApp, IonRouterOutlet } from '@ionic/angular';
 
 @Component({
   selector: 'app-root',

--- a/static/usage/v9/navigation/angular/dashboard_page_component_ts.md
+++ b/static/usage/v9/navigation/angular/dashboard_page_component_ts.md
@@ -10,7 +10,7 @@ import {
   IonTitle,
   IonToolbar,
   IonRouterLink,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-dashboard-page',

--- a/static/usage/v9/navigation/angular/dashboard_page_component_ts.md
+++ b/static/usage/v9/navigation/angular/dashboard_page_component_ts.md
@@ -1,16 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import {
-  IonContent,
-  IonHeader,
-  IonItem,
-  IonLabel,
-  IonList,
-  IonTitle,
-  IonToolbar,
-  IonRouterLink,
-} from '@ionic/angular';
+import { IonContent, IonHeader, IonItem, IonLabel, IonList, IonTitle, IonToolbar, IonRouterLink } from '@ionic/angular';
 
 @Component({
   selector: 'app-dashboard-page',

--- a/static/usage/v9/navigation/angular/example_component_ts.md
+++ b/static/usage/v9/navigation/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon, IonLabel, IonTabBar, IonTabButton, IonTabs } from '@ionic/angular/standalone';
+import { IonIcon, IonLabel, IonTabBar, IonTabButton, IonTabs } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { gridOutline, settingsOutline } from 'ionicons/icons';
 

--- a/static/usage/v9/navigation/angular/item_detail_page_component_ts.md
+++ b/static/usage/v9/navigation/angular/item_detail_page_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonBackButton, IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-item-detail-page',

--- a/static/usage/v9/navigation/angular/settings_page_component_ts.md
+++ b/static/usage/v9/navigation/angular/settings_page_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-settings-page',

--- a/static/usage/v9/note/basic/angular/example_component_ts.md
+++ b/static/usage/v9/note/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonNote } from '@ionic/angular/standalone';
+import { IonNote } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/note/item/angular/example_component_ts.md
+++ b/static/usage/v9/note/item/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonNote } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonNote } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/note/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/note/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonNote } from '@ionic/angular/standalone';
+import { IonNote } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/note/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/note/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonNote } from '@ionic/angular/standalone';
+import { IonNote } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/picker/basic/angular/example_component_ts.md
+++ b/static/usage/v9/picker/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonPicker, IonPickerColumn, IonPickerColumnOption } from '@ionic/angular/standalone';
+import { IonPicker, IonPickerColumn, IonPickerColumnOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/picker/modal/angular/example_component_ts.md
+++ b/static/usage/v9/picker/modal/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonPickerColumn,
   IonPickerColumnOption,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/picker/prefix-suffix/angular/example_component_ts.md
+++ b/static/usage/v9/picker/prefix-suffix/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonPicker, IonPickerColumn, IonPickerColumnOption } from '@ionic/angular/standalone';
+import { IonPicker, IonPickerColumn, IonPickerColumnOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/picker/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/picker/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonPicker, IonPickerColumn, IonPickerColumnOption } from '@ionic/angular/standalone';
+import { IonPicker, IonPickerColumn, IonPickerColumnOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/popover/customization/positioning/angular/example_component_ts.md
+++ b/static/usage/v9/popover/customization/positioning/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonPopover } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/popover/customization/sizing/angular/example_component_ts.md
+++ b/static/usage/v9/popover/customization/sizing/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonPopover } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/popover/customization/styling/angular/example_component_ts.md
+++ b/static/usage/v9/popover/customization/styling/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonPopover } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/popover/nested/angular/example_component_ts.md
+++ b/static/usage/v9/popover/nested/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonItem, IonList, IonPopover } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonItem, IonList, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/popover/performance/mount/angular/example_component_ts.md
+++ b/static/usage/v9/popover/performance/mount/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonPopover } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/popover/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v9/popover/presenting/controller/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, PopoverController } from '@ionic/angular/standalone';
+import { IonButton, PopoverController } from '@ionic/angular';
 
 import { PopoverComponent } from './popover.component';
 

--- a/static/usage/v9/popover/presenting/controller/angular/popover_component_ts.md
+++ b/static/usage/v9/popover/presenting/controller/angular/popover_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent } from '@ionic/angular/standalone';
+import { IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-popover',

--- a/static/usage/v9/popover/presenting/inline-isopen/angular/example_component_ts.md
+++ b/static/usage/v9/popover/presenting/inline-isopen/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import { IonButton, IonContent, IonPopover } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/popover/presenting/inline-trigger/angular/example_component_ts.md
+++ b/static/usage/v9/popover/presenting/inline-trigger/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonPopover } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonPopover } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/progress-bar/buffer/angular/example_component_ts.md
+++ b/static/usage/v9/progress-bar/buffer/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, signal } from '@angular/core';
-import { IonProgressBar } from '@ionic/angular/standalone';
+import { IonProgressBar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/progress-bar/determinate/angular/example_component_ts.md
+++ b/static/usage/v9/progress-bar/determinate/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, signal } from '@angular/core';
-import { IonProgressBar } from '@ionic/angular/standalone';
+import { IonProgressBar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/progress-bar/indeterminate/angular/example_component_ts.md
+++ b/static/usage/v9/progress-bar/indeterminate/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonProgressBar } from '@ionic/angular/standalone';
+import { IonProgressBar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/progress-bar/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/progress-bar/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonProgressBar } from '@ionic/angular/standalone';
+import { IonProgressBar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/progress-bar/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/progress-bar/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonProgressBar } from '@ionic/angular/standalone';
+import { IonProgressBar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/progress-bar/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/progress-bar/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonProgressBar } from '@ionic/angular/standalone';
+import { IonProgressBar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/alignment/angular/example_component_ts.md
+++ b/static/usage/v9/radio/alignment/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/basic/angular/example_component_ts.md
+++ b/static/usage/v9/radio/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/empty-selection/angular/example_component_ts.md
+++ b/static/usage/v9/radio/empty-selection/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/radio/helper-error/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { IonRadioGroup, IonRadio, IonButton } from '@ionic/angular/standalone';
+import { IonRadioGroup, IonRadio, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/justify/angular/example_component_ts.md
+++ b/static/usage/v9/radio/justify/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/label-placement/angular/example_component_ts.md
+++ b/static/usage/v9/radio/label-placement/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/label-wrap/angular/example_component_ts.md
+++ b/static/usage/v9/radio/label-wrap/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/radio/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/radio/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/radio/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonRadio, IonRadioGroup } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/radio/using-comparewith/angular/example_component_ts.md
+++ b/static/usage/v9/radio/using-comparewith/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonRadio, IonRadioGroup } from '@ionic/angular';
 
 interface Food {
   id: number;

--- a/static/usage/v9/range/basic/angular/example_component_ts.md
+++ b/static/usage/v9/range/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/dual-knobs/angular/example_component_ts.md
+++ b/static/usage/v9/range/dual-knobs/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/ion-change-event/angular/example_component_ts.md
+++ b/static/usage/v9/range/ion-change-event/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange, RangeCustomEvent } from '@ionic/angular/standalone';
+import { IonRange, RangeCustomEvent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/ion-knob-move-event/angular/example_component_ts.md
+++ b/static/usage/v9/range/ion-knob-move-event/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange, RangeCustomEvent } from '@ionic/angular/standalone';
+import { IonRange, RangeCustomEvent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/label-slot/angular/example_component_ts.md
+++ b/static/usage/v9/range/label-slot/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange, IonText } from '@ionic/angular/standalone';
+import { IonRange, IonText } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/labels/angular/example_component_ts.md
+++ b/static/usage/v9/range/labels/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/no-visible-label/angular/example_component_ts.md
+++ b/static/usage/v9/range/no-visible-label/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/pins/angular/example_component_ts.md
+++ b/static/usage/v9/range/pins/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/slots/angular/example_component_ts.md
+++ b/static/usage/v9/range/slots/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon, IonRange } from '@ionic/angular/standalone';
+import { IonIcon, IonRange } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { snowOutline, sunnyOutline } from 'ionicons/icons';

--- a/static/usage/v9/range/snapping-ticks/angular/example_component_ts.md
+++ b/static/usage/v9/range/snapping-ticks/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/range/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/range/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/range/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRange } from '@ionic/angular/standalone';
+import { IonRange } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/refresher/advanced/angular/example_component_ts.md
+++ b/static/usage/v9/refresher/advanced/angular/example_component_ts.md
@@ -12,7 +12,7 @@ import {
   IonTitle,
   IonToolbar,
   RefresherCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { ellipse } from 'ionicons/icons';

--- a/static/usage/v9/refresher/basic/angular/example_component_ts.md
+++ b/static/usage/v9/refresher/basic/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonTitle,
   IonToolbar,
   RefresherCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/refresher/custom-content/angular/example_component_ts.md
+++ b/static/usage/v9/refresher/custom-content/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonTitle,
   IonToolbar,
   RefresherCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/refresher/custom-scroll-target/angular/example_component_ts.md
+++ b/static/usage/v9/refresher/custom-scroll-target/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonTitle,
   IonToolbar,
   RefresherCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/refresher/pull-properties/angular/example_component_ts.md
+++ b/static/usage/v9/refresher/pull-properties/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonTitle,
   IonToolbar,
   RefresherCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/basic/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/basic/angular/example_component_ts.md
@@ -7,7 +7,7 @@ import {
   IonReorder,
   IonReorderGroup,
   ReorderEndCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/basic/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/basic/angular/example_component_ts.md
@@ -1,13 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonItem,
-  IonLabel,
-  IonList,
-  IonReorder,
-  IonReorderGroup,
-  ReorderEndCustomEvent,
-} from '@ionic/angular';
+import { IonItem, IonLabel, IonList, IonReorder, IonReorderGroup, ReorderEndCustomEvent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/custom-icon/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/custom-icon/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonReorder,
   IonReorderGroup,
   ReorderEndCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { pizza } from 'ionicons/icons';

--- a/static/usage/v9/reorder/custom-scroll-target/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/custom-scroll-target/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonList,
   IonReorder,
   IonReorderGroup,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/reorder-move-event/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/reorder-move-event/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonReorderGroup,
   ReorderEndCustomEvent,
   ReorderMoveCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/reorder-start-end-events/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/reorder-start-end-events/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonReorder,
   IonReorderGroup,
   IonIcon,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { caretDown, ellipse, warning } from 'ionicons/icons';
 

--- a/static/usage/v9/reorder/toggling-disabled/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/toggling-disabled/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonReorder,
   IonReorderGroup,
   ReorderEndCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/updating-data/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/updating-data/angular/example_component_ts.md
@@ -7,7 +7,7 @@ import {
   IonReorder,
   IonReorderGroup,
   ReorderEndCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/updating-data/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/updating-data/angular/example_component_ts.md
@@ -1,13 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonItem,
-  IonLabel,
-  IonList,
-  IonReorder,
-  IonReorderGroup,
-  ReorderEndCustomEvent,
-} from '@ionic/angular';
+import { IonItem, IonLabel, IonList, IonReorder, IonReorderGroup, ReorderEndCustomEvent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/wrapper/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/wrapper/angular/example_component_ts.md
@@ -7,7 +7,7 @@ import {
   IonReorder,
   IonReorderGroup,
   ReorderEndCustomEvent,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/reorder/wrapper/angular/example_component_ts.md
+++ b/static/usage/v9/reorder/wrapper/angular/example_component_ts.md
@@ -1,13 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonItem,
-  IonLabel,
-  IonList,
-  IonReorder,
-  IonReorderGroup,
-  ReorderEndCustomEvent,
-} from '@ionic/angular';
+import { IonItem, IonLabel, IonList, IonReorder, IonReorderGroup, ReorderEndCustomEvent } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/ripple-effect/basic/angular/example_component_ts.md
+++ b/static/usage/v9/ripple-effect/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRippleEffect } from '@ionic/angular/standalone';
+import { IonRippleEffect } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/ripple-effect/customizing/angular/example_component_ts.md
+++ b/static/usage/v9/ripple-effect/customizing/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRippleEffect } from '@ionic/angular/standalone';
+import { IonRippleEffect } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/ripple-effect/type/angular/example_component_ts.md
+++ b/static/usage/v9/ripple-effect/type/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonRippleEffect } from '@ionic/angular/standalone';
+import { IonRippleEffect } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/searchbar/basic/angular/example_component_ts.md
+++ b/static/usage/v9/searchbar/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSearchbar } from '@ionic/angular/standalone';
+import { IonSearchbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/searchbar/cancel-button/angular/example_component_ts.md
+++ b/static/usage/v9/searchbar/cancel-button/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSearchbar } from '@ionic/angular/standalone';
+import { IonSearchbar } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { trash } from 'ionicons/icons';

--- a/static/usage/v9/searchbar/clear-button/angular/example_component_ts.md
+++ b/static/usage/v9/searchbar/clear-button/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSearchbar } from '@ionic/angular/standalone';
+import { IonSearchbar } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { trashBin } from 'ionicons/icons';

--- a/static/usage/v9/searchbar/debounce/angular/example_component_ts.md
+++ b/static/usage/v9/searchbar/debounce/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonList, IonSearchbar } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonList, IonSearchbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/searchbar/search-icon/angular/example_component_ts.md
+++ b/static/usage/v9/searchbar/search-icon/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSearchbar } from '@ionic/angular/standalone';
+import { IonSearchbar } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { searchCircle } from 'ionicons/icons';

--- a/static/usage/v9/searchbar/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/searchbar/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSearchbar } from '@ionic/angular/standalone';
+import { IonSearchbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/searchbar/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/searchbar/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSearchbar } from '@ionic/angular/standalone';
+import { IonSearchbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/segment-button/basic/angular/example_component_ts.md
+++ b/static/usage/v9/segment-button/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/segment-button/layout/angular/example_component_ts.md
+++ b/static/usage/v9/segment-button/layout/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon, IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonIcon, IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { call, heart, pin } from 'ionicons/icons';

--- a/static/usage/v9/segment-button/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/segment-button/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/segment-button/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/segment-button/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/segment/basic/angular/example_component_ts.md
+++ b/static/usage/v9/segment/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/segment/scrollable/angular/example_component_ts.md
+++ b/static/usage/v9/segment/scrollable/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonIcon, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { barbell, basket, call, globe, heart, home, person, pin, star, trash } from 'ionicons/icons';

--- a/static/usage/v9/segment/swipeable/angular/example_component_ts.md
+++ b/static/usage/v9/segment/swipeable/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonSegment, IonSegmentButton, IonSegmentContent, IonSegmentView } from '@ionic/angular/standalone';
+import { IonLabel, IonSegment, IonSegmentButton, IonSegmentContent, IonSegmentView } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/segment/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/segment/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/segment/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/segment/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular/standalone';
+import { IonLabel, IonSegment, IonSegmentButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/basic/multiple-selection/angular/example_component_ts.md
+++ b/static/usage/v9/select/basic/multiple-selection/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/basic/responding-to-interaction/angular/example_component_ts.md
+++ b/static/usage/v9/select/basic/responding-to-interaction/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/basic/single-selection/angular/example_component_ts.md
+++ b/static/usage/v9/select/basic/single-selection/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/customization/button-text/angular/example_component_ts.md
+++ b/static/usage/v9/select/customization/button-text/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/customization/custom-toggle-icons/angular/example_component_ts.md
+++ b/static/usage/v9/select/customization/custom-toggle-icons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { add, remove } from 'ionicons/icons';

--- a/static/usage/v9/select/customization/icon-flip-behavior/angular/example_component_ts.md
+++ b/static/usage/v9/select/customization/icon-flip-behavior/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { caretDownSharp } from 'ionicons/icons';

--- a/static/usage/v9/select/customization/interface-options/angular/example_component_ts.md
+++ b/static/usage/v9/select/customization/interface-options/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/customization/styling-select/angular/example_component_ts.md
+++ b/static/usage/v9/select/customization/styling-select/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/fill/angular/example_component_ts.md
+++ b/static/usage/v9/select/fill/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/select/helper-error/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { IonSelect, IonSelectOption, IonButton } from '@ionic/angular/standalone';
+import { IonSelect, IonSelectOption, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/interfaces/action-sheet/angular/example_component_ts.md
+++ b/static/usage/v9/select/interfaces/action-sheet/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/interfaces/modal/angular/example_component_ts.md
+++ b/static/usage/v9/select/interfaces/modal/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/interfaces/popover/angular/example_component_ts.md
+++ b/static/usage/v9/select/interfaces/popover/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/justify/angular/example_component_ts.md
+++ b/static/usage/v9/select/justify/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/label-placement/angular/example_component_ts.md
+++ b/static/usage/v9/select/label-placement/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/label-slot/angular/example_component_ts.md
+++ b/static/usage/v9/select/label-slot/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption, IonText } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption, IonText } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/no-visible-label/angular/example_component_ts.md
+++ b/static/usage/v9/select/no-visible-label/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/select/objects-as-values/multiple-selection/angular/example_component_ts.md
+++ b/static/usage/v9/select/objects-as-values/multiple-selection/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 interface Food {
   id: number;

--- a/static/usage/v9/select/objects-as-values/using-comparewith/angular/example_component_ts.md
+++ b/static/usage/v9/select/objects-as-values/using-comparewith/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 interface Food {
   id: number;

--- a/static/usage/v9/select/rich-content-options/angular/example_component_ts.md
+++ b/static/usage/v9/select/rich-content-options/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonBadge, IonIcon, IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonBadge, IonIcon, IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { airplane, bus, car, train } from 'ionicons/icons';
 

--- a/static/usage/v9/select/rich-content-options/angular/main_ts.md
+++ b/static/usage/v9/select/rich-content-options/angular/main_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
-import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';

--- a/static/usage/v9/select/start-end-slots/angular/example_component_ts.md
+++ b/static/usage/v9/select/start-end-slots/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonIcon, IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular/standalone';
+import { IonButton, IonIcon, IonItem, IonList, IonSelect, IonSelectOption } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { eye, leaf } from 'ionicons/icons';

--- a/static/usage/v9/select/typeahead/angular/example_component_ts.md
+++ b/static/usage/v9/select/typeahead/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component, ViewChild } from '@angular/core';
-import { IonContent, IonItem, IonLabel, IonList, IonModal } from '@ionic/angular/standalone';
+import { IonContent, IonItem, IonLabel, IonList, IonModal } from '@ionic/angular';
 import { Item } from './types';
 
 import { TypeaheadComponent } from './typeahead.component';

--- a/static/usage/v9/select/typeahead/angular/typeahead_component_ts.md
+++ b/static/usage/v9/select/typeahead/angular/typeahead_component_ts.md
@@ -13,7 +13,7 @@ import {
   IonSearchbar,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { Item } from './types';
 

--- a/static/usage/v9/skeleton-text/basic/angular/example_component_ts.md
+++ b/static/usage/v9/skeleton-text/basic/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonListHeader,
   IonSkeletonText,
   IonThumbnail,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { musicalNotes } from 'ionicons/icons';

--- a/static/usage/v9/skeleton-text/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/skeleton-text/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonList, IonListHeader, IonSkeletonText, IonThumbnail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/spinner/basic/angular/example_component_ts.md
+++ b/static/usage/v9/spinner/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonSpinner } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonSpinner } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/spinner/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/spinner/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSpinner } from '@ionic/angular/standalone';
+import { IonSpinner } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/spinner/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/spinner/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSpinner } from '@ionic/angular/standalone';
+import { IonSpinner } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/spinner/theming/resizing/angular/example_component_ts.md
+++ b/static/usage/v9/spinner/theming/resizing/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonSpinner } from '@ionic/angular/standalone';
+import { IonSpinner } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/split-pane/basic/angular/example_component_ts.md
+++ b/static/usage/v9/split-pane/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonMenu, IonSplitPane, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonMenu, IonSplitPane, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/split-pane/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/split-pane/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonMenu, IonSplitPane, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonMenu, IonSplitPane, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/tabs/basic/angular/example_component_ts.md
+++ b/static/usage/v9/tabs/basic/angular/example_component_ts.md
@@ -10,7 +10,7 @@ import {
   IonTabs,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { library, playCircle, radio, search } from 'ionicons/icons';

--- a/static/usage/v9/tabs/router/angular/app_component_ts.md
+++ b/static/usage/v9/tabs/router/angular/app_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { IonApp, IonRouterOutlet } from '@ionic/angular';
 
 @Component({
   selector: 'app-root',

--- a/static/usage/v9/tabs/router/angular/example_component_ts.md
+++ b/static/usage/v9/tabs/router/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon, IonTabBar, IonTabButton, IonTabs } from '@ionic/angular/standalone';
+import { IonIcon, IonTabBar, IonTabButton, IonTabs } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { library, playCircle, radio, search } from 'ionicons/icons';

--- a/static/usage/v9/tabs/router/angular/home_page_component_ts.md
+++ b/static/usage/v9/tabs/router/angular/home_page_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-home-page',

--- a/static/usage/v9/tabs/router/angular/library_page_component_ts.md
+++ b/static/usage/v9/tabs/router/angular/library_page_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-library-page',

--- a/static/usage/v9/tabs/router/angular/radio_page_component_ts.md
+++ b/static/usage/v9/tabs/router/angular/radio_page_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-radio-page',

--- a/static/usage/v9/tabs/router/angular/search_page_component_ts.md
+++ b/static/usage/v9/tabs/router/angular/search_page_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-search-page',

--- a/static/usage/v9/tabs/select-method/angular/example_component_ts.md
+++ b/static/usage/v9/tabs/select-method/angular/example_component_ts.md
@@ -11,7 +11,7 @@ import {
   IonTabs,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { library, playCircle, radio, search } from 'ionicons/icons';

--- a/static/usage/v9/text/basic/angular/example_component_ts.md
+++ b/static/usage/v9/text/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonIcon, IonText } from '@ionic/angular/standalone';
+import { IonIcon, IonText } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { warning } from 'ionicons/icons';

--- a/static/usage/v9/textarea/autogrow/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/autogrow/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonTextarea } from '@ionic/angular/standalone';
+import { IonItem, IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/basic/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonTextarea } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/clear-on-edit/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/clear-on-edit/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonTextarea } from '@ionic/angular/standalone';
+import { IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/counter/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/counter/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonTextarea } from '@ionic/angular/standalone';
+import { IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/fill/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/fill/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonTextarea } from '@ionic/angular/standalone';
+import { IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/helper-error/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonTextarea } from '@ionic/angular/standalone';
+import { IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/label-placement/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/label-placement/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonTextarea } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/label-slot/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/label-slot/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonText, IonTextarea } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonText, IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/no-visible-label/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/no-visible-label/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonTextarea } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/textarea/start-end-slots/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/start-end-slots/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonIcon, IonItem, IonList, IonTextarea } from '@ionic/angular/standalone';
+import { IonButton, IonIcon, IonItem, IonList, IonTextarea } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { eye, lockClosed } from 'ionicons/icons';

--- a/static/usage/v9/textarea/theming/angular/example_component_ts.md
+++ b/static/usage/v9/textarea/theming/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonTextarea } from '@ionic/angular/standalone';
+import { IonTextarea } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/theming/always-dark-mode/angular/example_component_ts.md
+++ b/static/usage/v9/theming/always-dark-mode/angular/example_component_ts.md
@@ -16,7 +16,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { personCircle, personCircleOutline, sunny, sunnyOutline } from 'ionicons/icons';

--- a/static/usage/v9/theming/always-high-contrast-mode/angular/example_component_ts.md
+++ b/static/usage/v9/theming/always-high-contrast-mode/angular/example_component_ts.md
@@ -16,7 +16,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { personCircle, personCircleOutline, sunny, sunnyOutline } from 'ionicons/icons';

--- a/static/usage/v9/theming/class-dark-mode/angular/example_component_ts.md
+++ b/static/usage/v9/theming/class-dark-mode/angular/example_component_ts.md
@@ -16,7 +16,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { personCircle, personCircleOutline, sunny, sunnyOutline } from 'ionicons/icons';

--- a/static/usage/v9/theming/class-high-contrast-mode/angular/example_component_ts.md
+++ b/static/usage/v9/theming/class-high-contrast-mode/angular/example_component_ts.md
@@ -16,7 +16,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { personCircle, personCircleOutline, sunny, sunnyOutline } from 'ionicons/icons';

--- a/static/usage/v9/theming/system-dark-mode/angular/example_component_ts.md
+++ b/static/usage/v9/theming/system-dark-mode/angular/example_component_ts.md
@@ -16,7 +16,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { personCircle, personCircleOutline, sunny, sunnyOutline } from 'ionicons/icons';

--- a/static/usage/v9/theming/system-high-contrast-mode/angular/example_component_ts.md
+++ b/static/usage/v9/theming/system-high-contrast-mode/angular/example_component_ts.md
@@ -16,7 +16,7 @@ import {
   IonTitle,
   IonToggle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { personCircle, personCircleOutline, sunny, sunnyOutline } from 'ionicons/icons';

--- a/static/usage/v9/thumbnail/basic/angular/example_component_ts.md
+++ b/static/usage/v9/thumbnail/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonThumbnail } from '@ionic/angular/standalone';
+import { IonThumbnail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/thumbnail/item/angular/example_component_ts.md
+++ b/static/usage/v9/thumbnail/item/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonLabel, IonThumbnail } from '@ionic/angular/standalone';
+import { IonItem, IonLabel, IonThumbnail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/thumbnail/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/thumbnail/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonThumbnail } from '@ionic/angular/standalone';
+import { IonThumbnail } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/title/basic/angular/example_component_ts.md
+++ b/static/usage/v9/title/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/title/collapsible-large-title/basic/angular/example_component_ts.md
+++ b/static/usage/v9/title/collapsible-large-title/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonItem, IonList, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonItem, IonList, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/title/collapsible-large-title/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/title/collapsible-large-title/buttons/angular/example_component_ts.md
@@ -9,7 +9,7 @@ import {
   IonList,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/title/collapsible-large-title/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/title/collapsible-large-title/buttons/angular/example_component_ts.md
@@ -1,15 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonButton,
-  IonButtons,
-  IonContent,
-  IonHeader,
-  IonItem,
-  IonList,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonButton, IonButtons, IonContent, IonHeader, IonItem, IonList, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/title/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/title/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonContent, IonHeader, IonItem, IonList, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonItem, IonList, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/toast/buttons/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonToast } from '@ionic/angular/standalone';
+import { IonButton, IonToast } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/icon/angular/example_component_ts.md
+++ b/static/usage/v9/toast/icon/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonToast } from '@ionic/angular/standalone';
+import { IonButton, IonToast } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { globe } from 'ionicons/icons';

--- a/static/usage/v9/toast/inline/basic/angular/example_component_ts.md
+++ b/static/usage/v9/toast/inline/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonHeader, IonTitle, IonToast, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonTitle, IonToast, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/inline/is-open/angular/example_component_ts.md
+++ b/static/usage/v9/toast/inline/is-open/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonHeader, IonTitle, IonToast, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonHeader, IonTitle, IonToast, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/layout/angular/example_component_ts.md
+++ b/static/usage/v9/toast/layout/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonToast } from '@ionic/angular/standalone';
+import { IonButton, IonToast } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/position-anchor/angular/example_component_ts.md
+++ b/static/usage/v9/toast/position-anchor/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonFooter, IonHeader, IonTitle, IonToast, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonFooter, IonHeader, IonTitle, IonToast, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/presenting/controller/angular/example_component_ts.md
+++ b/static/usage/v9/toast/presenting/controller/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, ToastController } from '@ionic/angular/standalone';
+import { IonButton, ToastController } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/swipe-gesture/angular/example_component_ts.md
+++ b/static/usage/v9/toast/swipe-gesture/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonContent, IonFooter, IonTitle, IonToast, IonToolbar } from '@ionic/angular/standalone';
+import { IonButton, IonContent, IonFooter, IonTitle, IonToast, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toast/theming/angular/example_component_ts.md
+++ b/static/usage/v9/toast/theming/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonButton, IonToast } from '@ionic/angular/standalone';
+import { IonButton, IonToast } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/alignment/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/alignment/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/basic/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/helper-error/angular/example_component_ts.md
@@ -1,7 +1,7 @@
 ```ts
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/justify/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/justify/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonToggle } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/label-placement/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/label-placement/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/list/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/list/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonItem, IonList, IonToggle } from '@ionic/angular/standalone';
+import { IonItem, IonList, IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/on-off/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/on-off/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toggle/theming/css-shadow-parts/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/theming/css-shadow-parts/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonToggle } from '@ionic/angular/standalone';
+import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toolbar/basic/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/basic/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonFooter, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonFooter, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toolbar/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/buttons/angular/example_component_ts.md
@@ -1,14 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import {
-  IonBackButton,
-  IonButton,
-  IonButtons,
-  IonIcon,
-  IonMenuButton,
-  IonTitle,
-  IonToolbar,
-} from '@ionic/angular';
+import { IonBackButton, IonButton, IonButtons, IonIcon, IonMenuButton, IonTitle, IonToolbar } from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { create, ellipsisHorizontal, ellipsisVertical, helpCircle, personCircle, search, star } from 'ionicons/icons';

--- a/static/usage/v9/toolbar/buttons/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/buttons/angular/example_component_ts.md
@@ -8,7 +8,7 @@ import {
   IonMenuButton,
   IonTitle,
   IonToolbar,
-} from '@ionic/angular/standalone';
+} from '@ionic/angular';
 
 import { addIcons } from 'ionicons';
 import { create, ellipsisHorizontal, ellipsisVertical, helpCircle, personCircle, search, star } from 'ionicons/icons';

--- a/static/usage/v9/toolbar/progress-bars/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/progress-bars/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonHeader, IonProgressBar, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonHeader, IonProgressBar, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toolbar/searchbars/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/searchbars/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonHeader, IonSearchbar, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonHeader, IonSearchbar, IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toolbar/segments/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/segments/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonToolbar } from '@ionic/angular/standalone';
+import { IonHeader, IonLabel, IonSegment, IonSegmentButton, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toolbar/theming/colors/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/theming/colors/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',

--- a/static/usage/v9/toolbar/theming/css-properties/angular/example_component_ts.md
+++ b/static/usage/v9/toolbar/theming/css-properties/angular/example_component_ts.md
@@ -1,6 +1,6 @@
 ```ts
 import { Component } from '@angular/core';
-import { IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonTitle, IonToolbar } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Update v9 static code examples with new standalone Angular component import path (`@ionic/angular/standalone` -> `@ionic/angular`).

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [X] Documentation
- [ ] Other (CI, chores, etc.)

## Platforms Affected
- [X] Android
- [X] iOS
- [X] Web