### PR TITLE
docs(datetime): update method links for confirmation buttons section

### DIFF
--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -302,7 +302,7 @@ By default, `ionChange` is emitted with the new datetime value whenever a new da
 
 ### Showing Confirmation Buttons
 
-The default Done and Cancel buttons are already preconfigured to call the [`confirm`](#confirm) and [`cancel`](#cancel) methods, respectively.
+The default Done and Cancel buttons are already preconfigured to call the [`confirm`](#method-confirm) and [`cancel`](#method-cancel) methods, respectively.
 
 <ShowingConfirmationButtons />
 


### PR DESCRIPTION
Issue URL: N/A

## What is the current behavior?

The "Showing Confirmation Buttons" section of the `ion-datetime` docs links to the `confirm` and `cancel` methods using `(#confirm)` and `(#cancel)`. The generated method anchors now carry a `method-` prefix (`{#method-confirm}`, `{#method-cancel}`), so these links no longer resolve and don't scroll to the Methods section.

## What is the new behavior?

The links point to the correct anchors, `(#method-confirm)` and `(#method-cancel)`, so they once again jump to the corresponding entries in the Methods section.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No other method links were found broken.
