### PR TITLE
docs(capacitor): document Capacitor 7 minimum and v2 removal for v9

### DIFF
--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -97,16 +97,20 @@ Note that later versions of Ionic do not support iOS 13; see [mobile support tab
 
 ### Native Bridges
 
-|  Framework   |               Cordova                |        Capacitor         |
-| :----------: | :----------------------------------: | :----------------------: |
-| V5 - Angular | cordova-android 8.X, cordova-ios 5.X |        Latest 2.X        |
-|  V5 - React  |            Not supported             |        Latest 2.x        |
-|   V5 - Vue   |            Not supported             |        Latest 2.X        |
-| V4 - Angular | cordova-android 8.X, cordova-ios 5.X |        Latest 2.X        |
-|  V4 - React  |            Not supported             |        Latest 2.x        |
-|      V3      | cordova-android 8.X, cordova-ios 5.X | Not officially supported |
+|   Framework    |               Cordova                |        Capacitor         |
+| :------------: | :----------------------------------: | :----------------------: |
+|  V9: Angular   | cordova-android 8.X, cordova-ios 5.X |           7.X+           |
+|   V9: React    |            Not supported             |           7.x+           |
+|    V9: Vue     |            Not supported             |           7.X+           |
+| V5-V8: Angular | cordova-android 8.X, cordova-ios 5.X |           2.X+           |
+|  V5-V8: React  |            Not supported             |           2.x+           |
+|   V5-V8: Vue   |            Not supported             |           2.X+           |
+|  V4: Angular   | cordova-android 8.X, cordova-ios 5.X |           2.X+           |
+|   V4: React    |            Not supported             |           2.x+           |
+|       V3       | cordova-android 8.X, cordova-ios 5.X | Not officially supported |
 
 - As iOS and Android (and related tools) are updated, you can expect more updates for Cordova and Capacitor, so it is recommended to stay on the latest version(s) of Cordova and Capacitor.
+- Starting with Ionic v9, Capacitor 7 is the minimum officially supported version. Earlier versions of Ionic ran on Capacitor 2 and later.
 
 ### Ionic Platform & Products
 

--- a/docs/updating/9-0.md
+++ b/docs/updating/9-0.md
@@ -432,6 +432,12 @@ Safari >=16
 iOS >=16
 ```
 
+### Capacitor
+
+Ionic 9 officially supports Capacitor 7 and later. Native platform detection no longer falls back to the Capacitor 2 `isNative` flag; `isCapacitorNative` now relies solely on `Capacitor.isNativePlatform()`, which was added in Capacitor 3.
+
+If your app is still on Capacitor 2, it will no longer be detected as running on a native platform, so `isPlatform('capacitor')`, `isPlatform('hybrid')`, and `getPlatforms()` will report `web` instead of native. Upgrade to Capacitor 7 or later by following the [Capacitor updating guides](https://capacitorjs.com/docs/updating/7-0).
+
 ### Legacy Picker
 
 1. Remove any usages of the `ion-picker-legacy` and `ion-picker-legacy-column` components. These components have been removed in Ionic 9. The recommended path forward is to use `ion-picker` inside a modal. Review the [Picker in Modal documentation](../api/picker.md#picker-in-modal) for more information.


### PR DESCRIPTION
Documenting our minimum capacitor support version as of Ionic Framework v9, per https://github.com/ionic-team/ionic-framework/pull/31275

Upgrade guide preview: https://ionic-docs-git-fw-6255-ionic1.vercel.app/docs/updating/9-0#capacitor
Native bridge support page preview: https://ionic-docs-git-fw-6255-ionic1.vercel.app/docs/reference/support#native-bridges