### PR TITLE
fix(release-notes): properly pull in release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,42 @@ npm install
 npm start
 ```
 
+#### GitHub Token
+
+The documentation build requires a GitHub Personal Access Token to fetch Ionic Framework release notes.
+
+**Local Development:**
+
+1. Create a [fine-grained Personal Access Token](https://github.com/settings/personal-access-tokens/new) with:
+
+   - **Repository access**: Public repositories (read-only)
+   - **Expiration**: 366 days (update annually)
+
+2. Add the token to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
+
+   ```sh
+   export GITHUB_TOKEN=github_pat_...
+   ```
+
+3. Reload your shell or run `source ~/.zshrc` (or equivalent)
+
+**Vercel (Production):**
+
+1. Create a [fine-grained Personal Access Token](https://github.com/settings/personal-access-tokens/new) with the same settings as above, but with:
+
+   - **Owner**: ionic-team organization (not your personal account)
+
+2. Add the token to Vercel project settings:
+
+   - Go to your project on Vercel
+   - Navigate to **Settings → Environment Variables**
+   - Add `GITHUB_TOKEN` with the token value
+   - Select Production and Preview environments
+
+3. Redeploy the project for the token to take effect
+
+Without the token, the build will fail with an error message indicating the token is missing.
+
 ### Linting Documentation
 
 This repository uses [Prettier](https://prettier.io/), an opinionated code formatter, in order to keep consistent formatting throughout the documentation. Run the following command to automatically fix all formatting, and then push any changes:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "crowdin:sync": "docusaurus write-translations && crowdin upload && crowdin download",
     "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus",
-    "generate-markdown": "node scripts/native.mjs && concurrently \"node scripts/cli.mjs\" \"node scripts/release-notes.mjs\"",
+    "generate-markdown": "node scripts/native.mjs && node scripts/cli.mjs && node scripts/release-notes.mjs",
     "lint": "npm run prettier -- --write",
     "serve": "docusaurus serve",
     "playground:new": "hygen playground new",

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -15,6 +15,7 @@ const commandToKebab = (str) =>
   const { commands } = cliJSON;
 
   commands.map(writePage);
+  console.log(`📟 CLI Commands Generated`);
 })();
 
 function writePage(page) {

--- a/scripts/native.mjs
+++ b/scripts/native.mjs
@@ -97,7 +97,7 @@ async function getPkgJsonData(pluginId) {
 
 async function main() {
   await Promise.all(pluginApis.map(buildPluginApiDocs));
-  console.log(`Plugin API Files Updated 🎸`);
+  console.log(`🔌 Capacitor Plugins Generated`);
 }
 
 function toTitleCase(str) {

--- a/scripts/native.mjs
+++ b/scripts/native.mjs
@@ -1,7 +1,6 @@
 import { writeFileSync } from 'fs';
 import fetch from 'node-fetch';
 
-// replace with latest once it's relased
 const tag = 'latest';
 
 const pluginApis = [
@@ -51,7 +50,7 @@ function createApiPage(pluginId, readme, pkgJson) {
 
   /**
    * Cleanup and transform JSDoc content for compatibility with MDX/Docusaurus:
-   * 
+   *
    * - Remove HTML comments (`<!-- ... -->`) which are not valid in MDX and will cause parsing errors.
    * - Escape `{` characters inside <code> blocks because MDX treats `{}` as JavaScript expressions. Unescaped `{` inside code blocks can cause parsing errors.
    * - Convert JSDoc-style {@link URL|Text} and {@link URL} to proper Markdown links:

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -15,22 +15,15 @@ const OUTPUT_PATH = resolve(__dirname, '../src/components/page/reference/Release
 //   task: async () => outputJson(OUTPUT_PATH, await getReleases(), { spaces: 2 })
 // };
 
-// Get the GitHub Releases from Ionic
+// Get the GitHub Releases from Ionic Framework
 // -------------------------------------------------------------------------------
-// This requires an environment GITHUB_TOKEN otherwise it may fail
-//
-// To add a GITHUB_TOKEN, follow the steps to create a personal access token:
-// https://docs.github.com/en/enterprise-cloud@latest/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
-// and then authorize it to work with SSO:
-// https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on
+// Fetches from the public GitHub API. Unauthenticated requests have a 60 req/hour limit.
+// To increase the rate limit, set a GITHUB_TOKEN environment variable.
 const getReleases = async () => {
   try {
-    const request = await fetch(new URL('repos/ionic-team/ionic/releases', 'https://api.github.com'), {
-      headers: {
-        Authorization: process.env.GITHUB_TOKEN !== undefined ? `token ${process.env.GITHUB_TOKEN}` : '',
-      },
-    });
-
+    const url = new URL('repos/ionic-team/ionic-framework/releases', 'https://api.github.com');
+    const headers = process.env.GITHUB_TOKEN ? { Authorization: `token ${process.env.GITHUB_TOKEN}` } : {};
+    const request = await fetch(url, { headers });
     const releases = await request.json();
 
     // Check that the response is an array in case it was
@@ -97,8 +90,29 @@ function getVersionType(version) {
 }
 
 async function run() {
-  const { outputJson } = pkg;
-  outputJson(OUTPUT_PATH, await getReleases(), { spaces: 2 });
+  const { outputJson, readJson } = pkg;
+  const newReleases = await getReleases();
+
+  // Successfully fetched new releases, save them
+  if (newReleases.length > 0) {
+    outputJson(OUTPUT_PATH, newReleases, { spaces: 2 });
+    console.log(`🚀 Release Notes Generated`);
+    return;
+  }
+
+  // If the fetch failed but we have existing data, keep it
+  try {
+    const existingData = await readJson(OUTPUT_PATH);
+    if (Array.isArray(existingData) && existingData.length > 0) {
+      console.log(`🚀 Release Notes Preserved`);
+      return;
+    }
+  } catch (error) {
+    console.warn(`⚠️  Could not read existing release notes: ${error.message}`);
+  }
+
+  // If we have no new data and no cached data, error
+  throw new Error('Failed to fetch release notes from GitHub and no cached data available');
 }
 
 run();

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -10,57 +10,59 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const OUTPUT_PATH = resolve(__dirname, '../src/components/page/reference/ReleaseNotes/release-notes.json');
 
-// export default {
-//   title: 'Build Release Notes data',
-//   task: async () => outputJson(OUTPUT_PATH, await getReleases(), { spaces: 2 })
-// };
-
 // Get the GitHub Releases from Ionic Framework
 // -------------------------------------------------------------------------------
-// Fetches from the public GitHub API. Unauthenticated requests have a 60 req/hour limit.
-// To increase the rate limit, set a GITHUB_TOKEN environment variable.
+// Requires a GITHUB_TOKEN environment variable.
+// Refer to CONTRIBUTING.md for setup instructions.
 const getReleases = async () => {
-  try {
-    const url = new URL('repos/ionic-team/ionic-framework/releases', 'https://api.github.com');
-    const headers = process.env.GITHUB_TOKEN ? { Authorization: `token ${process.env.GITHUB_TOKEN}` } : {};
-    const request = await fetch(url, { headers });
-    const releases = await request.json();
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error('GITHUB_TOKEN environment variable is required.');
+  }
 
-    // Check that the response is an array in case it was
-    // successful but returned an object
-    if (Array.isArray(releases)) {
-      return releases
-        .filter((release) => {
-          const releasePattern = /^v(\d+)\.(\d+)\.(\d+)$/;
+  const url = new URL('repos/ionic-team/ionic-framework/releases', 'https://api.github.com');
+  const headers = { Authorization: `token ${process.env.GITHUB_TOKEN}` };
+  const request = await fetch(url, { headers });
 
-          // All non-prerelease, non-alpha, non-beta, non-rc release
-          return releasePattern.test(release.tag_name);
-        })
-        .map((release) => {
-          const body = renderMarkdown(release.body.replace(/^#.*/, '')).value;
-          const published_at = parseDate(release.published_at);
-          const version = release.tag_name.replace('v', '');
-          const type = getVersionType(version);
-          const { name, tag_name } = release;
+  if (!request.ok) {
+    const error = await request.json().catch(() => ({}));
+    let message = `GitHub API returned ${request.status} ${request.statusText}: ${error.message ?? 'Unknown error'}.`;
 
-          return {
-            body,
-            name,
-            published_at,
-            tag_name,
-            type,
-            version,
-          };
-        })
-        .sort((a, b) => {
-          return -compare(a.tag_name, b.tag_name);
-        });
-    } else {
-      console.error('There was an issue getting releases:', releases);
-      return [];
+    if (request.status === 401 && error.message?.includes('Bad credentials')) {
+      message += ' Check that GITHUB_TOKEN is set and is a valid GitHub Personal Access Token.';
     }
-  } catch (error) {
-    return [];
+
+    throw new Error(message);
+  }
+
+  const releases = await request.json();
+
+  // Check that the response is an array in case it was
+  // successful but returned an object
+  if (Array.isArray(releases)) {
+    return releases
+      .filter((release) => {
+        const releasePattern = /^v(\d+)\.(\d+)\.(\d+)$/;
+        return releasePattern.test(release.tag_name);
+      })
+      .map((release) => {
+        const body = renderMarkdown(release.body.replace(/^#.*/, '')).value;
+        const published_at = parseDate(release.published_at);
+        const version = release.tag_name.replace('v', '');
+        const type = getVersionType(version);
+        const { name, tag_name } = release;
+
+        return {
+          body,
+          name,
+          published_at,
+          tag_name,
+          type,
+          version,
+        };
+      })
+      .sort((a, b) => -compare(a.tag_name, b.tag_name));
+  } else {
+    throw new Error('GitHub API returned an unexpected response format.');
   }
 };
 
@@ -90,29 +92,15 @@ function getVersionType(version) {
 }
 
 async function run() {
-  const { outputJson, readJson } = pkg;
-  const newReleases = await getReleases();
-
-  // Successfully fetched new releases, save them
-  if (newReleases.length > 0) {
-    outputJson(OUTPUT_PATH, newReleases, { spaces: 2 });
-    console.log(`🚀 Release Notes Generated`);
-    return;
-  }
-
-  // If the fetch failed but we have existing data, keep it
+  const { outputJson } = pkg;
   try {
-    const existingData = await readJson(OUTPUT_PATH);
-    if (Array.isArray(existingData) && existingData.length > 0) {
-      console.log(`🚀 Release Notes Preserved`);
-      return;
-    }
+    const releases = await getReleases();
+    outputJson(OUTPUT_PATH, releases, { spaces: 2 });
+    console.log(`🚀 Release Notes Generated`);
   } catch (error) {
-    console.warn(`⚠️  Could not read existing release notes: ${error.message}`);
+    console.error(`\n❌ Release Notes Failed\n  ⇢ ${error.message}\n`);
+    process.exit(1);
   }
-
-  // If we have no new data and no cached data, error
-  throw new Error('Failed to fetch release notes from GitHub and no cached data available');
 }
 
 run();

--- a/src/components/page/reference/ReleaseNotes/index.tsx
+++ b/src/components/page/reference/ReleaseNotes/index.tsx
@@ -26,7 +26,7 @@ https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating
     return [
       <p>
         Unable to load Releases. Please see all releases{' '}
-        <a href="https://github.com/ionic-team/ionic/releases" target="_blank">
+        <a href="https://github.com/ionic-team/ionic-framework/releases" target="_blank">
           on GitHub
         </a>
         .
@@ -38,7 +38,7 @@ https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating
     <article>
       <p className={styles.intro}>
         A complete release history for Ionic Framework is available{' '}
-        <a href="https://github.com/ionic-team/ionic/releases" target="_blank">
+        <a href="https://github.com/ionic-team/ionic-framework/releases" target="_blank">
           on GitHub
         </a>
         . Documentation for recent releases can also be found below.
@@ -53,7 +53,7 @@ https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating
           <section className={clsx(styles['release-note'], styles[`release-note-${release.type}`])}>
             <div className={styles['release-info']}>
               <div className={styles['release-header']}>
-                <a href={`https://github.com/ionic-team/ionic/releases/v${release.version}`}>
+                <a href={`https://github.com/ionic-team/ionic-framework/releases/v${release.version}`}>
                   <h2>
                     <span className={styles['release-version']}>{release.version}</span>
                   </h2>
@@ -79,7 +79,7 @@ https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating
       </div>
       <blockquote>
         To see more releases, visit{' '}
-        <a href="https://github.com/ionic-team/ionic/releases/" target="_blank">
+        <a href="https://github.com/ionic-team/ionic-framework/releases/" target="_blank">
           GitHub
         </a>
         .


### PR DESCRIPTION
This PR fixes the release notes generation failing on Vercel:

- Updates the repository path to ionic-team/ionic-framework
- Added fallback to preserve cached release notes if fetch fails
- Improved build output with cleaner logging

Production Release Notes: https://ionicframework.com/docs/reference/release-notes
Branch Release Notes: https://ionic-docs-git-fix-release-notes-ionic1.vercel.app/docs/reference/release-notes