### PR TITLE
docs(angular): remove standalone true from v8 and v9 playgrounds

### DIFF
--- a/static/usage/v8/checkbox/helper-error/angular/example_component_ts.md
+++ b/static/usage/v8/checkbox/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonCheckbox, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonCheckbox, IonButton, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',

--- a/static/usage/v8/modal/drag-move-event/angular/example_component_ts.md
+++ b/static/usage/v8/modal/drag-move-event/angular/example_component_ts.md
@@ -6,7 +6,6 @@ import type { ModalDragEventDetail } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  standalone: true,
   imports: [IonButton, IonContent, IonHeader, IonLabel, IonModal, IonTitle, IonToolbar],
 })
 export class ExampleComponent {

--- a/static/usage/v8/modal/drag-start-end-events/angular/example_component_ts.md
+++ b/static/usage/v8/modal/drag-start-end-events/angular/example_component_ts.md
@@ -6,7 +6,6 @@ import type { ModalDragEventDetail } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  standalone: true,
   imports: [IonButton, IonContent, IonHeader, IonLabel, IonModal, IonTitle, IonToolbar],
 })
 export class ExampleComponent {

--- a/static/usage/v8/radio/helper-error/angular/example_component_ts.md
+++ b/static/usage/v8/radio/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonRadioGroup, IonRadio, IonButton } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonRadioGroup, IonRadio, IonButton, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',

--- a/static/usage/v8/select/helper-error/angular/example_component_ts.md
+++ b/static/usage/v8/select/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonSelect, IonSelectOption, IonButton } from '@ionic/angular/standalone
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonSelect, IonSelectOption, IonButton, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',

--- a/static/usage/v8/toggle/helper-error/angular/example_component_ts.md
+++ b/static/usage/v8/toggle/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonToggle } from '@ionic/angular/standalone';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonToggle, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',

--- a/static/usage/v9/checkbox/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/checkbox/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonCheckbox, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonCheckbox, IonButton, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',

--- a/static/usage/v9/modal/drag-move-event/angular/example_component_ts.md
+++ b/static/usage/v9/modal/drag-move-event/angular/example_component_ts.md
@@ -6,7 +6,6 @@ import type { ModalDragEventDetail } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  standalone: true,
   imports: [IonButton, IonContent, IonHeader, IonLabel, IonModal, IonTitle, IonToolbar],
 })
 export class ExampleComponent {

--- a/static/usage/v9/modal/drag-start-end-events/angular/example_component_ts.md
+++ b/static/usage/v9/modal/drag-start-end-events/angular/example_component_ts.md
@@ -6,7 +6,6 @@ import type { ModalDragEventDetail } from '@ionic/angular/standalone';
 @Component({
   selector: 'app-example',
   templateUrl: 'example.component.html',
-  standalone: true,
   imports: [IonButton, IonContent, IonHeader, IonLabel, IonModal, IonTitle, IonToolbar],
 })
 export class ExampleComponent {

--- a/static/usage/v9/radio/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/radio/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonRadioGroup, IonRadio, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonRadioGroup, IonRadio, IonButton, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',

--- a/static/usage/v9/select/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/select/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonSelect, IonSelectOption, IonButton } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonSelect, IonSelectOption, IonButton, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',

--- a/static/usage/v9/toggle/helper-error/angular/example_component_ts.md
+++ b/static/usage/v9/toggle/helper-error/angular/example_component_ts.md
@@ -5,7 +5,6 @@ import { IonToggle } from '@ionic/angular';
 
 @Component({
   selector: 'app-example',
-  standalone: true,
   imports: [IonToggle, ReactiveFormsModule],
   templateUrl: './example.component.html',
   styleUrl: './example.component.css',


### PR DESCRIPTION
I noticed some playgrounds still include `standalone: true` which is no longer needed as it is the default. 