### PR TITLE
docs(testing): add componentOnReady guidance and a Vue testing page

### DIFF
--- a/docs/angular/testing.md
+++ b/docs/angular/testing.md
@@ -109,6 +109,34 @@ describe('TabsPage', () => {
 
 When doing component class testing, the component object is accessed using the component object defined via `component = fixture.componentInstance;`. This is an instance of the component class. When doing DOM testing, the `fixture.nativeElement` property is used. This is the actual `HTMLElement` for the component, which allows the test to use standard HTML API methods such as `HTMLElement.querySelector` in order to examine the DOM.
 
+### Waiting for Components
+
+When testing Ionic components, use the `componentOnReady` helper exported from `@ionic/core` rather than calling `el.componentOnReady()` directly. The `el.componentOnReady()` method only exists on lazy-loaded elements and calling it directly throws an error on custom-element builds, which is what standalone projects use. The helper handles both. It awaits the element's own `componentOnReady()` promise when that exists. Otherwise it waits one animation frame, giving the component's inner contents a chance to render. Wait for the callback before asserting against the rendered DOM or running accessibility tests.
+
+```tsx
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { componentOnReady } from '@ionic/core';
+import { HomePage } from './home.page';
+
+describe('HomePage', () => {
+  let fixture: ComponentFixture<HomePage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomePage],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HomePage);
+    fixture.detectChanges();
+  });
+
+  it('renders the submit button', async () => {
+    const button = fixture.nativeElement.querySelector('ion-button');
+    await new Promise<void>((resolve) => componentOnReady(button, () => resolve()));
+    expect(button.textContent).toContain('Submit');
+  });
+});
+```
+
 ## Services
 
 Services often fall into one of two broad categories: utility services that perform calculations and other operations, and data services that perform primarily HTTP operations and data manipulation.
@@ -177,11 +205,6 @@ describe('PayrolService', () => {
   });
 });
 ```
-
-### Waiting for Components
-
-When testing Ionic components, use the `componentOnReady` helper exported from `@ionic/core` rather than calling `el.componentOnReady()` directly. That method only exists on lazy-loaded elements. Calling it directly throws on custom-element builds, which is what standalone projects use. The helper handles both. It awaits the element's own `componentOnReady()` promise when that exists. Otherwise it waits one animation frame, giving the component's inner contents a chance to render. Wait for the callback before asserting against the rendered DOM or running accessibility tests.
-
 
 #### Testing HTTP Data Services
 

--- a/docs/angular/testing.md
+++ b/docs/angular/testing.md
@@ -178,6 +178,47 @@ describe('PayrolService', () => {
 });
 ```
 
+### Import `componentOnReady` for standalone projects
+
+When testing Ionic components, use the exported `componentOnReady` helper from `@ionic/core` instead of calling `el.componentOnReady()` directly. The helper works with both lazy-loaded and custom-element builds, making it more likely the component has finished rendering before making assertions against its rendered DOM or running accessibility tests. See an example here:
+
+```tsx
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { axe, toHaveNoViolations } from 'jasmine-axe';
+import { componentOnReady } from '@ionic/core';
+
+import { Component } from './component';
+
+describe('Component', () => {
+  let component: Component;
+  let fixture: ComponentFixture<Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Component],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should pass accessibility test', async () => {
+    const el = fixture.nativeElement.querySelector('ion-button');
+
+    await new Promise<void>((resolve) => {
+      componentOnReady(el, () => resolve());
+    });
+
+    jasmine.addMatchers(toHaveNoViolations);
+
+    const a11y = await axe(fixture.nativeElement);
+
+    expect(a11y).toHaveNoViolations();
+  });
+});
+```
+
 #### Testing HTTP Data Services
 
 Most services that perform HTTP operations will use Angular's HttpClient service in order to perform those operations. For such tests, it is suggested to use Angular's `HttpClientTestingModule`. For detailed documentation of this module, please see Angular's <a href="https://angular.io/guide/http#testing-http-requests" target="_blank">Angular's Testing HTTP requests</a> guide.

--- a/docs/angular/testing.md
+++ b/docs/angular/testing.md
@@ -178,46 +178,10 @@ describe('PayrolService', () => {
 });
 ```
 
-### Import `componentOnReady` for standalone projects
+### Waiting for Components
 
-When testing Ionic components, use the exported `componentOnReady` helper from `@ionic/core` instead of calling `el.componentOnReady()` directly. The helper works with both lazy-loaded and custom-element builds, making it more likely the component has finished rendering before making assertions against its rendered DOM or running accessibility tests. See an example here:
+When testing Ionic components, use the `componentOnReady` helper exported from `@ionic/core` rather than calling `el.componentOnReady()` directly. That method only exists on lazy-loaded elements. Calling it directly throws on custom-element builds, which is what standalone projects use. The helper handles both. It awaits the element's own `componentOnReady()` promise when that exists. Otherwise it waits one animation frame, giving the component's inner contents a chance to render. Wait for the callback before asserting against the rendered DOM or running accessibility tests.
 
-```tsx
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { axe, toHaveNoViolations } from 'jasmine-axe';
-import { componentOnReady } from '@ionic/core';
-
-import { Component } from './component';
-
-describe('Component', () => {
-  let component: Component;
-  let fixture: ComponentFixture<Component>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [Component],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(Component);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should pass accessibility test', async () => {
-    const el = fixture.nativeElement.querySelector('ion-button');
-
-    await new Promise<void>((resolve) => {
-      componentOnReady(el, () => resolve());
-    });
-
-    jasmine.addMatchers(toHaveNoViolations);
-
-    const a11y = await axe(fixture.nativeElement);
-
-    expect(a11y).toHaveNoViolations();
-  });
-});
-```
 
 #### Testing HTTP Data Services
 

--- a/docs/react/testing/unit-testing/best-practices.md
+++ b/docs/react/testing/unit-testing/best-practices.md
@@ -68,7 +68,7 @@ test('renders the submit button', async () => {
     </IonApp>
   );
 
-  const button = container.querySelector('ion-button');
+  const button = container.querySelector('ion-button')!;
 
   await new Promise<void>((resolve) => componentOnReady(button, () => resolve()));
 

--- a/docs/react/testing/unit-testing/best-practices.md
+++ b/docs/react/testing/unit-testing/best-practices.md
@@ -50,6 +50,24 @@ test('example', async () => {
 
 For more information on `user-event`, see the [user-event documentation](https://testing-library.com/docs/user-event/intro/).
 
-## Import `componentOnReady` for standalone projects
+## Waiting for Components
 
 When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/react` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.
+
+```tsx
+import { test, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { componentOnReady } from '@ionic/core';
+
+import App from './App';
+
+test('renders the submit button', async () => {
+  const { container } = render(<App />);
+
+  const button = container.querySelector('ion-button');
+
+  await new Promise<void>((resolve) => componentOnReady(button!, () => resolve()));
+
+  expect(button?.textContent).toContain('Submit');
+});
+```

--- a/docs/react/testing/unit-testing/best-practices.md
+++ b/docs/react/testing/unit-testing/best-practices.md
@@ -52,4 +52,4 @@ For more information on `user-event`, see the [user-event documentation](https:/
 
 ## Import `componentOnReady` for standalone projects
 
-When testing Ionic components, use the exported `componentOnReady` helper from `@ionic/core` instead of calling `el.componentOnReady()` directly. The helper works with both lazy-loaded and custom-element builds, making it more likely the component has finished rendering before making assertions against its rendered DOM or running accessibility tests.
+When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/react` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.

--- a/docs/react/testing/unit-testing/best-practices.md
+++ b/docs/react/testing/unit-testing/best-practices.md
@@ -54,20 +54,3 @@ For more information on `user-event`, see the [user-event documentation](https:/
 
 When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/react` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.
 
-```tsx
-import { test, expect } from 'vitest';
-import { render } from '@testing-library/react';
-import { componentOnReady } from '@ionic/core';
-
-import App from './App';
-
-test('renders the submit button', async () => {
-  const { container } = render(<App />);
-
-  const button = container.querySelector('ion-button');
-
-  await new Promise<void>((resolve) => componentOnReady(button!, () => resolve()));
-
-  expect(button?.textContent).toContain('Submit');
-});
-```

--- a/docs/react/testing/unit-testing/best-practices.md
+++ b/docs/react/testing/unit-testing/best-practices.md
@@ -54,3 +54,24 @@ For more information on `user-event`, see the [user-event documentation](https:/
 
 When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/react` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.
 
+```tsx
+import { IonApp } from '@ionic/react';
+import { render } from '@testing-library/react';
+import { componentOnReady } from '@ionic/core';
+
+import Example from './Example';
+
+test('renders the submit button', async () => {
+  const { container } = render(
+    <IonApp>
+      <Example />
+    </IonApp>
+  );
+
+  const button = container.querySelector('ion-button');
+
+  await new Promise<void>((resolve) => componentOnReady(button, () => resolve()));
+
+  expect(button.textContent).toContain('Submit');
+});
+```

--- a/docs/react/testing/unit-testing/best-practices.md
+++ b/docs/react/testing/unit-testing/best-practices.md
@@ -49,3 +49,7 @@ test('example', async () => {
 ```
 
 For more information on `user-event`, see the [user-event documentation](https://testing-library.com/docs/user-event/intro/).
+
+## Import `componentOnReady` for standalone projects
+
+When testing Ionic components, use the exported `componentOnReady` helper from `@ionic/core` instead of calling `el.componentOnReady()` directly. The helper works with both lazy-loaded and custom-element builds, making it more likely the component has finished rendering before making assertions against its rendered DOM or running accessibility tests.

--- a/docs/vue/testing.md
+++ b/docs/vue/testing.md
@@ -1,0 +1,25 @@
+---
+title: Testing
+---
+
+<head>
+  <title>Vue Unit and End-to-End Testing for Ionic App Components</title>
+  <meta
+    name="description"
+    content="Vue apps created using Ionic are automatically set up for unit and end-to-end testing. Read to learn more about testing tools for Ionic components."
+  />
+</head>
+
+# Testing Ionic Vue
+
+This document provides an overview of how to test an application built with `@ionic/vue`. It covers the basics of testing with Vue, as well as the specific tools and libraries developers can use to test their applications.
+
+## Introduction
+
+Testing is an important part of the development process, and it helps to ensure that an application is working as intended.
+
+## Best Practices
+
+### Import `componentOnReady` for standalone projects
+
+When testing Ionic components, use the exported `componentOnReady` helper from `@ionic/core` instead of calling `el.componentOnReady()` directly. The helper works with both lazy-loaded and custom-element builds, making it more likely the component has finished rendering before making assertions against its rendered DOM or running accessibility tests.

--- a/docs/vue/testing.md
+++ b/docs/vue/testing.md
@@ -18,3 +18,19 @@ This document provides an overview of how to test an application built with `@io
 
 When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/vue` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.
 
+```ts
+import { mount } from '@vue/test-utils';
+import { componentOnReady } from '@ionic/core';
+
+import Example from './Example.vue';
+
+test('renders the submit button', async () => {
+  const wrapper = mount(Example);
+
+  const button = wrapper.find('ion-button').element;
+
+  await new Promise<void>((resolve) => componentOnReady(button, () => resolve()));
+
+  expect(button.textContent).toContain('Submit');
+});
+```

--- a/docs/vue/testing.md
+++ b/docs/vue/testing.md
@@ -12,14 +12,10 @@ title: Testing
 
 # Testing Ionic Vue
 
-This document provides an overview of how to test an application built with `@ionic/vue`. It covers the basics of testing with Vue, as well as the specific tools and libraries developers can use to test their applications.
+This document provides an overview of how to test an application built with `@ionic/vue`. Applications generated with the Ionic CLI are set up for unit testing with [Vitest](https://vitest.dev) and [Vue Test Utils](https://test-utils.vuejs.org), and for end-to-end testing with [Cypress](https://www.cypress.io).
 
-## Introduction
+## Unit Testing
 
-Testing is an important part of the development process, and it helps to ensure that an application is working as intended.
+### Waiting for Components
 
-## Best Practices
-
-### Import `componentOnReady` for standalone projects
-
-When testing Ionic components, use the exported `componentOnReady` helper from `@ionic/core` instead of calling `el.componentOnReady()` directly. The helper works with both lazy-loaded and custom-element builds, making it more likely the component has finished rendering before making assertions against its rendered DOM or running accessibility tests.
+When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/vue` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.

--- a/docs/vue/testing.md
+++ b/docs/vue/testing.md
@@ -10,8 +10,6 @@ title: Testing
   />
 </head>
 
-# Testing Ionic Vue
-
 This document provides an overview of how to test an application built with `@ionic/vue`. Applications generated with the Ionic CLI are set up for unit testing with [Vitest](https://vitest.dev) and [Vue Test Utils](https://test-utils.vuejs.org), and for end-to-end testing with [Cypress](https://www.cypress.io).
 
 ## Unit Testing

--- a/docs/vue/testing.md
+++ b/docs/vue/testing.md
@@ -17,3 +17,30 @@ This document provides an overview of how to test an application built with `@io
 ### Waiting for Components
 
 When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/vue` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.
+
+```tsx
+import { mount } from '@vue/test-utils';
+import { IonApp } from '@ionic/vue';
+import { componentOnReady } from '@ionic/core';
+
+import Example from './Example.vue';
+
+const TestComponent = {
+  components: { IonApp, Example },
+  template: `
+    <ion-app>
+      <Example />
+    </ion-app>
+  `,
+};
+
+test('renders the submit button', async () => {
+  const wrapper = mount(TestComponent);
+
+  const button = wrapper.element.querySelector('ion-button')!;
+
+  await new Promise<void>((resolve) => componentOnReady(button, () => resolve()));
+
+  expect(button.textContent).toContain('Submit');
+});
+```

--- a/docs/vue/testing.md
+++ b/docs/vue/testing.md
@@ -18,29 +18,3 @@ This document provides an overview of how to test an application built with `@io
 
 When you need to wait for an Ionic component to render before asserting against its DOM, use the `componentOnReady` helper exported from `@ionic/core`. Do not call `el.componentOnReady()` directly. `@ionic/vue` uses Stencil's custom elements build, where that method does not exist on the element. The helper waits one animation frame instead, giving the component's inner contents a chance to render.
 
-```tsx
-import { mount } from '@vue/test-utils';
-import { IonApp } from '@ionic/vue';
-import { componentOnReady } from '@ionic/core';
-
-import Example from './Example.vue';
-
-const TestComponent = {
-  components: { IonApp, Example },
-  template: `
-    <ion-app>
-      <Example />
-    </ion-app>
-  `,
-};
-
-test('renders the submit button', async () => {
-  const wrapper = mount(TestComponent);
-
-  const button = wrapper.element.querySelector('ion-button')!;
-
-  await new Promise<void>((resolve) => componentOnReady(button, () => resolve()));
-
-  expect(button.textContent).toContain('Submit');
-});
-```

--- a/sidebars.js
+++ b/sidebars.js
@@ -183,6 +183,7 @@ module.exports = {
         'vue/slides',
         'vue/utility-functions',
         'vue/platform',
+        'vue/testing',
         'vue/pwa',
         'vue/storage',
         'vue/troubleshooting',


### PR DESCRIPTION
Resolves #3808

## Description
<!--- Describe your changes in detail -->
- Adds guidance about import `componentOnReady` for standalone projects from `@ionic/core` as a helper to improve testing when working with Ionic standalone, for Angular, React, and Vue
- Adds a testing page for Vue (mostly a starter template with the standalone guidance above)
- Adds specific testing example in the case of Angular w/the import implemented and then the helper called in the test.

## Change Type
- [ ] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [x] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->

Standalone users can't always consistently test what they need without better guidance.

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
There is a companion issue (https://github.com/ionic-team/ionic-framework/issues/31312) and PR (https://github.com/ionic-team/ionic-framework/pull/31313) in ionic-framework that might need to be coordinated for language tweaks.