### PR TITLE
docs(modal): document isDismissing on ModalDragEventDetail

### DIFF
--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -321,6 +321,23 @@ interface ModalDragEventDetail {
    * snap to upon release.
    */
   snapBreakpoint?: number;
+  /**
+   * Whether the modal will begin dismissing when the drag gesture ends.
+   *
+   * In a sheet modal, this is `true` when the modal will snap to a
+   * breakpoint of 0. In a card modal, it is `true` when the gesture
+   * passed the threshold required to close the modal.
+   *
+   * If a `canDismiss` callback is set, it can still cancel the dismiss
+   * after this event is emitted. Listen for `ionModalDidDismiss` to
+   * confirm that the modal closed.
+   *
+   * This property is only included on `ionDragEnd`.
+   *
+   * This can be used to react as soon as the user releases the modal,
+   * such as dismissing the keyboard while the modal animates away.
+   */
+  isDismissing?: boolean;
 }
 ```
 

--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -322,7 +322,8 @@ interface ModalDragEventDetail {
    */
   snapBreakpoint?: number;
   /**
-   * Whether the modal will begin dismissing when the drag gesture ends.
+   * Whether the modal is attempting to dismiss when the drag gesture
+   * ends.
    *
    * In a sheet modal, this is `true` when the modal will snap to a
    * breakpoint of 0. In a card modal, it is `true` when the gesture


### PR DESCRIPTION
Issue URL: https://github.com/ionic-team/ionic-framework/issues/31001

## What is the current behavior?

`ModalDragEventDetail` documents `currentY`, `deltaY`, `velocityY`, `progress`, and `snapBreakpoint`. The `isDismissing` property added in [ionic-framework#31002](https://github.com/ionic-team/ionic-framework/pull/31002) is
undocumented, so there is no reference for when it is `true` or which event includes it.

## What is the new behavior?

Documents `isDismissing` in the `ModalDragEventDetail` interface:

- When it is `true` for sheet modals, snapping to a breakpoint of 0, and for card modals, passing the threshold required to close.
- That a `canDismiss` callback can still cancel the dismiss after the event is emitted, and that `ionModalDidDismiss` confirms the modal closed.
- That the property is only included on `ionDragEnd`, not `ionDragMove`.
- A use case, reacting as soon as the user releases the modal, such as dismissing the keyboard.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

[Preview](https://ionic-docs-git-fw-7123-ionic1.vercel.app/docs/api/modal#modaldrageventdetail)
