### PR TITLE
chore(docusaurus): enable faster

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,7 @@ docs/native
 versioned_docs/version-v*/native
 docs/cli/commands
 docs/reference/glossary.md
+versioned_docs/version-v*/reference/glossary.md
 
 static/code/stackblitz
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,10 @@ docs/api
 docs/native
 versioned_docs/version-v*/native
 docs/cli/commands
+# Each definition in these files is one line of prose inside a JSX <section>.
+# Prettier's mdx parser reflows those children and moves link text onto its own
+# line, which MDX then wraps in a paragraph, rendering invalid HTML such as
+# <a><p>Android SDK</p></a>. Formatting these files reintroduces that markup.
 docs/reference/glossary.md
 versioned_docs/version-v*/reference/glossary.md
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [require.resolve('@docusaurus/core/lib/babel/preset')],
-};

--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -340,7 +340,7 @@ Effects such as Cube or Fade can be used in Swiper Element with no additional im
 ```
 
 :::note
-For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">Swiper API effects documentation</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">Swiper API fade effect documentation</a>.
 :::
 
 ## Wrap Up

--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -71,7 +71,7 @@ From there, we just have to replace `ion-slides` elements with `swiper-container
 
 By default, make sure you import the `register` function from `swiper/element/bundle`. This uses the bundled version of Swiper, which automatically includes all modules and stylesheets needed to run Swiper's various features.
 
-If you would like to use the Core version instead, which does not include additional modules automatically, see <a href="https://swiperjs.com/element#core-version-and-modules" target="_blank" rel="noopener noreferrer">https://swiperjs.com/element#core-version-and-modules</a>. The rest of this migration guide will assume you are using the bundled version.
+If you would like to use the Core version instead, which does not include additional modules automatically, refer to <a href="https://swiperjs.com/element#core-version-and-modules" target="_blank" rel="noopener noreferrer">Swiper's core version and modules documentation</a>. The rest of this migration guide will assume you are using the bundled version.
 
 ## Swiping with Style
 
@@ -93,7 +93,7 @@ If you were using the CSS custom properties found on `ion-slides`, below is a li
 | `--scroll-bar-background`          | `--swiper-scrollbar-bg-color`               |
 | `--scroll-bar-background-active`   | `--swiper-scrollbar-drag-bg-color`          |
 
-For additional custom CSS, because Swiper Element uses Shadow DOM encapsulation, styles will need to be injected into the Shadow DOM scope. See <a href="https://swiperjs.com/element#injecting-styles" target="_blank" rel="noopener noreferrer">https://swiperjs.com/element#injecting-styles</a> for instructions.
+For additional custom CSS, because Swiper Element uses Shadow DOM encapsulation, styles will need to be injected into the Shadow DOM scope. Refer to <a href="https://swiperjs.com/element#injecting-styles" target="_blank" rel="noopener noreferrer">Swiper's guide on injecting styles</a> for instructions.
 
 ### Additional `ion-slides` Styles
 
@@ -227,7 +227,7 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | pager   | Use the `pagination` property instead.                                                                                                  |
 
 :::note
-All properties available in Swiper Element can be found at <a href="https://swiperjs.com/swiper-api#parameters" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#parameters</a>.
+All properties available in Swiper Element can be found in the <a href="https://swiperjs.com/swiper-api#parameters" target="_blank" rel="noopener noreferrer">Swiper API parameters documentation</a>.
 :::
 
 ## Events
@@ -276,7 +276,7 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `swiperinit`                       |
 
 :::note
-All events available in Swiper Element can be found at <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#events</a> and should be lowercased and prefixed with the word `swiper`.
+All events available in Swiper Element can be found in the <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">Swiper API events documentation</a> and should be lowercased and prefixed with the word `swiper`.
 :::
 
 ## Methods
@@ -328,7 +328,7 @@ Below is a full list of method changes when going from `ion-slides` to Swiper El
 | `stopAutoplay()`     | Use the `autoplay` property instead.                                                 |
 
 :::note
-All methods and properties available on the Swiper instance can be found at <a href="https://swiperjs.com/swiper-api#methods-and-properties" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#methods-and-properties</a>.
+All methods and properties available on the Swiper instance can be found in the <a href="https://swiperjs.com/swiper-api#methods-and-properties" target="_blank" rel="noopener noreferrer">Swiper API methods and properties documentation</a>.
 :::
 
 ## Effects
@@ -340,7 +340,7 @@ Effects such as Cube or Fade can be used in Swiper Element with no additional im
 ```
 
 :::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#fade-effect</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">Swiper API effects documentation</a>.
 :::
 
 ## Wrap Up
@@ -361,6 +361,6 @@ If you are running into issues with the migration, please create a post on the [
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
-If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
+If you are running into problems with the Swiper library, new bugs should be filed on the <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">Swiper issue tracker</a>.
 
-If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">Ionic Framework issue tracker</a>.

--- a/docs/components.md
+++ b/docs/components.md
@@ -49,9 +49,7 @@ Ionic apps are made of high-level building blocks called Components, which allow
 </DocsCard>
 
 <DocsCard header="Card" href="api/card" icon="/icons/component-card-icon.png">
-  <p>
-    Cards are a great way to display an important piece of content, and can contain images, buttons, text, and more.
-  </p>
+  Cards are a great way to display an important piece of content, and can contain images, buttons, text, and more.
 </DocsCard>
 
 <DocsCard header="Checkbox" href="api/checkbox" icon="/icons/component-checkbox-icon.png">
@@ -91,10 +89,8 @@ Ionic apps are made of high-level building blocks called Components, which allow
 </DocsCard>
 
 <DocsCard header="Item" href="api/item" img="/icons/feature-component-item-icon.png">
-  <p>
-    Items are elements that can contain text, icons, avatars, images, inputs, and any other native or custom elements.
-    Items can be swiped, deleted, reordered, edited, and more.
-  </p>
+  Items are elements that can contain text, icons, avatars, images, inputs, and any other native or custom elements.
+  Items can be swiped, deleted, reordered, edited, and more.
 </DocsCard>
 
 <DocsCard header="List" href="api/list" icon="/icons/component-lists-icon.png">
@@ -102,10 +98,8 @@ Ionic apps are made of high-level building blocks called Components, which allow
 </DocsCard>
 
 <DocsCard header="Media" href="api/avatar" icon="/icons/component-media-icon.png">
-  <p>
-    A collection of media components, including avatars, icons, images, and thumbnails, designed to enhance visual
-    content.
-  </p>
+  A collection of media components, including avatars, icons, images, and thumbnails, designed to enhance visual
+  content.
 </DocsCard>
 
 <DocsCard header="Menu" href="api/menu" icon="/icons/component-menu-icon.png">

--- a/docs/contributing/coc.md
+++ b/docs/contributing/coc.md
@@ -8,6 +8,6 @@ We promise to extend courtesy and respect to everyone involved in this project r
 
 If any member of the community violates this code of conduct, the maintainers of the Ionic project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please email us at <a href="mailto:devrel@ionic.io">devrel@ionic.io</a>.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please <a href="mailto:devrel@ionic.io">email us</a>.
 
 Please click <a href="https://ionic.io/code-of-conduct" target="_blank" rel="noopener">here</a> to review to Ionic's full code of conduct.

--- a/docs/contributing/coc.md
+++ b/docs/contributing/coc.md
@@ -8,6 +8,6 @@ We promise to extend courtesy and respect to everyone involved in this project r
 
 If any member of the community violates this code of conduct, the maintainers of the Ionic project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please <a href="mailto:devrel@ionic.io">email us</a>.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please email us at devrel@ionic.io.
 
 Please click <a href="https://ionic.io/code-of-conduct" target="_blank" rel="noopener">here</a> to review to Ionic's full code of conduct.

--- a/docs/javascript/overview.md
+++ b/docs/javascript/overview.md
@@ -53,9 +53,7 @@ $ npm run dev █
   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript"
   icon="/icons/logo-javascript-icon.png"
 >
-  <p>
-    Learn more about JavaScript's core concepts, tools, and best practices from the official JavaScript documentation.
-  </p>
+  Learn more about JavaScript's core concepts, tools, and best practices from the official JavaScript documentation.
 </DocsCard>
 
 <DocsCard header="Navigation" href="/docs/api/router" icon="/icons/component-navigation-icon.png">

--- a/docs/react/slides.md
+++ b/docs/react/slides.md
@@ -257,7 +257,7 @@ export default Home;
 ```
 
 :::note
-See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#usage</a> for a full list of modules.
+Refer to <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener noreferrer">Swiper's React usage documentation</a> for a full list of modules.
 :::
 
 ## The IonicSlides Module
@@ -356,7 +356,7 @@ Below is a full list of property changes when going from `IonSlides` to Swiper R
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
-All properties available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-props</a>.
+All properties available in Swiper React can be found in the <a href="https://swiperjs.com/react#swiper-props" target="_blank" rel="noopener noreferrer">Swiper React props documentation</a>.
 :::
 
 ## Events
@@ -413,7 +413,7 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | `onIonSlidesDidLoad`        | `onInit`                       |
 
 :::note
-All events available in Swiper can be found at <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#events</a>.
+All events available in Swiper can be found in the <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">Swiper API events documentation</a>.
 :::
 
 ## Methods
@@ -545,7 +545,7 @@ export default Home;
 ```
 
 :::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/react#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#effects</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/react#effects" target="_blank" rel="noopener noreferrer">Swiper React effects documentation</a>.
 :::
 
 ## Wrap Up
@@ -566,6 +566,6 @@ If you are running into issues with the migration, please create a post on the [
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
-If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
+If you are running into problems with the Swiper library, new bugs should be filed on the <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">Swiper issue tracker</a>.
 
-If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">Ionic Framework issue tracker</a>.

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -16,63 +16,51 @@ title: Glossary
   <a href="#a11y">
     <h3>Accessibility</h3>
   </a>
-  <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility" target="_blank">Accessibility</a> (a11y) is the practice of enabling as many people as possible to use the content, even if people have limited abilities. This include people with disabilities, those using mobile devices, and those with slow network connections. Content should be developed to be as accessible as technology allows.
-  </p>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility" target="_blank">Accessibility</a> (a11y) is the practice of enabling as many people as possible to use the content, even if people have limited abilities. This include people with disabilities, those using mobile devices, and those with slow network connections. Content should be developed to be as accessible as technology allows.
 </section>
 
 <section id="android-sdk">
   <a href="#android-sdk">
     <h3>Android SDK</h3>
   </a>
-  <p>
-    The <a href="http://developer.android.com/sdk/index.html" target="_blank">Android SDK</a> is a software development kit built for developers building for Google's Android Platform. It includes tools for building, testing, and debugging Android applications.
-  </p>
+  The <a href="http://developer.android.com/sdk/index.html" target="_blank">Android SDK</a> is a software development kit built for developers building for Google's Android Platform. It includes tools for building, testing, and debugging Android applications.
 </section>
 
 <section id="android-studio">
   <a href="#android-studio">
     <h3>Android Studio</h3>
   </a>
-  <p>
-    <a href="https://developer.android.com/studio/" target="_blank">Android Studio</a> is the official
-    Integrated Development Environment (IDE) for Native Android app development.
-  </p>
+  <a href="https://developer.android.com/studio/" target="_blank">Android Studio</a> is the official
+  Integrated Development Environment (IDE) for Native Android app development.
 </section>
 
 <section id="autoprefixer">
   <a href="#autoprefixer">
     <h3>Autoprefixer</h3>
   </a>
-  <p>
-    <a href="https://github.com/postcss/autoprefixer" target="_blank">Autoprefixer</a> is a tool that adds
-    vendor-specific-prefixes to hand-written Sass/CSS code. This ensures that standardized CSS rules
-    you write will be applied across all supporting browsers. For example, instead of having to know every flexbox
-    syntax used by various browsers, autoprefixer allows you to just write <code>display: flex;</code> and it'll
-    automatically plug in the correct CSS.
-  </p>
+  <a href="https://github.com/postcss/autoprefixer" target="_blank">Autoprefixer</a> is a tool that adds
+  vendor-specific-prefixes to hand-written Sass/CSS code. This ensures that standardized CSS rules
+  you write will be applied across all supporting browsers. For example, instead of having to know every flexbox
+  syntax used by various browsers, autoprefixer allows you to just write <code>display: flex;</code> and it'll
+  automatically plug in the correct CSS.
 </section>
 
 <section id="bundling">
   <a href="#bundling">
     <h3>Bundling</h3>
   </a>
-  <p>
-    Bundling is the process of taking an app's dependencies (code you've written plus any npm modules installed) and
-    compiling/transpiling them down to one single file.
-  </p>
+  Bundling is the process of taking an app's dependencies (code you've written plus any npm modules installed) and
+  compiling/transpiling them down to one single file.
 </section>
 
 <section id="capacitor">
   <a href="#capacitor">
     <h3>Capacitor</h3>
   </a>
-  <p>
-    <a href="https://capacitorjs.com/" target="_blank">Capacitor</a> is an open source cross-platform app runtime
-    that allows web-based apps to run natively on iOS, Android, Electron, and the web. It's helpful to refer to these
-    apps "Native Progressive Web Apps" and they represent the next evolution beyond the traditional Hybrid app mentality.
-    Capacitor was created and is actively developed/supported by Ionic, the company.
-  </p>
+  <a href="https://capacitorjs.com/" target="_blank">Capacitor</a> is an open source cross-platform app runtime
+  that allows web-based apps to run natively on iOS, Android, Electron, and the web. It's helpful to refer to these
+  apps "Native Progressive Web Apps" and they represent the next evolution beyond the traditional Hybrid app mentality.
+  Capacitor was created and is actively developed/supported by Ionic, the company.
 </section>
 
 <!-- cspell:disable -->
@@ -81,14 +69,12 @@ title: Glossary
   <a href="#cli">
     <h3>CLI</h3>
   </a>
-  <p>
-    A CLI, or <strong>C</strong>ommand-<strong>L</strong>ine <strong>I</strong>nterface, is a text-based interface for
-    interacting with a program. The common command-line app for a Mac user is the Terminal app, and Windows users often
-    use Command Prompt. The Ionic community often uses this term to refer to
-    <a href="https://ionicframework.com/docs/cli">Ionic's CLI</a>. Ionic's CLI can be used for a number of things, such
-    as creating production builds of an app, running the development server, and accessing
-    <a href="https://ionic.io/appflow" target="_blank">Ionic commercial services</a>.
-  </p>
+  A CLI, or <strong>C</strong>ommand-<strong>L</strong>ine <strong>I</strong>nterface, is a text-based interface for
+  interacting with a program. The common command-line app for a Mac user is the Terminal app, and Windows users often
+  use Command Prompt. The Ionic community often uses this term to refer to
+  <a href="https://ionicframework.com/docs/cli">Ionic's CLI</a>. Ionic's CLI can be used for a number of things, such
+  as creating production builds of an app, running the development server, and accessing
+  <a href="https://ionic.io/appflow" target="_blank">Ionic commercial services</a>.
 </section>
 
 <!-- cspell:enable -->
@@ -97,383 +83,315 @@ title: Glossary
   <a href="#commonjs">
     <h3>CommonJS</h3>
   </a>
-  <p>
-    <a href="https://webpack.github.io/docs/commonjs.html" target="_blank">CommonJS</a> is a group that defines
-    standard formats for JavaScript APIs. They have defined standards for JavaScript modules and packages.
-  </p>
+  <a href="https://webpack.github.io/docs/commonjs.html" target="_blank">CommonJS</a> is a group that defines
+  standard formats for JavaScript APIs. They have defined standards for JavaScript modules and packages.
 </section>
 
 <section id="cordova">
   <a href="#cordova">
     <h3>Cordova</h3>
   </a>
-  <p>
-    <a href="https://cordova.apache.org" target="_blank">Apache Cordova</a> is an open source mobile application
-    development framework that transforms standard HTML/CSS/JS into full-fledged native apps. It provides a JavaScript
-    API for accessing native device functionality, such as the camera or accelerometer. Cordova contains the necessary
-    build tools for packaging webapps for iOS, Android, and Windows Phone.
-  </p>
+  <a href="https://cordova.apache.org" target="_blank">Apache Cordova</a> is an open source mobile application
+  development framework that transforms standard HTML/CSS/JS into full-fledged native apps. It provides a JavaScript
+  API for accessing native device functionality, such as the camera or accelerometer. Cordova contains the necessary
+  build tools for packaging webapps for iOS, Android, and Windows Phone.
 </section>
 
 <section id="cors">
   <a href="#cors">
     <h3>CORS</h3>
   </a>
-  <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">CORS</a>
-    (Cross-Origin Resource Sharing) is a mechanism for servers to control client access to web assets. See the
-    <a href="../troubleshooting/cors">CORS FAQs</a> for more information.
-  </p>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">CORS</a>
+  (Cross-Origin Resource Sharing) is a mechanism for servers to control client access to web assets. See the
+  <a href="../troubleshooting/cors">CORS FAQs</a> for more information.
 </section>
 
 <section id="css-variables">
   <a href="#css-variables">
     <h3>CSS Variables</h3>
   </a>
-  <p>
-    You may be familiar with variables from Sass.
-    <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">CSS Variables</a>
-    enable the same functionality but are built into the browser. CSS Variables are available in all evergreen browsers.
-  </p>
+  You may be familiar with variables from Sass.
+  <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">CSS Variables</a>
+  enable the same functionality but are built into the browser. CSS Variables are available in all evergreen browsers.
 </section>
 
 <section id="decorators">
   <a href="#decorators">
     <h3>Decorators</h3>
   </a>
-  <p>
-    Decorators are expressions that return a function. They allow you to take an existing function, and extend its
-    behavior. With TypeScript, you can also decorate <i>classes</i> and <i>parameters</i>. When you decorate a
-    <strong>class</strong>, you are wrapping and extending the behavior of its constructor. In other words, the
-    decorator will add some functionality when the constructor is called, and will then return the original constructor.
-    When you decorate a <strong>parameter</strong>, you are wrapping the argument that gets passed in for that
-    parameter. The decorator will add functionality when an argument is passed to the method, and then return the
-    original argument.
-  </p>
+  Decorators are expressions that return a function. They allow you to take an existing function, and extend its
+  behavior. With TypeScript, you can also decorate <i>classes</i> and <i>parameters</i>. When you decorate a
+  <strong>class</strong>, you are wrapping and extending the behavior of its constructor. In other words, the
+  decorator will add some functionality when the constructor is called, and will then return the original constructor.
+  When you decorate a <strong>parameter</strong>, you are wrapping the argument that gets passed in for that
+  parameter. The decorator will add functionality when an argument is passed to the method, and then return the
+  original argument.
 </section>
 
 <section id="es5">
   <a href="#es5">
     <h3>ES5</h3>
   </a>
-  <p>
-    ES5 refers to EcmaScript 5th Edition. A simple way to put it is that ES5 is the version of JavaScript which
-    developers are most familiar with today.
-  </p>
+  ES5 refers to EcmaScript 5th Edition. A simple way to put it is that ES5 is the version of JavaScript which
+  developers are most familiar with today.
 </section>
 
 <section id="es2015-es6">
   <a href="#es2015-es6">
     <h3>ES2015/ES6</h3>
   </a>
-  <p>
-    A wide range of new features were introduced in this version of JavaScript, including classes, modules, iterators,
-    and promises. Evergreen browsers (Chrome, Safari, Firefox and Edge) have full support for ES6, but to use ES6
-    features in older browsers, tools such as <a href="#babel">Babel</a> and <a href="#typescript">TypeScript</a> have
-    to <a href="#transpiler">transpile</a> ES6 code down to ES5.
-  </p>
+  A wide range of new features were introduced in this version of JavaScript, including classes, modules, iterators,
+  and promises. Evergreen browsers (Chrome, Safari, Firefox and Edge) have full support for ES6, but to use ES6
+  features in older browsers, tools such as <a href="#babel">Babel</a> and <a href="#typescript">TypeScript</a> have
+  to <a href="#transpiler">transpile</a> ES6 code down to ES5.
 </section>
 
 <section id="es2016-es7">
   <a href="#es2016-es7">
     <h3>ES2016/ES7</h3>
   </a>
-  <p>
-    This version of JavaScript added a number of new features to the language, including <code>Array.includes</code> and
-    the exponentiation operator. This version of JavaScript is fully supported by all evergreen browsers (Chrome,
-    Safari, Firefox and Edge)
-  </p>
+  This version of JavaScript added a number of new features to the language, including <code>Array.includes</code> and
+  the exponentiation operator. This version of JavaScript is fully supported by all evergreen browsers (Chrome,
+  Safari, Firefox and Edge)
 </section>
 
 <section id="es2017-es8">
   <a href="#es2017-es8">
     <h3>ES2017/ES8</h3>
   </a>
-  <p>
-    This version of JavaScript is the latest standard. It is currently in the final stage before becoming the new
-    official standard. This spec includes Async/Await (already in all evergreen browsers) and shared memory/atomics.
-  </p>
+  This version of JavaScript is the latest standard. It is currently in the final stage before becoming the new
+  official standard. This spec includes Async/Await (already in all evergreen browsers) and shared memory/atomics.
 </section>
 
 <section id="genymotion">
   <a href="#genymotion">
     <h3>Genymotion</h3>
   </a>
-  <p>
-    Genymotion is a third-party Android emulator. It is extremely fast, and is useful for quickly testing your app on
-    Android. Check out our <a href="../developing/tips#using-genymotion-android">resource section</a> on Genymotion for
-    more info.
-  </p>
+  Genymotion is a third-party Android emulator. It is extremely fast, and is useful for quickly testing your app on
+  Android. Check out our <a href="../developing/tips#using-genymotion-android">resource section</a> on Genymotion for
+  more info.
 </section>
 
 <section id="git">
   <a href="#git">
     <h3>Git</h3>
   </a>
-  <p>
-    <a href="https://git-scm.com/" target="_blank">Git</a> is a distributed version control system for managing code.
-    It allows development teams to contribute code to the same project without causing code conflicts.
-  </p>
+  <a href="https://git-scm.com/" target="_blank">Git</a> is a distributed version control system for managing code.
+  It allows development teams to contribute code to the same project without causing code conflicts.
 </section>
 
 <section id="gulp">
   <a href="#gulp">
     <h3>Gulp</h3>
   </a>
-  <p>
-    <a href="http://gulpjs.com/" target="_blank">Gulp</a> is a tool for running tasks which can be used to build your app.
-    Common build tasks include transpiling <a href="#es2015-es6">ES6</a> to <a href="#es5">ES5</a>, turning
-    <a href="#sass">Sass</a> into CSS, minifying code, and concatenating files.
-  </p>
+  <a href="http://gulpjs.com/" target="_blank">Gulp</a> is a tool for running tasks which can be used to build your app.
+  Common build tasks include transpiling <a href="#es2015-es6">ES6</a> to <a href="#es5">ES5</a>, turning
+  <a href="#sass">Sass</a> into CSS, minifying code, and concatenating files.
 </section>
 
 <section id="es-modules">
   <a href="#es-modules">
     <h3>ES Modules</h3>
   </a>
-  <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import" target="_blank">ES Modules</a>
-    brings the concept of modules natively to JavaScript. With modules, classes and variables are no longer in the
-    global scope and have to be explicitly imported into your project to be used. This makes it much easier to
-    understand where your code is coming from and increases modularity and compartmentalization of functionality.
-  </p>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import" target="_blank">ES Modules</a>
+  brings the concept of modules natively to JavaScript. With modules, classes and variables are no longer in the
+  global scope and have to be explicitly imported into your project to be used. This makes it much easier to
+  understand where your code is coming from and increases modularity and compartmentalization of functionality.
 </section>
 
 <section id="ionicons">
   <a href="#ionicons">
     <h3>Ionicons</h3>
   </a>
-  <p>
-    <a href="https://ionic.io/ionicons/" target="_blank">Ionicons</a> is an open-source icon set used and created
-    by Ionic. It includes 1:1 iOS and Material Design icons, as well as commonly used social/application icons.
-    Ionicons is included by default in Ionic distributions, but they can also be used in any project.
-  </p>
+  <a href="https://ionic.io/ionicons/" target="_blank">Ionicons</a> is an open-source icon set used and created
+  by Ionic. It includes 1:1 iOS and Material Design icons, as well as commonly used social/application icons.
+  Ionicons is included by default in Ionic distributions, but they can also be used in any project.
 </section>
 
 <section id="karma">
   <a href="#karma">
     <h3>Karma</h3>
   </a>
-  <p>
-    <a href="https://karma-runner.github.io/latest/index.html" target="_blank">Karma</a> is a test runner that
-    will run an app's test inside a real browser. It executes test cases, written in any testing framework, in
-    a real browser. Karma was originally written for use with Angular 1.
-  </p>
+  <a href="https://karma-runner.github.io/latest/index.html" target="_blank">Karma</a> is a test runner that
+  will run an app's test inside a real browser. It executes test cases, written in any testing framework, in
+  a real browser. Karma was originally written for use with Angular 1.
 </section>
 
 <section id="module">
   <a href="#module">
     <h3>Module</h3>
   </a>
-  <p>
-    Modules in JavaScript are small, independent, and reusable pieces or code that are isolated from one another and the
-    Global scope.
-  </p>
+  Modules in JavaScript are small, independent, and reusable pieces or code that are isolated from one another and the
+  Global scope.
 </section>
 
 <section id="monorepo">
   <a href="#monorepo">
     <h3>Monorepo</h3>
   </a>
-  <p>
-    A <strong>monorepo</strong> is a single git repository with multiple projects. Advantages include simpler
-    organization, shared tooling and dependencies, and better collaboration with teammates.
-  </p>
+  A <strong>monorepo</strong> is a single git repository with multiple projects. Advantages include simpler
+  organization, shared tooling and dependencies, and better collaboration with teammates.
 </section>
 
 <section id="livereload">
   <a href="#livereload">
     <h3>Live Reload</h3>
   </a>
-  <p>
-    <strong>Live Reload</strong> (or <strong>live-reload</strong>) is a tool that automatically reloads the browser or
-    <a href="../core-concepts/webview">Web View</a> when it detects changes in your app. In some cases, it can replace
-    parts of your app without having to reload the entire window. See the
-    <a href="../cli/livereload">Live Reload docs</a> for more information.
-  </p>
+  <strong>Live Reload</strong> (or <strong>live-reload</strong>) is a tool that automatically reloads the browser or
+  <a href="../core-concepts/webview">Web View</a> when it detects changes in your app. In some cases, it can replace
+  parts of your app without having to reload the entire window. See the
+  <a href="../cli/livereload">Live Reload docs</a> for more information.
 </section>
 
 <section id="node">
   <a href="#node">
     <h3>Node</h3>
   </a>
-  <p>
-    <a href="https://nodejs.org/" target="_blank">Node</a> is a runtime environment that allows JavaScript to be
-    written on the server-side. In addition to being used for web services, node is often used to build developer
-    tools, such as the <a href="#cli">Ionic CLI</a>.
-  </p>
+  <a href="https://nodejs.org/" target="_blank">Node</a> is a runtime environment that allows JavaScript to be
+  written on the server-side. In addition to being used for web services, node is often used to build developer
+  tools, such as the <a href="#cli">Ionic CLI</a>.
 </section>
 
 <section id="npm">
   <a href="#npm">
     <h3>npm</h3>
   </a>
-  <p>
-    <a href="https://www.npmjs.com/" target="_blank">npm</a> is the package manager for <a href="#node">node</a>.
-    It allows developers to install, share, and package node modules. Ionic can be installed with npm, along with
-    a number of its dependencies.
-  </p>
+  <a href="https://www.npmjs.com/" target="_blank">npm</a> is the package manager for <a href="#node">node</a>.
+  It allows developers to install, share, and package node modules. Ionic can be installed with npm, along with
+  a number of its dependencies.
 </section>
 
 <section id="observable">
   <a href="#observable">
     <h3>Observable</h3>
   </a>
-  <p>
-    An observable is an object that emits events (or notifications). An observer is an object that listens for these
-    events, and does something when an event is received. Together, they create a pattern that can be used for
-    programming asynchronously.
-  </p>
+  An observable is an object that emits events (or notifications). An observer is an object that listens for these
+  events, and does something when an event is received. Together, they create a pattern that can be used for
+  programming asynchronously.
 </section>
 
 <section id="package-id">
   <a href="#package-id">
     <h3>Package ID</h3>
   </a>
-  <p>
-    Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the
-    <strong>Package ID</strong> is used for identifying apps published to the App Store/Play Store. It is a string
-    formatted in <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">reverse-DNS notation</a>.
-  </p>
+  Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the
+  <strong>Package ID</strong> is used for identifying apps published to the App Store/Play Store. It is a string
+  formatted in <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">reverse-DNS notation</a>.
 </section>
 
 <section id="polyfill">
   <a href="#polyfill">
     <h3>Polyfill</h3>
   </a>
-  <p>
-    A <a href="https://remysharp.com/2010/10/08/what-is-a-polyfill" target="_blank">polyfill</a> is a bit of code that
-    adds functionality to the browser and normalizes browser differences. This is similar to a <a href="#shim">shim</a>,
-    but where a shim has it's own API, a polyfill let's the expect API of the browser be used.
-  </p>
+  A <a href="https://remysharp.com/2010/10/08/what-is-a-polyfill" target="_blank">polyfill</a> is a bit of code that
+  adds functionality to the browser and normalizes browser differences. This is similar to a <a href="#shim">shim</a>,
+  but where a shim has it's own API, a polyfill let's the expect API of the browser be used.
 </section>
 
 <section id="protractor">
   <a href="#protractor">
     <h3>Protractor</h3>
   </a>
-  <p>
-    <a href="https://angular.github.io/protractor/#/" target="_blank">Protractor</a> is a testing framework written for
-    and by the Angular team. Protractor can be used with test runners, like Karma, for end-to-end testing. Test runners
-    allow you to quickly and programmatically verify code quality.
-  </p>
+  <a href="https://angular.github.io/protractor/#/" target="_blank">Protractor</a> is a testing framework written for
+  and by the Angular team. Protractor can be used with test runners, like Karma, for end-to-end testing. Test runners
+  allow you to quickly and programmatically verify code quality.
 </section>
 
 <section id="sass">
   <a href="#sass">
     <h3>Sass</h3>
   </a>
-  <p>
-    Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features
-    such as <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">variables</a>,
-    <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">mixins</a>, and
-    <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">loops</a>.
-  </p>
+  Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features
+  such as <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">variables</a>,
+  <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">mixins</a>, and
+  <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">loops</a>.
 </section>
 
 <section id="scoped">
   <a href="#scoped">
     <h3>Scoped Encapsulation</h3>
   </a>
-  <p>
-    A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a
-    data attribute at run time. Overriding scoped selectors in CSS requires a
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a>
-    selector. Scoped components can also be styled using
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>.
-  </p>
+  A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a
+  data attribute at run time. Overriding scoped selectors in CSS requires a
+  <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a>
+  selector. Scoped components can also be styled using
+  <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>.
 </section>
 
 <section id="shadow">
   <a href="#shadow">
     <h3>Shadow DOM</h3>
   </a>
-  <p>
-    <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a>
-    is a native browser solution for DOM and style encapsulation of a component. It shields the component from its
-    surrounding environment. To externally style internal elements of a Shadow DOM component you must use
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>
-    or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a>.
-  </p>
+  <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a>
+  is a native browser solution for DOM and style encapsulation of a component. It shields the component from its
+  surrounding environment. To externally style internal elements of a Shadow DOM component you must use
+  <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>
+  or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a>.
 </section>
 
 <section id="shim">
   <a href="#shim">
     <h3>Shim</h3>
   </a>
-  <p>
-    A shim is a piece of code that normalizes an APIs across browsers. A shim can have it's own API that hides the
-    browser specific implementation from the end user.
-  </p>
+  A shim is a piece of code that normalizes an APIs across browsers. A shim can have it's own API that hides the
+  browser specific implementation from the end user.
 </section>
 
 <section id="transpiler">
   <a href="#transpiler">
     <h3>Transpiler</h3>
   </a>
-  <p>
-    Transpilation is the process of converting code from one language to another language prior to execution. Typically,
-    a transpiler will convert a high-level language to another high-level language. The most common type of
-    <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a>
-    (<a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
-  </p>
+  Transpilation is the process of converting code from one language to another language prior to execution. Typically,
+  a transpiler will convert a high-level language to another high-level language. The most common type of
+  <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a>
+  (<a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
 </section>
 
 <section id="typescript">
   <a href="#typescript">
     <h3>TypeScript</h3>
   </a>
-  <p>
-    <a href="http://www.typescriptlang.org" target="_blank">TypeScript</a> is a superset of JavaScript,
-    which means it gives you JavaScript, along with a number of extra features such as
-    <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">type declarations</a>
-    and <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">interfaces</a>.
-    Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
-  </p>
+  <a href="http://www.typescriptlang.org" target="_blank">TypeScript</a> is a superset of JavaScript,
+  which means it gives you JavaScript, along with a number of extra features such as
+  <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">type declarations</a>
+  and <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">interfaces</a>.
+  Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
 </section>
 
 <section id="unit-tests">
   <a href="#unit-tests">
     <h3>Unit Tests</h3>
   </a>
-  <p>
-    Unit Tests and unit testing are a way to test small pieces of code to see if they behave as expected. Unit testing
-    frameworks include Jasmine, Mocha, QUnit, and many others.
-  </p>
+  Unit Tests and unit testing are a way to test small pieces of code to see if they behave as expected. Unit testing
+  frameworks include Jasmine, Mocha, QUnit, and many others.
 </section>
 
 <section id="webpack">
   <a href="#webpack">
     <h3>Webpack</h3>
   </a>
-  <p>
-    <a href="https://webpack.github.io/" target="_blank">Webpack</a> bundles together JavaScript modules and other assets.
-    It can be used to create single or multiple "chunks" that are only loaded when needed. Webpack can be used to take
-    many files and dependencies and bundle them into one file, or other types.
-  </p>
+  <a href="https://webpack.github.io/" target="_blank">Webpack</a> bundles together JavaScript modules and other assets.
+  It can be used to create single or multiple "chunks" that are only loaded when needed. Webpack can be used to take
+  many files and dependencies and bundle them into one file, or other types.
 </section>
 
 <section id="web-standards">
   <a href="#web-standards">
     <h3>Web Standards</h3>
   </a>
-  <p>
-    The <a href="https://www.w3.org/" target="_blank">World Wide Web Consortium</a> (W3C) is the standards organization
-    for the Web. Together, industry leaders and the public work together to develop
-    <a href="https://www.w3.org/standards/" target="_blank">web standards</a>, which are a set of protocols, specifications,
-    and technologies that define the Web Platform.
-  </p>
+  The <a href="https://www.w3.org/" target="_blank">World Wide Web Consortium</a> (W3C) is the standards organization
+  for the Web. Together, industry leaders and the public work together to develop
+  <a href="https://www.w3.org/standards/" target="_blank">web standards</a>, which are a set of protocols, specifications,
+  and technologies that define the Web Platform.
 </section>
 
 <section id="xcode">
   <a href="#xcode">
     <h3>Xcode</h3>
   </a>
-  <p>
-    <a href="https://developer.apple.com/xcode/" target="_blank">Xcode</a> is an Apple IDE (integrated development
-    environment) for software development on Apple operating systems (macOS, iOS, watchOS and tvOS), with extensions
-    available for other languages and platforms.
-  </p>
+  <a href="https://developer.apple.com/xcode/" target="_blank">Xcode</a> is an Apple IDE (integrated development
+  environment) for software development on Apple operating systems (macOS, iOS, watchOS and tvOS), with extensions
+  available for other languages and platforms.
 </section>
 
 </div>

--- a/docs/theming/css-shadow-parts.md
+++ b/docs/theming/css-shadow-parts.md
@@ -123,13 +123,7 @@ CSS Shadow Parts are supported in the recent versions of all of the major browse
 
 ### Vendor Prefixed Pseudo-Elements
 
-<p>
-  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix" target="_blank" rel="noopener noreferrer">
-    Vendor prefixed
-  </a>{' '}
-  pseudo-elements are not supported at this time. An example of this would be any of the `::-webkit-scrollbar`
-  pseudo-elements:
-</p>
+Pseudo-elements that are <a href="https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix" target="_blank" rel="noopener noreferrer">vendor prefixed</a> are not supported at this time. An example of this would be any of the `::-webkit-scrollbar` pseudo-elements:
 
 ```css
 /* Does NOT work */

--- a/docs/vue/slides.md
+++ b/docs/vue/slides.md
@@ -212,7 +212,7 @@ const modules = [Autoplay, Keyboard, Pagination, Scrollbar, Zoom];
 ```
 
 :::note
-See <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#usage</a> for a full list of modules.
+Refer to <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noreferrer">Swiper's Vue usage documentation</a> for a full list of modules.
 :::
 
 ## The IonicSlides Module
@@ -294,7 +294,7 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
-All properties available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-props</a>.
+All properties available in Swiper Vue can be found in the <a href="https://swiperjs.com/vue#swiper-props" target="_blank" rel="noopener noreferrer">Swiper Vue props documentation</a>.
 :::
 
 ## Events
@@ -347,7 +347,7 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `init`                       |
 
 :::note
-All events available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-events</a>.
+All events available in Swiper Vue can be found in the <a href="https://swiperjs.com/vue#swiper-events" target="_blank" rel="noopener noreferrer">Swiper Vue events documentation</a>.
 :::
 
 ## Methods
@@ -472,7 +472,7 @@ const modules = [EffectFade, IonicSlides];
 ```
 
 :::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/vue#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#effects</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/vue#effects" target="_blank" rel="noopener noreferrer">Swiper Vue effects documentation</a>.
 :::
 
 ## Wrap Up
@@ -493,6 +493,6 @@ If you are running into issues with the migration, please create a post on the [
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
-If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
+If you are running into problems with the Swiper library, new bugs should be filed on the <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">Swiper issue tracker</a>.
 
-If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">Ionic Framework issue tracker</a>.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,6 +47,20 @@ module.exports = {
     },
   },
   onBrokenLinks: 'warn',
+  /**
+   * Docusaurus Faster replaces the Webpack/Babel/Terser toolchain with
+   * Rspack/SWC/Lightning CSS, which cuts build times and memory usage on a
+   * site with this many versioned pages. It becomes the default in v4.
+   *
+   * `removeLegacyPostBuildHeadAttribute` is required by the `ssgWorkerThreads`
+   * part of `faster`, so it has to be enabled alongside it.
+   */
+  future: {
+    v4: {
+      removeLegacyPostBuildHeadAttribute: true,
+    },
+    faster: true,
+  },
   markdown: {
     hooks: {
       onBrokenMarkdownLinks: 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.10.2",
+        "@docusaurus/faster": "^3.10.2",
         "@docusaurus/mdx-loader": "^3.10.2",
         "@docusaurus/plugin-client-redirects": "^3.10.2",
         "@docusaurus/preset-classic": "^3.10.2",
@@ -4027,6 +4028,30 @@
         "node": ">=20.0"
       }
     },
+    "node_modules/@docusaurus/faster": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.10.2.tgz",
+      "integrity": "sha512-p/5E5/RyHv+QWusJMPN5i3OMJTqTgkhuwzVbB1AReDWTUHXQCmf5mlTFzGiDrWeQWIDOKsuOPn1jJh0s9LUOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/types": "3.10.2",
+        "@rspack/core": "^1.7.10",
+        "@swc/core": "^1.15.40",
+        "@swc/html": "^1.15.40",
+        "browserslist": "^4.24.2",
+        "lightningcss": "^1.27.0",
+        "semver": "^7.5.4",
+        "swc-loader": "^0.2.6",
+        "tslib": "^2.6.0",
+        "webpack": "^5.95.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/types": "*"
+      }
+    },
     "node_modules/@docusaurus/logger": {
       "version": "3.10.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.2.tgz",
@@ -4784,6 +4809,37 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
@@ -5431,6 +5487,71 @@
         "react": ">=16"
       }
     },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/runtime-core": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/webpack-bundler-runtime": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -5753,6 +5874,194 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg=="
+    },
+    "node_modules/@rspack/binding": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.12.tgz",
+      "integrity": "sha512-f4HHuLbvuld8Ba4iB/4ibse5XrKxFrgmM3S4P2AOKnPlekAFlBjmltCuaTL/W2ggYvILaVY+YcFXrEH1rrKeQA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.7.12",
+        "@rspack/binding-darwin-x64": "1.7.12",
+        "@rspack/binding-linux-arm64-gnu": "1.7.12",
+        "@rspack/binding-linux-arm64-musl": "1.7.12",
+        "@rspack/binding-linux-x64-gnu": "1.7.12",
+        "@rspack/binding-linux-x64-musl": "1.7.12",
+        "@rspack/binding-wasm32-wasi": "1.7.12",
+        "@rspack/binding-win32-arm64-msvc": "1.7.12",
+        "@rspack/binding-win32-ia32-msvc": "1.7.12",
+        "@rspack/binding-win32-x64-msvc": "1.7.12"
+      }
+    },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.12.tgz",
+      "integrity": "sha512-rbFprJaJiqrmfy8SHth8EsoRS0wg4bXcucwj9NiMzpGFq14Opw8c04iQ6H9BECYzgmN0PKZ9rh41LdVvhdZe4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.12.tgz",
+      "integrity": "sha512-jnOp+/UXOJa9xqUb8KXH03sysoO2e4Ij6tw6MqDdmdj8n/A8PQENRPUbW9AwXpPtVDJPus9r4fi7b3+6e4B8Hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.12.tgz",
+      "integrity": "sha512-C8owWG+yvo7X0oVLIXetkoJhIFBP1LYNcAQqtgLmJnQLQDklGuP83dKC+zISGQWpjawHfZ1ER96vLgoTrxKZdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.12.tgz",
+      "integrity": "sha512-i51WWI64aRpsfSki6rN0aepPqXkVfS+vZM7+4bWDcmnhUmdMvhIPcYg0QRk3DtyJnu33jqNLM0WHY78k00NyfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.12.tgz",
+      "integrity": "sha512-MSos0FuPEefqo9V92ULd5hggKG29EkSNg1zDcypy0OkpsKh5pfjVxTLYFXgTcVyFoUQQbdG8zFBzYbwmJ8V4ew==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.12.tgz",
+      "integrity": "sha512-JcAMVKXOnjfpC3coWjCFPWD3Yl8RBw6a+IXQQ8mfRlHaHMIiOv8IfZqx15XRxMUn49CtP7Z0Na8iiAg2aKrcfw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.12.tgz",
+      "integrity": "sha512-n+ZqP6ZMc0nhOgvadg5VhEs9ojtbES80AcWeFnmGkbzIszvGSO63GKNiRkXtjJ9KFuRzytbbmsCqkUVH+Tywxg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "1.0.7"
+      }
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.12.tgz",
+      "integrity": "sha512-8+h5fYDXYdmugbdfZ+D1y8IQ3rv2EhSfyGP7vBe+bjNyaMa4jWrpucmZbtxojUL1AzaeuHbvMdj9UO/gelk/+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.12.tgz",
+      "integrity": "sha512-cDMGwTRSa2p9fNBVe1wTRkF2AEXZ9ARWW36QeC5CkLaI0Ezz8lvhF2+CSOPnhaQ1O1qtn0L0SF+lFnrY+I7xGQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.12.tgz",
+      "integrity": "sha512-wIqFvlgFqrgUyj/6S/FJcvShnkZOmIeXTfqvheLY67MGq8qd8jb1YimQVKAIrmWB3yuJKUFACI3Ag1UBtEedEA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/core": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.12.tgz",
+      "integrity": "sha512-6CwFIHlhRmXfZoMj3v9MZ1SMTPBn+cHVXeMIeaGp5sufqinKsISbsqHu6ZMJu2wDSmZLdmQJX6zLxkhcAUlhkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.22.0",
+        "@rspack/binding": "1.7.12",
+        "@rspack/lite-tapable": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/lite-tapable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+      "license": "MIT"
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -6097,6 +6406,507 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
+      "integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.47",
+        "@swc/core-darwin-x64": "1.15.47",
+        "@swc/core-linux-arm-gnueabihf": "1.15.47",
+        "@swc/core-linux-arm64-gnu": "1.15.47",
+        "@swc/core-linux-arm64-musl": "1.15.47",
+        "@swc/core-linux-ppc64-gnu": "1.15.47",
+        "@swc/core-linux-s390x-gnu": "1.15.47",
+        "@swc/core-linux-x64-gnu": "1.15.47",
+        "@swc/core-linux-x64-musl": "1.15.47",
+        "@swc/core-win32-arm64-msvc": "1.15.47",
+        "@swc/core-win32-ia32-msvc": "1.15.47",
+        "@swc/core-win32-x64-msvc": "1.15.47"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
+      "integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
+      "integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
+      "integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
+      "integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
+      "integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
+      "integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
+      "integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
+      "integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
+      "integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
+      "integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
+      "integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/html": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.15.47.tgz",
+      "integrity": "sha512-Olu/8OORvYB+43v2/85nHe1EA8WSvWp8D3kctEAput/o4F+EWCK0nr4yGTqvWB7Z+ODz0k+vnxpvHQYzsKP2LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "@swc/html-darwin-arm64": "1.15.47",
+        "@swc/html-darwin-x64": "1.15.47",
+        "@swc/html-linux-arm-gnueabihf": "1.15.47",
+        "@swc/html-linux-arm64-gnu": "1.15.47",
+        "@swc/html-linux-arm64-musl": "1.15.47",
+        "@swc/html-linux-ppc64-gnu": "1.15.47",
+        "@swc/html-linux-s390x-gnu": "1.15.47",
+        "@swc/html-linux-x64-gnu": "1.15.47",
+        "@swc/html-linux-x64-musl": "1.15.47",
+        "@swc/html-win32-arm64-msvc": "1.15.47",
+        "@swc/html-win32-ia32-msvc": "1.15.47",
+        "@swc/html-win32-x64-msvc": "1.15.47"
+      }
+    },
+    "node_modules/@swc/html-darwin-arm64": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.15.47.tgz",
+      "integrity": "sha512-Qe3FXNLO/k2WN7xmBP8SzBrtLvlIbyqa8cceUOI0opE4gk+myk5qIk022MiGJOgiF1B21/wMXgA08gYjQ2lP2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-darwin-x64": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.15.47.tgz",
+      "integrity": "sha512-khCOiWmqlqi8yz+F/ePExhht/+3/cz1XzKV7raPKVynzd6sPxYtFQlNubj305s2soEXgkYYIH0zVVLwiMOVn6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-arm-gnueabihf": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.15.47.tgz",
+      "integrity": "sha512-7VRqaOEQEFPHSbUcnobmI59WbFK9M35Sse8TFN3hHxOlK9fINJ9yN5FuE9XEeRQAk+PFdR6WrIcF1Xwx1Cpi8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-arm64-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.15.47.tgz",
+      "integrity": "sha512-Ri9MmQqVRiEWuRfpkSTqz0bguvejXQcqQAkoW1Hke6+DColfzETcgNWa/Kw/ii5A/SS9Nb7acKaYdIw1vMBPwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-arm64-musl": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.15.47.tgz",
+      "integrity": "sha512-NyXRQiVBkeutgCwCxUUaFqZdDmpZONs7Zz3AZGoY35s9GwXF412Nt22fK/e7lO/sM6G/+S3rOom/0xTmUQSK6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-ppc64-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-ppc64-gnu/-/html-linux-ppc64-gnu-1.15.47.tgz",
+      "integrity": "sha512-rQ+XLJHFzu0e4M5p1+8kF2FKzI7WO9KPPji87OuicHZVrDCEqg7/jSGu3hys9CjIQIYVfR+tAFuZz3Q1/jOoNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-s390x-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-s390x-gnu/-/html-linux-s390x-gnu-1.15.47.tgz",
+      "integrity": "sha512-w6bitHrllrE3lqmf14cT3spmWhZHGts1O08O4adzxztSPto7O5GM3IerqZm/NtsqlxNsfbVHnhaNXxXWe/8Q+Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-x64-gnu": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.15.47.tgz",
+      "integrity": "sha512-FTA7E29gcyadd71prg8sJUVacYrIhAXS8L7p48yCfgcNOKquofN1TDOrHVOyYMoxplL3FUwwbN+AZxWO7QfWPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-x64-musl": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.15.47.tgz",
+      "integrity": "sha512-g+K1GKUrj+S9o8Qsgii2g7ooMzZ750R4IAqH5CVElIA5FTMAx7KGnu9ga6aEnRwwLYxY3s1k/nN+ls0NEk240g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-win32-arm64-msvc": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.15.47.tgz",
+      "integrity": "sha512-5Iw3i00JdTySi+ccc2CM5bxY+8TZivQmcTqUC6mUdAY0/KYBgSe1/L294UJQ4OTLQqNDOYXY9jdb070zZUX7jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-win32-ia32-msvc": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.15.47.tgz",
+      "integrity": "sha512-YkKd0hbIOeuFC1Sg7uGKkU2JhL+c9vAJlT6P0nRbWCAL71n01IPbdtbW6PmvgVmI7pxRYucXpr4pg839nX5+9Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-win32-x64-msvc": {
+      "version": "1.15.47",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.15.47.tgz",
+      "integrity": "sha512-w9Ug+VB9hlHT4hTWIJSB40AdF+qs5w07CYq/+ef1vQRjT5naN6/SKuXmr9/CKLn3T7A9z3lRMPKE4+lmtUkBOQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
+      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -6106,6 +6916,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/acorn": {
@@ -9098,6 +9918,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -12248,6 +13077,267 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -19108,6 +20198,19 @@
       "dependencies": {
         "lower-case": "^1.1.1",
         "upper-case": "^1.1.1"
+      }
+    },
+    "node_modules/swc-loader": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.7.tgz",
+      "integrity": "sha512-nwYWw3Fh9ame3Rtm7StS9SBLpHRRnYcK7bnpF3UKZmesAK0gw2/ADvlURFAINmPvKtDLzp+GBiP9yLoEjg6S9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1.2.147",
+        "webpack": ">=2"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.2",
+    "@docusaurus/faster": "^3.10.2",
     "@docusaurus/mdx-loader": "^3.10.2",
     "@docusaurus/plugin-client-redirects": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",

--- a/versioned_docs/version-v7/angular/slides.md
+++ b/versioned_docs/version-v7/angular/slides.md
@@ -340,7 +340,7 @@ Effects such as Cube or Fade can be used in Swiper Element with no additional im
 ```
 
 :::note
-For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">Swiper API effects documentation</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">Swiper API fade effect documentation</a>.
 :::
 
 ## Wrap Up

--- a/versioned_docs/version-v7/angular/slides.md
+++ b/versioned_docs/version-v7/angular/slides.md
@@ -71,7 +71,7 @@ From there, we just have to replace `ion-slides` elements with `swiper-container
 
 By default, make sure you import the `register` function from `swiper/element/bundle`. This uses the bundled version of Swiper, which automatically includes all modules and stylesheets needed to run Swiper's various features.
 
-If you would like to use the Core version instead, which does not include additional modules automatically, see <a href="https://swiperjs.com/element#core-version-and-modules" target="_blank" rel="noopener noreferrer">https://swiperjs.com/element#core-version-and-modules</a>. The rest of this migration guide will assume you are using the bundled version.
+If you would like to use the Core version instead, which does not include additional modules automatically, refer to <a href="https://swiperjs.com/element#core-version-and-modules" target="_blank" rel="noopener noreferrer">Swiper's core version and modules documentation</a>. The rest of this migration guide will assume you are using the bundled version.
 
 ## Swiping with Style
 
@@ -93,7 +93,7 @@ If you were using the CSS custom properties found on `ion-slides`, below is a li
 | `--scroll-bar-background`          | `--swiper-scrollbar-bg-color`               |
 | `--scroll-bar-background-active`   | `--swiper-scrollbar-drag-bg-color`          |
 
-For additional custom CSS, because Swiper Element uses Shadow DOM encapsulation, styles will need to be injected into the Shadow DOM scope. See <a href="https://swiperjs.com/element#injecting-styles" target="_blank" rel="noopener noreferrer">https://swiperjs.com/element#injecting-styles</a> for instructions.
+For additional custom CSS, because Swiper Element uses Shadow DOM encapsulation, styles will need to be injected into the Shadow DOM scope. Refer to <a href="https://swiperjs.com/element#injecting-styles" target="_blank" rel="noopener noreferrer">Swiper's guide on injecting styles</a> for instructions.
 
 ### Additional `ion-slides` Styles
 
@@ -227,7 +227,7 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | pager   | Use the `pagination` property instead.                                                                                                  |
 
 :::note
-All properties available in Swiper Element can be found at <a href="https://swiperjs.com/swiper-api#parameters" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#parameters</a>.
+All properties available in Swiper Element can be found in the <a href="https://swiperjs.com/swiper-api#parameters" target="_blank" rel="noopener noreferrer">Swiper API parameters documentation</a>.
 :::
 
 ## Events
@@ -276,7 +276,7 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `init`                       |
 
 :::note
-All events available in Swiper Element can be found at <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#events</a>.
+All events available in Swiper Element can be found in the <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">Swiper API events documentation</a>.
 :::
 
 ## Methods
@@ -328,7 +328,7 @@ Below is a full list of method changes when going from `ion-slides` to Swiper El
 | `stopAutoplay()`     | Use the `autoplay` property instead.                                                 |
 
 :::note
-All methods and properties available on the Swiper instance can be found at <a href="https://swiperjs.com/swiper-api#methods-and-properties" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#methods-and-properties</a>.
+All methods and properties available on the Swiper instance can be found in the <a href="https://swiperjs.com/swiper-api#methods-and-properties" target="_blank" rel="noopener noreferrer">Swiper API methods and properties documentation</a>.
 :::
 
 ## Effects
@@ -340,7 +340,7 @@ Effects such as Cube or Fade can be used in Swiper Element with no additional im
 ```
 
 :::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#fade-effect</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/swiper-api#fade-effect" target="_blank" rel="noopener noreferrer">Swiper API effects documentation</a>.
 :::
 
 ## Wrap Up
@@ -361,6 +361,6 @@ If you are running into issues with the migration, please create a post on the [
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
-If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
+If you are running into problems with the Swiper library, new bugs should be filed on the <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">Swiper issue tracker</a>.
 
-If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">Ionic Framework issue tracker</a>.

--- a/versioned_docs/version-v7/components.md
+++ b/versioned_docs/version-v7/components.md
@@ -49,9 +49,7 @@ Ionic apps are made of high-level building blocks called Components, which allow
 </DocsCard>
 
 <DocsCard header="Card" href="api/card" icon="/icons/component-card-icon.png">
-  <p>
-    Cards are a great way to display an important piece of content, and can contain images, buttons, text, and more.
-  </p>
+  Cards are a great way to display an important piece of content, and can contain images, buttons, text, and more.
 </DocsCard>
 
 <DocsCard header="Checkbox" href="api/checkbox" icon="/icons/component-checkbox-icon.png">
@@ -91,10 +89,8 @@ Ionic apps are made of high-level building blocks called Components, which allow
 </DocsCard>
 
 <DocsCard header="Item" href="api/item" img="/icons/feature-component-item-icon.png">
-  <p>
-    Items are elements that can contain text, icons, avatars, images, inputs, and any other native or custom elements.
-    Items can be swiped, deleted, reordered, edited, and more.
-  </p>
+  Items are elements that can contain text, icons, avatars, images, inputs, and any other native or custom elements.
+  Items can be swiped, deleted, reordered, edited, and more.
 </DocsCard>
 
 <DocsCard header="List" href="api/list" icon="/icons/component-lists-icon.png">
@@ -102,10 +98,8 @@ Ionic apps are made of high-level building blocks called Components, which allow
 </DocsCard>
 
 <DocsCard header="Media" href="api/avatar" icon="/icons/component-media-icon.png">
-  <p>
-    A collection of media components, including avatars, icons, images, and thumbnails, designed to enhance visual
-    content.
-  </p>
+  A collection of media components, including avatars, icons, images, and thumbnails, designed to enhance visual
+  content.
 </DocsCard>
 
 <DocsCard header="Menu" href="api/menu" icon="/icons/component-menu-icon.png">

--- a/versioned_docs/version-v7/contributing/coc.md
+++ b/versioned_docs/version-v7/contributing/coc.md
@@ -8,6 +8,6 @@ We promise to extend courtesy and respect to everyone involved in this project r
 
 If any member of the community violates this code of conduct, the maintainers of the Ionic project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please email us at <a href="mailto:devrel@ionic.io">devrel@ionic.io</a>.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please <a href="mailto:devrel@ionic.io">email us</a>.
 
 Please click <a href="https://ionic.io/code-of-conduct" target="_blank" rel="noopener">here</a> to review to Ionic's full code of conduct.

--- a/versioned_docs/version-v7/contributing/coc.md
+++ b/versioned_docs/version-v7/contributing/coc.md
@@ -8,6 +8,6 @@ We promise to extend courtesy and respect to everyone involved in this project r
 
 If any member of the community violates this code of conduct, the maintainers of the Ionic project may take action, removing issues, comments, and PRs or blocking accounts as deemed appropriate.
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please <a href="mailto:devrel@ionic.io">email us</a>.
+If you are subject to or witness unacceptable behavior, or have any other concerns, please email us at devrel@ionic.io.
 
 Please click <a href="https://ionic.io/code-of-conduct" target="_blank" rel="noopener">here</a> to review to Ionic's full code of conduct.

--- a/versioned_docs/version-v7/layout/dynamic-font-scaling.md
+++ b/versioned_docs/version-v7/layout/dynamic-font-scaling.md
@@ -93,7 +93,6 @@ However, the `em` unit has a compounding effect which can cause issues. In the f
     <div class="child">Child element with 80px</div>
   </div>
 </div>
-```
 
 <div style={{ fontSize: '20px' }}>
   Parent element with 20px
@@ -102,6 +101,7 @@ However, the `em` unit has a compounding effect which can cause issues. In the f
     <div style={{ fontSize: '2em' }}>Child element with 80px</div>
   </div>
 </div>
+```
 
 Due to this compounding effect, we strongly recommend using `rem` units instead of `em` units when working with Dynamic Font Scaling. `rem` units set the font size of an element relative to the font size of the root element, which is typically `<html>`. The default font size of the root element is typically `16px`.
 

--- a/versioned_docs/version-v7/react/slides.md
+++ b/versioned_docs/version-v7/react/slides.md
@@ -257,7 +257,7 @@ export default Home;
 ```
 
 :::note
-See <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#usage</a> for a full list of modules.
+Refer to <a href="https://swiperjs.com/react#usage" target="_blank" rel="noopener noreferrer">Swiper's React usage documentation</a> for a full list of modules.
 :::
 
 ## The IonicSlides Module
@@ -356,7 +356,7 @@ Below is a full list of property changes when going from `IonSlides` to Swiper R
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
-All properties available in Swiper React can be found at <a href="https://swiperjs.com/react#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#swiper-props</a>.
+All properties available in Swiper React can be found in the <a href="https://swiperjs.com/react#swiper-props" target="_blank" rel="noopener noreferrer">Swiper React props documentation</a>.
 :::
 
 ## Events
@@ -413,7 +413,7 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | `onIonSlidesDidLoad`        | `onInit`                       |
 
 :::note
-All events available in Swiper can be found at <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/swiper-api#events</a>.
+All events available in Swiper can be found in the <a href="https://swiperjs.com/swiper-api#events" target="_blank" rel="noopener noreferrer">Swiper API events documentation</a>.
 :::
 
 ## Methods
@@ -545,7 +545,7 @@ export default Home;
 ```
 
 :::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/react#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/react#effects</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/react#effects" target="_blank" rel="noopener noreferrer">Swiper React effects documentation</a>.
 :::
 
 ## Wrap Up
@@ -566,6 +566,6 @@ If you are running into issues with the migration, please create a post on the [
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
-If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
+If you are running into problems with the Swiper library, new bugs should be filed on the <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">Swiper issue tracker</a>.
 
-If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">Ionic Framework issue tracker</a>.

--- a/versioned_docs/version-v7/reference/glossary.md
+++ b/versioned_docs/version-v7/reference/glossary.md
@@ -16,80 +16,42 @@ title: Glossary
   <a href="#a11y">
     <h3>Accessibility</h3>
   </a>
-  <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility" target="_blank">
-      Accessibility
-    </a>{' '}
-    (a11y) is the practice of enabling as many people as possible to use the content, even if people have limited
-    abilities. This includes people with disabilities, those using mobile devices, and those with slow network
-    connections. Content should be developed to be as accessible as technology allows.
-  </p>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility" target="_blank">Accessibility</a> (a11y) is the practice of enabling as many people as possible to use the content, even if people have limited abilities. This includes people with disabilities, those using mobile devices, and those with slow network connections. Content should be developed to be as accessible as technology allows.
 </section>
 
 <section id="android-sdk">
   <a href="#android-sdk">
     <h3>Android SDK</h3>
   </a>
-  <p>
-    The{' '}
-    <a href="http://developer.android.com/sdk/index.html" target="_blank">
-      Android SDK
-    </a>{' '}
-    is a software development kit built for developers building for Google's Android Platform. It includes tools for
-    building, testing, and debugging Android applications.
-  </p>
+  The <a href="http://developer.android.com/sdk/index.html" target="_blank">Android SDK</a> is a software development kit built for developers building for Google's Android Platform. It includes tools for building, testing, and debugging Android applications.
 </section>
 
 <section id="android-studio">
   <a href="#android-studio">
     <h3>Android Studio</h3>
   </a>
-  <p>
-    <a href="https://developer.android.com/studio/" target="_blank">
-      Android Studio
-    </a>{' '}
-    is the official Integrated Development Environment (IDE) for Native Android app development.
-  </p>
+  <a href="https://developer.android.com/studio/" target="_blank">Android Studio</a> is the official Integrated Development Environment (IDE) for Native Android app development.
 </section>
 
 <section id="autoprefixer">
   <a href="#autoprefixer">
     <h3>Autoprefixer</h3>
   </a>
-  <p>
-    <a href="https://github.com/postcss/autoprefixer" target="_blank">
-      Autoprefixer
-    </a>{' '}
-    is a tool that adds vendor-specific-prefixes to hand-written Sass/CSS code. This ensures that standardized CSS rules
-    you write will be applied across all supporting browsers. For example, instead of having to know every flexbox
-    syntax used by various browsers, autoprefixer allows you to just write <code>display: flex;</code> and it'll
-    automatically plug in the correct CSS.
-  </p>
+  <a href="https://github.com/postcss/autoprefixer" target="_blank">Autoprefixer</a> is a tool that adds vendor-specific-prefixes to hand-written Sass/CSS code. This ensures that standardized CSS rules you write will be applied across all supporting browsers. For example, instead of having to know every flexbox syntax used by various browsers, autoprefixer allows you to just write <code>display: flex;</code> and it'll automatically plug in the correct CSS.
 </section>
 
 <section id="bundling">
   <a href="#bundling">
     <h3>Bundling</h3>
   </a>
-  <p>
-    Bundling is the process of taking an app's dependencies (code you've written plus any npm modules installed) and
-    compiling/transpiling them down to one single file.
-  </p>
+  Bundling is the process of taking an app's dependencies (code you've written plus any npm modules installed) and compiling/transpiling them down to one single file.
 </section>
 
 <section id="capacitor">
   <a href="#capacitor">
     <h3>Capacitor</h3>
   </a>
-  <p>
-    <a href="https://capacitorjs.com/" target="_blank">
-      Capacitor
-    </a>{' '}
-    is an open source cross-platform app runtime that allows web-based apps to run natively on iOS, Android, Electron,
-    and the web. It's helpful to refer to these apps "Native Progressive Web Apps" and they represent the next evolution
-    beyond the traditional Hybrid app mentality. Capacitor was created and is actively developed/supported by Ionic, the
-    company.
-  </p>
+  <a href="https://capacitorjs.com/" target="_blank">Capacitor</a> is an open source cross-platform app runtime that allows web-based apps to run natively on iOS, Android, Electron, and the web. It's helpful to refer to these apps "Native Progressive Web Apps" and they represent the next evolution beyond the traditional Hybrid app mentality. Capacitor was created and is actively developed/supported by Ionic, the company.
 </section>
 
 <!-- cspell:disable -->
@@ -98,17 +60,7 @@ title: Glossary
   <a href="#cli">
     <h3>CLI</h3>
   </a>
-  <p>
-    A CLI, or <strong>C</strong>ommand-<strong>L</strong>ine <strong>I</strong>nterface, is a text-based interface for
-    interacting with a program. The common command-line app for a Mac user is the Terminal app, and Windows users often
-    use Command Prompt. The Ionic community often uses this term to refer to{' '}
-    <a href="https://ionicframework.com/docs/cli">Ionic's CLI</a>. Ionic's CLI can be used for a number of things, such
-    as creating production builds of an app, running the development server, and accessing{' '}
-    <a href="https://ionic.io/appflow" target="_blank">
-      Ionic commercial services
-    </a>
-    .
-  </p>
+  A CLI, or <strong>C</strong>ommand-<strong>L</strong>ine <strong>I</strong>nterface, is a text-based interface for interacting with a program. The common command-line app for a Mac user is the Terminal app, and Windows users often use Command Prompt. The Ionic community often uses this term to refer to <a href="https://ionicframework.com/docs/cli">Ionic's CLI</a>. Ionic's CLI can be used for a number of things, such as creating production builds of an app, running the development server, and accessing <a href="https://ionic.io/appflow" target="_blank">Ionic commercial services</a> .
 </section>
 
 <!-- cspell:enable -->
@@ -117,454 +69,238 @@ title: Glossary
   <a href="#commonjs">
     <h3>CommonJS</h3>
   </a>
-  <p>
-    <a href="https://webpack.github.io/docs/commonjs.html" target="_blank">
-      CommonJS
-    </a>{' '}
-    is a group that defines standard formats for JavaScript APIs. They have defined standards for JavaScript modules and
-    packages.
-  </p>
+  <a href="https://webpack.github.io/docs/commonjs.html" target="_blank">CommonJS</a> is a group that defines standard formats for JavaScript APIs. They have defined standards for JavaScript modules and packages.
 </section>
 
 <section id="cordova">
   <a href="#cordova">
     <h3>Cordova</h3>
   </a>
-  <p>
-    <a href="https://cordova.apache.org" target="_blank">
-      Apache Cordova
-    </a>{' '}
-    is an open source mobile application development framework that transforms standard HTML/CSS/JS into full-fledged
-    native apps. It provides a JavaScript API for accessing native device functionality, such as the camera or
-    accelerometer. Cordova contains the necessary build tools for packaging webapps for iOS, Android, and Windows Phone.
-  </p>
+  <a href="https://cordova.apache.org" target="_blank">Apache Cordova</a> is an open source mobile application development framework that transforms standard HTML/CSS/JS into full-fledged native apps. It provides a JavaScript API for accessing native device functionality, such as the camera or accelerometer. Cordova contains the necessary build tools for packaging webapps for iOS, Android, and Windows Phone.
 </section>
 
 <section id="cors">
   <a href="#cors">
     <h3>CORS</h3>
   </a>
-  <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">
-      CORS
-    </a>{' '}
-    (Cross-Origin Resource Sharing) is a mechanism for servers to control client access to web assets. See the{' '}
-    <a href="../troubleshooting/cors">CORS FAQs</a> for more information.
-  </p>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS" target="_blank">CORS</a> (Cross-Origin Resource Sharing) is a mechanism for servers to control client access to web assets. See the <a href="../troubleshooting/cors">CORS FAQs</a> for more information.
 </section>
 
 <section id="css-variables">
   <a href="#css-variables">
     <h3>CSS Variables</h3>
   </a>
-  <p>
-    You may be familiar with variables from Sass.{' '}
-    <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">
-      CSS Variables
-    </a>{' '}
-    enable the same functionality but are built into the browser. CSS Variables are available in all evergreen browsers.
-  </p>
+  You may be familiar with variables from Sass. <a href="https://developers.google.com/web/updates/2016/02/css-variables-why-should-you-care" target="_blank">CSS Variables</a> enable the same functionality but are built into the browser. CSS Variables are available in all evergreen browsers.
 </section>
 
 <section id="decorators">
   <a href="#decorators">
     <h3>Decorators</h3>
   </a>
-  <p>
-    Decorators are expressions that return a function. They allow you to take an existing function, and extend its
-    behavior. With TypeScript, you can also decorate <i>classes</i> and <i>parameters</i>. When you decorate a{' '}
-    <strong>class</strong>, you are wrapping and extending the behavior of its constructor. In other words, the
-    decorator will add some functionality when the constructor is called, and will then return the original constructor.
-    When you decorate a <strong>parameter</strong>, you are wrapping the argument that gets passed in for that
-    parameter. The decorator will add functionality when an argument is passed to the method, and then return the
-    original argument.
-  </p>
+  Decorators are expressions that return a function. They allow you to take an existing function, and extend its behavior. With TypeScript, you can also decorate <i>classes</i> and <i>parameters</i>. When you decorate a <strong>class</strong>, you are wrapping and extending the behavior of its constructor. In other words, the decorator will add some functionality when the constructor is called, and will then return the original constructor. When you decorate a <strong>parameter</strong>, you are wrapping the argument that gets passed in for that parameter. The decorator will add functionality when an argument is passed to the method, and then return the original argument.
 </section>
 
 <section id="es5">
   <a href="#es5">
     <h3>ES5</h3>
   </a>
-  <p>
-    ES5 refers to EcmaScript 5th Edition. A simple way to put it is that ES5 is the version of JavaScript which
-    developers are most familiar with today.
-  </p>
+  ES5 refers to EcmaScript 5th Edition. A simple way to put it is that ES5 is the version of JavaScript which developers are most familiar with today.
 </section>
 
 <section id="es2015-es6">
   <a href="#es2015-es6">
     <h3>ES2015/ES6</h3>
   </a>
-  <p>
-    A wide range of new features were introduced in this version of JavaScript, including classes, modules, iterators,
-    and promises. Evergreen browsers (Chrome, Safari, Firefox and Edge) have full support for ES6, but to use ES6
-    features in older browsers, tools such as <a href="#babel">Babel</a> and <a href="#typescript">TypeScript</a> have
-    to <a href="#transpiler">transpile</a> ES6 code down to ES5.
-  </p>
+  A wide range of new features were introduced in this version of JavaScript, including classes, modules, iterators, and promises. Evergreen browsers (Chrome, Safari, Firefox and Edge) have full support for ES6, but to use ES6 features in older browsers, tools such as <a href="#babel">Babel</a> and <a href="#typescript">TypeScript</a> have to <a href="#transpiler">transpile</a> ES6 code down to ES5.
 </section>
 
 <section id="es2016-es7">
   <a href="#es2016-es7">
     <h3>ES2016/ES7</h3>
   </a>
-  <p>
-    This version of JavaScript added a number of new features to the language, including <code>Array.includes</code> and
-    the exponentiation operator. This version of JavaScript is fully supported by all evergreen browsers (Chrome,
-    Safari, Firefox and Edge)
-  </p>
+  This version of JavaScript added a number of new features to the language, including <code>Array.includes</code> and the exponentiation operator. This version of JavaScript is fully supported by all evergreen browsers (Chrome, Safari, Firefox and Edge)
 </section>
 
 <section id="es2017-es8">
   <a href="#es2017-es8">
     <h3>ES2017/ES8</h3>
   </a>
-  <p>
-    This version of JavaScript is the latest standard. It is currently in the final stage before becoming the new
-    official standard. This spec includes Async/Await (already in all evergreen browsers) and shared memory/atomics.
-  </p>
+  This version of JavaScript is the latest standard. It is currently in the final stage before becoming the new official standard. This spec includes Async/Await (already in all evergreen browsers) and shared memory/atomics.
 </section>
 
 <section id="genymotion">
   <a href="#genymotion">
     <h3>Genymotion</h3>
   </a>
-  <p>
-    Genymotion is a third-party Android emulator. It is extremely fast, and is useful for quickly testing your app on
-    Android. Check out our <a href="../developing/tips#using-genymotion-android">resource section</a> on Genymotion for
-    more info.
-  </p>
+  Genymotion is a third-party Android emulator. It is extremely fast, and is useful for quickly testing your app on Android. Check out our <a href="../developing/tips#using-genymotion-android">resource section</a> on Genymotion for more info.
 </section>
 
 <section id="git">
   <a href="#git">
     <h3>Git</h3>
   </a>
-  <p>
-    <a href="https://git-scm.com/" target="_blank">
-      Git
-    </a>{' '}
-    is a distributed version control system for managing code. It allows development teams to contribute code to the
-    same project without causing code conflicts.
-  </p>
+  <a href="https://git-scm.com/" target="_blank">Git</a> is a distributed version control system for managing code. It allows development teams to contribute code to the same project without causing code conflicts.
 </section>
 
 <section id="gulp">
   <a href="#gulp">
     <h3>Gulp</h3>
   </a>
-  <p>
-    <a href="http://gulpjs.com/" target="_blank">
-      Gulp
-    </a>{' '}
-    is a tool for running tasks which can be used to build your app. Common build tasks include transpiling{' '}
-    <a href="#es2015-es6">ES6</a> to <a href="#es5">ES5</a>, turning <a href="#sass">Sass</a> into CSS, minifying code,
-    and concatenating files.
-  </p>
+  <a href="http://gulpjs.com/" target="_blank">Gulp</a> is a tool for running tasks which can be used to build your app. Common build tasks include transpiling <a href="#es2015-es6">ES6</a> to <a href="#es5">ES5</a>, turning <a href="#sass">Sass</a> into CSS, minifying code, and concatenating files.
 </section>
 
 <section id="es-modules">
   <a href="#es-modules">
     <h3>ES Modules</h3>
   </a>
-  <p>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import" target="_blank">
-      ES Modules
-    </a>{' '}
-    brings the concept of modules natively to JavaScript. With modules, classes and variables are no longer in the
-    global scope and have to be explicitly imported into your project to be used. This makes it much easier to
-    understand where your code is coming from and increases modularity and compartmentalization of functionality.
-  </p>
+  <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import" target="_blank">ES Modules</a> brings the concept of modules natively to JavaScript. With modules, classes and variables are no longer in the global scope and have to be explicitly imported into your project to be used. This makes it much easier to understand where your code is coming from and increases modularity and compartmentalization of functionality.
 </section>
 
 <section id="ionicons">
   <a href="#ionicons">
     <h3>Ionicons</h3>
   </a>
-  <p>
-    <a href="https://ionic.io/ionicons/" target="_blank">
-      Ionicons
-    </a>{' '}
-    is an open-source icon set used and created by Ionic. It includes 1:1 iOS and Material Design icons, as well as
-    commonly used social/application icons. Ionicons is included by default in Ionic distributions, but they can also be
-    used in any project.
-  </p>
+  <a href="https://ionic.io/ionicons/" target="_blank">Ionicons</a> is an open-source icon set used and created by Ionic. It includes 1:1 iOS and Material Design icons, as well as commonly used social/application icons. Ionicons is included by default in Ionic distributions, but they can also be used in any project.
 </section>
 
 <section id="karma">
   <a href="#karma">
     <h3>Karma</h3>
   </a>
-  <p>
-    <a href="https://karma-runner.github.io/latest/index.html" target="_blank">
-      Karma
-    </a>{' '}
-    is a test runner that will run an app's test inside a real browser. It executes test cases, written in any testing
-    framework, in a real browser. Karma was originally written for use with Angular 1.
-  </p>
+  <a href="https://karma-runner.github.io/latest/index.html" target="_blank">Karma</a> is a test runner that will run an app's test inside a real browser. It executes test cases, written in any testing framework, in a real browser. Karma was originally written for use with Angular 1.
 </section>
 
 <section id="module">
   <a href="#module">
     <h3>Module</h3>
   </a>
-  <p>
-    Modules in JavaScript are small, independent, and reusable pieces or code that are isolated from one another and the
-    Global scope.
-  </p>
+  Modules in JavaScript are small, independent, and reusable pieces or code that are isolated from one another and the Global scope.
 </section>
 
 <section id="monorepo">
   <a href="#monorepo">
     <h3>Monorepo</h3>
   </a>
-  <p>
-    A <strong>monorepo</strong> is a single git repository with multiple projects. Advantages include simpler
-    organization, shared tooling and dependencies, and better collaboration with teammates.
-  </p>
+  A <strong>monorepo</strong> is a single git repository with multiple projects. Advantages include simpler organization, shared tooling and dependencies, and better collaboration with teammates.
 </section>
 
 <section id="livereload">
   <a href="#livereload">
     <h3>Live Reload</h3>
   </a>
-  <p>
-    <strong>Live Reload</strong> (or <strong>live-reload</strong>) is a tool that automatically reloads the browser or{' '}
-    <a href="../core-concepts/webview">Web View</a> when it detects changes in your app. In some cases, it can replace
-    parts of your app without having to reload the entire window. See the{' '}
-    <a href="../cli/livereload">Live Reload docs</a> for more information.
-  </p>
+  <strong>Live Reload</strong> (or <strong>live-reload</strong>) is a tool that automatically reloads the browser or <a href="../core-concepts/webview">Web View</a> when it detects changes in your app. In some cases, it can replace parts of your app without having to reload the entire window. See the <a href="../cli/livereload">Live Reload docs</a> for more information.
 </section>
 
 <section id="node">
   <a href="#node">
     <h3>Node</h3>
   </a>
-  <p>
-    <a href="https://nodejs.org/" target="_blank">
-      Node
-    </a>{' '}
-    is a runtime environment that allows JavaScript to be written on the server-side. In addition to being used for web
-    services, node is often used to build developer tools, such as the <a href="#cli">Ionic CLI</a>.
-  </p>
+  <a href="https://nodejs.org/" target="_blank">Node</a> is a runtime environment that allows JavaScript to be written on the server-side. In addition to being used for web services, node is often used to build developer tools, such as the <a href="#cli">Ionic CLI</a>.
 </section>
 
 <section id="npm">
   <a href="#npm">
     <h3>npm</h3>
   </a>
-  <p>
-    <a href="https://www.npmjs.com/" target="_blank">
-      npm
-    </a>{' '}
-    is the package manager for <a href="#node">node</a>. It allows developers to install, share, and package node
-    modules. Ionic can be installed with npm, along with a number of its dependencies.
-  </p>
+  <a href="https://www.npmjs.com/" target="_blank">npm</a> is the package manager for <a href="#node">node</a>. It allows developers to install, share, and package node modules. Ionic can be installed with npm, along with a number of its dependencies.
 </section>
 
 <section id="observable">
   <a href="#observable">
     <h3>Observable</h3>
   </a>
-  <p>
-    An observable is an object that emits events (or notifications). An observer is an object that listens for these
-    events, and does something when an event is received. Together, they create a pattern that can be used for
-    programming asynchronously.
-  </p>
+  An observable is an object that emits events (or notifications). An observer is an object that listens for these events, and does something when an event is received. Together, they create a pattern that can be used for programming asynchronously.
 </section>
 
 <section id="package-id">
   <a href="#package-id">
     <h3>Package ID</h3>
   </a>
-  <p>
-    Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the{' '}
-    <strong>Package ID</strong> is used for identifying apps published to the App Store/Play Store. It is a string
-    formatted in{' '}
-    <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">
-      reverse-DNS notation
-    </a>
-    .
-  </p>
+  Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the <strong>Package ID</strong> is used for identifying apps published to the App Store/Play Store. It is a string formatted in <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">reverse-DNS notation</a> .
 </section>
 
 <section id="polyfill">
   <a href="#polyfill">
     <h3>Polyfill</h3>
   </a>
-  <p>
-    A{' '}
-    <a href="https://remysharp.com/2010/10/08/what-is-a-polyfill" target="_blank">
-      polyfill
-    </a>{' '}
-    is a bit of code that adds functionality to the browser and normalizes browser differences. This is similar to a{' '}
-    <a href="#shim">shim</a>, but where a shim has it's own API, a polyfill let's the expect API of the browser be used.
-  </p>
+  A <a href="https://remysharp.com/2010/10/08/what-is-a-polyfill" target="_blank">polyfill</a> is a bit of code that adds functionality to the browser and normalizes browser differences. This is similar to a <a href="#shim">shim</a>, but where a shim has it's own API, a polyfill let's the expect API of the browser be used.
 </section>
 
 <section id="protractor">
   <a href="#protractor">
     <h3>Protractor</h3>
   </a>
-  <p>
-    <a href="https://angular.github.io/protractor/#/" target="_blank">
-      Protractor
-    </a>{' '}
-    is a testing framework written for and by the Angular team. Protractor can be used with test runners, like Karma,
-    for end-to-end testing. Test runners allow you to quickly and programmatically verify code quality.
-  </p>
+  <a href="https://angular.github.io/protractor/#/" target="_blank">Protractor</a> is a testing framework written for and by the Angular team. Protractor can be used with test runners, like Karma, for end-to-end testing. Test runners allow you to quickly and programmatically verify code quality.
 </section>
 
 <section id="sass">
   <a href="#sass">
     <h3>Sass</h3>
   </a>
-  <p>
-    Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features
-    such as{' '}
-    <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">
-      variables
-    </a>
-    , <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">
-      mixins
-    </a>, and <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">
-      loops
-    </a>.
-  </p>
+  Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features such as <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">variables</a> , <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">mixins</a>, and <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">loops</a>.
 </section>
 
 <section id="scoped">
   <a href="#scoped">
     <h3>Scoped Encapsulation</h3>
   </a>
-  <p>
-    A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a
-    data attribute at run time. Overriding scoped selectors in CSS requires a{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">
-      higher specificity
-    </a>{' '}
-    selector. Scoped components can also be styled using{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">
-      CSS Custom Properties
-    </a>
-    .
-  </p>
+  A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a data attribute at run time. Overriding scoped selectors in CSS requires a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a> selector. Scoped components can also be styled using <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> .
 </section>
 
 <section id="shadow">
   <a href="#shadow">
     <h3>Shadow DOM</h3>
   </a>
-  <p>
-    <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">
-      Shadow DOM
-    </a>{' '}
-    is a native browser solution for DOM and style encapsulation of a component. It shields the component from its
-    surrounding environment. To externally style internal elements of a Shadow DOM component you must use{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">
-      CSS Custom Properties
-    </a>{' '}
-    or{' '}
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">
-      CSS Shadow Parts
-    </a>
-    .
-  </p>
+  <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a> is a native browser solution for DOM and style encapsulation of a component. It shields the component from its surrounding environment. To externally style internal elements of a Shadow DOM component you must use <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a> .
 </section>
 
 <section id="shim">
   <a href="#shim">
     <h3>Shim</h3>
   </a>
-  <p>
-    A shim is a piece of code that normalizes an APIs across browsers. A shim can have it's own API that hides the
-    browser specific implementation from the end user.
-  </p>
+  A shim is a piece of code that normalizes an APIs across browsers. A shim can have it's own API that hides the browser specific implementation from the end user.
 </section>
 
 <section id="transpiler">
   <a href="#transpiler">
     <h3>Transpiler</h3>
   </a>
-  <p>
-    Transpilation is the process of converting code from one language to another language prior to execution. Typically,
-    a transpiler will convert a high-level language to another high-level language. The most common type of{' '}
-    <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a> (
-    <a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
-  </p>
+  Transpilation is the process of converting code from one language to another language prior to execution. Typically, a transpiler will convert a high-level language to another high-level language. The most common type of <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a> ( <a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
 </section>
 
 <section id="typescript">
   <a href="#typescript">
     <h3>TypeScript</h3>
   </a>
-  <p>
-    <a href="http://www.typescriptlang.org" target="_blank">
-      TypeScript
-    </a>{' '}
-    is a superset of JavaScript, which means it gives you JavaScript, along with a number of extra features such as{' '}
-    <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">
-      type declarations
-    </a>{' '}
-    and{' '}
-    <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">
-      interfaces
-    </a>
-    . Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
-  </p>
+  <a href="http://www.typescriptlang.org" target="_blank">TypeScript</a> is a superset of JavaScript, which means it gives you JavaScript, along with a number of extra features such as <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">type declarations</a> and <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">interfaces</a> . Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
 </section>
 
 <section id="unit-tests">
   <a href="#unit-tests">
     <h3>Unit Tests</h3>
   </a>
-  <p>
-    Unit Tests and unit testing are a way to test small pieces of code to see if they behave as expected. Unit testing
-    frameworks include Jasmine, Mocha, QUnit, and many others.
-  </p>
+  Unit Tests and unit testing are a way to test small pieces of code to see if they behave as expected. Unit testing frameworks include Jasmine, Mocha, QUnit, and many others.
 </section>
 
 <section id="webpack">
   <a href="#webpack">
     <h3>Webpack</h3>
   </a>
-  <p>
-    <a href="https://webpack.github.io/" target="_blank">
-      Webpack
-    </a>{' '}
-    bundles together JavaScript modules and other assets. It can be used to create single or multiple "chunks" that are
-    only loaded when needed. Webpack can be used to take many files and dependencies and bundle them into one file, or
-    other types.
-  </p>
+  <a href="https://webpack.github.io/" target="_blank">Webpack</a> bundles together JavaScript modules and other assets. It can be used to create single or multiple "chunks" that are only loaded when needed. Webpack can be used to take many files and dependencies and bundle them into one file, or other types.
 </section>
 
 <section id="web-standards">
   <a href="#web-standards">
     <h3>Web Standards</h3>
   </a>
-  <p>
-    The{' '}
-    <a href="https://www.w3.org/" target="_blank">
-      World Wide Web Consortium
-    </a>{' '}
-    (W3C) is the standards organization for the Web. Together, industry leaders and the public work together to develop{' '}
-    <a href="https://www.w3.org/standards/" target="_blank">
-      web standards
-    </a>
-    , which are a set of protocols, specifications, and technologies that define the Web Platform.
-  </p>
+  The <a href="https://www.w3.org/" target="_blank">World Wide Web Consortium</a> (W3C) is the standards organization for the Web. Together, industry leaders and the public work together to develop <a href="https://www.w3.org/standards/" target="_blank">web standards</a> , which are a set of protocols, specifications, and technologies that define the Web Platform.
 </section>
 
 <section id="xcode">
   <a href="#xcode">
     <h3>Xcode</h3>
   </a>
-  <p>
-    <a href="https://developer.apple.com/xcode/" target="_blank">
-      Xcode
-    </a>{' '}
-    is an Apple IDE (integrated development environment) for software development on Apple operating systems (macOS,
-    iOS, watchOS and tvOS), with extensions available for other languages and platforms.
-  </p>
+  <a href="https://developer.apple.com/xcode/" target="_blank">Xcode</a> is an Apple IDE (integrated development environment) for software development on Apple operating systems (macOS, iOS, watchOS and tvOS), with extensions available for other languages and platforms.
 </section>
 
 </div>

--- a/versioned_docs/version-v7/reference/glossary.md
+++ b/versioned_docs/version-v7/reference/glossary.md
@@ -60,7 +60,7 @@ title: Glossary
   <a href="#cli">
     <h3>CLI</h3>
   </a>
-  A CLI, or <strong>C</strong>ommand-<strong>L</strong>ine <strong>I</strong>nterface, is a text-based interface for interacting with a program. The common command-line app for a Mac user is the Terminal app, and Windows users often use Command Prompt. The Ionic community often uses this term to refer to <a href="https://ionicframework.com/docs/cli">Ionic's CLI</a>. Ionic's CLI can be used for a number of things, such as creating production builds of an app, running the development server, and accessing <a href="https://ionic.io/appflow" target="_blank">Ionic commercial services</a> .
+  A CLI, or <strong>C</strong>ommand-<strong>L</strong>ine <strong>I</strong>nterface, is a text-based interface for interacting with a program. The common command-line app for a Mac user is the Terminal app, and Windows users often use Command Prompt. The Ionic community often uses this term to refer to <a href="https://ionicframework.com/docs/cli">Ionic's CLI</a>. Ionic's CLI can be used for a number of things, such as creating production builds of an app, running the development server, and accessing <a href="https://ionic.io/appflow" target="_blank">Ionic commercial services</a>.
 </section>
 
 <!-- cspell:enable -->
@@ -216,7 +216,7 @@ title: Glossary
   <a href="#package-id">
     <h3>Package ID</h3>
   </a>
-  Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the <strong>Package ID</strong> is used for identifying apps published to the App Store/Play Store. It is a string formatted in <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">reverse-DNS notation</a> .
+  Referred to by Apple as <strong>Bundle ID</strong> and by Android as <strong>Application ID</strong>, the <strong>Package ID</strong> is used for identifying apps published to the App Store/Play Store. It is a string formatted in <a href="https://en.wikipedia.org/wiki/Reverse_domain_name_notation" target="_blank">reverse-DNS notation</a>.
 </section>
 
 <section id="polyfill">
@@ -237,21 +237,21 @@ title: Glossary
   <a href="#sass">
     <h3>Sass</h3>
   </a>
-  Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features such as <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">variables</a> , <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">mixins</a>, and <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">loops</a>.
+  Sass is a stylesheet language that compiles to CSS and is used by Ionic. Sass is like CSS, but with extra features such as <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_" target="_blank">variables</a>, <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins" target="_blank">mixins</a>, and <a href="http://sass-lang.com/documentation/file.SASS_REFERENCE.html#_10" target="_blank">loops</a>.
 </section>
 
 <section id="scoped">
   <a href="#scoped">
     <h3>Scoped Encapsulation</h3>
   </a>
-  A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a data attribute at run time. Overriding scoped selectors in CSS requires a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a> selector. Scoped components can also be styled using <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> .
+  A component that uses scoped encapsulation will automatically scope its CSS by appending each of the styles with a data attribute at run time. Overriding scoped selectors in CSS requires a <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity" target="_blank">higher specificity</a> selector. Scoped components can also be styled using <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a>.
 </section>
 
 <section id="shadow">
   <a href="#shadow">
     <h3>Shadow DOM</h3>
   </a>
-  <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a> is a native browser solution for DOM and style encapsulation of a component. It shields the component from its surrounding environment. To externally style internal elements of a Shadow DOM component you must use <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a> .
+  <a href="https://developers.google.com/web/fundamentals/web-components/shadowdom" target="_blank">Shadow DOM</a> is a native browser solution for DOM and style encapsulation of a component. It shields the component from its surrounding environment. To externally style internal elements of a Shadow DOM component you must use <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables" target="_blank">CSS Custom Properties</a> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part" target="_blank">CSS Shadow Parts</a>.
 </section>
 
 <section id="shim">
@@ -265,14 +265,14 @@ title: Glossary
   <a href="#transpiler">
     <h3>Transpiler</h3>
   </a>
-  Transpilation is the process of converting code from one language to another language prior to execution. Typically, a transpiler will convert a high-level language to another high-level language. The most common type of <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a> ( <a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
+  Transpilation is the process of converting code from one language to another language prior to execution. Typically, a transpiler will convert a high-level language to another high-level language. The most common type of <em>transpilation</em> in Ionic Framework is converting <a href="#es2015-es6">ES2015/ES6</a> (<a href="#typescript">TypeScript</a>) to <a href="#es5">ES5</a> (traditional JavaScript).
 </section>
 
 <section id="typescript">
   <a href="#typescript">
     <h3>TypeScript</h3>
   </a>
-  <a href="http://www.typescriptlang.org" target="_blank">TypeScript</a> is a superset of JavaScript, which means it gives you JavaScript, along with a number of extra features such as <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">type declarations</a> and <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">interfaces</a> . Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
+  <a href="http://www.typescriptlang.org" target="_blank">TypeScript</a> is a superset of JavaScript, which means it gives you JavaScript, along with a number of extra features such as <a href="http://www.typescriptlang.org/Handbook#basic-types" target="_blank">type declarations</a> and <a href="http://www.typescriptlang.org/Handbook#interfaces" target="_blank">interfaces</a>. Although Ionic is built with TypeScript, using it to build an Ionic app is completely optional.
 </section>
 
 <section id="unit-tests">
@@ -293,7 +293,7 @@ title: Glossary
   <a href="#web-standards">
     <h3>Web Standards</h3>
   </a>
-  The <a href="https://www.w3.org/" target="_blank">World Wide Web Consortium</a> (W3C) is the standards organization for the Web. Together, industry leaders and the public work together to develop <a href="https://www.w3.org/standards/" target="_blank">web standards</a> , which are a set of protocols, specifications, and technologies that define the Web Platform.
+  The <a href="https://www.w3.org/" target="_blank">World Wide Web Consortium</a> (W3C) is the standards organization for the Web. Together, industry leaders and the public work together to develop <a href="https://www.w3.org/standards/" target="_blank">web standards</a>, which are a set of protocols, specifications, and technologies that define the Web Platform.
 </section>
 
 <section id="xcode">

--- a/versioned_docs/version-v7/theming/css-shadow-parts.md
+++ b/versioned_docs/version-v7/theming/css-shadow-parts.md
@@ -123,13 +123,7 @@ CSS Shadow Parts are supported in the recent versions of all of the major browse
 
 ### Vendor Prefixed Pseudo-Elements
 
-<p>
-  <a href="https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix" target="_blank" rel="noopener noreferrer">
-    Vendor prefixed
-  </a>{' '}
-  pseudo-elements are not supported at this time. An example of this would be any of the `::-webkit-scrollbar`
-  pseudo-elements:
-</p>
+Pseudo-elements that are <a href="https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix" target="_blank" rel="noopener noreferrer">vendor prefixed</a> are not supported at this time. An example of this would be any of the `::-webkit-scrollbar` pseudo-elements:
 
 ```css
 /* Does NOT work */

--- a/versioned_docs/version-v7/vue/slides.md
+++ b/versioned_docs/version-v7/vue/slides.md
@@ -212,7 +212,7 @@ const modules = [Autoplay, Keyboard, Pagination, Scrollbar, Zoom];
 ```
 
 :::note
-See <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#usage</a> for a full list of modules.
+Refer to <a href="https://swiperjs.com/vue#usage" target="_blank" rel="noopener noreferrer">Swiper's Vue usage documentation</a> for a full list of modules.
 :::
 
 ## The IonicSlides Module
@@ -294,7 +294,7 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
-All properties available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-props" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-props</a>.
+All properties available in Swiper Vue can be found in the <a href="https://swiperjs.com/vue#swiper-props" target="_blank" rel="noopener noreferrer">Swiper Vue props documentation</a>.
 :::
 
 ## Events
@@ -347,7 +347,7 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `init`                       |
 
 :::note
-All events available in Swiper Vue can be found at <a href="https://swiperjs.com/vue#swiper-events" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#swiper-events</a>.
+All events available in Swiper Vue can be found in the <a href="https://swiperjs.com/vue#swiper-events" target="_blank" rel="noopener noreferrer">Swiper Vue events documentation</a>.
 :::
 
 ## Methods
@@ -472,7 +472,7 @@ const modules = [EffectFade, IonicSlides];
 ```
 
 :::note
-For more information on effects in Swiper, please see <a href="https://swiperjs.com/vue#effects" target="_blank" rel="noopener noreferrer">https://swiperjs.com/vue#effects</a>.
+For more information on effects in Swiper, please refer to the <a href="https://swiperjs.com/vue#effects" target="_blank" rel="noopener noreferrer">Swiper Vue effects documentation</a>.
 :::
 
 ## Wrap Up
@@ -493,6 +493,6 @@ If you are running into issues with the migration, please create a post on the [
 
 Before opening an issue, please consider creating a post on the <a href="https://github.com/nolimits4web/swiper/discussions" target="_blank" rel="noopener noreferrer">Swiper Discussion Board</a> or the <a href="https://forum.ionicframework.com" target="_blank">Ionic Forum</a> to see if your issue can be resolved by the community.
 
-If you are running into problems with the Swiper library, new bugs should be filed on the Swiper repo: <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">https://github.com/nolimits4web/swiper/issues</a>
+If you are running into problems with the Swiper library, new bugs should be filed on the <a href="https://github.com/nolimits4web/swiper/issues" target="_blank" rel="noopener noreferrer">Swiper issue tracker</a>.
 
-If you are running into problems with the `IonicSlides` module, new bugs should be filed on the Ionic Framework repo: <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">https://github.com/ionic-team/ionic-framework/issues</a>
+If you are running into problems with the `IonicSlides` module, new bugs should be filed on the <a href="https://github.com/ionic-team/ionic-framework/issues" target="_blank" rel="noopener noreferrer">Ionic Framework issue tracker</a>.


### PR DESCRIPTION
Issue URL: internal

## What is the current behavior?

The docs build with the default Docusaurus toolchain: Webpack for bundling, Babel for transpiling, Terser for JS minification, and html-minifier-terser for HTML. A full English build takes about 91s wall clock and 166s of CPU.

Docusaurus Faster was experimental until 3.10, which marks it stable and renames the config flag. It becomes the default in v4 and is already used for newly initialized v3 sites, so staying on the old toolchain leaves us behind on both build times and v4 readiness.

## What is the new behavior?

Docusaurus Faster is enabled, swapping in Rspack, SWC, and Lightning CSS.

- Adds `@docusaurus/faster` and sets `future.faster: true`
- Enables `future.v4.removeLegacyPostBuildHeadAttribute`, which the `ssgWorkerThreads` part of `faster` requires. Nothing in this repo reads the legacy `head` argument in `postBuild`, so this is inert for us
- Deletes `babel.config.js`, which SWC replaces and which Docusaurus warns about while it is still present

Build time drops from 91s to 21s wall clock, and CPU from 166s to 51s.

SWC's HTML minifier is spec-strict where html-minifier-terser was permissive, so enabling Faster surfaced 16 pages of pre-existing invalid markup. Those are fixed here rather than suppressed, taking the build from 16 SSG warnings to 0:

| Cause | Pages |
| --- | --- |
| A URL used as its own link text, which Markdown autolinked into a nested anchor | The 6 Swiper migration pages, current and v7 |
| An email address used as its own link text, same mechanism | Code of conduct, current and v7 |
| A multi-line raw `<p>`, which MDX gave a second paragraph inside | Components and glossary (current and v7), JavaScript overview |
| The above, plus an anchor starting the paragraph | CSS Shadow Parts, current and v7 |
| A code fence that closed early, rendering markup whose inner `<div>` landed inside a `<p>` | v7 Dynamic Font Scaling |

Link text is now descriptive rather than a raw URL, which also makes these links usable with a screen reader, and the surrounding prose uses "refer to" in place of "see".

**`.prettierignore` gained an entry for the versioned glossaries, and it is not a suppression.** The v7 glossary was prettier-clean before this PR. Each definition is a single line of prose inside a JSX `<section>`, and prettier's mdx parser reflows those children so that link text lands on its own line. MDX then wraps that text in a paragraph, producing `<a><p>Android SDK</p></a>`, which is the exact invalid markup this PR removes. Running `npm run lint` without the entry would undo the fix, so the ignore is what makes it durable. The current-version glossary has been ignored for the same reason for some time; the rationale is now written above both entries in the file. For the same underlying reason, verify markup fixes in these files with `npx prettier --check <file>` rather than relying on a build alone.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**`npm run clear` is less forgiving now.** `future.faster` includes `rspackPersistentCache`, and deleting `node_modules/.cache` while a dev server is running makes Rspack panic and abort the process instead of falling back to a cold rebuild. Restarting `npm start` recovers fully. This only happens if the cache is destroyed underneath a live compile, so it is a heads-up rather than a blocker.
