### PR TITLE
fix(i18n): add unique keys to duplicate sidebar categories

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -72,6 +72,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Build Your First App',
+          key: 'angular-your-first-app',
           items: [
             'angular/your-first-app',
             'angular/your-first-app/taking-photos',
@@ -114,6 +115,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Build Your First App',
+          key: 'react-your-first-app',
           items: [
             'react/your-first-app',
             'react/your-first-app/taking-photos',
@@ -164,6 +166,7 @@ module.exports = {
         {
           type: 'category',
           label: 'Build Your First App',
+          key: 'vue-your-first-app',
           items: [
             'vue/your-first-app',
             'vue/your-first-app/taking-photos',

--- a/versioned_sidebars/version-v7-sidebars.json
+++ b/versioned_sidebars/version-v7-sidebars.json
@@ -83,6 +83,7 @@
         {
           "type": "category",
           "label": "Build Your First App",
+          "key": "angular-your-first-app",
           "items": [
             "angular/your-first-app",
             "angular/your-first-app/taking-photos",
@@ -116,6 +117,7 @@
         {
           "type": "category",
           "label": "Build Your First App",
+          "key": "react-your-first-app",
           "items": [
             "react/your-first-app",
             "react/your-first-app/taking-photos",
@@ -166,6 +168,7 @@
         {
           "type": "category",
           "label": "Build Your First App",
+          "key": "vue-your-first-app",
           "items": [
             "vue/your-first-app",
             "vue/your-first-app/taking-photos",


### PR DESCRIPTION
Issue URL: N/A

## What is the current behavior?

The production build fails on main. `docusaurus build` completes `en` and then throws on `ja`:

```
[ERROR] Error: Unable to build website for locale ja.
  [cause]: Error: Multiple docs sidebar items produce the same translation key.
  - `sidebar.docs.category.Build Your First App`: 3 duplicates found
```

Three sidebar categories, one per framework, all use the label "Build Your First App". Docusaurus derives a category's translation id as `sidebar.docs.category.${category.key ?? category.label}`, so all three collapse onto a single id.

## What is the new behavior?

Each of those categories gets a unique `key`, so each gets its own translation id and the `ja` build succeeds:

```js
label: 'Build Your First App',
key: 'angular-your-first-app',
```

Six additions in two files: `sidebars.js` (current/v8) and `versioned_sidebars/version-v7-sidebars.json`. Labels are untouched, so the sidebar looks identical.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**Why the React 19 upgrade surfaced this**

React 19 did not introduce the duplicate labels, which have been there for years. It forced the Docusaurus bump that turned them into an error. `@docusaurus/plugin-debug@3.7.0` pinned `react-json-view-lite: ^1.2.0`, and no 1.x release of that package supports React 19, so clearing the last peer warning required moving the Docusaurus family to 3.10.2. Somewhere in that range Docusaurus added the `ensureNoSidebarDuplicateEntries` validation: it appears 0 times in `plugin-content-docs@3.7.0` and twice in `3.10.2`. What was previously tolerated, three categories silently sharing one translation string, is now fatal.

**Why it was not caught before merging**

Two things hid it, and both are worth fixing separately. First, `build:preview` is `docusaurus build --locale en` while only `build:production` builds all locales, so no PR preview has ever exercised `ja`. Second, even building `ja` locally passes, because Docusaurus infers whether to translate from whether `i18n/<locale>` exists, and that directory is only created on CI by `scripts/i18n.sh` during prebuild. Creating an empty `i18n/ja` locally reproduces the failure exactly, which is how this fix was verified: failing before, passing after.