### PR TITLE
chore(tooling): add mdx to prettier and cspell, ignore archived docs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,10 @@ versioned_docs/version-v*/native
 docs/cli/commands
 docs/reference/glossary.md
 
+# Archived versions
+versioned_docs/version-v5
+versioned_docs/version-v6
+
 static/code/stackblitz
 
 .docusaurus

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,8 @@
     "versioned_docs/**/api",
     "versioned_docs/**/cli",
     "versioned_docs/**/native",
+    "versioned_docs/version-v5",
+    "versioned_docs/version-v6",
     "node_modules"
   ],
   "flagWords": [

--- a/docs/deployment/play-store.mdx
+++ b/docs/deployment/play-store.mdx
@@ -69,15 +69,15 @@ If you haven't made the switch to Android app bundles yet, you will need to opt 
 First, create a new app in the Google Play Console. In order to enable app signing, you'll need to navigate to the new release screen, on one of the Production, Open testing, closed testing, or internal testing pages.
 Select the Create new release button as seen below (it doesn't matter which release type, since you don't have to actually go through with creating a new release right now):
 
-![Google Play Console's Production tab with arrow pointing to the 'Create new release' button.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-release-1024x561.png "Google Play Console New Release Creation")
+![Google Play Console's Production tab with arrow pointing to the 'Create new release' button.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-release-1024x561.png 'Google Play Console New Release Creation')
 
 Under the App integrity section, click the **Change app signing key** button:
 
-![Google Play Console's App integrity section with the 'Change app signing key' button highlighted.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-signingkey.png "Google Play Console Change App Signing Key Option")
+![Google Play Console's App integrity section with the 'Change app signing key' button highlighted.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-signingkey.png 'Google Play Console Change App Signing Key Option')
 
 Next, select the **Export and upload a key from Java Keystore** option. This is the only way in which you can retain the key and have Google Play use it for signing. If you're using Appflow to build Android apps in the cloud, this is also the required option so you can upload the keystore file to Appflow.
 
-![The Google Play Console showing the option to 'Export and upload a key from Java Keystore'.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-export-1024x564.png "Google Play Console Export and Upload Key Option")
+![The Google Play Console showing the option to 'Export and upload a key from Java Keystore'.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-export-1024x564.png 'Google Play Console Export and Upload Key Option')
 
 Follow the instructions on the screen to generate the Keystore and you can use the same Keystore file to sign your app in the Appflow dashboard as well. If you need any help generating the Keystore file, you can refer to our docs [here](https://ionic.io/docs/appflow/package/credentials#android-certificates).
 Once the generated zip file has been uploaded, you're all set! Build an AAB binary signed with the keystore file then upload it to Google Play.
@@ -88,7 +88,7 @@ As of now, existing apps aren't required to use the AAB format, but you can stil
 
 To opt into app signing, you'll need to upload the app signing key used to sign previous releases of the app. Navigate to Setup -> App integrity, then choose one of the two methods seen in the screenshot below. Once the key has been uploaded, you can enroll in Play App Signing.
 
-![The opt-in options for Play App Signing in the Google Play Console.](https://blog.ionicframework.com/wp-content/uploads/2021/12/existingapps-optin.png "Google Play Console Opt-in to Play App Signing")
+![The opt-in options for Play App Signing in the Google Play Console.](https://blog.ionicframework.com/wp-content/uploads/2021/12/existingapps-optin.png 'Google Play Console Opt-in to Play App Signing')
 
 :::tip
 With smaller app sizes, improved performance, and enhanced security, the AAB binary format is a win for app developers and users alike. If you have an existing Android app using the APK format, consider migrating to AAB to take advantage of all the great features it provides.
@@ -140,7 +140,7 @@ Making a developer account with Google Play costs $25 USD.
 
 Once a developer account has been created, go ahead and click the `Create an Application`
 
-![The Google Play Store Developer Console with the 'CREATE APPLICATION' button highlighted.](/img/publishing/newAppGPlay.png "Google Play Store Create Application Button")
+![The Google Play Store Developer Console with the 'CREATE APPLICATION' button highlighted.](/img/publishing/newAppGPlay.png 'Google Play Store Create Application Button')
 
 Be sure to fill out the description for the app along with providing screenshots and additional info.
 When ready, upload the signed release AAB/APK that was generated and publish the app.

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "serve": "docusaurus serve",
     "playground:new": "hygen playground new",
     "prestart": "npm run generate-markdown",
-    "prettier": "prettier \"./**/*.{html,ts,tsx,js,jsx,md}\" --cache",
+    "prettier": "prettier \"./**/*.{html,ts,tsx,js,jsx,md,mdx}\" --cache",
     "start": "docusaurus start",
     "swizzle": "docusaurus swizzle",
-    "spellcheck": "cspell --no-progress \"**/*.md\""
+    "spellcheck": "cspell --no-progress \"**/*.{md,mdx}\""
   },
   "browserslist": {
     "production": [

--- a/versioned_docs/version-v7/deployment/play-store.mdx
+++ b/versioned_docs/version-v7/deployment/play-store.mdx
@@ -69,15 +69,15 @@ If you haven't made the switch to Android app bundles yet, you will need to opt 
 First, create a new app in the Google Play Console. In order to enable app signing, you'll need to navigate to the new release screen, on one of the Production, Open testing, closed testing, or internal testing pages.
 Select the Create new release button as seen below (it doesn't matter which release type, since you don't have to actually go through with creating a new release right now):
 
-![Google Play Console's Production tab with arrow pointing to the 'Create new release' button.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-release-1024x561.png "Google Play Console New Release Creation")
+![Google Play Console's Production tab with arrow pointing to the 'Create new release' button.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-release-1024x561.png 'Google Play Console New Release Creation')
 
 Under the App integrity section, click the **Change app signing key** button:
 
-![Google Play Console's App integrity section with the 'Change app signing key' button highlighted.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-signingkey.png "Google Play Console Change App Signing Key Option")
+![Google Play Console's App integrity section with the 'Change app signing key' button highlighted.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-signingkey.png 'Google Play Console Change App Signing Key Option')
 
 Next, select the **Export and upload a key from Java Keystore** option. This is the only way in which you can retain the key and have Google Play use it for signing. If you're using Appflow to build Android apps in the cloud, this is also the required option so you can upload the keystore file to Appflow.
 
-![The Google Play Console showing the option to 'Export and upload a key from Java Keystore'.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-export-1024x564.png "Google Play Console Export and Upload Key Option")
+![The Google Play Console showing the option to 'Export and upload a key from Java Keystore'.](https://blog.ionicframework.com/wp-content/uploads/2021/12/newapps-export-1024x564.png 'Google Play Console Export and Upload Key Option')
 
 Follow the instructions on the screen to generate the Keystore and you can use the same Keystore file to sign your app in the Appflow dashboard as well. If you need any help generating the Keystore file, you can refer to our docs [here](https://ionic.io/docs/appflow/package/credentials#android-certificates).
 Once the generated zip file has been uploaded, you're all set! Build an AAB binary signed with the keystore file then upload it to Google Play.
@@ -88,7 +88,7 @@ As of now, existing apps aren't required to use the AAB format, but you can stil
 
 To opt into app signing, you'll need to upload the app signing key used to sign previous releases of the app. Navigate to Setup -> App integrity, then choose one of the two methods seen in the screenshot below. Once the key has been uploaded, you can enroll in Play App Signing.
 
-![The opt-in options for Play App Signing in the Google Play Console.](https://blog.ionicframework.com/wp-content/uploads/2021/12/existingapps-optin.png "Google Play Console Opt-in to Play App Signing")
+![The opt-in options for Play App Signing in the Google Play Console.](https://blog.ionicframework.com/wp-content/uploads/2021/12/existingapps-optin.png 'Google Play Console Opt-in to Play App Signing')
 
 :::tip
 With smaller app sizes, improved performance, and enhanced security, the AAB binary format is a win for app developers and users alike. If you have an existing Android app using the APK format, consider migrating to AAB to take advantage of all the great features it provides.
@@ -140,7 +140,7 @@ Making a developer account with Google Play costs $25 USD.
 
 Once a developer account has been created, go ahead and click the `Create an Application`
 
-![The Google Play Store Developer Console with the 'CREATE APPLICATION' button highlighted.](/img/publishing/newAppGPlay.png "Google Play Store Create Application Button")
+![The Google Play Store Developer Console with the 'CREATE APPLICATION' button highlighted.](/img/publishing/newAppGPlay.png 'Google Play Store Create Application Button')
 
 Be sure to fill out the description for the app along with providing screenshots and additional info.
 When ready, upload the signed release AAB/APK that was generated and publish the app.


### PR DESCRIPTION
Issue URL: internal

## What is the current behavior?

Prettier and cspell both only look at `.md`, so the tracked `.mdx` files in the repo have never been formatted or spellchecked. `docs/deployment/play-store.mdx` and its v7 copy have drifted as a result.

Separately, both tools run over `versioned_docs/version-v5` and `versioned_docs/version-v6`. Those versions are not listed in `versions.json`, so Docusaurus never builds them. They are served from standalone deployments listed in `versionsArchived.json`, which means tooling is formatting and spellchecking 696 files that ship from somewhere else.

## What is the new behavior?

`.mdx` is treated as a first class doc extension by both tools, and archived versions are excluded from both.

- `prettier` glob now includes `mdx`
- `spellcheck` glob now includes `mdx`
- `.prettierignore` and `cspell.json` both skip `versioned_docs/version-v5` and `versioned_docs/version-v6`
- Formatted the two live `.mdx` files, which are now in scope

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is groundwork for migrating our docs from `.md` to `.mdx`, which Docusaurus [recommends](https://docusaurus.io/blog/releases/3.10#strict-mdx) ahead of v4.

### How to test

1. Verify `npm run lint` works
2. Verify `npm run spellcheck` works
