### PR TITLE
chore(docs): migrate HTML comments to MDX comment syntax

### DIFF
--- a/docs/angular/performance.md
+++ b/docs/angular/performance.md
@@ -56,7 +56,7 @@ For more information on how Angular manages change propagation with `ngFor` see 
 
 ## From the Community
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 [High Performance Animations in Ionic](https://www.joshmorony.com/high-performance-animations-in-ionic/) - Josh Morony
 
@@ -66,7 +66,7 @@ For more information on how Angular manages change propagation with `ngFor` see 
 
 [Ionic Framework is Fast (But Your Code Might Not Be)](https://www.joshmorony.com/ionic-framework-is-fast-but-your-code-might-not-be/) - Josh Morony
 
-<!-- cspell:enable -->
+{/* cspell:enable */}
 
 :::note
 Do you have a guide you'd like to share? Click the _Edit this page_ button below.

--- a/docs/api/buttons.md
+++ b/docs/api/buttons.md
@@ -62,7 +62,7 @@ This feature is only available for iOS.
 
 :::
 
-<!-- Reuse the playground from the Title directory -->
+{/* Reuse the playground from the Title directory */}
 import CollapsibleLargeTitleButtons from '@site/static/usage/v8/title/collapsible-large-title/buttons/index.md';
 
 <CollapsibleLargeTitleButtons />

--- a/docs/api/datetime-button.md
+++ b/docs/api/datetime-button.md
@@ -47,19 +47,12 @@ import FormatOptions from '@site/static/usage/v8/datetime-button/format-options/
 
 `ion-datetime-button` must be associated with a mounted `ion-datetime` instance. As a result, [Inline Modals](./modal#inline-modals-recommended) and [Inline Popovers](./popover#inline-popovers) with the `keepContentsMounted` property set to `true` must be used.
 
-<!--
-## Customization
-
-TODO
-
-### Buttons
-
-TODO
-
-### Theming
-
-TODO
--->
+{/* ## Customization */}
+{/* TODO */}
+{/* ### Buttons */}
+{/* TODO */}
+{/* ### Theming */}
+{/* TODO */}
 
 ## Properties
 <Props />

--- a/docs/api/item.md
+++ b/docs/api/item.md
@@ -179,19 +179,12 @@ import DetailArrows from '@site/static/usage/v8/item/detail-arrows/index.md';
 <DetailArrows />
 
 
-<!--
-
-TODO add this functionality back as a css variable
-
-This feature is not enabled by default on clickable items for the `md` mode, but it can be enabled by setting the following CSS variable:
-
-```css
---item-detail-push-show: true;
-```
-
-See the [theming documentation](/docs/theming/css-variables) for more information.
-
--->
+{/* TODO add this functionality back as a css variable */}
+{/* This feature is not enabled by default on clickable items for the `md` mode, but it can be enabled by setting the following CSS variable: */}
+{/* ```css */}
+{/* --item-detail-push-show: true; */}
+{/* ``` */}
+{/* See the [theming documentation](/docs/theming/css-variables) for more information. */}
 
 
 ## Item Lines

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -48,7 +48,7 @@ import Indeterminate from '@site/static/usage/v8/progress-bar/indeterminate/inde
 
 ## Progress Bars in Toolbars
 
-<!-- Reuse the playground from the Toolbar directory -->
+{/* Reuse the playground from the Toolbar directory */}
 import Toolbar from '@site/static/usage/v8/toolbar/progress-bars/index.md';
 
 <Toolbar />

--- a/docs/api/searchbar.md
+++ b/docs/api/searchbar.md
@@ -58,7 +58,7 @@ import CancelButton from '@site/static/usage/v8/searchbar/cancel-button/index.md
 
 Searchbars are styled to look native when placed inside of a toolbar. In iOS, searchbars should be placed in their own toolbar, under a toolbar that contains the page title. In Material Design, searchbars are either persistently displayed in their own toolbar, or expand over a toolbar containing the page title.
 
-<!-- Reuse the playground from the Toolbar directory -->
+{/* Reuse the playground from the Toolbar directory */}
 import Toolbar from '@site/static/usage/v8/toolbar/searchbars/index.md';
 
 <Toolbar />

--- a/docs/api/segment-content.md
+++ b/docs/api/segment-content.md
@@ -27,7 +27,7 @@ for more information on how to use segment contents.
 Each `ion-segment-content` needs a unique `id` attribute. This will be used to link the segment content to a segment button via the button's
 [contentId property](./segment-button.md#properties).
 
-<!-- Reuse swipeable segments playground -->
+{/* Reuse swipeable segments playground */}
 
 import Swipeable from '@site/static/usage/v8/segment/swipeable/index.md';
 

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -43,7 +43,7 @@ import Scrollable from '@site/static/usage/v8/segment/scrollable/index.md';
 
 ## Segments in Toolbars
 
-<!-- Reuse the playground from the Toolbar directory -->
+{/* Reuse the playground from the Toolbar directory */}
 import Toolbar from '@site/static/usage/v8/toolbar/segments/index.md';
 
 <Toolbar />

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ Be sure to run `ionic <command> --help` in your project directory.
 For some commands, such as `ionic serve`, the help documentation is contextual to the type of your project, e.g. React vs Angular.
 :::
 
-<!-- TODO: image? -->
+{/* TODO: image? */}
 
 ## Architecture
 

--- a/docs/core-concepts/what-are-progressive-web-apps.md
+++ b/docs/core-concepts/what-are-progressive-web-apps.md
@@ -11,7 +11,7 @@ title: Progressive Web Apps
   />
 </head>
 
-<!-- TOC goes here -->
+{/* TOC goes here */}
 
 ### The web...but better
 
@@ -47,7 +47,7 @@ To be considered a Progressive Web App, your app must be:
 
 - Linkable - Easily share via URL and not require complex installation.
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 <em>
   <a href="https://addyosmani.com/blog/getting-started-with-progressive-web-apps/" target="_blank">
@@ -55,7 +55,7 @@ To be considered a Progressive Web App, your app must be:
   </a>
 </em>
 
-<!-- cspell:enable -->
+{/* cspell:enable */}
 
 There is a lot here, but it boils down to a few points for Ionic apps.
 

--- a/docs/developer-resources/courses.md
+++ b/docs/developer-resources/courses.md
@@ -2,7 +2,7 @@
 
 ### [Elite Ionic](https://www.joshmorony.com/elite/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Josh Morony
 
@@ -10,7 +10,7 @@ Elite Ionic is an online course for Ionic developers who want to move past the b
 
 ### [Ionic Academy](https://ionicacademy.com/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Simon Grimm
 
@@ -18,7 +18,7 @@ Learn Ionic with step-by-step video courses & quick wins from one of the Ionic c
 
 ### [Ionic Framework: Tips, Tricks & Techniques](https://www.packtpub.com/mobile/ionic-framework-tips-tricks-and-techniques-video)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Charles Muzonzini
 
@@ -26,7 +26,7 @@ In this course, you will master tips and best practices for Ionic 4 & Ionic 5 th
 
 ### [Building Desktop Apps with Ionic and Electron](https://pluralsight.pxf.io/VeMXO)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Michael Callaghan at Pluralsight
 
@@ -41,7 +41,7 @@ Windows and macOS users.
 
 ### [Building Progressive Web Apps with Ionic](https://pluralsight.pxf.io/Ly2EY)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Michael Callaghan at Pluralsight
 
@@ -58,7 +58,7 @@ Progressive Web Application anywhere you desire.
 
 ### [Ionic CLI](https://pluralsight.pxf.io/ionic-cli)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Michael Callaghan at Pluralsight
 
@@ -72,36 +72,36 @@ the confidence to use the Ionic CLI as part of your everyday Ionic development.
 
 ### [Wordpress Rest API and Ionic 4 (Angular) App With Auth](https://www.udemy.com/course/wordpress-rest-api-and-ionic-3-crud/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Baljeet Singh at Udemy
 
 ### [Building Mobile Apps with Ionic 2, Angular 2, and TypeScript](https://app.pluralsight.com/library/courses/ionic2-angular2-typescript-mobile-apps/table-of-contents)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Pluralsight
 
 ### [Introducing Ionic 2](http://shop.oreilly.com/product/0636920050353.do)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Mathieu Chauvinc
 
 ### [Ionic 2 Master Course](https://www.udemy.com/ionic-2-tutorial/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Udemy
 
 ### [Introducing Ionic 2](https://www.udemy.com/introducing-ionic-2/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Udemy
 
 ### [Ionic 2 Solutions](https://www.packtpub.com/web-development/ionic-2-solutions-video)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Hoc Phan

--- a/docs/developing/managing-focus.md
+++ b/docs/developing/managing-focus.md
@@ -183,7 +183,7 @@ export class ExampleComponent {
 ```
 
 ```html
-{/* example.component.html */}
+<!-- example.component.html -->
 <ion-modal (didPresent)="onDidPresent()">
   <ion-input #input></ion-input>
 </ion-modal>

--- a/docs/developing/managing-focus.md
+++ b/docs/developing/managing-focus.md
@@ -183,7 +183,7 @@ export class ExampleComponent {
 ```
 
 ```html
-<!-- example.component.html -->
+{/* example.component.html */}
 <ion-modal (didPresent)="onDidPresent()">
   <ion-input #input></ion-input>
 </ion-modal>

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,7 +139,7 @@ Ionic is actively developed and maintained full-time by a core team, and its eco
 
 There are millions of Ionic developers in over 200 countries worldwide. Here are some ways to join:
 
-<!-- prettier-ignore -->
+{/* prettier-ignore */}
 - <a href="https://forum.ionicframework.com/" target="_blank">Forum:</a> A great place for asking questions and sharing ideas.
 - <a href="https://twitter.com/ionicframework" target="_blank">Twitter:</a> Where we post updates and share content from the Ionic community.
 - <a href="https://github.com/ionic-team/ionic" target="_blank">GitHub:</a> For reporting bugs or requesting new features, create an issue here. PRs welcome!

--- a/docs/react/navigation.md
+++ b/docs/react/navigation.md
@@ -649,8 +649,8 @@ For more info on routing in React using the React Router implementation that Ion
 
 ## From the Community
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 [Ionic 4 and React: Navigation](https://alligator.io/ionic/ionic-4-react-navigation) - Paul Halliday
 
-<!-- cspell:enable -->
+{/* cspell:enable */}

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -75,7 +75,7 @@ title: Glossary
   </p>
 </section>
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 <section id="cli">
   <a href="#cli">
@@ -91,7 +91,7 @@ title: Glossary
   </p>
 </section>
 
-<!-- cspell:enable -->
+{/* cspell:enable */}
 
 <section id="commonjs">
   <a href="#commonjs">

--- a/docs/reference/versioning.md
+++ b/docs/reference/versioning.md
@@ -1,6 +1,6 @@
 # Versioning
 
-<!-- TOC goes here -->
+{/* TOC goes here */}
 
 Ionic Framework follows the <a href="https://semver.org/" target="_blank">Semantic Versioning (SemVer)</a> convention: <code>major.minor.patch.</code> Incompatible API changes increment the <code>major</code> version, adding backwards-compatible functionality increments the <code>minor</code> version, and backwards-compatible bug fixes increment the <code>patch</code> version.
 

--- a/docs/troubleshooting/native.md
+++ b/docs/troubleshooting/native.md
@@ -18,14 +18,13 @@ Code Signing Error: Failed to create provisioning profile. The app ID "com.csfor
 
 Running an app on an iOS device requires a provisioning profile. If a provisioning profile has not been created yet follow these directions:
 
-1. <strong>Set the [Package ID](../reference/glossary.md#package-id).</strong>
+1. **Set the [Package ID](../reference/glossary.md#package-id).**
 
    For Capacitor, open the `capacitor.config.json` file and modify the `appId` property.
 
    For Cordova, open the `config.xml` file and modify the `id` attribute of the root element, `<widget>`. See [the Cordova documentation](https://cordova.apache.org/docs/en/latest/config_ref/#widget) for more information.
 
-<!-- prettier-ignore -->
-2. <strong>Open the project in <b>Xcode</b>.</strong>
+2. **Open the project in <b>Xcode</b>.**
 
    For Capacitor, run the following to open the app in Xcode:
 
@@ -35,15 +34,13 @@ Running an app on an iOS device requires a provisioning profile. If a provisioni
 
    For Cordova, open Xcode. Use **File** &raquo; **Open** and locate the app. Open the app's `platforms/ios` directory.
 
-<!-- prettier-ignore -->
-3. <strong>In <b>Project navigator</b>, select the project root to open the project editor. Under the **Identity** section, verify that the Package ID that was set matches the Bundle Identifier.</strong>
+3. **In <b>Project navigator</b>, select the project root to open the project editor. Under the <b>Identity</b> section, verify that the Package ID that was set matches the Bundle Identifier.**
 
-   ![Xcode showing the Identity section for an iOS app with fields for Display Name, Bundle Identifier, Version, and Build.](/img/running/ios-xcode-identity-setup.png "Xcode Identity Section")
+   ![Xcode showing the Identity section for an iOS app with fields for Display Name, Bundle Identifier, Version, and Build.](/img/running/ios-xcode-identity-setup.png 'Xcode Identity Section')
 
-<!-- prettier-ignore -->
-4. <strong>In the same project editor, under the <b>Signing</b> section, ensure <b>Automatically manage signing</b> is enabled.</strong> Then, select a Development Team. Given a Development Team, Xcode will attempt to automatically prepare provisioning and signing.
+4. **In the same project editor, under the <b>Signing</b> section, ensure <b>Automatically manage signing</b> is enabled.** Then, select a Development Team. Given a Development Team, Xcode will attempt to automatically prepare provisioning and signing.
 
-   ![Xcode showing the Signing section with 'Automatically manage signing' enabled and a Development Team selected.](/img/running/ios-xcode-signing-setup.png "Xcode Signing Section")
+   ![Xcode showing the Signing section with 'Automatically manage signing' enabled and a Development Team selected.](/img/running/ios-xcode-signing-setup.png 'Xcode Signing Section')
 
 ## Xcode build error 65
 

--- a/docs/troubleshooting/runtime.md
+++ b/docs/troubleshooting/runtime.md
@@ -208,7 +208,7 @@ class MyApp {
 }
 ```
 
-<!-- This is referenced in Ionic Framework component documentation so we explicitly define the anchor so it remains consistent. -->
+{/* This is referenced in Ionic Framework component documentation so we explicitly define the anchor so it remains consistent. */}
 
 ## Accessing `this` in a function callback returns `undefined` {#accessing-this}
 

--- a/versioned_docs/version-v7/angular/performance.md
+++ b/versioned_docs/version-v7/angular/performance.md
@@ -56,7 +56,7 @@ For more information on how Angular manages change propagation with `ngFor` see 
 
 ## From the Community
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 [High Performance Animations in Ionic](https://www.joshmorony.com/high-performance-animations-in-ionic/) - Josh Morony
 
@@ -66,7 +66,7 @@ For more information on how Angular manages change propagation with `ngFor` see 
 
 [Ionic Framework is Fast (But Your Code Might Not Be)](https://www.joshmorony.com/ionic-framework-is-fast-but-your-code-might-not-be/) - Josh Morony
 
-<!-- cspell:enable -->
+{/* cspell:enable */}
 
 :::note
 Do you have a guide you'd like to share? Click the _Edit this page_ button below.

--- a/versioned_docs/version-v7/api/buttons.md
+++ b/versioned_docs/version-v7/api/buttons.md
@@ -62,7 +62,7 @@ This feature is only available for iOS.
 
 :::
 
-<!-- Reuse the playground from the Title directory -->
+{/* Reuse the playground from the Title directory */}
 
 import CollapsibleLargeTitleButtons from '@site/static/usage/v7/title/collapsible-large-title/buttons/index.md';
 

--- a/versioned_docs/version-v7/api/datetime-button.md
+++ b/versioned_docs/version-v7/api/datetime-button.md
@@ -51,19 +51,12 @@ import FormatOptions from '@site/static/usage/v7/datetime-button/format-options/
 
 `ion-datetime-button` must be associated with a mounted `ion-datetime` instance. As a result, [Inline Modals](./modal#inline-modals-recommended) and [Inline Popovers](./popover#inline-popovers) with the `keepContentsMounted` property set to `true` must be used.
 
-<!--
-## Customization
-
-TODO
-
-### Buttons
-
-TODO
-
-### Theming
-
-TODO
--->
+{/* ## Customization */}
+{/* TODO */}
+{/* ### Buttons */}
+{/* TODO */}
+{/* ### Theming */}
+{/* TODO */}
 
 ## Properties
 

--- a/versioned_docs/version-v7/api/item.md
+++ b/versioned_docs/version-v7/api/item.md
@@ -292,19 +292,12 @@ import DetailArrows from '@site/static/usage/v7/item/detail-arrows/index.md';
 
 <DetailArrows />
 
-<!--
-
-TODO add this functionality back as a css variable
-
-This feature is not enabled by default on clickable items for the `md` mode, but it can be enabled by setting the following CSS variable:
-
-```css
---item-detail-push-show: true;
-```
-
-See the [theming documentation](/docs/theming/css-variables) for more information.
-
--->
+{/* TODO add this functionality back as a css variable */}
+{/* This feature is not enabled by default on clickable items for the `md` mode, but it can be enabled by setting the following CSS variable: */}
+{/* ```css */}
+{/* --item-detail-push-show: true; */}
+{/* ``` */}
+{/* See the [theming documentation](/docs/theming/css-variables) for more information. */}
 
 ## Item Lines
 

--- a/versioned_docs/version-v7/api/progress-bar.md
+++ b/versioned_docs/version-v7/api/progress-bar.md
@@ -49,7 +49,7 @@ import Indeterminate from '@site/static/usage/v7/progress-bar/indeterminate/inde
 
 ## Progress Bars in Toolbars
 
-<!-- Reuse the playground from the Toolbar directory -->
+{/* Reuse the playground from the Toolbar directory */}
 
 import Toolbar from '@site/static/usage/v7/toolbar/progress-bars/index.md';
 

--- a/versioned_docs/version-v7/api/searchbar.md
+++ b/versioned_docs/version-v7/api/searchbar.md
@@ -57,7 +57,7 @@ import CancelButton from '@site/static/usage/v7/searchbar/cancel-button/index.md
 
 Searchbars are styled to look native when placed inside of a toolbar. In iOS, searchbars should be placed in their own toolbar, under a toolbar that contains the page title. In Material Design, searchbars are either persistently displayed in their own toolbar, or expand over a toolbar containing the page title.
 
-<!-- Reuse the playground from the Toolbar directory -->
+{/* Reuse the playground from the Toolbar directory */}
 
 import Toolbar from '@site/static/usage/v7/toolbar/searchbars/index.md';
 

--- a/versioned_docs/version-v7/api/segment.md
+++ b/versioned_docs/version-v7/api/segment.md
@@ -43,7 +43,7 @@ import Scrollable from '@site/static/usage/v7/segment/scrollable/index.md';
 
 ## Segments in Toolbars
 
-<!-- Reuse the playground from the Toolbar directory -->
+{/* Reuse the playground from the Toolbar directory */}
 
 import Toolbar from '@site/static/usage/v7/toolbar/segments/index.md';
 

--- a/versioned_docs/version-v7/cli.md
+++ b/versioned_docs/version-v7/cli.md
@@ -37,7 +37,7 @@ Be sure to run `ionic <command> --help` in your project directory.
 For some commands, such as `ionic serve`, the help documentation is contextual to the type of your project, e.g. React vs Angular.
 :::
 
-<!-- TODO: image? -->
+{/* TODO: image? */}
 
 ## Architecture
 

--- a/versioned_docs/version-v7/core-concepts/what-are-progressive-web-apps.md
+++ b/versioned_docs/version-v7/core-concepts/what-are-progressive-web-apps.md
@@ -11,7 +11,7 @@ title: Progressive Web Apps
   />
 </head>
 
-<!-- TOC goes here -->
+{/* TOC goes here */}
 
 ### The web...but better
 
@@ -47,7 +47,7 @@ To be considered a Progressive Web App, your app must be:
 
 - Linkable - Easily share via URL and not require complex installation.
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 <em>
   <a href="https://addyosmani.com/blog/getting-started-with-progressive-web-apps/" target="_blank">
@@ -55,7 +55,7 @@ To be considered a Progressive Web App, your app must be:
   </a>
 </em>
 
-<!-- cspell:enable -->
+{/* cspell:enable */}
 
 There is a lot here, but it boils down to a few points for Ionic apps.
 

--- a/versioned_docs/version-v7/developer-resources/courses.md
+++ b/versioned_docs/version-v7/developer-resources/courses.md
@@ -2,7 +2,7 @@
 
 ### [Elite Ionic](https://www.joshmorony.com/elite/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Josh Morony
 
@@ -10,7 +10,7 @@ Elite Ionic is an online course for Ionic developers who want to move past the b
 
 ### [Ionic Academy](https://ionicacademy.com/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Simon Grimm
 
@@ -18,7 +18,7 @@ Learn Ionic with step-by-step video courses & quick wins from one of the Ionic c
 
 ### [Ionic Framework: Tips, Tricks & Techniques](https://www.packtpub.com/mobile/ionic-framework-tips-tricks-and-techniques-video)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Charles Muzonzini
 
@@ -26,7 +26,7 @@ In this course, you will master tips and best practices for Ionic 4 & Ionic 5 th
 
 ### [Building Desktop Apps with Ionic and Electron](https://pluralsight.pxf.io/VeMXO)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Michael Callaghan at Pluralsight
 
@@ -41,7 +41,7 @@ Windows and macOS users.
 
 ### [Building Progressive Web Apps with Ionic](https://pluralsight.pxf.io/Ly2EY)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Michael Callaghan at Pluralsight
 
@@ -58,7 +58,7 @@ Progressive Web Application anywhere you desire.
 
 ### [Ionic CLI](https://pluralsight.pxf.io/ionic-cli)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Michael Callaghan at Pluralsight
 
@@ -72,36 +72,36 @@ the confidence to use the Ionic CLI as part of your everyday Ionic development.
 
 ### [Wordpress Rest API and Ionic 4 (Angular) App With Auth](https://www.udemy.com/course/wordpress-rest-api-and-ionic-3-crud/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Baljeet Singh at Udemy
 
 ### [Building Mobile Apps with Ionic 2, Angular 2, and TypeScript](https://app.pluralsight.com/library/courses/ionic2-angular2-typescript-mobile-apps/table-of-contents)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Pluralsight
 
 ### [Introducing Ionic 2](http://shop.oreilly.com/product/0636920050353.do)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Mathieu Chauvinc
 
 ### [Ionic 2 Master Course](https://www.udemy.com/ionic-2-tutorial/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Udemy
 
 ### [Introducing Ionic 2](https://www.udemy.com/introducing-ionic-2/)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Udemy
 
 ### [Ionic 2 Solutions](https://www.packtpub.com/web-development/ionic-2-solutions-video)
 
-<!-- cspell:disable-next-line -->
+{/* cspell:disable-next-line */}
 
 by Hoc Phan

--- a/versioned_docs/version-v7/developing/managing-focus.md
+++ b/versioned_docs/version-v7/developing/managing-focus.md
@@ -181,7 +181,7 @@ export class ExampleComponent {
 ```
 
 ```html
-{/* example.component.html */}
+<!-- example.component.html -->
 <ion-modal (didPresent)="onDidPresent()">
   <ion-input #input></ion-input>
 </ion-modal>

--- a/versioned_docs/version-v7/developing/managing-focus.md
+++ b/versioned_docs/version-v7/developing/managing-focus.md
@@ -181,7 +181,7 @@ export class ExampleComponent {
 ```
 
 ```html
-<!-- example.component.html -->
+{/* example.component.html */}
 <ion-modal (didPresent)="onDidPresent()">
   <ion-input #input></ion-input>
 </ion-modal>

--- a/versioned_docs/version-v7/index.md
+++ b/versioned_docs/version-v7/index.md
@@ -139,7 +139,7 @@ Ionic is actively developed and maintained full-time by a core team, and its eco
 
 There are millions of Ionic developers in over 200 countries worldwide. Here are some ways to join:
 
-<!-- prettier-ignore -->
+{/* prettier-ignore */}
 - <a href="https://forum.ionicframework.com/" target="_blank">Forum:</a> A great place for asking questions and sharing ideas.
 - <a href="https://twitter.com/ionicframework" target="_blank">Twitter:</a> Where we post updates and share content from the Ionic community.
 - <a href="https://github.com/ionic-team/ionic" target="_blank">GitHub:</a> For reporting bugs or requesting new features, create an issue here. PRs welcome!

--- a/versioned_docs/version-v7/react/navigation.md
+++ b/versioned_docs/version-v7/react/navigation.md
@@ -649,8 +649,8 @@ For more info on routing in React using the React Router implementation that Ion
 
 ## From the Community
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 [Ionic 4 and React: Navigation](https://alligator.io/ionic/ionic-4-react-navigation) - Paul Halliday
 
-<!-- cspell:enable -->
+{/* cspell:enable */}

--- a/versioned_docs/version-v7/reference/glossary.md
+++ b/versioned_docs/version-v7/reference/glossary.md
@@ -92,7 +92,7 @@ title: Glossary
   </p>
 </section>
 
-<!-- cspell:disable -->
+{/* cspell:disable */}
 
 <section id="cli">
   <a href="#cli">
@@ -111,7 +111,7 @@ title: Glossary
   </p>
 </section>
 
-<!-- cspell:enable -->
+{/* cspell:enable */}
 
 <section id="commonjs">
   <a href="#commonjs">

--- a/versioned_docs/version-v7/reference/versioning.md
+++ b/versioned_docs/version-v7/reference/versioning.md
@@ -1,6 +1,6 @@
 # Versioning
 
-<!-- TOC goes here -->
+{/* TOC goes here */}
 
 Ionic Framework follows the <a href="https://semver.org/" target="_blank">Semantic Versioning (SemVer)</a> convention: <code>major.minor.patch.</code> Incompatible API changes increment the <code>major</code> version, adding backwards-compatible functionality increments the <code>minor</code> version, and backwards-compatible bug fixes increment the <code>patch</code> version.
 

--- a/versioned_docs/version-v7/troubleshooting/native.md
+++ b/versioned_docs/version-v7/troubleshooting/native.md
@@ -18,14 +18,13 @@ Code Signing Error: Failed to create provisioning profile. The app ID "com.csfor
 
 Running an app on an iOS device requires a provisioning profile. If a provisioning profile has not been created yet follow these directions:
 
-1. <strong>Set the [Package ID](../reference/glossary.md#package-id).</strong>
+1. **Set the [Package ID](../reference/glossary.md#package-id).**
 
    For Capacitor, open the `capacitor.config.json` file and modify the `appId` property.
 
    For Cordova, open the `config.xml` file and modify the `id` attribute of the root element, `<widget>`. See [the Cordova documentation](https://cordova.apache.org/docs/en/latest/config_ref/#widget) for more information.
 
-<!-- prettier-ignore -->
-2. <strong>Open the project in <b>Xcode</b>.</strong>
+2. **Open the project in <b>Xcode</b>.**
 
    For Capacitor, run the following to open the app in Xcode:
 
@@ -35,15 +34,13 @@ Running an app on an iOS device requires a provisioning profile. If a provisioni
 
    For Cordova, open Xcode. Use **File** &raquo; **Open** and locate the app. Open the app's `platforms/ios` directory.
 
-<!-- prettier-ignore -->
-3. <strong>In <b>Project navigator</b>, select the project root to open the project editor. Under the **Identity** section, verify that the Package ID that was set matches the Bundle Identifier.</strong>
+3. **In <b>Project navigator</b>, select the project root to open the project editor. Under the <b>Identity</b> section, verify that the Package ID that was set matches the Bundle Identifier.**
 
-   ![Xcode showing the Identity section for an iOS app with fields for Display Name, Bundle Identifier, Version, and Build.](/img/running/ios-xcode-identity-setup.png "Xcode Identity Section")
+   ![Xcode showing the Identity section for an iOS app with fields for Display Name, Bundle Identifier, Version, and Build.](/img/running/ios-xcode-identity-setup.png 'Xcode Identity Section')
 
-<!-- prettier-ignore -->
-4. <strong>In the same project editor, under the <b>Signing</b> section, ensure <b>Automatically manage signing</b> is enabled.</strong> Then, select a Development Team. Given a Development Team, Xcode will attempt to automatically prepare provisioning and signing.
+4. **In the same project editor, under the <b>Signing</b> section, ensure <b>Automatically manage signing</b> is enabled.** Then, select a Development Team. Given a Development Team, Xcode will attempt to automatically prepare provisioning and signing.
 
-   ![Xcode showing the Signing section with 'Automatically manage signing' enabled and a Development Team selected.](/img/running/ios-xcode-signing-setup.png "Xcode Signing Section")
+   ![Xcode showing the Signing section with 'Automatically manage signing' enabled and a Development Team selected.](/img/running/ios-xcode-signing-setup.png 'Xcode Signing Section')
 
 ## Xcode build error 65
 

--- a/versioned_docs/version-v7/troubleshooting/runtime.md
+++ b/versioned_docs/version-v7/troubleshooting/runtime.md
@@ -208,7 +208,7 @@ class MyApp {
 }
 ```
 
-<!-- This is referenced in Ionic Framework component documentation so we explicitly define the anchor so it remains consistent. -->
+{/* This is referenced in Ionic Framework component documentation so we explicitly define the anchor so it remains consistent. */}
 
 ## Accessing `this` in a function callback returns `undefined` {#accessing-this}
 


### PR DESCRIPTION
Issue URL:

## What is the current behavior?

Our docs use HTML comments (`<!-- ... -->`) for authoring notes and tooling directives. These are not valid MDX. Docusaurus only accepts them today because of the `markdown.mdx1Compat.comments` shim, which strips them before MDX parses the file. That shim is disabled by default in Docusaurus v4 via `future.v4.mdx1CompatDisabledByDefault`.

Separately, `troubleshooting/native.md` used three `<!-- prettier-ignore -->` guards inside an ordered list. Those guards were doing more than suppressing formatting: an HTML comment is a block level node, so each one **split the list**, which is why steps 2, 3, and 4 each restarted their own numbering instead of forming one list of four.

## What is the new behavior?

HTML comments in the live docs trees are migrated to [MDX comment syntax](https://docusaurus.io/blog/releases/3.10#strict-comments), and the `native.md` guards are removed by fixing what they were working around.

- 59 single-line notes converted from `<!-- ... -->` to `{/* ... */}`
- 4 multiline commented-out blocks converted to per-line `{/* ... */}` comments
- `index.md`'s 2 guards converted; the JSX form is honored there because the guard precedes the start of a list, which is a real node boundary
- `native.md`'s 6 guards deleted entirely, by replacing the `<strong>` wrappers with Markdown `**`

The `native.md` change is the substantive one. Prettier was reflowing the `<strong>` children onto their own lines, after which MDX wrapped that text in its own paragraph and emitted invalid `<strong><p>...</p></strong>`. The guards existed to prevent that. Using Markdown emphasis instead removes the hazard at the source, so no guard is needed and the four steps now form a single well-formed ordered list. Nested `<b>` tags are preserved; one `**Identity**` became `<b>Identity</b>` to avoid nesting `**` inside `**`, matching how the file already marks up `<b>Xcode</b>` and `<b>Signing</b>`.

Multiline blocks use per-line comments because Prettier mangles every multiline form into `{/\*`, which then fails to compile. Verified against three variants: with blank lines, without blank lines, and with a `{""` expression prefix. All three were mangled.

110 HTML comments are intentionally left in place: 108 inside code fences and 2 inside inline code spans, where they are example markup shown to readers rather than real comments.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is part of a series preparing the docs for the `.md` to `.mdx` migration. 

### How to test

Review the pages below. The comment changes should be invisible, since comments never rendered. Confirm no stray `<!--`, `{/*`, or `*/}` text appears anywhere on the page.

One page deserves a closer look:

1. **Native Errors** — the numbered steps under "Code Signing errors" should render as a single list numbered 1 through 4, with each step's body content correctly indented beneath it, and the step titles still bold:
   https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/troubleshooting/native

**Current (v8)**

- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/angular/performance
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/api/buttons
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/api/datetime-button
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/api/item
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/api/progress-bar
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/api/searchbar
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/api/segment
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/api/segment-content
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/cli
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/core-concepts/what-are-progressive-web-apps
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/developer-resources/courses
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/developing/managing-focus
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/react/navigation
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/reference/glossary
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/reference/versioning
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/troubleshooting/native
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/troubleshooting/runtime

**v7**

- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/angular/performance
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/api/buttons
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/api/datetime-button
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/api/item
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/api/progress-bar
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/api/searchbar
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/api/segment
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/cli
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/core-concepts/what-are-progressive-web-apps
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/developer-resources/courses
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/developing/managing-focus
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/react/navigation
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/reference/glossary
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/reference/versioning
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/troubleshooting/native
- https://ionic-docs-git-fw-6456-pt3-ionic1.vercel.app/docs/v7/troubleshooting/runtime

