### PR TITLE
chore(ci): pin github actions to commit shas

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,9 +19,9 @@ jobs:
         os: [windows-latest, macOS-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: ⚙️ Use Node.js ${{ matrix.node_version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ matrix.node_version }}
     - name: 🕸️ Install Dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -90,7 +90,8 @@
   "schedule": ["every weekday before 11am"],
   "semanticCommits": "enabled",
   "includePaths": [
-    "static/code/stackblitz/**/*/package.json"
+    "static/code/stackblitz/**/*/package.json",
+    ".github/workflows/**"
   ],
   "ignorePaths": [
     "static/code/stackblitz/v6/**"


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

The workflow references its GitHub Actions by floating major tags, `actions/checkout@v4` and `actions/setup-node@v4`. A tag is mutable, so whoever controls the action repository can repoint it at different code, and every subsequent CI run picks that code up with no change on our side. This is the supply chain risk behind the recent run of compromised action releases.

Renovate is also scoped to the stackblitz sample apps only, via `includePaths`, so nothing under `.github/workflows` is visible to it.


## What is the new behavior?

Both actions are pinned to a full commit SHA, with the version in a trailing comment for readability. A SHA is immutable, so CI runs the exact code that was reviewed. The SHAs and the comment format match what `ionic-framework` already uses, keeping the two repos consistent:

- `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
- `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`

`.github/workflows/**` is added to `includePaths` in `renovate.json`. This is required rather than optional: a pin that is never bumped stops receiving security patches, which would leave us worse off than the floating tags.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A