### PR TITLE
chore(prettierignore): add versioned api

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@ legacy-stencil-components
 scripts/bak
 
 docs/api
+versioned_docs/version-v*/api
 docs/native
 versioned_docs/version-v*/native
 docs/cli/commands


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

Prettier ignore has the API page added but not the versioned API page.

## What is the new behavior?

- Added the versioned API page to prettier ignore

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A