### PR TITLE
chore(api): generate component API partials as .mdx

### DIFF
--- a/docs/api/accordion-group.md
+++ b/docs/api/accordion-group.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-accordion-group"
 ---
-import Props from '@ionic-internal/component-api/v9/accordion-group/props.md';
-import Events from '@ionic-internal/component-api/v9/accordion-group/events.md';
-import Methods from '@ionic-internal/component-api/v9/accordion-group/methods.md';
-import Parts from '@ionic-internal/component-api/v9/accordion-group/parts.md';
+import Props from '@ionic-internal/component-api/v9/accordion-group/props.mdx';
+import Events from '@ionic-internal/component-api/v9/accordion-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/accordion-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/accordion-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/accordion-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/accordion-group/slots.md';
+import Slots from '@ionic-internal/component-api/v9/accordion-group/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-accordion"
 ---
-import Props from '@ionic-internal/component-api/v9/accordion/props.md';
-import Events from '@ionic-internal/component-api/v9/accordion/events.md';
-import Methods from '@ionic-internal/component-api/v9/accordion/methods.md';
-import Parts from '@ionic-internal/component-api/v9/accordion/parts.md';
+import Props from '@ionic-internal/component-api/v9/accordion/props.mdx';
+import Events from '@ionic-internal/component-api/v9/accordion/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/accordion/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/accordion/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/accordion/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/accordion/slots.md';
+import Slots from '@ionic-internal/component-api/v9/accordion/slots.mdx';
 
 <head>
   <title>ion-accordion: Accordion Components: How to Build & Examples</title>

--- a/docs/api/action-sheet.md
+++ b/docs/api/action-sheet.md
@@ -4,12 +4,12 @@ title: "ion-action-sheet"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v9/action-sheet/props.md';
-import Events from '@ionic-internal/component-api/v9/action-sheet/events.md';
-import Methods from '@ionic-internal/component-api/v9/action-sheet/methods.md';
-import Parts from '@ionic-internal/component-api/v9/action-sheet/parts.md';
+import Props from '@ionic-internal/component-api/v9/action-sheet/props.mdx';
+import Events from '@ionic-internal/component-api/v9/action-sheet/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/action-sheet/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/action-sheet/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/action-sheet/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/action-sheet/slots.md';
+import Slots from '@ionic-internal/component-api/v9/action-sheet/slots.mdx';
 
 <head>
   <title>ion-action-sheet: Action Sheet Dialog for iOS and Android</title>

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -4,12 +4,12 @@ title: "ion-alert"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v9/alert/props.md';
-import Events from '@ionic-internal/component-api/v9/alert/events.md';
-import Methods from '@ionic-internal/component-api/v9/alert/methods.md';
-import Parts from '@ionic-internal/component-api/v9/alert/parts.md';
+import Props from '@ionic-internal/component-api/v9/alert/props.mdx';
+import Events from '@ionic-internal/component-api/v9/alert/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/alert/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/alert/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/alert/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/alert/slots.md';
+import Slots from '@ionic-internal/component-api/v9/alert/slots.mdx';
 
 <head>
   <title>ion-alert: Ionic Alert Buttons with Custom Message Prompts</title>

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-app"
 ---
-import Props from '@ionic-internal/component-api/v9/app/props.md';
-import Events from '@ionic-internal/component-api/v9/app/events.md';
-import Methods from '@ionic-internal/component-api/v9/app/methods.md';
-import Parts from '@ionic-internal/component-api/v9/app/parts.md';
+import Props from '@ionic-internal/component-api/v9/app/props.mdx';
+import Events from '@ionic-internal/component-api/v9/app/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/app/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/app/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/app/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/app/slots.md';
+import Slots from '@ionic-internal/component-api/v9/app/slots.mdx';
 
 <head>
   <title>ion-app: Container Element for an Ionic Application</title>

--- a/docs/api/avatar.md
+++ b/docs/api/avatar.md
@@ -2,12 +2,12 @@
 title: "ion-avatar"
 ---
 
-import Props from '@ionic-internal/component-api/v9/avatar/props.md';
-import Events from '@ionic-internal/component-api/v9/avatar/events.md';
-import Methods from '@ionic-internal/component-api/v9/avatar/methods.md';
-import Parts from '@ionic-internal/component-api/v9/avatar/parts.md';
+import Props from '@ionic-internal/component-api/v9/avatar/props.mdx';
+import Events from '@ionic-internal/component-api/v9/avatar/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/avatar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/avatar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/avatar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/avatar/slots.md';
+import Slots from '@ionic-internal/component-api/v9/avatar/slots.mdx';
 
 <head>
   <title>ion-avatar: Circular Application Avatar Icon Component</title>

--- a/docs/api/back-button.md
+++ b/docs/api/back-button.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-back-button"
 ---
-import Props from '@ionic-internal/component-api/v9/back-button/props.md';
-import Events from '@ionic-internal/component-api/v9/back-button/events.md';
-import Methods from '@ionic-internal/component-api/v9/back-button/methods.md';
-import Parts from '@ionic-internal/component-api/v9/back-button/parts.md';
+import Props from '@ionic-internal/component-api/v9/back-button/props.mdx';
+import Events from '@ionic-internal/component-api/v9/back-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/back-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/back-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/back-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/back-button/slots.md';
+import Slots from '@ionic-internal/component-api/v9/back-button/slots.mdx';
 
 <head>
   <title>ion-back-button: Custom Menu Back Button for Applications</title>

--- a/docs/api/backdrop.md
+++ b/docs/api/backdrop.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-backdrop"
 ---
-import Props from '@ionic-internal/component-api/v9/backdrop/props.md';
-import Events from '@ionic-internal/component-api/v9/backdrop/events.md';
-import Methods from '@ionic-internal/component-api/v9/backdrop/methods.md';
-import Parts from '@ionic-internal/component-api/v9/backdrop/parts.md';
+import Props from '@ionic-internal/component-api/v9/backdrop/props.mdx';
+import Events from '@ionic-internal/component-api/v9/backdrop/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/backdrop/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/backdrop/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/backdrop/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/backdrop/slots.md';
+import Slots from '@ionic-internal/component-api/v9/backdrop/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-badge"
 ---
-import Props from '@ionic-internal/component-api/v9/badge/props.md';
-import Events from '@ionic-internal/component-api/v9/badge/events.md';
-import Methods from '@ionic-internal/component-api/v9/badge/methods.md';
-import Parts from '@ionic-internal/component-api/v9/badge/parts.md';
+import Props from '@ionic-internal/component-api/v9/badge/props.mdx';
+import Events from '@ionic-internal/component-api/v9/badge/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/badge/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/badge/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/badge/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/badge/slots.md';
+import Slots from '@ionic-internal/component-api/v9/badge/slots.mdx';
 
 <head>
   <title>ion-badge: iOS & Android App Notification Badge Icons</title>

--- a/docs/api/breadcrumb.md
+++ b/docs/api/breadcrumb.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-breadcrumb"
 ---
-import Props from '@ionic-internal/component-api/v9/breadcrumb/props.md';
-import Events from '@ionic-internal/component-api/v9/breadcrumb/events.md';
-import Methods from '@ionic-internal/component-api/v9/breadcrumb/methods.md';
-import Parts from '@ionic-internal/component-api/v9/breadcrumb/parts.md';
+import Props from '@ionic-internal/component-api/v9/breadcrumb/props.mdx';
+import Events from '@ionic-internal/component-api/v9/breadcrumb/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/breadcrumb/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/breadcrumb/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/breadcrumb/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/breadcrumb/slots.md';
+import Slots from '@ionic-internal/component-api/v9/breadcrumb/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/breadcrumbs.md
+++ b/docs/api/breadcrumbs.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-breadcrumbs"
 ---
-import Props from '@ionic-internal/component-api/v9/breadcrumbs/props.md';
-import Events from '@ionic-internal/component-api/v9/breadcrumbs/events.md';
-import Methods from '@ionic-internal/component-api/v9/breadcrumbs/methods.md';
-import Parts from '@ionic-internal/component-api/v9/breadcrumbs/parts.md';
+import Props from '@ionic-internal/component-api/v9/breadcrumbs/props.mdx';
+import Events from '@ionic-internal/component-api/v9/breadcrumbs/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/breadcrumbs/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/breadcrumbs/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/breadcrumbs/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/breadcrumbs/slots.md';
+import Slots from '@ionic-internal/component-api/v9/breadcrumbs/slots.mdx';
 
 
 

--- a/docs/api/button.md
+++ b/docs/api/button.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-button"
 ---
-import Props from '@ionic-internal/component-api/v9/button/props.md';
-import Events from '@ionic-internal/component-api/v9/button/events.md';
-import Methods from '@ionic-internal/component-api/v9/button/methods.md';
-import Parts from '@ionic-internal/component-api/v9/button/parts.md';
+import Props from '@ionic-internal/component-api/v9/button/props.mdx';
+import Events from '@ionic-internal/component-api/v9/button/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/button/slots.md';
+import Slots from '@ionic-internal/component-api/v9/button/slots.mdx';
 
 <head>
   <title>ion-button: Style Buttons with Custom CSS Properties</title>

--- a/docs/api/buttons.md
+++ b/docs/api/buttons.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-buttons"
 ---
-import Props from '@ionic-internal/component-api/v9/buttons/props.md';
-import Events from '@ionic-internal/component-api/v9/buttons/events.md';
-import Methods from '@ionic-internal/component-api/v9/buttons/methods.md';
-import Parts from '@ionic-internal/component-api/v9/buttons/parts.md';
+import Props from '@ionic-internal/component-api/v9/buttons/props.mdx';
+import Events from '@ionic-internal/component-api/v9/buttons/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/buttons/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/buttons/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/buttons/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/buttons/slots.md';
+import Slots from '@ionic-internal/component-api/v9/buttons/slots.mdx';
 
 <head>
   <title>ion-buttons: Toolbar Element with Named Slots for Buttons</title>

--- a/docs/api/card-content.md
+++ b/docs/api/card-content.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-card-content"
 ---
-import Props from '@ionic-internal/component-api/v9/card-content/props.md';
-import Events from '@ionic-internal/component-api/v9/card-content/events.md';
-import Methods from '@ionic-internal/component-api/v9/card-content/methods.md';
-import Parts from '@ionic-internal/component-api/v9/card-content/parts.md';
+import Props from '@ionic-internal/component-api/v9/card-content/props.mdx';
+import Events from '@ionic-internal/component-api/v9/card-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/card-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/card-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/card-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/card-content/slots.md';
+import Slots from '@ionic-internal/component-api/v9/card-content/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/card-header.md
+++ b/docs/api/card-header.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-card-header"
 ---
-import Props from '@ionic-internal/component-api/v9/card-header/props.md';
-import Events from '@ionic-internal/component-api/v9/card-header/events.md';
-import Methods from '@ionic-internal/component-api/v9/card-header/methods.md';
-import Parts from '@ionic-internal/component-api/v9/card-header/parts.md';
+import Props from '@ionic-internal/component-api/v9/card-header/props.mdx';
+import Events from '@ionic-internal/component-api/v9/card-header/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/card-header/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/card-header/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/card-header/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/card-header/slots.md';
+import Slots from '@ionic-internal/component-api/v9/card-header/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/card-subtitle.md
+++ b/docs/api/card-subtitle.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-card-subtitle"
 ---
-import Props from '@ionic-internal/component-api/v9/card-subtitle/props.md';
-import Events from '@ionic-internal/component-api/v9/card-subtitle/events.md';
-import Methods from '@ionic-internal/component-api/v9/card-subtitle/methods.md';
-import Parts from '@ionic-internal/component-api/v9/card-subtitle/parts.md';
+import Props from '@ionic-internal/component-api/v9/card-subtitle/props.mdx';
+import Events from '@ionic-internal/component-api/v9/card-subtitle/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/card-subtitle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/card-subtitle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/card-subtitle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/card-subtitle/slots.md';
+import Slots from '@ionic-internal/component-api/v9/card-subtitle/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/card-title.md
+++ b/docs/api/card-title.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-card-title"
 ---
-import Props from '@ionic-internal/component-api/v9/card-title/props.md';
-import Events from '@ionic-internal/component-api/v9/card-title/events.md';
-import Methods from '@ionic-internal/component-api/v9/card-title/methods.md';
-import Parts from '@ionic-internal/component-api/v9/card-title/parts.md';
+import Props from '@ionic-internal/component-api/v9/card-title/props.mdx';
+import Events from '@ionic-internal/component-api/v9/card-title/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/card-title/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/card-title/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/card-title/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/card-title/slots.md';
+import Slots from '@ionic-internal/component-api/v9/card-title/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/card.md
+++ b/docs/api/card.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-card"
 ---
-import Props from '@ionic-internal/component-api/v9/card/props.md';
-import Events from '@ionic-internal/component-api/v9/card/events.md';
-import Methods from '@ionic-internal/component-api/v9/card/methods.md';
-import Parts from '@ionic-internal/component-api/v9/card/parts.md';
+import Props from '@ionic-internal/component-api/v9/card/props.mdx';
+import Events from '@ionic-internal/component-api/v9/card/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/card/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/card/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/card/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/card/slots.md';
+import Slots from '@ionic-internal/component-api/v9/card/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -2,12 +2,12 @@
 title: "ion-checkbox"
 ---
 
-import Props from '@ionic-internal/component-api/v9/checkbox/props.md';
-import Events from '@ionic-internal/component-api/v9/checkbox/events.md';
-import Methods from '@ionic-internal/component-api/v9/checkbox/methods.md';
-import Parts from '@ionic-internal/component-api/v9/checkbox/parts.md';
+import Props from '@ionic-internal/component-api/v9/checkbox/props.mdx';
+import Events from '@ionic-internal/component-api/v9/checkbox/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/checkbox/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/checkbox/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/checkbox/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/checkbox/slots.md';
+import Slots from '@ionic-internal/component-api/v9/checkbox/slots.mdx';
 
 <head>
   <title>ion-checkbox: Ionic App Checkbox to Select Multiple Options</title>

--- a/docs/api/chip.md
+++ b/docs/api/chip.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-chip"
 ---
-import Props from '@ionic-internal/component-api/v9/chip/props.md';
-import Events from '@ionic-internal/component-api/v9/chip/events.md';
-import Methods from '@ionic-internal/component-api/v9/chip/methods.md';
-import Parts from '@ionic-internal/component-api/v9/chip/parts.md';
+import Props from '@ionic-internal/component-api/v9/chip/props.mdx';
+import Events from '@ionic-internal/component-api/v9/chip/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/chip/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/chip/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/chip/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/chip/slots.md';
+import Slots from '@ionic-internal/component-api/v9/chip/slots.mdx';
 
 <head>
   <title>ion-chip: Text, Icon and Avatar for Ionic Framework Apps</title>

--- a/docs/api/col.md
+++ b/docs/api/col.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-col"
 ---
-import Props from '@ionic-internal/component-api/v9/col/props.md';
-import Events from '@ionic-internal/component-api/v9/col/events.md';
-import Methods from '@ionic-internal/component-api/v9/col/methods.md';
-import Parts from '@ionic-internal/component-api/v9/col/parts.md';
+import Props from '@ionic-internal/component-api/v9/col/props.mdx';
+import Events from '@ionic-internal/component-api/v9/col/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/col/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/col/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/col/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/col/slots.md';
+import Slots from '@ionic-internal/component-api/v9/col/slots.mdx';
 
 <head>
   <title>ion-col: Column Component Padding and Other Properties</title>

--- a/docs/api/content.md
+++ b/docs/api/content.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-content"
 ---
-import Props from '@ionic-internal/component-api/v9/content/props.md';
-import Events from '@ionic-internal/component-api/v9/content/events.md';
-import Methods from '@ionic-internal/component-api/v9/content/methods.md';
-import Parts from '@ionic-internal/component-api/v9/content/parts.md';
+import Props from '@ionic-internal/component-api/v9/content/props.mdx';
+import Events from '@ionic-internal/component-api/v9/content/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/content/slots.md';
+import Slots from '@ionic-internal/component-api/v9/content/slots.mdx';
 
 <head>
   <title>ion-content: Scrollable Component for Ionic App Content</title>

--- a/docs/api/datetime-button.md
+++ b/docs/api/datetime-button.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-datetime-button"
 ---
-import Props from '@ionic-internal/component-api/v9/datetime-button/props.md';
-import Events from '@ionic-internal/component-api/v9/datetime-button/events.md';
-import Methods from '@ionic-internal/component-api/v9/datetime-button/methods.md';
-import Parts from '@ionic-internal/component-api/v9/datetime-button/parts.md';
+import Props from '@ionic-internal/component-api/v9/datetime-button/props.mdx';
+import Events from '@ionic-internal/component-api/v9/datetime-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/datetime-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/datetime-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/datetime-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/datetime-button/slots.md';
+import Slots from '@ionic-internal/component-api/v9/datetime-button/slots.mdx';
 
 <head>
   <title>ion-datetime-button: Ionic Input for Datetime Picker</title>

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-datetime"
 ---
-import Props from '@ionic-internal/component-api/v9/datetime/props.md';
-import Events from '@ionic-internal/component-api/v9/datetime/events.md';
-import Methods from '@ionic-internal/component-api/v9/datetime/methods.md';
-import Parts from '@ionic-internal/component-api/v9/datetime/parts.md';
+import Props from '@ionic-internal/component-api/v9/datetime/props.mdx';
+import Events from '@ionic-internal/component-api/v9/datetime/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/datetime/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/datetime/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/datetime/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/datetime/slots.md';
+import Slots from '@ionic-internal/component-api/v9/datetime/slots.mdx';
 
 import Basic from '@site/static/usage/v9/datetime/basic/index.md';
 

--- a/docs/api/fab-button.md
+++ b/docs/api/fab-button.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-fab-button"
 ---
-import Props from '@ionic-internal/component-api/v9/fab-button/props.md';
-import Events from '@ionic-internal/component-api/v9/fab-button/events.md';
-import Methods from '@ionic-internal/component-api/v9/fab-button/methods.md';
-import Parts from '@ionic-internal/component-api/v9/fab-button/parts.md';
+import Props from '@ionic-internal/component-api/v9/fab-button/props.mdx';
+import Events from '@ionic-internal/component-api/v9/fab-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/fab-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/fab-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/fab-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/fab-button/slots.md';
+import Slots from '@ionic-internal/component-api/v9/fab-button/slots.mdx';
 
 <head>
   <title>ion-fab-button: Ionic FAB Button Icon for Primary Action</title>

--- a/docs/api/fab-list.md
+++ b/docs/api/fab-list.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-fab-list"
 ---
-import Props from '@ionic-internal/component-api/v9/fab-list/props.md';
-import Events from '@ionic-internal/component-api/v9/fab-list/events.md';
-import Methods from '@ionic-internal/component-api/v9/fab-list/methods.md';
-import Parts from '@ionic-internal/component-api/v9/fab-list/parts.md';
+import Props from '@ionic-internal/component-api/v9/fab-list/props.mdx';
+import Events from '@ionic-internal/component-api/v9/fab-list/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/fab-list/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/fab-list/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/fab-list/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/fab-list/slots.md';
+import Slots from '@ionic-internal/component-api/v9/fab-list/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/fab.md
+++ b/docs/api/fab.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-fab"
 ---
-import Props from '@ionic-internal/component-api/v9/fab/props.md';
-import Events from '@ionic-internal/component-api/v9/fab/events.md';
-import Methods from '@ionic-internal/component-api/v9/fab/methods.md';
-import Parts from '@ionic-internal/component-api/v9/fab/parts.md';
+import Props from '@ionic-internal/component-api/v9/fab/props.mdx';
+import Events from '@ionic-internal/component-api/v9/fab/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/fab/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/fab/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/fab/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/fab/slots.md';
+import Slots from '@ionic-internal/component-api/v9/fab/slots.mdx';
 
 <head>
   <title>ion-fab: Ionic Floating Action Button for Android and iOS</title>

--- a/docs/api/footer.md
+++ b/docs/api/footer.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-footer"
 ---
-import Props from '@ionic-internal/component-api/v9/footer/props.md';
-import Events from '@ionic-internal/component-api/v9/footer/events.md';
-import Methods from '@ionic-internal/component-api/v9/footer/methods.md';
-import Parts from '@ionic-internal/component-api/v9/footer/parts.md';
+import Props from '@ionic-internal/component-api/v9/footer/props.mdx';
+import Events from '@ionic-internal/component-api/v9/footer/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/footer/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/footer/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/footer/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/footer/slots.md';
+import Slots from '@ionic-internal/component-api/v9/footer/slots.mdx';
 
 <head>
   <title>ion-footer: Page Footer | Ionic App Footer Root Component</title>

--- a/docs/api/grid.md
+++ b/docs/api/grid.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-grid"
 ---
-import Props from '@ionic-internal/component-api/v9/grid/props.md';
-import Events from '@ionic-internal/component-api/v9/grid/events.md';
-import Methods from '@ionic-internal/component-api/v9/grid/methods.md';
-import Parts from '@ionic-internal/component-api/v9/grid/parts.md';
+import Props from '@ionic-internal/component-api/v9/grid/props.mdx';
+import Events from '@ionic-internal/component-api/v9/grid/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/grid/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/grid/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/grid/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/grid/slots.md';
+import Slots from '@ionic-internal/component-api/v9/grid/slots.mdx';
 
 <head>
   <title>ion-grid: Display Grids for Mobile-First Custom App Layout</title>

--- a/docs/api/header.md
+++ b/docs/api/header.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-header"
 ---
-import Props from '@ionic-internal/component-api/v9/header/props.md';
-import Events from '@ionic-internal/component-api/v9/header/events.md';
-import Methods from '@ionic-internal/component-api/v9/header/methods.md';
-import Parts from '@ionic-internal/component-api/v9/header/parts.md';
+import Props from '@ionic-internal/component-api/v9/header/props.mdx';
+import Events from '@ionic-internal/component-api/v9/header/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/header/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/header/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/header/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/header/slots.md';
+import Slots from '@ionic-internal/component-api/v9/header/slots.mdx';
 
 <head>
   <title>ion-header: Header Parent Component for Ionic Framework Apps</title>

--- a/docs/api/img.md
+++ b/docs/api/img.md
@@ -2,12 +2,12 @@
 title: "ion-img"
 ---
 
-import Props from '@ionic-internal/component-api/v9/img/props.md';
-import Events from '@ionic-internal/component-api/v9/img/events.md';
-import Methods from '@ionic-internal/component-api/v9/img/methods.md';
-import Parts from '@ionic-internal/component-api/v9/img/parts.md';
+import Props from '@ionic-internal/component-api/v9/img/props.mdx';
+import Events from '@ionic-internal/component-api/v9/img/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/img/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/img/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/img/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/img/slots.md';
+import Slots from '@ionic-internal/component-api/v9/img/slots.mdx';
 
 <head>
   <title>ion-img: Img Tag to Lazy Load Images in Viewport</title>

--- a/docs/api/infinite-scroll-content.md
+++ b/docs/api/infinite-scroll-content.md
@@ -2,12 +2,12 @@
 title: "ion-infinite-scroll-content"
 ---
 
-import Props from '@ionic-internal/component-api/v9/infinite-scroll-content/props.md';
-import Events from '@ionic-internal/component-api/v9/infinite-scroll-content/events.md';
-import Methods from '@ionic-internal/component-api/v9/infinite-scroll-content/methods.md';
-import Parts from '@ionic-internal/component-api/v9/infinite-scroll-content/parts.md';
+import Props from '@ionic-internal/component-api/v9/infinite-scroll-content/props.mdx';
+import Events from '@ionic-internal/component-api/v9/infinite-scroll-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/infinite-scroll-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/infinite-scroll-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/infinite-scroll-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/infinite-scroll-content/slots.md';
+import Slots from '@ionic-internal/component-api/v9/infinite-scroll-content/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/infinite-scroll.md
+++ b/docs/api/infinite-scroll.md
@@ -2,12 +2,12 @@
 title: "ion-infinite-scroll"
 ---
 
-import Props from '@ionic-internal/component-api/v9/infinite-scroll/props.md';
-import Events from '@ionic-internal/component-api/v9/infinite-scroll/events.md';
-import Methods from '@ionic-internal/component-api/v9/infinite-scroll/methods.md';
-import Parts from '@ionic-internal/component-api/v9/infinite-scroll/parts.md';
+import Props from '@ionic-internal/component-api/v9/infinite-scroll/props.mdx';
+import Events from '@ionic-internal/component-api/v9/infinite-scroll/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/infinite-scroll/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/infinite-scroll/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/infinite-scroll/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/infinite-scroll/slots.md';
+import Slots from '@ionic-internal/component-api/v9/infinite-scroll/slots.mdx';
 
 <head>
   <title>ion-infinite-scroll: Infinite Scroller Action Component</title>

--- a/docs/api/input-otp.md
+++ b/docs/api/input-otp.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-input-otp"
 ---
-import Props from '@ionic-internal/component-api/v9/input-otp/props.md';
-import Events from '@ionic-internal/component-api/v9/input-otp/events.md';
-import Methods from '@ionic-internal/component-api/v9/input-otp/methods.md';
-import Parts from '@ionic-internal/component-api/v9/input-otp/parts.md';
+import Props from '@ionic-internal/component-api/v9/input-otp/props.mdx';
+import Events from '@ionic-internal/component-api/v9/input-otp/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/input-otp/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/input-otp/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/input-otp/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/input-otp/slots.md';
+import Slots from '@ionic-internal/component-api/v9/input-otp/slots.mdx';
 
 <head>
   <title>ion-input-otp: One-Time Password Input Component</title>

--- a/docs/api/input-password-toggle.md
+++ b/docs/api/input-password-toggle.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-input-password-toggle"
 ---
-import Props from '@ionic-internal/component-api/v9/input-password-toggle/props.md';
-import Events from '@ionic-internal/component-api/v9/input-password-toggle/events.md';
-import Methods from '@ionic-internal/component-api/v9/input-password-toggle/methods.md';
-import Parts from '@ionic-internal/component-api/v9/input-password-toggle/parts.md';
+import Props from '@ionic-internal/component-api/v9/input-password-toggle/props.mdx';
+import Events from '@ionic-internal/component-api/v9/input-password-toggle/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/input-password-toggle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/input-password-toggle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/input-password-toggle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/input-password-toggle/slots.md';
+import Slots from '@ionic-internal/component-api/v9/input-password-toggle/slots.mdx';
 
 <head>
   <title>ion-input-password-toggle: Toggle the visibility of a password in Input</title>

--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-input"
 ---
-import Props from '@ionic-internal/component-api/v9/input/props.md';
-import Events from '@ionic-internal/component-api/v9/input/events.md';
-import Methods from '@ionic-internal/component-api/v9/input/methods.md';
-import Parts from '@ionic-internal/component-api/v9/input/parts.md';
+import Props from '@ionic-internal/component-api/v9/input/props.mdx';
+import Events from '@ionic-internal/component-api/v9/input/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/input/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/input/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/input/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/input/slots.md';
+import Slots from '@ionic-internal/component-api/v9/input/slots.mdx';
 
 <head>
   <title>ion-input: Custom Input With Styling and CSS Properties</title>

--- a/docs/api/item-divider.md
+++ b/docs/api/item-divider.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-item-divider"
 ---
-import Props from '@ionic-internal/component-api/v9/item-divider/props.md';
-import Events from '@ionic-internal/component-api/v9/item-divider/events.md';
-import Methods from '@ionic-internal/component-api/v9/item-divider/methods.md';
-import Parts from '@ionic-internal/component-api/v9/item-divider/parts.md';
+import Props from '@ionic-internal/component-api/v9/item-divider/props.mdx';
+import Events from '@ionic-internal/component-api/v9/item-divider/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/item-divider/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/item-divider/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/item-divider/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/item-divider/slots.md';
+import Slots from '@ionic-internal/component-api/v9/item-divider/slots.mdx';
 
 <head>
   <title>ion-item-divider: Item Divider Block Element for Ionic Apps</title>

--- a/docs/api/item-group.md
+++ b/docs/api/item-group.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-item-group"
 ---
-import Props from '@ionic-internal/component-api/v9/item-group/props.md';
-import Events from '@ionic-internal/component-api/v9/item-group/events.md';
-import Methods from '@ionic-internal/component-api/v9/item-group/methods.md';
-import Parts from '@ionic-internal/component-api/v9/item-group/parts.md';
+import Props from '@ionic-internal/component-api/v9/item-group/props.mdx';
+import Events from '@ionic-internal/component-api/v9/item-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/item-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/item-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/item-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/item-group/slots.md';
+import Slots from '@ionic-internal/component-api/v9/item-group/slots.mdx';
 
 <head>
   <title>ion-item-group: Group Items to Divide into Multiple Sections</title>

--- a/docs/api/item-option.md
+++ b/docs/api/item-option.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-item-option"
 ---
-import Props from '@ionic-internal/component-api/v9/item-option/props.md';
-import Events from '@ionic-internal/component-api/v9/item-option/events.md';
-import Methods from '@ionic-internal/component-api/v9/item-option/methods.md';
-import Parts from '@ionic-internal/component-api/v9/item-option/parts.md';
+import Props from '@ionic-internal/component-api/v9/item-option/props.mdx';
+import Events from '@ionic-internal/component-api/v9/item-option/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/item-option/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/item-option/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/item-option/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/item-option/slots.md';
+import Slots from '@ionic-internal/component-api/v9/item-option/slots.mdx';
 
 <head>
   <title>ion-item-option: Option Button for Sliding Item in Ionic</title>

--- a/docs/api/item-options.md
+++ b/docs/api/item-options.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-item-options"
 ---
-import Props from '@ionic-internal/component-api/v9/item-options/props.md';
-import Events from '@ionic-internal/component-api/v9/item-options/events.md';
-import Methods from '@ionic-internal/component-api/v9/item-options/methods.md';
-import Parts from '@ionic-internal/component-api/v9/item-options/parts.md';
+import Props from '@ionic-internal/component-api/v9/item-options/props.mdx';
+import Events from '@ionic-internal/component-api/v9/item-options/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/item-options/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/item-options/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/item-options/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/item-options/slots.md';
+import Slots from '@ionic-internal/component-api/v9/item-options/slots.mdx';
 
 <head>
   <title>ion-item-options: Option Button Components for Ionic Apps</title>

--- a/docs/api/item-sliding.md
+++ b/docs/api/item-sliding.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-item-sliding"
 ---
-import Props from '@ionic-internal/component-api/v9/item-sliding/props.md';
-import Events from '@ionic-internal/component-api/v9/item-sliding/events.md';
-import Methods from '@ionic-internal/component-api/v9/item-sliding/methods.md';
-import Parts from '@ionic-internal/component-api/v9/item-sliding/parts.md';
+import Props from '@ionic-internal/component-api/v9/item-sliding/props.mdx';
+import Events from '@ionic-internal/component-api/v9/item-sliding/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/item-sliding/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/item-sliding/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/item-sliding/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/item-sliding/slots.md';
+import Slots from '@ionic-internal/component-api/v9/item-sliding/slots.mdx';
 
 <head>
   <title>ion-item-sliding: Slide Buttons | Slide Right to Left</title>

--- a/docs/api/item.md
+++ b/docs/api/item.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-item"
 ---
-import Props from '@ionic-internal/component-api/v9/item/props.md';
-import Events from '@ionic-internal/component-api/v9/item/events.md';
-import Methods from '@ionic-internal/component-api/v9/item/methods.md';
-import Parts from '@ionic-internal/component-api/v9/item/parts.md';
+import Props from '@ionic-internal/component-api/v9/item/props.mdx';
+import Events from '@ionic-internal/component-api/v9/item/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/item/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/item/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/item/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/item/slots.md';
+import Slots from '@ionic-internal/component-api/v9/item/slots.mdx';
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import BestPracticeFigure from '@components/global/BestPracticeFigure';

--- a/docs/api/label.md
+++ b/docs/api/label.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-label"
 ---
-import Props from '@ionic-internal/component-api/v9/label/props.md';
-import Events from '@ionic-internal/component-api/v9/label/events.md';
-import Methods from '@ionic-internal/component-api/v9/label/methods.md';
-import Parts from '@ionic-internal/component-api/v9/label/parts.md';
+import Props from '@ionic-internal/component-api/v9/label/props.mdx';
+import Events from '@ionic-internal/component-api/v9/label/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/label/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/label/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/label/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/label/slots.md';
+import Slots from '@ionic-internal/component-api/v9/label/slots.mdx';
 
 <head>
   <title>ion-label: Item Label Color and Properties for Applications</title>

--- a/docs/api/list-header.md
+++ b/docs/api/list-header.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-list-header"
 ---
-import Props from '@ionic-internal/component-api/v9/list-header/props.md';
-import Events from '@ionic-internal/component-api/v9/list-header/events.md';
-import Methods from '@ionic-internal/component-api/v9/list-header/methods.md';
-import Parts from '@ionic-internal/component-api/v9/list-header/parts.md';
+import Props from '@ionic-internal/component-api/v9/list-header/props.mdx';
+import Events from '@ionic-internal/component-api/v9/list-header/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/list-header/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/list-header/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/list-header/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/list-header/slots.md';
+import Slots from '@ionic-internal/component-api/v9/list-header/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/list.md
+++ b/docs/api/list.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-list"
 ---
-import Props from '@ionic-internal/component-api/v9/list/props.md';
-import Events from '@ionic-internal/component-api/v9/list/events.md';
-import Methods from '@ionic-internal/component-api/v9/list/methods.md';
-import Parts from '@ionic-internal/component-api/v9/list/parts.md';
+import Props from '@ionic-internal/component-api/v9/list/props.mdx';
+import Events from '@ionic-internal/component-api/v9/list/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/list/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/list/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/list/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/list/slots.md';
+import Slots from '@ionic-internal/component-api/v9/list/slots.mdx';
 
 <head>
   <title>ion-list: Item List View Component for iOS and Android Apps</title>

--- a/docs/api/loading.md
+++ b/docs/api/loading.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-loading"
 ---
-import Props from '@ionic-internal/component-api/v9/loading/props.md';
-import Events from '@ionic-internal/component-api/v9/loading/events.md';
-import Methods from '@ionic-internal/component-api/v9/loading/methods.md';
-import Parts from '@ionic-internal/component-api/v9/loading/parts.md';
+import Props from '@ionic-internal/component-api/v9/loading/props.mdx';
+import Events from '@ionic-internal/component-api/v9/loading/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/loading/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/loading/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/loading/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/loading/slots.md';
+import Slots from '@ionic-internal/component-api/v9/loading/slots.mdx';
 
 <head>
   <title>ion-loading: Loading | Application Loading Indicator Overlay</title>

--- a/docs/api/menu-button.md
+++ b/docs/api/menu-button.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-menu-button"
 ---
-import Props from '@ionic-internal/component-api/v9/menu-button/props.md';
-import Events from '@ionic-internal/component-api/v9/menu-button/events.md';
-import Methods from '@ionic-internal/component-api/v9/menu-button/methods.md';
-import Parts from '@ionic-internal/component-api/v9/menu-button/parts.md';
+import Props from '@ionic-internal/component-api/v9/menu-button/props.mdx';
+import Events from '@ionic-internal/component-api/v9/menu-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/menu-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/menu-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/menu-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/menu-button/slots.md';
+import Slots from '@ionic-internal/component-api/v9/menu-button/slots.mdx';
 
 <head>
   <title>ion-menu-button: Menu Button to Open an App Menu on a Page</title>

--- a/docs/api/menu-toggle.md
+++ b/docs/api/menu-toggle.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-menu-toggle"
 ---
-import Props from '@ionic-internal/component-api/v9/menu-toggle/props.md';
-import Events from '@ionic-internal/component-api/v9/menu-toggle/events.md';
-import Methods from '@ionic-internal/component-api/v9/menu-toggle/methods.md';
-import Parts from '@ionic-internal/component-api/v9/menu-toggle/parts.md';
+import Props from '@ionic-internal/component-api/v9/menu-toggle/props.mdx';
+import Events from '@ionic-internal/component-api/v9/menu-toggle/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/menu-toggle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/menu-toggle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/menu-toggle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/menu-toggle/slots.md';
+import Slots from '@ionic-internal/component-api/v9/menu-toggle/slots.mdx';
 
 <head>
   <title>ion-menu-toggle: MenuToggle Component to Open/Close Menus</title>

--- a/docs/api/menu.md
+++ b/docs/api/menu.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-menu"
 ---
-import Props from '@ionic-internal/component-api/v9/menu/props.md';
-import Events from '@ionic-internal/component-api/v9/menu/events.md';
-import Methods from '@ionic-internal/component-api/v9/menu/methods.md';
-import Parts from '@ionic-internal/component-api/v9/menu/parts.md';
+import Props from '@ionic-internal/component-api/v9/menu/props.mdx';
+import Events from '@ionic-internal/component-api/v9/menu/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/menu/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/menu/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/menu/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/menu/slots.md';
+import Slots from '@ionic-internal/component-api/v9/menu/slots.mdx';
 
 <head>
   <title>ion-menu: API Framework Docs for Types of Menu Components</title>

--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-modal"
 ---
-import Props from '@ionic-internal/component-api/v9/modal/props.md';
-import Events from '@ionic-internal/component-api/v9/modal/events.md';
-import Methods from '@ionic-internal/component-api/v9/modal/methods.md';
-import Parts from '@ionic-internal/component-api/v9/modal/parts.md';
+import Props from '@ionic-internal/component-api/v9/modal/props.mdx';
+import Events from '@ionic-internal/component-api/v9/modal/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/modal/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/modal/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/modal/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/modal/slots.md';
+import Slots from '@ionic-internal/component-api/v9/modal/slots.mdx';
 
 <head>
   <title>ion-modal: Ionic Mobile App Custom Modal API Component</title>

--- a/docs/api/nav-link.md
+++ b/docs/api/nav-link.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-nav-link"
 ---
-import Props from '@ionic-internal/component-api/v9/nav-link/props.md';
-import Events from '@ionic-internal/component-api/v9/nav-link/events.md';
-import Methods from '@ionic-internal/component-api/v9/nav-link/methods.md';
-import Parts from '@ionic-internal/component-api/v9/nav-link/parts.md';
+import Props from '@ionic-internal/component-api/v9/nav-link/props.mdx';
+import Events from '@ionic-internal/component-api/v9/nav-link/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/nav-link/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/nav-link/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/nav-link/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/nav-link/slots.md';
+import Slots from '@ionic-internal/component-api/v9/nav-link/slots.mdx';
 
 <head>
   <title>ion-nav-link: Navigation Links to a Specified Component</title>

--- a/docs/api/nav.md
+++ b/docs/api/nav.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-nav"
 ---
-import Props from '@ionic-internal/component-api/v9/nav/props.md';
-import Events from '@ionic-internal/component-api/v9/nav/events.md';
-import Methods from '@ionic-internal/component-api/v9/nav/methods.md';
-import Parts from '@ionic-internal/component-api/v9/nav/parts.md';
+import Props from '@ionic-internal/component-api/v9/nav/props.mdx';
+import Events from '@ionic-internal/component-api/v9/nav/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/nav/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/nav/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/nav/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/nav/slots.md';
+import Slots from '@ionic-internal/component-api/v9/nav/slots.mdx';
 
 <head>
   <title>ion-nav: Nav View Component for Ionic Framework Apps</title>

--- a/docs/api/note.md
+++ b/docs/api/note.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-note"
 ---
-import Props from '@ionic-internal/component-api/v9/note/props.md';
-import Events from '@ionic-internal/component-api/v9/note/events.md';
-import Methods from '@ionic-internal/component-api/v9/note/methods.md';
-import Parts from '@ionic-internal/component-api/v9/note/parts.md';
+import Props from '@ionic-internal/component-api/v9/note/props.mdx';
+import Events from '@ionic-internal/component-api/v9/note/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/note/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/note/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/note/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/note/slots.md';
+import Slots from '@ionic-internal/component-api/v9/note/slots.mdx';
 
 <head>
   <title>ion-note: Note Text Elements for iOS and Android Ionic Apps</title>

--- a/docs/api/picker-column-option.md
+++ b/docs/api/picker-column-option.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-picker-column-option"
 ---
-import Props from '@ionic-internal/component-api/v9/picker-column-option/props.md';
-import Events from '@ionic-internal/component-api/v9/picker-column-option/events.md';
-import Methods from '@ionic-internal/component-api/v9/picker-column-option/methods.md';
-import Parts from '@ionic-internal/component-api/v9/picker-column-option/parts.md';
+import Props from '@ionic-internal/component-api/v9/picker-column-option/props.mdx';
+import Events from '@ionic-internal/component-api/v9/picker-column-option/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/picker-column-option/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/picker-column-option/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/picker-column-option/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/picker-column-option/slots.md';
+import Slots from '@ionic-internal/component-api/v9/picker-column-option/slots.mdx';
 
 <head>
   <title>ion-picker-column-option: The individual options within a column in a picker.</title>

--- a/docs/api/picker-column.md
+++ b/docs/api/picker-column.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-picker-column"
 ---
-import Props from '@ionic-internal/component-api/v9/picker-column/props.md';
-import Events from '@ionic-internal/component-api/v9/picker-column/events.md';
-import Methods from '@ionic-internal/component-api/v9/picker-column/methods.md';
-import Parts from '@ionic-internal/component-api/v9/picker-column/parts.md';
+import Props from '@ionic-internal/component-api/v9/picker-column/props.mdx';
+import Events from '@ionic-internal/component-api/v9/picker-column/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/picker-column/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/picker-column/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/picker-column/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/picker-column/slots.md';
+import Slots from '@ionic-internal/component-api/v9/picker-column/slots.mdx';
 
 <head>
   <title>ion-picker-column: Individual columns within a picker</title>

--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-picker"
 ---
-import Props from '@ionic-internal/component-api/v9/picker/props.md';
-import Events from '@ionic-internal/component-api/v9/picker/events.md';
-import Methods from '@ionic-internal/component-api/v9/picker/methods.md';
-import Parts from '@ionic-internal/component-api/v9/picker/parts.md';
+import Props from '@ionic-internal/component-api/v9/picker/props.mdx';
+import Events from '@ionic-internal/component-api/v9/picker/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/picker/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/picker/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/picker/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/picker/slots.md';
+import Slots from '@ionic-internal/component-api/v9/picker/slots.mdx';
 
 <head>
   <title>ion-picker: Display a list of options in columns</title>

--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-popover"
 ---
-import Props from '@ionic-internal/component-api/v9/popover/props.md';
-import Events from '@ionic-internal/component-api/v9/popover/events.md';
-import Methods from '@ionic-internal/component-api/v9/popover/methods.md';
-import Parts from '@ionic-internal/component-api/v9/popover/parts.md';
+import Props from '@ionic-internal/component-api/v9/popover/props.mdx';
+import Events from '@ionic-internal/component-api/v9/popover/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/popover/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/popover/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/popover/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/popover/slots.md';
+import Slots from '@ionic-internal/component-api/v9/popover/slots.mdx';
 
 <head>
   <title>ion-popover: iOS / Android Popover UI Dialog Component</title>

--- a/docs/api/progress-bar.md
+++ b/docs/api/progress-bar.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-progress-bar"
 ---
-import Props from '@ionic-internal/component-api/v9/progress-bar/props.md';
-import Events from '@ionic-internal/component-api/v9/progress-bar/events.md';
-import Methods from '@ionic-internal/component-api/v9/progress-bar/methods.md';
-import Parts from '@ionic-internal/component-api/v9/progress-bar/parts.md';
+import Props from '@ionic-internal/component-api/v9/progress-bar/props.mdx';
+import Events from '@ionic-internal/component-api/v9/progress-bar/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/progress-bar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/progress-bar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/progress-bar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/progress-bar/slots.md';
+import Slots from '@ionic-internal/component-api/v9/progress-bar/slots.mdx';
 
 <head>
   <title>ion-progress-bar: App Progress Bar for Loading Indicator</title>

--- a/docs/api/radio-group.md
+++ b/docs/api/radio-group.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-radio-group"
 ---
-import Props from '@ionic-internal/component-api/v9/radio-group/props.md';
-import Events from '@ionic-internal/component-api/v9/radio-group/events.md';
-import Methods from '@ionic-internal/component-api/v9/radio-group/methods.md';
-import Parts from '@ionic-internal/component-api/v9/radio-group/parts.md';
+import Props from '@ionic-internal/component-api/v9/radio-group/props.mdx';
+import Events from '@ionic-internal/component-api/v9/radio-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/radio-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/radio-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/radio-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/radio-group/slots.md';
+import Slots from '@ionic-internal/component-api/v9/radio-group/slots.mdx';
 
 <head>
   <title>ion-radio-group: Radio Button Group Usage for Ionic Apps</title>

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-radio"
 ---
-import Props from '@ionic-internal/component-api/v9/radio/props.md';
-import Events from '@ionic-internal/component-api/v9/radio/events.md';
-import Methods from '@ionic-internal/component-api/v9/radio/methods.md';
-import Parts from '@ionic-internal/component-api/v9/radio/parts.md';
+import Props from '@ionic-internal/component-api/v9/radio/props.mdx';
+import Events from '@ionic-internal/component-api/v9/radio/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/radio/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/radio/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/radio/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/radio/slots.md';
+import Slots from '@ionic-internal/component-api/v9/radio/slots.mdx';
 
 <head>
   <title>ion-radio: Radio Component for iOS and Android</title>

--- a/docs/api/range.md
+++ b/docs/api/range.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-range"
 ---
-import Props from '@ionic-internal/component-api/v9/range/props.md';
-import Events from '@ionic-internal/component-api/v9/range/events.md';
-import Methods from '@ionic-internal/component-api/v9/range/methods.md';
-import Parts from '@ionic-internal/component-api/v9/range/parts.md';
+import Props from '@ionic-internal/component-api/v9/range/props.mdx';
+import Events from '@ionic-internal/component-api/v9/range/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/range/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/range/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/range/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/range/slots.md';
+import Slots from '@ionic-internal/component-api/v9/range/slots.mdx';
 
 <head>
   <title>ion-range: Range Slider Knob Controls with Labels</title>

--- a/docs/api/refresher-content.md
+++ b/docs/api/refresher-content.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-refresher-content"
 ---
-import Props from '@ionic-internal/component-api/v9/refresher-content/props.md';
-import Events from '@ionic-internal/component-api/v9/refresher-content/events.md';
-import Methods from '@ionic-internal/component-api/v9/refresher-content/methods.md';
-import Parts from '@ionic-internal/component-api/v9/refresher-content/parts.md';
+import Props from '@ionic-internal/component-api/v9/refresher-content/props.mdx';
+import Events from '@ionic-internal/component-api/v9/refresher-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/refresher-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/refresher-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/refresher-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/refresher-content/slots.md';
+import Slots from '@ionic-internal/component-api/v9/refresher-content/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/refresher.md
+++ b/docs/api/refresher.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-refresher"
 ---
-import Props from '@ionic-internal/component-api/v9/refresher/props.md';
-import Events from '@ionic-internal/component-api/v9/refresher/events.md';
-import Methods from '@ionic-internal/component-api/v9/refresher/methods.md';
-import Parts from '@ionic-internal/component-api/v9/refresher/parts.md';
+import Props from '@ionic-internal/component-api/v9/refresher/props.mdx';
+import Events from '@ionic-internal/component-api/v9/refresher/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/refresher/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/refresher/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/refresher/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/refresher/slots.md';
+import Slots from '@ionic-internal/component-api/v9/refresher/slots.mdx';
 
 <head>
   <title>ion-refresher: Pull-to-Refresh Page Content on Ionic Apps</title>

--- a/docs/api/reorder-group.md
+++ b/docs/api/reorder-group.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-reorder-group"
 ---
-import Props from '@ionic-internal/component-api/v9/reorder-group/props.md';
-import Events from '@ionic-internal/component-api/v9/reorder-group/events.md';
-import Methods from '@ionic-internal/component-api/v9/reorder-group/methods.md';
-import Parts from '@ionic-internal/component-api/v9/reorder-group/parts.md';
+import Props from '@ionic-internal/component-api/v9/reorder-group/props.mdx';
+import Events from '@ionic-internal/component-api/v9/reorder-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/reorder-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/reorder-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/reorder-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/reorder-group/slots.md';
+import Slots from '@ionic-internal/component-api/v9/reorder-group/slots.mdx';
 
 <head>
   <title>ion-reorder-group: Wrapper Component for Reorder Items</title>

--- a/docs/api/reorder.md
+++ b/docs/api/reorder.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-reorder"
 ---
-import Props from '@ionic-internal/component-api/v9/reorder/props.md';
-import Events from '@ionic-internal/component-api/v9/reorder/events.md';
-import Methods from '@ionic-internal/component-api/v9/reorder/methods.md';
-import Parts from '@ionic-internal/component-api/v9/reorder/parts.md';
+import Props from '@ionic-internal/component-api/v9/reorder/props.mdx';
+import Events from '@ionic-internal/component-api/v9/reorder/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/reorder/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/reorder/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/reorder/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/reorder/slots.md';
+import Slots from '@ionic-internal/component-api/v9/reorder/slots.mdx';
 
 <head>
   <title>ion-reorder: Drag and Drop Icon to Reorder Items</title>

--- a/docs/api/ripple-effect.md
+++ b/docs/api/ripple-effect.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-ripple-effect"
 ---
-import Props from '@ionic-internal/component-api/v9/ripple-effect/props.md';
-import Events from '@ionic-internal/component-api/v9/ripple-effect/events.md';
-import Methods from '@ionic-internal/component-api/v9/ripple-effect/methods.md';
-import Parts from '@ionic-internal/component-api/v9/ripple-effect/parts.md';
+import Props from '@ionic-internal/component-api/v9/ripple-effect/props.mdx';
+import Events from '@ionic-internal/component-api/v9/ripple-effect/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/ripple-effect/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/ripple-effect/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/ripple-effect/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/ripple-effect/slots.md';
+import Slots from '@ionic-internal/component-api/v9/ripple-effect/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/docs/api/route-redirect.md
+++ b/docs/api/route-redirect.md
@@ -2,12 +2,12 @@
 title: "ion-route-redirect"
 ---
 
-import Props from '@ionic-internal/component-api/v9/route-redirect/props.md';
-import Events from '@ionic-internal/component-api/v9/route-redirect/events.md';
-import Methods from '@ionic-internal/component-api/v9/route-redirect/methods.md';
-import Parts from '@ionic-internal/component-api/v9/route-redirect/parts.md';
+import Props from '@ionic-internal/component-api/v9/route-redirect/props.mdx';
+import Events from '@ionic-internal/component-api/v9/route-redirect/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/route-redirect/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/route-redirect/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/route-redirect/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/route-redirect/slots.md';
+import Slots from '@ionic-internal/component-api/v9/route-redirect/slots.mdx';
 
 <head>
   <title>ion-route-redirect: Redirect 'from' a URL 'to' Another URL</title>

--- a/docs/api/route.md
+++ b/docs/api/route.md
@@ -4,12 +4,12 @@ title: "ion-route"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v9/route/props.md';
-import Events from '@ionic-internal/component-api/v9/route/events.md';
-import Methods from '@ionic-internal/component-api/v9/route/methods.md';
-import Parts from '@ionic-internal/component-api/v9/route/parts.md';
+import Props from '@ionic-internal/component-api/v9/route/props.mdx';
+import Events from '@ionic-internal/component-api/v9/route/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/route/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/route/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/route/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/route/slots.md';
+import Slots from '@ionic-internal/component-api/v9/route/slots.mdx';
 
 <head>
   <title>ion-route: API Route Component for Ionic Framework Apps</title>

--- a/docs/api/router-link.md
+++ b/docs/api/router-link.md
@@ -2,12 +2,12 @@
 title: "ion-router-link"
 ---
 
-import Props from '@ionic-internal/component-api/v9/router-link/props.md';
-import Events from '@ionic-internal/component-api/v9/router-link/events.md';
-import Methods from '@ionic-internal/component-api/v9/router-link/methods.md';
-import Parts from '@ionic-internal/component-api/v9/router-link/parts.md';
+import Props from '@ionic-internal/component-api/v9/router-link/props.mdx';
+import Events from '@ionic-internal/component-api/v9/router-link/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/router-link/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/router-link/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/router-link/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/router-link/slots.md';
+import Slots from '@ionic-internal/component-api/v9/router-link/slots.mdx';
 
 <head>
   <title>ion-router-link: Navigate To a Specified Link</title>

--- a/docs/api/router-outlet.md
+++ b/docs/api/router-outlet.md
@@ -2,12 +2,12 @@
 title: "ion-router-outlet"
 ---
 
-import Props from '@ionic-internal/component-api/v9/router-outlet/props.md';
-import Events from '@ionic-internal/component-api/v9/router-outlet/events.md';
-import Methods from '@ionic-internal/component-api/v9/router-outlet/methods.md';
-import Parts from '@ionic-internal/component-api/v9/router-outlet/parts.md';
+import Props from '@ionic-internal/component-api/v9/router-outlet/props.mdx';
+import Events from '@ionic-internal/component-api/v9/router-outlet/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/router-outlet/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/router-outlet/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/router-outlet/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/router-outlet/slots.md';
+import Slots from '@ionic-internal/component-api/v9/router-outlet/slots.mdx';
 
 
 

--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -2,12 +2,12 @@
 title: "ion-router"
 ---
 
-import Props from '@ionic-internal/component-api/v9/router/props.md';
-import Events from '@ionic-internal/component-api/v9/router/events.md';
-import Methods from '@ionic-internal/component-api/v9/router/methods.md';
-import Parts from '@ionic-internal/component-api/v9/router/parts.md';
+import Props from '@ionic-internal/component-api/v9/router/props.mdx';
+import Events from '@ionic-internal/component-api/v9/router/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/router/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/router/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/router/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/router/slots.md';
+import Slots from '@ionic-internal/component-api/v9/router/slots.mdx';
 
 <head>
   <title>ion-router: Router Component to Coordinate URL Navigation</title>

--- a/docs/api/row.md
+++ b/docs/api/row.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-row"
 ---
-import Props from '@ionic-internal/component-api/v9/row/props.md';
-import Events from '@ionic-internal/component-api/v9/row/events.md';
-import Methods from '@ionic-internal/component-api/v9/row/methods.md';
-import Parts from '@ionic-internal/component-api/v9/row/parts.md';
+import Props from '@ionic-internal/component-api/v9/row/props.mdx';
+import Events from '@ionic-internal/component-api/v9/row/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/row/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/row/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/row/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/row/slots.md';
+import Slots from '@ionic-internal/component-api/v9/row/slots.mdx';
 
 <head>
   <title>ion-row: Horizontal Row Components of the Grid System</title>

--- a/docs/api/searchbar.md
+++ b/docs/api/searchbar.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-searchbar"
 ---
-import Props from '@ionic-internal/component-api/v9/searchbar/props.md';
-import Events from '@ionic-internal/component-api/v9/searchbar/events.md';
-import Methods from '@ionic-internal/component-api/v9/searchbar/methods.md';
-import Parts from '@ionic-internal/component-api/v9/searchbar/parts.md';
+import Props from '@ionic-internal/component-api/v9/searchbar/props.mdx';
+import Events from '@ionic-internal/component-api/v9/searchbar/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/searchbar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/searchbar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/searchbar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/searchbar/slots.md';
+import Slots from '@ionic-internal/component-api/v9/searchbar/slots.mdx';
 
 <head>
   <title>ion-searchbar: Search Bar for Searching a Collection</title>

--- a/docs/api/segment-button.md
+++ b/docs/api/segment-button.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-segment-button"
 ---
-import Props from '@ionic-internal/component-api/v9/segment-button/props.md';
-import Events from '@ionic-internal/component-api/v9/segment-button/events.md';
-import Methods from '@ionic-internal/component-api/v9/segment-button/methods.md';
-import Parts from '@ionic-internal/component-api/v9/segment-button/parts.md';
+import Props from '@ionic-internal/component-api/v9/segment-button/props.mdx';
+import Events from '@ionic-internal/component-api/v9/segment-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/segment-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/segment-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/segment-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/segment-button/slots.md';
+import Slots from '@ionic-internal/component-api/v9/segment-button/slots.mdx';
 
 <head>
   <title>ion-segment-button | Segment Button Icon and Segment Value</title>

--- a/docs/api/segment-content.md
+++ b/docs/api/segment-content.md
@@ -2,12 +2,12 @@
 title: "ion-segment-content"
 ---
 
-import Props from '@ionic-internal/component-api/v9/segment-content/props.md';
-import Events from '@ionic-internal/component-api/v9/segment-content/events.md';
-import Methods from '@ionic-internal/component-api/v9/segment-content/methods.md';
-import Parts from '@ionic-internal/component-api/v9/segment-content/parts.md';
+import Props from '@ionic-internal/component-api/v9/segment-content/props.mdx';
+import Events from '@ionic-internal/component-api/v9/segment-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/segment-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/segment-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/segment-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/segment-content/slots.md';
+import Slots from '@ionic-internal/component-api/v9/segment-content/slots.mdx';
 
 <head>
   <title>ion-segment-content: Display control element for swipeable segments</title>

--- a/docs/api/segment-view.md
+++ b/docs/api/segment-view.md
@@ -2,12 +2,12 @@
 title: "ion-segment-view"
 ---
 
-import Props from '@ionic-internal/component-api/v9/segment-view/props.md';
-import Events from '@ionic-internal/component-api/v9/segment-view/events.md';
-import Methods from '@ionic-internal/component-api/v9/segment-view/methods.md';
-import Parts from '@ionic-internal/component-api/v9/segment-view/parts.md';
+import Props from '@ionic-internal/component-api/v9/segment-view/props.mdx';
+import Events from '@ionic-internal/component-api/v9/segment-view/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/segment-view/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/segment-view/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/segment-view/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/segment-view/slots.md';
+import Slots from '@ionic-internal/component-api/v9/segment-view/slots.mdx';
 
 <head>
   <title>ion-segment-view: Controller element for swipeable segments</title>

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-segment"
 ---
-import Props from '@ionic-internal/component-api/v9/segment/props.md';
-import Events from '@ionic-internal/component-api/v9/segment/events.md';
-import Methods from '@ionic-internal/component-api/v9/segment/methods.md';
-import Parts from '@ionic-internal/component-api/v9/segment/parts.md';
+import Props from '@ionic-internal/component-api/v9/segment/props.mdx';
+import Events from '@ionic-internal/component-api/v9/segment/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/segment/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/segment/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/segment/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/segment/slots.md';
+import Slots from '@ionic-internal/component-api/v9/segment/slots.mdx';
 
 <head>
   <title>ion-segment: API Documentation for Segmented Controls</title>

--- a/docs/api/select-option.md
+++ b/docs/api/select-option.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-select-option"
 ---
-import Props from '@ionic-internal/component-api/v9/select-option/props.md';
-import Events from '@ionic-internal/component-api/v9/select-option/events.md';
-import Methods from '@ionic-internal/component-api/v9/select-option/methods.md';
-import Parts from '@ionic-internal/component-api/v9/select-option/parts.md';
+import Props from '@ionic-internal/component-api/v9/select-option/props.mdx';
+import Events from '@ionic-internal/component-api/v9/select-option/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/select-option/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/select-option/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/select-option/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/select-option/slots.md';
+import Slots from '@ionic-internal/component-api/v9/select-option/slots.mdx';
 
 <head>
   <title>ion-select-option: Option For a Select Dialog</title>

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-select"
 ---
-import Props from '@ionic-internal/component-api/v9/select/props.md';
-import Events from '@ionic-internal/component-api/v9/select/events.md';
-import Methods from '@ionic-internal/component-api/v9/select/methods.md';
-import Parts from '@ionic-internal/component-api/v9/select/parts.md';
+import Props from '@ionic-internal/component-api/v9/select/props.mdx';
+import Events from '@ionic-internal/component-api/v9/select/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/select/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/select/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/select/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/select/slots.md';
+import Slots from '@ionic-internal/component-api/v9/select/slots.mdx';
 
 <head>
   <title>ion-select: Select One or Multiple Value Boxes or Placeholders</title>

--- a/docs/api/skeleton-text.md
+++ b/docs/api/skeleton-text.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-skeleton-text"
 ---
-import Props from '@ionic-internal/component-api/v9/skeleton-text/props.md';
-import Events from '@ionic-internal/component-api/v9/skeleton-text/events.md';
-import Methods from '@ionic-internal/component-api/v9/skeleton-text/methods.md';
-import Parts from '@ionic-internal/component-api/v9/skeleton-text/parts.md';
+import Props from '@ionic-internal/component-api/v9/skeleton-text/props.mdx';
+import Events from '@ionic-internal/component-api/v9/skeleton-text/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/skeleton-text/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/skeleton-text/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/skeleton-text/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/skeleton-text/slots.md';
+import Slots from '@ionic-internal/component-api/v9/skeleton-text/slots.mdx';
 
 <head>
   <title>ion-skeleton-text: Skeleton Loading Placeholder for Text</title>

--- a/docs/api/spinner.md
+++ b/docs/api/spinner.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-spinner"
 ---
-import Props from '@ionic-internal/component-api/v9/spinner/props.md';
-import Events from '@ionic-internal/component-api/v9/spinner/events.md';
-import Methods from '@ionic-internal/component-api/v9/spinner/methods.md';
-import Parts from '@ionic-internal/component-api/v9/spinner/parts.md';
+import Props from '@ionic-internal/component-api/v9/spinner/props.mdx';
+import Events from '@ionic-internal/component-api/v9/spinner/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/spinner/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/spinner/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/spinner/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/spinner/slots.md';
+import Slots from '@ionic-internal/component-api/v9/spinner/slots.mdx';
 
 <head>
   <title>ion-spinner: Animated Spinner Icon Components and Properties</title>

--- a/docs/api/split-pane.md
+++ b/docs/api/split-pane.md
@@ -2,12 +2,12 @@
 title: "ion-split-pane"
 ---
 
-import Props from '@ionic-internal/component-api/v9/split-pane/props.md';
-import Events from '@ionic-internal/component-api/v9/split-pane/events.md';
-import Methods from '@ionic-internal/component-api/v9/split-pane/methods.md';
-import Parts from '@ionic-internal/component-api/v9/split-pane/parts.md';
+import Props from '@ionic-internal/component-api/v9/split-pane/props.mdx';
+import Events from '@ionic-internal/component-api/v9/split-pane/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/split-pane/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/split-pane/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/split-pane/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/split-pane/slots.md';
+import Slots from '@ionic-internal/component-api/v9/split-pane/slots.mdx';
 
 <head>
   <title>ion-split-pane: Split Plane for Menus and Multi-View Layouts</title>

--- a/docs/api/tab-bar.md
+++ b/docs/api/tab-bar.md
@@ -4,12 +4,12 @@ title: "ion-tab-bar"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v9/tab-bar/props.md';
-import Events from '@ionic-internal/component-api/v9/tab-bar/events.md';
-import Methods from '@ionic-internal/component-api/v9/tab-bar/methods.md';
-import Parts from '@ionic-internal/component-api/v9/tab-bar/parts.md';
+import Props from '@ionic-internal/component-api/v9/tab-bar/props.mdx';
+import Events from '@ionic-internal/component-api/v9/tab-bar/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/tab-bar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/tab-bar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/tab-bar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/tab-bar/slots.md';
+import Slots from '@ionic-internal/component-api/v9/tab-bar/slots.mdx';
 
 <head>
   <title>ion-tab-bar: Tab Bar Component with CSS Custom Properties</title>

--- a/docs/api/tab-button.md
+++ b/docs/api/tab-button.md
@@ -4,12 +4,12 @@ title: "ion-tab-button"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v9/tab-button/props.md';
-import Events from '@ionic-internal/component-api/v9/tab-button/events.md';
-import Methods from '@ionic-internal/component-api/v9/tab-button/methods.md';
-import Parts from '@ionic-internal/component-api/v9/tab-button/parts.md';
+import Props from '@ionic-internal/component-api/v9/tab-button/props.mdx';
+import Events from '@ionic-internal/component-api/v9/tab-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/tab-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/tab-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/tab-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/tab-button/slots.md';
+import Slots from '@ionic-internal/component-api/v9/tab-button/slots.mdx';
 
 
 

--- a/docs/api/tab.md
+++ b/docs/api/tab.md
@@ -2,12 +2,12 @@
 title: "ion-tab"
 ---
 
-import Props from '@ionic-internal/component-api/v9/tab/props.md';
-import Events from '@ionic-internal/component-api/v9/tab/events.md';
-import Methods from '@ionic-internal/component-api/v9/tab/methods.md';
-import Parts from '@ionic-internal/component-api/v9/tab/parts.md';
+import Props from '@ionic-internal/component-api/v9/tab/props.mdx';
+import Events from '@ionic-internal/component-api/v9/tab/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/tab/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/tab/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/tab/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/tab/slots.md';
+import Slots from '@ionic-internal/component-api/v9/tab/slots.mdx';
 
 <head>
   <title>ion-tab: Ionic Framework Application Component</title>

--- a/docs/api/tabs.md
+++ b/docs/api/tabs.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-tabs"
 ---
-import Props from '@ionic-internal/component-api/v9/tabs/props.md';
-import Events from '@ionic-internal/component-api/v9/tabs/events.md';
-import Methods from '@ionic-internal/component-api/v9/tabs/methods.md';
-import Parts from '@ionic-internal/component-api/v9/tabs/parts.md';
+import Props from '@ionic-internal/component-api/v9/tabs/props.mdx';
+import Events from '@ionic-internal/component-api/v9/tabs/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/tabs/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/tabs/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/tabs/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/tabs/slots.md';
+import Slots from '@ionic-internal/component-api/v9/tabs/slots.mdx';
 
 <head>
   <title>ion-tabs: Tab-Based Component for App Top-Level Navigation</title>

--- a/docs/api/text.md
+++ b/docs/api/text.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-text"
 ---
-import Props from '@ionic-internal/component-api/v9/text/props.md';
-import Events from '@ionic-internal/component-api/v9/text/events.md';
-import Methods from '@ionic-internal/component-api/v9/text/methods.md';
-import Parts from '@ionic-internal/component-api/v9/text/parts.md';
+import Props from '@ionic-internal/component-api/v9/text/props.mdx';
+import Events from '@ionic-internal/component-api/v9/text/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/text/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/text/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/text/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/text/slots.md';
+import Slots from '@ionic-internal/component-api/v9/text/slots.mdx';
 
 <head>
   <title>ion-text: Ionic App Component to Style or Change Text Color</title>

--- a/docs/api/textarea.md
+++ b/docs/api/textarea.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-textarea"
 ---
-import Props from '@ionic-internal/component-api/v9/textarea/props.md';
-import Events from '@ionic-internal/component-api/v9/textarea/events.md';
-import Methods from '@ionic-internal/component-api/v9/textarea/methods.md';
-import Parts from '@ionic-internal/component-api/v9/textarea/parts.md';
+import Props from '@ionic-internal/component-api/v9/textarea/props.mdx';
+import Events from '@ionic-internal/component-api/v9/textarea/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/textarea/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/textarea/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/textarea/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/textarea/slots.md';
+import Slots from '@ionic-internal/component-api/v9/textarea/slots.mdx';
 
 <head>
   <title>Ionic Textarea Component and CSS Properties for Multi-Line Input</title>

--- a/docs/api/thumbnail.md
+++ b/docs/api/thumbnail.md
@@ -2,12 +2,12 @@
 title: "ion-thumbnail"
 ---
 
-import Props from '@ionic-internal/component-api/v9/thumbnail/props.md';
-import Events from '@ionic-internal/component-api/v9/thumbnail/events.md';
-import Methods from '@ionic-internal/component-api/v9/thumbnail/methods.md';
-import Parts from '@ionic-internal/component-api/v9/thumbnail/parts.md';
+import Props from '@ionic-internal/component-api/v9/thumbnail/props.mdx';
+import Events from '@ionic-internal/component-api/v9/thumbnail/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/thumbnail/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/thumbnail/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/thumbnail/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/thumbnail/slots.md';
+import Slots from '@ionic-internal/component-api/v9/thumbnail/slots.mdx';
 
 <head>
   <title>ion-thumbnail: Thumbnail App Component for Images or Icons</title>

--- a/docs/api/title.md
+++ b/docs/api/title.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-title"
 ---
-import Props from '@ionic-internal/component-api/v9/title/props.md';
-import Events from '@ionic-internal/component-api/v9/title/events.md';
-import Methods from '@ionic-internal/component-api/v9/title/methods.md';
-import Parts from '@ionic-internal/component-api/v9/title/parts.md';
+import Props from '@ionic-internal/component-api/v9/title/props.mdx';
+import Events from '@ionic-internal/component-api/v9/title/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/title/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/title/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/title/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/title/slots.md';
+import Slots from '@ionic-internal/component-api/v9/title/slots.mdx';
 
 <head>
   <title>ion-title: Ionic Framework App Title Component for Toolbars</title>

--- a/docs/api/toast.md
+++ b/docs/api/toast.md
@@ -4,12 +4,12 @@ title: "ion-toast"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v9/toast/props.md';
-import Events from '@ionic-internal/component-api/v9/toast/events.md';
-import Methods from '@ionic-internal/component-api/v9/toast/methods.md';
-import Parts from '@ionic-internal/component-api/v9/toast/parts.md';
+import Props from '@ionic-internal/component-api/v9/toast/props.mdx';
+import Events from '@ionic-internal/component-api/v9/toast/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/toast/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/toast/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/toast/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/toast/slots.md';
+import Slots from '@ionic-internal/component-api/v9/toast/slots.mdx';
 
 <head>
   <title>ion-toast: A Dismissible App Notification Alert Component</title>

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-toggle"
 ---
-import Props from '@ionic-internal/component-api/v9/toggle/props.md';
-import Events from '@ionic-internal/component-api/v9/toggle/events.md';
-import Methods from '@ionic-internal/component-api/v9/toggle/methods.md';
-import Parts from '@ionic-internal/component-api/v9/toggle/parts.md';
+import Props from '@ionic-internal/component-api/v9/toggle/props.mdx';
+import Events from '@ionic-internal/component-api/v9/toggle/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/toggle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/toggle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/toggle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/toggle/slots.md';
+import Slots from '@ionic-internal/component-api/v9/toggle/slots.mdx';
 
 <head>
   <title>ion-toggle: Custom Toggle Button for Ionic Applications</title>

--- a/docs/api/toolbar.md
+++ b/docs/api/toolbar.md
@@ -1,12 +1,12 @@
 ---
 title: "ion-toolbar"
 ---
-import Props from '@ionic-internal/component-api/v9/toolbar/props.md';
-import Events from '@ionic-internal/component-api/v9/toolbar/events.md';
-import Methods from '@ionic-internal/component-api/v9/toolbar/methods.md';
-import Parts from '@ionic-internal/component-api/v9/toolbar/parts.md';
+import Props from '@ionic-internal/component-api/v9/toolbar/props.mdx';
+import Events from '@ionic-internal/component-api/v9/toolbar/events.mdx';
+import Methods from '@ionic-internal/component-api/v9/toolbar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v9/toolbar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v9/toolbar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v9/toolbar/slots.md';
+import Slots from '@ionic-internal/component-api/v9/toolbar/slots.mdx';
 
 <head>
   <title>ion-toolbar: Customize App Menu Toolbar Buttons and Icons</title>

--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -81,11 +81,37 @@ module.exports = function (context, options) {
          * directory within the plugin directory.
          */
         promises.push(
+          createData(`${basePath}/props.mdx`, data.props),
+          createData(`${basePath}/events.mdx`, data.events),
+          createData(`${basePath}/methods.mdx`, data.methods),
+          createData(`${basePath}/parts.mdx`, data.parts),
+          createData(`${basePath}/custom-props.mdx`, data.customProps),
+          createData(`${basePath}/slots.mdx`, data.slots)
+        );
+
+        /**
+         * TODO(FW-6456): Remove once all branches import the `.mdx` names instead of `.md`.
+         * Transitional: the `.md` names are still imported by pages this repo does not
+         * control on every branch at once.
+         *
+         * - `scripts/i18n.sh` copies the `translation/jp` branch's `docs/` tree into
+         *   `i18n/ja` on every build, and those copies still import `.md`.
+         * - Major branches keep their own api pages. Until each is rewritten, a sync that
+         *   brings this plugin over would otherwise leave them importing names it no longer
+         *   emits.
+         *
+         * Emitted unconditionally on purpose. Guarding on locale only holds on a branch whose
+         * pages have already been rewritten, so it reintroduces exactly the coupling this
+         * avoids. These land in `.docusaurus`, not a docs content root, so they are never
+         * routed as pages and the duplicate basenames cannot collide.
+         *
+         * Remove once `translation/jp` and every live branch import the `.mdx` names.
+         */
+        promises.push(
           createData(`${basePath}/props.md`, data.props),
           createData(`${basePath}/events.md`, data.events),
           createData(`${basePath}/methods.md`, data.methods),
           createData(`${basePath}/parts.md`, data.parts),
-          createData(`${basePath}/custom-props.mdx`, data.customProps),
           createData(`${basePath}/slots.md`, data.slots)
         );
       }

--- a/versioned_docs/version-v8/api/accordion-group.md
+++ b/versioned_docs/version-v8/api/accordion-group.md
@@ -2,12 +2,12 @@
 title: 'ion-accordion-group'
 ---
 
-import Props from '@ionic-internal/component-api/v8/accordion-group/props.md';
-import Events from '@ionic-internal/component-api/v8/accordion-group/events.md';
-import Methods from '@ionic-internal/component-api/v8/accordion-group/methods.md';
-import Parts from '@ionic-internal/component-api/v8/accordion-group/parts.md';
+import Props from '@ionic-internal/component-api/v8/accordion-group/props.mdx';
+import Events from '@ionic-internal/component-api/v8/accordion-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/accordion-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/accordion-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/accordion-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/accordion-group/slots.md';
+import Slots from '@ionic-internal/component-api/v8/accordion-group/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/accordion.md
+++ b/versioned_docs/version-v8/api/accordion.md
@@ -2,12 +2,12 @@
 title: 'ion-accordion'
 ---
 
-import Props from '@ionic-internal/component-api/v8/accordion/props.md';
-import Events from '@ionic-internal/component-api/v8/accordion/events.md';
-import Methods from '@ionic-internal/component-api/v8/accordion/methods.md';
-import Parts from '@ionic-internal/component-api/v8/accordion/parts.md';
+import Props from '@ionic-internal/component-api/v8/accordion/props.mdx';
+import Events from '@ionic-internal/component-api/v8/accordion/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/accordion/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/accordion/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/accordion/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/accordion/slots.md';
+import Slots from '@ionic-internal/component-api/v8/accordion/slots.mdx';
 
 <head>
   <title>ion-accordion: Accordion Components: How to Build & Examples</title>

--- a/versioned_docs/version-v8/api/action-sheet.md
+++ b/versioned_docs/version-v8/api/action-sheet.md
@@ -5,12 +5,12 @@ title: 'ion-action-sheet'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v8/action-sheet/props.md';
-import Events from '@ionic-internal/component-api/v8/action-sheet/events.md';
-import Methods from '@ionic-internal/component-api/v8/action-sheet/methods.md';
-import Parts from '@ionic-internal/component-api/v8/action-sheet/parts.md';
+import Props from '@ionic-internal/component-api/v8/action-sheet/props.mdx';
+import Events from '@ionic-internal/component-api/v8/action-sheet/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/action-sheet/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/action-sheet/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/action-sheet/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/action-sheet/slots.md';
+import Slots from '@ionic-internal/component-api/v8/action-sheet/slots.mdx';
 
 <head>
   <title>ion-action-sheet: Action Sheet Dialog for iOS and Android</title>

--- a/versioned_docs/version-v8/api/alert.md
+++ b/versioned_docs/version-v8/api/alert.md
@@ -5,12 +5,12 @@ title: 'ion-alert'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v8/alert/props.md';
-import Events from '@ionic-internal/component-api/v8/alert/events.md';
-import Methods from '@ionic-internal/component-api/v8/alert/methods.md';
-import Parts from '@ionic-internal/component-api/v8/alert/parts.md';
+import Props from '@ionic-internal/component-api/v8/alert/props.mdx';
+import Events from '@ionic-internal/component-api/v8/alert/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/alert/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/alert/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/alert/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/alert/slots.md';
+import Slots from '@ionic-internal/component-api/v8/alert/slots.mdx';
 
 <head>
   <title>ion-alert: Ionic Alert Buttons with Custom Message Prompts</title>

--- a/versioned_docs/version-v8/api/app.md
+++ b/versioned_docs/version-v8/api/app.md
@@ -2,12 +2,12 @@
 title: 'ion-app'
 ---
 
-import Props from '@ionic-internal/component-api/v8/app/props.md';
-import Events from '@ionic-internal/component-api/v8/app/events.md';
-import Methods from '@ionic-internal/component-api/v8/app/methods.md';
-import Parts from '@ionic-internal/component-api/v8/app/parts.md';
+import Props from '@ionic-internal/component-api/v8/app/props.mdx';
+import Events from '@ionic-internal/component-api/v8/app/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/app/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/app/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/app/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/app/slots.md';
+import Slots from '@ionic-internal/component-api/v8/app/slots.mdx';
 
 <head>
   <title>ion-app: Container Element for an Ionic Application</title>

--- a/versioned_docs/version-v8/api/avatar.md
+++ b/versioned_docs/version-v8/api/avatar.md
@@ -2,12 +2,12 @@
 title: 'ion-avatar'
 ---
 
-import Props from '@ionic-internal/component-api/v8/avatar/props.md';
-import Events from '@ionic-internal/component-api/v8/avatar/events.md';
-import Methods from '@ionic-internal/component-api/v8/avatar/methods.md';
-import Parts from '@ionic-internal/component-api/v8/avatar/parts.md';
+import Props from '@ionic-internal/component-api/v8/avatar/props.mdx';
+import Events from '@ionic-internal/component-api/v8/avatar/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/avatar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/avatar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/avatar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/avatar/slots.md';
+import Slots from '@ionic-internal/component-api/v8/avatar/slots.mdx';
 
 <head>
   <title>ion-avatar: Circular Application Avatar Icon Component</title>

--- a/versioned_docs/version-v8/api/back-button.md
+++ b/versioned_docs/version-v8/api/back-button.md
@@ -2,12 +2,12 @@
 title: 'ion-back-button'
 ---
 
-import Props from '@ionic-internal/component-api/v8/back-button/props.md';
-import Events from '@ionic-internal/component-api/v8/back-button/events.md';
-import Methods from '@ionic-internal/component-api/v8/back-button/methods.md';
-import Parts from '@ionic-internal/component-api/v8/back-button/parts.md';
+import Props from '@ionic-internal/component-api/v8/back-button/props.mdx';
+import Events from '@ionic-internal/component-api/v8/back-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/back-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/back-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/back-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/back-button/slots.md';
+import Slots from '@ionic-internal/component-api/v8/back-button/slots.mdx';
 
 <head>
   <title>ion-back-button: Custom Menu Back Button for Applications</title>

--- a/versioned_docs/version-v8/api/backdrop.md
+++ b/versioned_docs/version-v8/api/backdrop.md
@@ -2,12 +2,12 @@
 title: 'ion-backdrop'
 ---
 
-import Props from '@ionic-internal/component-api/v8/backdrop/props.md';
-import Events from '@ionic-internal/component-api/v8/backdrop/events.md';
-import Methods from '@ionic-internal/component-api/v8/backdrop/methods.md';
-import Parts from '@ionic-internal/component-api/v8/backdrop/parts.md';
+import Props from '@ionic-internal/component-api/v8/backdrop/props.mdx';
+import Events from '@ionic-internal/component-api/v8/backdrop/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/backdrop/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/backdrop/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/backdrop/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/backdrop/slots.md';
+import Slots from '@ionic-internal/component-api/v8/backdrop/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/badge.md
+++ b/versioned_docs/version-v8/api/badge.md
@@ -2,12 +2,12 @@
 title: 'ion-badge'
 ---
 
-import Props from '@ionic-internal/component-api/v8/badge/props.md';
-import Events from '@ionic-internal/component-api/v8/badge/events.md';
-import Methods from '@ionic-internal/component-api/v8/badge/methods.md';
-import Parts from '@ionic-internal/component-api/v8/badge/parts.md';
+import Props from '@ionic-internal/component-api/v8/badge/props.mdx';
+import Events from '@ionic-internal/component-api/v8/badge/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/badge/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/badge/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/badge/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/badge/slots.md';
+import Slots from '@ionic-internal/component-api/v8/badge/slots.mdx';
 
 <head>
   <title>ion-badge: iOS & Android App Notification Badge Icons</title>

--- a/versioned_docs/version-v8/api/breadcrumb.md
+++ b/versioned_docs/version-v8/api/breadcrumb.md
@@ -2,12 +2,12 @@
 title: 'ion-breadcrumb'
 ---
 
-import Props from '@ionic-internal/component-api/v8/breadcrumb/props.md';
-import Events from '@ionic-internal/component-api/v8/breadcrumb/events.md';
-import Methods from '@ionic-internal/component-api/v8/breadcrumb/methods.md';
-import Parts from '@ionic-internal/component-api/v8/breadcrumb/parts.md';
+import Props from '@ionic-internal/component-api/v8/breadcrumb/props.mdx';
+import Events from '@ionic-internal/component-api/v8/breadcrumb/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/breadcrumb/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/breadcrumb/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/breadcrumb/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/breadcrumb/slots.md';
+import Slots from '@ionic-internal/component-api/v8/breadcrumb/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/breadcrumbs.md
+++ b/versioned_docs/version-v8/api/breadcrumbs.md
@@ -2,12 +2,12 @@
 title: 'ion-breadcrumbs'
 ---
 
-import Props from '@ionic-internal/component-api/v8/breadcrumbs/props.md';
-import Events from '@ionic-internal/component-api/v8/breadcrumbs/events.md';
-import Methods from '@ionic-internal/component-api/v8/breadcrumbs/methods.md';
-import Parts from '@ionic-internal/component-api/v8/breadcrumbs/parts.md';
+import Props from '@ionic-internal/component-api/v8/breadcrumbs/props.mdx';
+import Events from '@ionic-internal/component-api/v8/breadcrumbs/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/breadcrumbs/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/breadcrumbs/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/breadcrumbs/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/breadcrumbs/slots.md';
+import Slots from '@ionic-internal/component-api/v8/breadcrumbs/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/button.md
+++ b/versioned_docs/version-v8/api/button.md
@@ -2,12 +2,12 @@
 title: 'ion-button'
 ---
 
-import Props from '@ionic-internal/component-api/v8/button/props.md';
-import Events from '@ionic-internal/component-api/v8/button/events.md';
-import Methods from '@ionic-internal/component-api/v8/button/methods.md';
-import Parts from '@ionic-internal/component-api/v8/button/parts.md';
+import Props from '@ionic-internal/component-api/v8/button/props.mdx';
+import Events from '@ionic-internal/component-api/v8/button/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/button/slots.md';
+import Slots from '@ionic-internal/component-api/v8/button/slots.mdx';
 
 <head>
   <title>ion-button: Style Buttons with Custom CSS Properties</title>

--- a/versioned_docs/version-v8/api/buttons.md
+++ b/versioned_docs/version-v8/api/buttons.md
@@ -2,12 +2,12 @@
 title: 'ion-buttons'
 ---
 
-import Props from '@ionic-internal/component-api/v8/buttons/props.md';
-import Events from '@ionic-internal/component-api/v8/buttons/events.md';
-import Methods from '@ionic-internal/component-api/v8/buttons/methods.md';
-import Parts from '@ionic-internal/component-api/v8/buttons/parts.md';
+import Props from '@ionic-internal/component-api/v8/buttons/props.mdx';
+import Events from '@ionic-internal/component-api/v8/buttons/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/buttons/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/buttons/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/buttons/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/buttons/slots.md';
+import Slots from '@ionic-internal/component-api/v8/buttons/slots.mdx';
 
 <head>
   <title>ion-buttons: Toolbar Element with Named Slots for Buttons</title>

--- a/versioned_docs/version-v8/api/card-content.md
+++ b/versioned_docs/version-v8/api/card-content.md
@@ -2,12 +2,12 @@
 title: 'ion-card-content'
 ---
 
-import Props from '@ionic-internal/component-api/v8/card-content/props.md';
-import Events from '@ionic-internal/component-api/v8/card-content/events.md';
-import Methods from '@ionic-internal/component-api/v8/card-content/methods.md';
-import Parts from '@ionic-internal/component-api/v8/card-content/parts.md';
+import Props from '@ionic-internal/component-api/v8/card-content/props.mdx';
+import Events from '@ionic-internal/component-api/v8/card-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/card-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/card-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/card-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/card-content/slots.md';
+import Slots from '@ionic-internal/component-api/v8/card-content/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/card-header.md
+++ b/versioned_docs/version-v8/api/card-header.md
@@ -2,12 +2,12 @@
 title: 'ion-card-header'
 ---
 
-import Props from '@ionic-internal/component-api/v8/card-header/props.md';
-import Events from '@ionic-internal/component-api/v8/card-header/events.md';
-import Methods from '@ionic-internal/component-api/v8/card-header/methods.md';
-import Parts from '@ionic-internal/component-api/v8/card-header/parts.md';
+import Props from '@ionic-internal/component-api/v8/card-header/props.mdx';
+import Events from '@ionic-internal/component-api/v8/card-header/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/card-header/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/card-header/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/card-header/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/card-header/slots.md';
+import Slots from '@ionic-internal/component-api/v8/card-header/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/card-subtitle.md
+++ b/versioned_docs/version-v8/api/card-subtitle.md
@@ -2,12 +2,12 @@
 title: 'ion-card-subtitle'
 ---
 
-import Props from '@ionic-internal/component-api/v8/card-subtitle/props.md';
-import Events from '@ionic-internal/component-api/v8/card-subtitle/events.md';
-import Methods from '@ionic-internal/component-api/v8/card-subtitle/methods.md';
-import Parts from '@ionic-internal/component-api/v8/card-subtitle/parts.md';
+import Props from '@ionic-internal/component-api/v8/card-subtitle/props.mdx';
+import Events from '@ionic-internal/component-api/v8/card-subtitle/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/card-subtitle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/card-subtitle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/card-subtitle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/card-subtitle/slots.md';
+import Slots from '@ionic-internal/component-api/v8/card-subtitle/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/card-title.md
+++ b/versioned_docs/version-v8/api/card-title.md
@@ -2,12 +2,12 @@
 title: 'ion-card-title'
 ---
 
-import Props from '@ionic-internal/component-api/v8/card-title/props.md';
-import Events from '@ionic-internal/component-api/v8/card-title/events.md';
-import Methods from '@ionic-internal/component-api/v8/card-title/methods.md';
-import Parts from '@ionic-internal/component-api/v8/card-title/parts.md';
+import Props from '@ionic-internal/component-api/v8/card-title/props.mdx';
+import Events from '@ionic-internal/component-api/v8/card-title/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/card-title/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/card-title/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/card-title/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/card-title/slots.md';
+import Slots from '@ionic-internal/component-api/v8/card-title/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/card.md
+++ b/versioned_docs/version-v8/api/card.md
@@ -2,12 +2,12 @@
 title: 'ion-card'
 ---
 
-import Props from '@ionic-internal/component-api/v8/card/props.md';
-import Events from '@ionic-internal/component-api/v8/card/events.md';
-import Methods from '@ionic-internal/component-api/v8/card/methods.md';
-import Parts from '@ionic-internal/component-api/v8/card/parts.md';
+import Props from '@ionic-internal/component-api/v8/card/props.mdx';
+import Events from '@ionic-internal/component-api/v8/card/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/card/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/card/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/card/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/card/slots.md';
+import Slots from '@ionic-internal/component-api/v8/card/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/checkbox.md
+++ b/versioned_docs/version-v8/api/checkbox.md
@@ -2,12 +2,12 @@
 title: 'ion-checkbox'
 ---
 
-import Props from '@ionic-internal/component-api/v8/checkbox/props.md';
-import Events from '@ionic-internal/component-api/v8/checkbox/events.md';
-import Methods from '@ionic-internal/component-api/v8/checkbox/methods.md';
-import Parts from '@ionic-internal/component-api/v8/checkbox/parts.md';
+import Props from '@ionic-internal/component-api/v8/checkbox/props.mdx';
+import Events from '@ionic-internal/component-api/v8/checkbox/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/checkbox/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/checkbox/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/checkbox/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/checkbox/slots.md';
+import Slots from '@ionic-internal/component-api/v8/checkbox/slots.mdx';
 
 <head>
   <title>ion-checkbox: Ionic App Checkbox to Select Multiple Options</title>

--- a/versioned_docs/version-v8/api/chip.md
+++ b/versioned_docs/version-v8/api/chip.md
@@ -2,12 +2,12 @@
 title: 'ion-chip'
 ---
 
-import Props from '@ionic-internal/component-api/v8/chip/props.md';
-import Events from '@ionic-internal/component-api/v8/chip/events.md';
-import Methods from '@ionic-internal/component-api/v8/chip/methods.md';
-import Parts from '@ionic-internal/component-api/v8/chip/parts.md';
+import Props from '@ionic-internal/component-api/v8/chip/props.mdx';
+import Events from '@ionic-internal/component-api/v8/chip/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/chip/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/chip/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/chip/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/chip/slots.md';
+import Slots from '@ionic-internal/component-api/v8/chip/slots.mdx';
 
 <head>
   <title>ion-chip: Text, Icon and Avatar for Ionic Framework Apps</title>

--- a/versioned_docs/version-v8/api/col.md
+++ b/versioned_docs/version-v8/api/col.md
@@ -2,12 +2,12 @@
 title: 'ion-col'
 ---
 
-import Props from '@ionic-internal/component-api/v8/col/props.md';
-import Events from '@ionic-internal/component-api/v8/col/events.md';
-import Methods from '@ionic-internal/component-api/v8/col/methods.md';
-import Parts from '@ionic-internal/component-api/v8/col/parts.md';
+import Props from '@ionic-internal/component-api/v8/col/props.mdx';
+import Events from '@ionic-internal/component-api/v8/col/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/col/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/col/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/col/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/col/slots.md';
+import Slots from '@ionic-internal/component-api/v8/col/slots.mdx';
 
 <head>
   <title>ion-col: Column Component Padding and Other Properties</title>

--- a/versioned_docs/version-v8/api/content.md
+++ b/versioned_docs/version-v8/api/content.md
@@ -2,12 +2,12 @@
 title: 'ion-content'
 ---
 
-import Props from '@ionic-internal/component-api/v8/content/props.md';
-import Events from '@ionic-internal/component-api/v8/content/events.md';
-import Methods from '@ionic-internal/component-api/v8/content/methods.md';
-import Parts from '@ionic-internal/component-api/v8/content/parts.md';
+import Props from '@ionic-internal/component-api/v8/content/props.mdx';
+import Events from '@ionic-internal/component-api/v8/content/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/content/slots.md';
+import Slots from '@ionic-internal/component-api/v8/content/slots.mdx';
 
 <head>
   <title>ion-content: Scrollable Component for Ionic App Content</title>

--- a/versioned_docs/version-v8/api/datetime-button.md
+++ b/versioned_docs/version-v8/api/datetime-button.md
@@ -2,12 +2,12 @@
 title: 'ion-datetime-button'
 ---
 
-import Props from '@ionic-internal/component-api/v8/datetime-button/props.md';
-import Events from '@ionic-internal/component-api/v8/datetime-button/events.md';
-import Methods from '@ionic-internal/component-api/v8/datetime-button/methods.md';
-import Parts from '@ionic-internal/component-api/v8/datetime-button/parts.md';
+import Props from '@ionic-internal/component-api/v8/datetime-button/props.mdx';
+import Events from '@ionic-internal/component-api/v8/datetime-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/datetime-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/datetime-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/datetime-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/datetime-button/slots.md';
+import Slots from '@ionic-internal/component-api/v8/datetime-button/slots.mdx';
 
 <head>
   <title>ion-datetime-button: Ionic Input for Datetime Picker</title>

--- a/versioned_docs/version-v8/api/datetime.md
+++ b/versioned_docs/version-v8/api/datetime.md
@@ -2,12 +2,12 @@
 title: 'ion-datetime'
 ---
 
-import Props from '@ionic-internal/component-api/v8/datetime/props.md';
-import Events from '@ionic-internal/component-api/v8/datetime/events.md';
-import Methods from '@ionic-internal/component-api/v8/datetime/methods.md';
-import Parts from '@ionic-internal/component-api/v8/datetime/parts.md';
+import Props from '@ionic-internal/component-api/v8/datetime/props.mdx';
+import Events from '@ionic-internal/component-api/v8/datetime/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/datetime/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/datetime/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/datetime/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/datetime/slots.md';
+import Slots from '@ionic-internal/component-api/v8/datetime/slots.mdx';
 
 import Basic from '@site/static/usage/v8/datetime/basic/index.md';
 

--- a/versioned_docs/version-v8/api/fab-button.md
+++ b/versioned_docs/version-v8/api/fab-button.md
@@ -2,12 +2,12 @@
 title: 'ion-fab-button'
 ---
 
-import Props from '@ionic-internal/component-api/v8/fab-button/props.md';
-import Events from '@ionic-internal/component-api/v8/fab-button/events.md';
-import Methods from '@ionic-internal/component-api/v8/fab-button/methods.md';
-import Parts from '@ionic-internal/component-api/v8/fab-button/parts.md';
+import Props from '@ionic-internal/component-api/v8/fab-button/props.mdx';
+import Events from '@ionic-internal/component-api/v8/fab-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/fab-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/fab-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/fab-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/fab-button/slots.md';
+import Slots from '@ionic-internal/component-api/v8/fab-button/slots.mdx';
 
 <head>
   <title>ion-fab-button: Ionic FAB Button Icon for Primary Action</title>

--- a/versioned_docs/version-v8/api/fab-list.md
+++ b/versioned_docs/version-v8/api/fab-list.md
@@ -2,12 +2,12 @@
 title: 'ion-fab-list'
 ---
 
-import Props from '@ionic-internal/component-api/v8/fab-list/props.md';
-import Events from '@ionic-internal/component-api/v8/fab-list/events.md';
-import Methods from '@ionic-internal/component-api/v8/fab-list/methods.md';
-import Parts from '@ionic-internal/component-api/v8/fab-list/parts.md';
+import Props from '@ionic-internal/component-api/v8/fab-list/props.mdx';
+import Events from '@ionic-internal/component-api/v8/fab-list/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/fab-list/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/fab-list/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/fab-list/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/fab-list/slots.md';
+import Slots from '@ionic-internal/component-api/v8/fab-list/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/fab.md
+++ b/versioned_docs/version-v8/api/fab.md
@@ -2,12 +2,12 @@
 title: 'ion-fab'
 ---
 
-import Props from '@ionic-internal/component-api/v8/fab/props.md';
-import Events from '@ionic-internal/component-api/v8/fab/events.md';
-import Methods from '@ionic-internal/component-api/v8/fab/methods.md';
-import Parts from '@ionic-internal/component-api/v8/fab/parts.md';
+import Props from '@ionic-internal/component-api/v8/fab/props.mdx';
+import Events from '@ionic-internal/component-api/v8/fab/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/fab/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/fab/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/fab/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/fab/slots.md';
+import Slots from '@ionic-internal/component-api/v8/fab/slots.mdx';
 
 <head>
   <title>ion-fab: Ionic Floating Action Button for Android and iOS</title>

--- a/versioned_docs/version-v8/api/footer.md
+++ b/versioned_docs/version-v8/api/footer.md
@@ -2,12 +2,12 @@
 title: 'ion-footer'
 ---
 
-import Props from '@ionic-internal/component-api/v8/footer/props.md';
-import Events from '@ionic-internal/component-api/v8/footer/events.md';
-import Methods from '@ionic-internal/component-api/v8/footer/methods.md';
-import Parts from '@ionic-internal/component-api/v8/footer/parts.md';
+import Props from '@ionic-internal/component-api/v8/footer/props.mdx';
+import Events from '@ionic-internal/component-api/v8/footer/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/footer/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/footer/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/footer/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/footer/slots.md';
+import Slots from '@ionic-internal/component-api/v8/footer/slots.mdx';
 
 <head>
   <title>ion-footer: Page Footer | Ionic App Footer Root Component</title>

--- a/versioned_docs/version-v8/api/grid.md
+++ b/versioned_docs/version-v8/api/grid.md
@@ -2,12 +2,12 @@
 title: 'ion-grid'
 ---
 
-import Props from '@ionic-internal/component-api/v8/grid/props.md';
-import Events from '@ionic-internal/component-api/v8/grid/events.md';
-import Methods from '@ionic-internal/component-api/v8/grid/methods.md';
-import Parts from '@ionic-internal/component-api/v8/grid/parts.md';
+import Props from '@ionic-internal/component-api/v8/grid/props.mdx';
+import Events from '@ionic-internal/component-api/v8/grid/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/grid/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/grid/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/grid/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/grid/slots.md';
+import Slots from '@ionic-internal/component-api/v8/grid/slots.mdx';
 
 <head>
   <title>ion-grid: Display Grids for Mobile-First Custom App Layout</title>

--- a/versioned_docs/version-v8/api/header.md
+++ b/versioned_docs/version-v8/api/header.md
@@ -2,12 +2,12 @@
 title: 'ion-header'
 ---
 
-import Props from '@ionic-internal/component-api/v8/header/props.md';
-import Events from '@ionic-internal/component-api/v8/header/events.md';
-import Methods from '@ionic-internal/component-api/v8/header/methods.md';
-import Parts from '@ionic-internal/component-api/v8/header/parts.md';
+import Props from '@ionic-internal/component-api/v8/header/props.mdx';
+import Events from '@ionic-internal/component-api/v8/header/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/header/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/header/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/header/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/header/slots.md';
+import Slots from '@ionic-internal/component-api/v8/header/slots.mdx';
 
 <head>
   <title>ion-header: Header Parent Component for Ionic Framework Apps</title>

--- a/versioned_docs/version-v8/api/img.md
+++ b/versioned_docs/version-v8/api/img.md
@@ -2,12 +2,12 @@
 title: 'ion-img'
 ---
 
-import Props from '@ionic-internal/component-api/v8/img/props.md';
-import Events from '@ionic-internal/component-api/v8/img/events.md';
-import Methods from '@ionic-internal/component-api/v8/img/methods.md';
-import Parts from '@ionic-internal/component-api/v8/img/parts.md';
+import Props from '@ionic-internal/component-api/v8/img/props.mdx';
+import Events from '@ionic-internal/component-api/v8/img/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/img/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/img/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/img/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/img/slots.md';
+import Slots from '@ionic-internal/component-api/v8/img/slots.mdx';
 
 <head>
   <title>ion-img: Img Tag to Lazy Load Images in Viewport</title>

--- a/versioned_docs/version-v8/api/infinite-scroll-content.md
+++ b/versioned_docs/version-v8/api/infinite-scroll-content.md
@@ -2,12 +2,12 @@
 title: 'ion-infinite-scroll-content'
 ---
 
-import Props from '@ionic-internal/component-api/v8/infinite-scroll-content/props.md';
-import Events from '@ionic-internal/component-api/v8/infinite-scroll-content/events.md';
-import Methods from '@ionic-internal/component-api/v8/infinite-scroll-content/methods.md';
-import Parts from '@ionic-internal/component-api/v8/infinite-scroll-content/parts.md';
+import Props from '@ionic-internal/component-api/v8/infinite-scroll-content/props.mdx';
+import Events from '@ionic-internal/component-api/v8/infinite-scroll-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/infinite-scroll-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/infinite-scroll-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/infinite-scroll-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/infinite-scroll-content/slots.md';
+import Slots from '@ionic-internal/component-api/v8/infinite-scroll-content/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/infinite-scroll.md
+++ b/versioned_docs/version-v8/api/infinite-scroll.md
@@ -2,12 +2,12 @@
 title: 'ion-infinite-scroll'
 ---
 
-import Props from '@ionic-internal/component-api/v8/infinite-scroll/props.md';
-import Events from '@ionic-internal/component-api/v8/infinite-scroll/events.md';
-import Methods from '@ionic-internal/component-api/v8/infinite-scroll/methods.md';
-import Parts from '@ionic-internal/component-api/v8/infinite-scroll/parts.md';
+import Props from '@ionic-internal/component-api/v8/infinite-scroll/props.mdx';
+import Events from '@ionic-internal/component-api/v8/infinite-scroll/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/infinite-scroll/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/infinite-scroll/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/infinite-scroll/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/infinite-scroll/slots.md';
+import Slots from '@ionic-internal/component-api/v8/infinite-scroll/slots.mdx';
 
 <head>
   <title>ion-infinite-scroll: Infinite Scroller Action Component</title>

--- a/versioned_docs/version-v8/api/input-otp.md
+++ b/versioned_docs/version-v8/api/input-otp.md
@@ -2,12 +2,12 @@
 title: 'ion-input-otp'
 ---
 
-import Props from '@ionic-internal/component-api/v8/input-otp/props.md';
-import Events from '@ionic-internal/component-api/v8/input-otp/events.md';
-import Methods from '@ionic-internal/component-api/v8/input-otp/methods.md';
-import Parts from '@ionic-internal/component-api/v8/input-otp/parts.md';
+import Props from '@ionic-internal/component-api/v8/input-otp/props.mdx';
+import Events from '@ionic-internal/component-api/v8/input-otp/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/input-otp/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/input-otp/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/input-otp/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/input-otp/slots.md';
+import Slots from '@ionic-internal/component-api/v8/input-otp/slots.mdx';
 
 <head>
   <title>ion-input-otp: One-Time Password Input Component</title>

--- a/versioned_docs/version-v8/api/input-password-toggle.md
+++ b/versioned_docs/version-v8/api/input-password-toggle.md
@@ -2,12 +2,12 @@
 title: 'ion-input-password-toggle'
 ---
 
-import Props from '@ionic-internal/component-api/v8/input-password-toggle/props.md';
-import Events from '@ionic-internal/component-api/v8/input-password-toggle/events.md';
-import Methods from '@ionic-internal/component-api/v8/input-password-toggle/methods.md';
-import Parts from '@ionic-internal/component-api/v8/input-password-toggle/parts.md';
+import Props from '@ionic-internal/component-api/v8/input-password-toggle/props.mdx';
+import Events from '@ionic-internal/component-api/v8/input-password-toggle/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/input-password-toggle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/input-password-toggle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/input-password-toggle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/input-password-toggle/slots.md';
+import Slots from '@ionic-internal/component-api/v8/input-password-toggle/slots.mdx';
 
 <head>
   <title>ion-input-password-toggle: Toggle the visibility of a password in Input</title>

--- a/versioned_docs/version-v8/api/input.md
+++ b/versioned_docs/version-v8/api/input.md
@@ -2,12 +2,12 @@
 title: 'ion-input'
 ---
 
-import Props from '@ionic-internal/component-api/v8/input/props.md';
-import Events from '@ionic-internal/component-api/v8/input/events.md';
-import Methods from '@ionic-internal/component-api/v8/input/methods.md';
-import Parts from '@ionic-internal/component-api/v8/input/parts.md';
+import Props from '@ionic-internal/component-api/v8/input/props.mdx';
+import Events from '@ionic-internal/component-api/v8/input/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/input/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/input/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/input/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/input/slots.md';
+import Slots from '@ionic-internal/component-api/v8/input/slots.mdx';
 
 <head>
   <title>ion-input: Custom Input With Styling and CSS Properties</title>

--- a/versioned_docs/version-v8/api/item-divider.md
+++ b/versioned_docs/version-v8/api/item-divider.md
@@ -2,12 +2,12 @@
 title: 'ion-item-divider'
 ---
 
-import Props from '@ionic-internal/component-api/v8/item-divider/props.md';
-import Events from '@ionic-internal/component-api/v8/item-divider/events.md';
-import Methods from '@ionic-internal/component-api/v8/item-divider/methods.md';
-import Parts from '@ionic-internal/component-api/v8/item-divider/parts.md';
+import Props from '@ionic-internal/component-api/v8/item-divider/props.mdx';
+import Events from '@ionic-internal/component-api/v8/item-divider/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/item-divider/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/item-divider/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/item-divider/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/item-divider/slots.md';
+import Slots from '@ionic-internal/component-api/v8/item-divider/slots.mdx';
 
 <head>
   <title>ion-item-divider: Item Divider Block Element for Ionic Apps</title>

--- a/versioned_docs/version-v8/api/item-group.md
+++ b/versioned_docs/version-v8/api/item-group.md
@@ -2,12 +2,12 @@
 title: 'ion-item-group'
 ---
 
-import Props from '@ionic-internal/component-api/v8/item-group/props.md';
-import Events from '@ionic-internal/component-api/v8/item-group/events.md';
-import Methods from '@ionic-internal/component-api/v8/item-group/methods.md';
-import Parts from '@ionic-internal/component-api/v8/item-group/parts.md';
+import Props from '@ionic-internal/component-api/v8/item-group/props.mdx';
+import Events from '@ionic-internal/component-api/v8/item-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/item-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/item-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/item-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/item-group/slots.md';
+import Slots from '@ionic-internal/component-api/v8/item-group/slots.mdx';
 
 <head>
   <title>ion-item-group: Group Items to Divide into Multiple Sections</title>

--- a/versioned_docs/version-v8/api/item-option.md
+++ b/versioned_docs/version-v8/api/item-option.md
@@ -2,12 +2,12 @@
 title: 'ion-item-option'
 ---
 
-import Props from '@ionic-internal/component-api/v8/item-option/props.md';
-import Events from '@ionic-internal/component-api/v8/item-option/events.md';
-import Methods from '@ionic-internal/component-api/v8/item-option/methods.md';
-import Parts from '@ionic-internal/component-api/v8/item-option/parts.md';
+import Props from '@ionic-internal/component-api/v8/item-option/props.mdx';
+import Events from '@ionic-internal/component-api/v8/item-option/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/item-option/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/item-option/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/item-option/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/item-option/slots.md';
+import Slots from '@ionic-internal/component-api/v8/item-option/slots.mdx';
 
 <head>
   <title>ion-item-option: Option Button for Sliding Item in Ionic</title>

--- a/versioned_docs/version-v8/api/item-options.md
+++ b/versioned_docs/version-v8/api/item-options.md
@@ -2,12 +2,12 @@
 title: 'ion-item-options'
 ---
 
-import Props from '@ionic-internal/component-api/v8/item-options/props.md';
-import Events from '@ionic-internal/component-api/v8/item-options/events.md';
-import Methods from '@ionic-internal/component-api/v8/item-options/methods.md';
-import Parts from '@ionic-internal/component-api/v8/item-options/parts.md';
+import Props from '@ionic-internal/component-api/v8/item-options/props.mdx';
+import Events from '@ionic-internal/component-api/v8/item-options/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/item-options/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/item-options/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/item-options/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/item-options/slots.md';
+import Slots from '@ionic-internal/component-api/v8/item-options/slots.mdx';
 
 <head>
   <title>ion-item-options: Option Button Components for Ionic Apps</title>

--- a/versioned_docs/version-v8/api/item-sliding.md
+++ b/versioned_docs/version-v8/api/item-sliding.md
@@ -2,12 +2,12 @@
 title: 'ion-item-sliding'
 ---
 
-import Props from '@ionic-internal/component-api/v8/item-sliding/props.md';
-import Events from '@ionic-internal/component-api/v8/item-sliding/events.md';
-import Methods from '@ionic-internal/component-api/v8/item-sliding/methods.md';
-import Parts from '@ionic-internal/component-api/v8/item-sliding/parts.md';
+import Props from '@ionic-internal/component-api/v8/item-sliding/props.mdx';
+import Events from '@ionic-internal/component-api/v8/item-sliding/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/item-sliding/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/item-sliding/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/item-sliding/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/item-sliding/slots.md';
+import Slots from '@ionic-internal/component-api/v8/item-sliding/slots.mdx';
 
 <head>
   <title>ion-item-sliding: Slide Buttons | Slide Right to Left</title>

--- a/versioned_docs/version-v8/api/item.md
+++ b/versioned_docs/version-v8/api/item.md
@@ -2,12 +2,12 @@
 title: 'ion-item'
 ---
 
-import Props from '@ionic-internal/component-api/v8/item/props.md';
-import Events from '@ionic-internal/component-api/v8/item/events.md';
-import Methods from '@ionic-internal/component-api/v8/item/methods.md';
-import Parts from '@ionic-internal/component-api/v8/item/parts.md';
+import Props from '@ionic-internal/component-api/v8/item/props.mdx';
+import Events from '@ionic-internal/component-api/v8/item/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/item/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/item/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/item/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/item/slots.md';
+import Slots from '@ionic-internal/component-api/v8/item/slots.mdx';
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import BestPracticeFigure from '@components/global/BestPracticeFigure';

--- a/versioned_docs/version-v8/api/label.md
+++ b/versioned_docs/version-v8/api/label.md
@@ -2,12 +2,12 @@
 title: 'ion-label'
 ---
 
-import Props from '@ionic-internal/component-api/v8/label/props.md';
-import Events from '@ionic-internal/component-api/v8/label/events.md';
-import Methods from '@ionic-internal/component-api/v8/label/methods.md';
-import Parts from '@ionic-internal/component-api/v8/label/parts.md';
+import Props from '@ionic-internal/component-api/v8/label/props.mdx';
+import Events from '@ionic-internal/component-api/v8/label/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/label/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/label/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/label/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/label/slots.md';
+import Slots from '@ionic-internal/component-api/v8/label/slots.mdx';
 
 <head>
   <title>ion-label: Item Label Color and Properties for Applications</title>

--- a/versioned_docs/version-v8/api/list-header.md
+++ b/versioned_docs/version-v8/api/list-header.md
@@ -2,12 +2,12 @@
 title: 'ion-list-header'
 ---
 
-import Props from '@ionic-internal/component-api/v8/list-header/props.md';
-import Events from '@ionic-internal/component-api/v8/list-header/events.md';
-import Methods from '@ionic-internal/component-api/v8/list-header/methods.md';
-import Parts from '@ionic-internal/component-api/v8/list-header/parts.md';
+import Props from '@ionic-internal/component-api/v8/list-header/props.mdx';
+import Events from '@ionic-internal/component-api/v8/list-header/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/list-header/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/list-header/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/list-header/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/list-header/slots.md';
+import Slots from '@ionic-internal/component-api/v8/list-header/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/list.md
+++ b/versioned_docs/version-v8/api/list.md
@@ -2,12 +2,12 @@
 title: 'ion-list'
 ---
 
-import Props from '@ionic-internal/component-api/v8/list/props.md';
-import Events from '@ionic-internal/component-api/v8/list/events.md';
-import Methods from '@ionic-internal/component-api/v8/list/methods.md';
-import Parts from '@ionic-internal/component-api/v8/list/parts.md';
+import Props from '@ionic-internal/component-api/v8/list/props.mdx';
+import Events from '@ionic-internal/component-api/v8/list/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/list/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/list/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/list/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/list/slots.md';
+import Slots from '@ionic-internal/component-api/v8/list/slots.mdx';
 
 <head>
   <title>ion-list: Item List View Component for iOS and Android Apps</title>

--- a/versioned_docs/version-v8/api/loading.md
+++ b/versioned_docs/version-v8/api/loading.md
@@ -2,12 +2,12 @@
 title: 'ion-loading'
 ---
 
-import Props from '@ionic-internal/component-api/v8/loading/props.md';
-import Events from '@ionic-internal/component-api/v8/loading/events.md';
-import Methods from '@ionic-internal/component-api/v8/loading/methods.md';
-import Parts from '@ionic-internal/component-api/v8/loading/parts.md';
+import Props from '@ionic-internal/component-api/v8/loading/props.mdx';
+import Events from '@ionic-internal/component-api/v8/loading/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/loading/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/loading/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/loading/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/loading/slots.md';
+import Slots from '@ionic-internal/component-api/v8/loading/slots.mdx';
 
 <head>
   <title>ion-loading: Loading | Application Loading Indicator Overlay</title>

--- a/versioned_docs/version-v8/api/menu-button.md
+++ b/versioned_docs/version-v8/api/menu-button.md
@@ -2,12 +2,12 @@
 title: 'ion-menu-button'
 ---
 
-import Props from '@ionic-internal/component-api/v8/menu-button/props.md';
-import Events from '@ionic-internal/component-api/v8/menu-button/events.md';
-import Methods from '@ionic-internal/component-api/v8/menu-button/methods.md';
-import Parts from '@ionic-internal/component-api/v8/menu-button/parts.md';
+import Props from '@ionic-internal/component-api/v8/menu-button/props.mdx';
+import Events from '@ionic-internal/component-api/v8/menu-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/menu-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/menu-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/menu-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/menu-button/slots.md';
+import Slots from '@ionic-internal/component-api/v8/menu-button/slots.mdx';
 
 <head>
   <title>ion-menu-button: Menu Button to Open an App Menu on a Page</title>

--- a/versioned_docs/version-v8/api/menu-toggle.md
+++ b/versioned_docs/version-v8/api/menu-toggle.md
@@ -2,12 +2,12 @@
 title: 'ion-menu-toggle'
 ---
 
-import Props from '@ionic-internal/component-api/v8/menu-toggle/props.md';
-import Events from '@ionic-internal/component-api/v8/menu-toggle/events.md';
-import Methods from '@ionic-internal/component-api/v8/menu-toggle/methods.md';
-import Parts from '@ionic-internal/component-api/v8/menu-toggle/parts.md';
+import Props from '@ionic-internal/component-api/v8/menu-toggle/props.mdx';
+import Events from '@ionic-internal/component-api/v8/menu-toggle/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/menu-toggle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/menu-toggle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/menu-toggle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/menu-toggle/slots.md';
+import Slots from '@ionic-internal/component-api/v8/menu-toggle/slots.mdx';
 
 <head>
   <title>ion-menu-toggle: MenuToggle Component to Open/Close Menus</title>

--- a/versioned_docs/version-v8/api/menu.md
+++ b/versioned_docs/version-v8/api/menu.md
@@ -2,12 +2,12 @@
 title: 'ion-menu'
 ---
 
-import Props from '@ionic-internal/component-api/v8/menu/props.md';
-import Events from '@ionic-internal/component-api/v8/menu/events.md';
-import Methods from '@ionic-internal/component-api/v8/menu/methods.md';
-import Parts from '@ionic-internal/component-api/v8/menu/parts.md';
+import Props from '@ionic-internal/component-api/v8/menu/props.mdx';
+import Events from '@ionic-internal/component-api/v8/menu/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/menu/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/menu/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/menu/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/menu/slots.md';
+import Slots from '@ionic-internal/component-api/v8/menu/slots.mdx';
 
 <head>
   <title>ion-menu: API Framework Docs for Types of Menu Components</title>

--- a/versioned_docs/version-v8/api/modal.md
+++ b/versioned_docs/version-v8/api/modal.md
@@ -2,12 +2,12 @@
 title: 'ion-modal'
 ---
 
-import Props from '@ionic-internal/component-api/v8/modal/props.md';
-import Events from '@ionic-internal/component-api/v8/modal/events.md';
-import Methods from '@ionic-internal/component-api/v8/modal/methods.md';
-import Parts from '@ionic-internal/component-api/v8/modal/parts.md';
+import Props from '@ionic-internal/component-api/v8/modal/props.mdx';
+import Events from '@ionic-internal/component-api/v8/modal/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/modal/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/modal/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/modal/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/modal/slots.md';
+import Slots from '@ionic-internal/component-api/v8/modal/slots.mdx';
 
 <head>
   <title>ion-modal: Ionic Mobile App Custom Modal API Component</title>

--- a/versioned_docs/version-v8/api/nav-link.md
+++ b/versioned_docs/version-v8/api/nav-link.md
@@ -2,12 +2,12 @@
 title: 'ion-nav-link'
 ---
 
-import Props from '@ionic-internal/component-api/v8/nav-link/props.md';
-import Events from '@ionic-internal/component-api/v8/nav-link/events.md';
-import Methods from '@ionic-internal/component-api/v8/nav-link/methods.md';
-import Parts from '@ionic-internal/component-api/v8/nav-link/parts.md';
+import Props from '@ionic-internal/component-api/v8/nav-link/props.mdx';
+import Events from '@ionic-internal/component-api/v8/nav-link/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/nav-link/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/nav-link/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/nav-link/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/nav-link/slots.md';
+import Slots from '@ionic-internal/component-api/v8/nav-link/slots.mdx';
 
 <head>
   <title>ion-nav-link: Navigation Links to a Specified Component</title>

--- a/versioned_docs/version-v8/api/nav.md
+++ b/versioned_docs/version-v8/api/nav.md
@@ -2,12 +2,12 @@
 title: 'ion-nav'
 ---
 
-import Props from '@ionic-internal/component-api/v8/nav/props.md';
-import Events from '@ionic-internal/component-api/v8/nav/events.md';
-import Methods from '@ionic-internal/component-api/v8/nav/methods.md';
-import Parts from '@ionic-internal/component-api/v8/nav/parts.md';
+import Props from '@ionic-internal/component-api/v8/nav/props.mdx';
+import Events from '@ionic-internal/component-api/v8/nav/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/nav/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/nav/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/nav/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/nav/slots.md';
+import Slots from '@ionic-internal/component-api/v8/nav/slots.mdx';
 
 <head>
   <title>ion-nav: Nav View Component for Ionic Framework Apps</title>

--- a/versioned_docs/version-v8/api/note.md
+++ b/versioned_docs/version-v8/api/note.md
@@ -2,12 +2,12 @@
 title: 'ion-note'
 ---
 
-import Props from '@ionic-internal/component-api/v8/note/props.md';
-import Events from '@ionic-internal/component-api/v8/note/events.md';
-import Methods from '@ionic-internal/component-api/v8/note/methods.md';
-import Parts from '@ionic-internal/component-api/v8/note/parts.md';
+import Props from '@ionic-internal/component-api/v8/note/props.mdx';
+import Events from '@ionic-internal/component-api/v8/note/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/note/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/note/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/note/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/note/slots.md';
+import Slots from '@ionic-internal/component-api/v8/note/slots.mdx';
 
 <head>
   <title>ion-note: Note Text Elements for iOS and Android Ionic Apps</title>

--- a/versioned_docs/version-v8/api/picker-column-option.md
+++ b/versioned_docs/version-v8/api/picker-column-option.md
@@ -2,12 +2,12 @@
 title: 'ion-picker-column-option'
 ---
 
-import Props from '@ionic-internal/component-api/v8/picker-column-option/props.md';
-import Events from '@ionic-internal/component-api/v8/picker-column-option/events.md';
-import Methods from '@ionic-internal/component-api/v8/picker-column-option/methods.md';
-import Parts from '@ionic-internal/component-api/v8/picker-column-option/parts.md';
+import Props from '@ionic-internal/component-api/v8/picker-column-option/props.mdx';
+import Events from '@ionic-internal/component-api/v8/picker-column-option/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/picker-column-option/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/picker-column-option/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/picker-column-option/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/picker-column-option/slots.md';
+import Slots from '@ionic-internal/component-api/v8/picker-column-option/slots.mdx';
 
 <head>
   <title>ion-picker-column-option: The individual options within a column in a picker.</title>

--- a/versioned_docs/version-v8/api/picker-column.md
+++ b/versioned_docs/version-v8/api/picker-column.md
@@ -2,12 +2,12 @@
 title: 'ion-picker-column'
 ---
 
-import Props from '@ionic-internal/component-api/v8/picker-column/props.md';
-import Events from '@ionic-internal/component-api/v8/picker-column/events.md';
-import Methods from '@ionic-internal/component-api/v8/picker-column/methods.md';
-import Parts from '@ionic-internal/component-api/v8/picker-column/parts.md';
+import Props from '@ionic-internal/component-api/v8/picker-column/props.mdx';
+import Events from '@ionic-internal/component-api/v8/picker-column/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/picker-column/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/picker-column/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/picker-column/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/picker-column/slots.md';
+import Slots from '@ionic-internal/component-api/v8/picker-column/slots.mdx';
 
 <head>
   <title>ion-picker-column: Individual columns within a picker</title>

--- a/versioned_docs/version-v8/api/picker-legacy.md
+++ b/versioned_docs/version-v8/api/picker-legacy.md
@@ -2,12 +2,12 @@
 title: 'ion-picker-legacy'
 ---
 
-import Props from '@ionic-internal/component-api/v8/picker-legacy/props.md';
-import Events from '@ionic-internal/component-api/v8/picker-legacy/events.md';
-import Methods from '@ionic-internal/component-api/v8/picker-legacy/methods.md';
-import Parts from '@ionic-internal/component-api/v8/picker-legacy/parts.md';
+import Props from '@ionic-internal/component-api/v8/picker-legacy/props.mdx';
+import Events from '@ionic-internal/component-api/v8/picker-legacy/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/picker-legacy/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/picker-legacy/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/picker-legacy/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/picker-legacy/slots.md';
+import Slots from '@ionic-internal/component-api/v8/picker-legacy/slots.mdx';
 
 <head>
   <title>ion-picker-legacy: A Dialog That Displays Buttons and Columns</title>

--- a/versioned_docs/version-v8/api/picker.md
+++ b/versioned_docs/version-v8/api/picker.md
@@ -2,12 +2,12 @@
 title: 'ion-picker'
 ---
 
-import Props from '@ionic-internal/component-api/v8/picker/props.md';
-import Events from '@ionic-internal/component-api/v8/picker/events.md';
-import Methods from '@ionic-internal/component-api/v8/picker/methods.md';
-import Parts from '@ionic-internal/component-api/v8/picker/parts.md';
+import Props from '@ionic-internal/component-api/v8/picker/props.mdx';
+import Events from '@ionic-internal/component-api/v8/picker/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/picker/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/picker/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/picker/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/picker/slots.md';
+import Slots from '@ionic-internal/component-api/v8/picker/slots.mdx';
 
 <head>
   <title>ion-picker: Display a list of options in columns</title>

--- a/versioned_docs/version-v8/api/popover.md
+++ b/versioned_docs/version-v8/api/popover.md
@@ -2,12 +2,12 @@
 title: 'ion-popover'
 ---
 
-import Props from '@ionic-internal/component-api/v8/popover/props.md';
-import Events from '@ionic-internal/component-api/v8/popover/events.md';
-import Methods from '@ionic-internal/component-api/v8/popover/methods.md';
-import Parts from '@ionic-internal/component-api/v8/popover/parts.md';
+import Props from '@ionic-internal/component-api/v8/popover/props.mdx';
+import Events from '@ionic-internal/component-api/v8/popover/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/popover/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/popover/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/popover/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/popover/slots.md';
+import Slots from '@ionic-internal/component-api/v8/popover/slots.mdx';
 
 <head>
   <title>ion-popover: iOS / Android Popover UI Dialog Component</title>

--- a/versioned_docs/version-v8/api/progress-bar.md
+++ b/versioned_docs/version-v8/api/progress-bar.md
@@ -2,12 +2,12 @@
 title: 'ion-progress-bar'
 ---
 
-import Props from '@ionic-internal/component-api/v8/progress-bar/props.md';
-import Events from '@ionic-internal/component-api/v8/progress-bar/events.md';
-import Methods from '@ionic-internal/component-api/v8/progress-bar/methods.md';
-import Parts from '@ionic-internal/component-api/v8/progress-bar/parts.md';
+import Props from '@ionic-internal/component-api/v8/progress-bar/props.mdx';
+import Events from '@ionic-internal/component-api/v8/progress-bar/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/progress-bar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/progress-bar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/progress-bar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/progress-bar/slots.md';
+import Slots from '@ionic-internal/component-api/v8/progress-bar/slots.mdx';
 
 <head>
   <title>ion-progress-bar: App Progress Bar for Loading Indicator</title>

--- a/versioned_docs/version-v8/api/radio-group.md
+++ b/versioned_docs/version-v8/api/radio-group.md
@@ -2,12 +2,12 @@
 title: 'ion-radio-group'
 ---
 
-import Props from '@ionic-internal/component-api/v8/radio-group/props.md';
-import Events from '@ionic-internal/component-api/v8/radio-group/events.md';
-import Methods from '@ionic-internal/component-api/v8/radio-group/methods.md';
-import Parts from '@ionic-internal/component-api/v8/radio-group/parts.md';
+import Props from '@ionic-internal/component-api/v8/radio-group/props.mdx';
+import Events from '@ionic-internal/component-api/v8/radio-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/radio-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/radio-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/radio-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/radio-group/slots.md';
+import Slots from '@ionic-internal/component-api/v8/radio-group/slots.mdx';
 
 <head>
   <title>ion-radio-group: Radio Button Group Usage for Ionic Apps</title>

--- a/versioned_docs/version-v8/api/radio.md
+++ b/versioned_docs/version-v8/api/radio.md
@@ -2,12 +2,12 @@
 title: 'ion-radio'
 ---
 
-import Props from '@ionic-internal/component-api/v8/radio/props.md';
-import Events from '@ionic-internal/component-api/v8/radio/events.md';
-import Methods from '@ionic-internal/component-api/v8/radio/methods.md';
-import Parts from '@ionic-internal/component-api/v8/radio/parts.md';
+import Props from '@ionic-internal/component-api/v8/radio/props.mdx';
+import Events from '@ionic-internal/component-api/v8/radio/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/radio/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/radio/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/radio/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/radio/slots.md';
+import Slots from '@ionic-internal/component-api/v8/radio/slots.mdx';
 
 <head>
   <title>ion-radio: Radio Component for iOS and Android</title>

--- a/versioned_docs/version-v8/api/range.md
+++ b/versioned_docs/version-v8/api/range.md
@@ -2,12 +2,12 @@
 title: 'ion-range'
 ---
 
-import Props from '@ionic-internal/component-api/v8/range/props.md';
-import Events from '@ionic-internal/component-api/v8/range/events.md';
-import Methods from '@ionic-internal/component-api/v8/range/methods.md';
-import Parts from '@ionic-internal/component-api/v8/range/parts.md';
+import Props from '@ionic-internal/component-api/v8/range/props.mdx';
+import Events from '@ionic-internal/component-api/v8/range/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/range/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/range/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/range/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/range/slots.md';
+import Slots from '@ionic-internal/component-api/v8/range/slots.mdx';
 
 <head>
   <title>ion-range: Range Slider Knob Controls with Labels</title>

--- a/versioned_docs/version-v8/api/refresher-content.md
+++ b/versioned_docs/version-v8/api/refresher-content.md
@@ -2,12 +2,12 @@
 title: 'ion-refresher-content'
 ---
 
-import Props from '@ionic-internal/component-api/v8/refresher-content/props.md';
-import Events from '@ionic-internal/component-api/v8/refresher-content/events.md';
-import Methods from '@ionic-internal/component-api/v8/refresher-content/methods.md';
-import Parts from '@ionic-internal/component-api/v8/refresher-content/parts.md';
+import Props from '@ionic-internal/component-api/v8/refresher-content/props.mdx';
+import Events from '@ionic-internal/component-api/v8/refresher-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/refresher-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/refresher-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/refresher-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/refresher-content/slots.md';
+import Slots from '@ionic-internal/component-api/v8/refresher-content/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/refresher.md
+++ b/versioned_docs/version-v8/api/refresher.md
@@ -2,12 +2,12 @@
 title: 'ion-refresher'
 ---
 
-import Props from '@ionic-internal/component-api/v8/refresher/props.md';
-import Events from '@ionic-internal/component-api/v8/refresher/events.md';
-import Methods from '@ionic-internal/component-api/v8/refresher/methods.md';
-import Parts from '@ionic-internal/component-api/v8/refresher/parts.md';
+import Props from '@ionic-internal/component-api/v8/refresher/props.mdx';
+import Events from '@ionic-internal/component-api/v8/refresher/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/refresher/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/refresher/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/refresher/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/refresher/slots.md';
+import Slots from '@ionic-internal/component-api/v8/refresher/slots.mdx';
 
 <head>
   <title>ion-refresher: Pull-to-Refresh Page Content on Ionic Apps</title>

--- a/versioned_docs/version-v8/api/reorder-group.md
+++ b/versioned_docs/version-v8/api/reorder-group.md
@@ -2,12 +2,12 @@
 title: 'ion-reorder-group'
 ---
 
-import Props from '@ionic-internal/component-api/v8/reorder-group/props.md';
-import Events from '@ionic-internal/component-api/v8/reorder-group/events.md';
-import Methods from '@ionic-internal/component-api/v8/reorder-group/methods.md';
-import Parts from '@ionic-internal/component-api/v8/reorder-group/parts.md';
+import Props from '@ionic-internal/component-api/v8/reorder-group/props.mdx';
+import Events from '@ionic-internal/component-api/v8/reorder-group/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/reorder-group/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/reorder-group/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/reorder-group/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/reorder-group/slots.md';
+import Slots from '@ionic-internal/component-api/v8/reorder-group/slots.mdx';
 
 <head>
   <title>ion-reorder-group: Wrapper Component for Reorder Items</title>

--- a/versioned_docs/version-v8/api/reorder.md
+++ b/versioned_docs/version-v8/api/reorder.md
@@ -2,12 +2,12 @@
 title: 'ion-reorder'
 ---
 
-import Props from '@ionic-internal/component-api/v8/reorder/props.md';
-import Events from '@ionic-internal/component-api/v8/reorder/events.md';
-import Methods from '@ionic-internal/component-api/v8/reorder/methods.md';
-import Parts from '@ionic-internal/component-api/v8/reorder/parts.md';
+import Props from '@ionic-internal/component-api/v8/reorder/props.mdx';
+import Events from '@ionic-internal/component-api/v8/reorder/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/reorder/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/reorder/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/reorder/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/reorder/slots.md';
+import Slots from '@ionic-internal/component-api/v8/reorder/slots.mdx';
 
 <head>
   <title>ion-reorder: Drag and Drop Icon to Reorder Items</title>

--- a/versioned_docs/version-v8/api/ripple-effect.md
+++ b/versioned_docs/version-v8/api/ripple-effect.md
@@ -2,12 +2,12 @@
 title: 'ion-ripple-effect'
 ---
 
-import Props from '@ionic-internal/component-api/v8/ripple-effect/props.md';
-import Events from '@ionic-internal/component-api/v8/ripple-effect/events.md';
-import Methods from '@ionic-internal/component-api/v8/ripple-effect/methods.md';
-import Parts from '@ionic-internal/component-api/v8/ripple-effect/parts.md';
+import Props from '@ionic-internal/component-api/v8/ripple-effect/props.mdx';
+import Events from '@ionic-internal/component-api/v8/ripple-effect/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/ripple-effect/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/ripple-effect/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/ripple-effect/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/ripple-effect/slots.md';
+import Slots from '@ionic-internal/component-api/v8/ripple-effect/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/route-redirect.md
+++ b/versioned_docs/version-v8/api/route-redirect.md
@@ -2,12 +2,12 @@
 title: 'ion-route-redirect'
 ---
 
-import Props from '@ionic-internal/component-api/v8/route-redirect/props.md';
-import Events from '@ionic-internal/component-api/v8/route-redirect/events.md';
-import Methods from '@ionic-internal/component-api/v8/route-redirect/methods.md';
-import Parts from '@ionic-internal/component-api/v8/route-redirect/parts.md';
+import Props from '@ionic-internal/component-api/v8/route-redirect/props.mdx';
+import Events from '@ionic-internal/component-api/v8/route-redirect/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/route-redirect/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/route-redirect/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/route-redirect/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/route-redirect/slots.md';
+import Slots from '@ionic-internal/component-api/v8/route-redirect/slots.mdx';
 
 <head>
   <title>ion-route-redirect: Redirect 'from' a URL 'to' Another URL</title>

--- a/versioned_docs/version-v8/api/route.md
+++ b/versioned_docs/version-v8/api/route.md
@@ -5,12 +5,12 @@ title: 'ion-route'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v8/route/props.md';
-import Events from '@ionic-internal/component-api/v8/route/events.md';
-import Methods from '@ionic-internal/component-api/v8/route/methods.md';
-import Parts from '@ionic-internal/component-api/v8/route/parts.md';
+import Props from '@ionic-internal/component-api/v8/route/props.mdx';
+import Events from '@ionic-internal/component-api/v8/route/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/route/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/route/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/route/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/route/slots.md';
+import Slots from '@ionic-internal/component-api/v8/route/slots.mdx';
 
 <head>
   <title>ion-route: API Route Component for Ionic Framework Apps</title>

--- a/versioned_docs/version-v8/api/router-link.md
+++ b/versioned_docs/version-v8/api/router-link.md
@@ -2,12 +2,12 @@
 title: 'ion-router-link'
 ---
 
-import Props from '@ionic-internal/component-api/v8/router-link/props.md';
-import Events from '@ionic-internal/component-api/v8/router-link/events.md';
-import Methods from '@ionic-internal/component-api/v8/router-link/methods.md';
-import Parts from '@ionic-internal/component-api/v8/router-link/parts.md';
+import Props from '@ionic-internal/component-api/v8/router-link/props.mdx';
+import Events from '@ionic-internal/component-api/v8/router-link/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/router-link/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/router-link/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/router-link/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/router-link/slots.md';
+import Slots from '@ionic-internal/component-api/v8/router-link/slots.mdx';
 
 <head>
   <title>ion-router-link: Navigate To a Specified Link</title>

--- a/versioned_docs/version-v8/api/router-outlet.md
+++ b/versioned_docs/version-v8/api/router-outlet.md
@@ -2,12 +2,12 @@
 title: 'ion-router-outlet'
 ---
 
-import Props from '@ionic-internal/component-api/v8/router-outlet/props.md';
-import Events from '@ionic-internal/component-api/v8/router-outlet/events.md';
-import Methods from '@ionic-internal/component-api/v8/router-outlet/methods.md';
-import Parts from '@ionic-internal/component-api/v8/router-outlet/parts.md';
+import Props from '@ionic-internal/component-api/v8/router-outlet/props.mdx';
+import Events from '@ionic-internal/component-api/v8/router-outlet/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/router-outlet/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/router-outlet/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/router-outlet/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/router-outlet/slots.md';
+import Slots from '@ionic-internal/component-api/v8/router-outlet/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/router.md
+++ b/versioned_docs/version-v8/api/router.md
@@ -2,12 +2,12 @@
 title: 'ion-router'
 ---
 
-import Props from '@ionic-internal/component-api/v8/router/props.md';
-import Events from '@ionic-internal/component-api/v8/router/events.md';
-import Methods from '@ionic-internal/component-api/v8/router/methods.md';
-import Parts from '@ionic-internal/component-api/v8/router/parts.md';
+import Props from '@ionic-internal/component-api/v8/router/props.mdx';
+import Events from '@ionic-internal/component-api/v8/router/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/router/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/router/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/router/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/router/slots.md';
+import Slots from '@ionic-internal/component-api/v8/router/slots.mdx';
 
 <head>
   <title>ion-router: Router Component to Coordinate URL Navigation</title>

--- a/versioned_docs/version-v8/api/row.md
+++ b/versioned_docs/version-v8/api/row.md
@@ -2,12 +2,12 @@
 title: 'ion-row'
 ---
 
-import Props from '@ionic-internal/component-api/v8/row/props.md';
-import Events from '@ionic-internal/component-api/v8/row/events.md';
-import Methods from '@ionic-internal/component-api/v8/row/methods.md';
-import Parts from '@ionic-internal/component-api/v8/row/parts.md';
+import Props from '@ionic-internal/component-api/v8/row/props.mdx';
+import Events from '@ionic-internal/component-api/v8/row/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/row/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/row/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/row/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/row/slots.md';
+import Slots from '@ionic-internal/component-api/v8/row/slots.mdx';
 
 <head>
   <title>ion-row: Horizontal Row Components of the Grid System</title>

--- a/versioned_docs/version-v8/api/searchbar.md
+++ b/versioned_docs/version-v8/api/searchbar.md
@@ -2,12 +2,12 @@
 title: 'ion-searchbar'
 ---
 
-import Props from '@ionic-internal/component-api/v8/searchbar/props.md';
-import Events from '@ionic-internal/component-api/v8/searchbar/events.md';
-import Methods from '@ionic-internal/component-api/v8/searchbar/methods.md';
-import Parts from '@ionic-internal/component-api/v8/searchbar/parts.md';
+import Props from '@ionic-internal/component-api/v8/searchbar/props.mdx';
+import Events from '@ionic-internal/component-api/v8/searchbar/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/searchbar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/searchbar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/searchbar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/searchbar/slots.md';
+import Slots from '@ionic-internal/component-api/v8/searchbar/slots.mdx';
 
 <head>
   <title>ion-searchbar: Search Bar for Searching a Collection</title>

--- a/versioned_docs/version-v8/api/segment-button.md
+++ b/versioned_docs/version-v8/api/segment-button.md
@@ -2,12 +2,12 @@
 title: 'ion-segment-button'
 ---
 
-import Props from '@ionic-internal/component-api/v8/segment-button/props.md';
-import Events from '@ionic-internal/component-api/v8/segment-button/events.md';
-import Methods from '@ionic-internal/component-api/v8/segment-button/methods.md';
-import Parts from '@ionic-internal/component-api/v8/segment-button/parts.md';
+import Props from '@ionic-internal/component-api/v8/segment-button/props.mdx';
+import Events from '@ionic-internal/component-api/v8/segment-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/segment-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/segment-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/segment-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/segment-button/slots.md';
+import Slots from '@ionic-internal/component-api/v8/segment-button/slots.mdx';
 
 <head>
   <title>ion-segment-button | Segment Button Icon and Segment Value</title>

--- a/versioned_docs/version-v8/api/segment-content.md
+++ b/versioned_docs/version-v8/api/segment-content.md
@@ -2,12 +2,12 @@
 title: 'ion-segment-content'
 ---
 
-import Props from '@ionic-internal/component-api/v8/segment-content/props.md';
-import Events from '@ionic-internal/component-api/v8/segment-content/events.md';
-import Methods from '@ionic-internal/component-api/v8/segment-content/methods.md';
-import Parts from '@ionic-internal/component-api/v8/segment-content/parts.md';
+import Props from '@ionic-internal/component-api/v8/segment-content/props.mdx';
+import Events from '@ionic-internal/component-api/v8/segment-content/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/segment-content/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/segment-content/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/segment-content/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/segment-content/slots.md';
+import Slots from '@ionic-internal/component-api/v8/segment-content/slots.mdx';
 
 <head>
   <title>ion-segment-content: Display control element for swipeable segments</title>

--- a/versioned_docs/version-v8/api/segment-view.md
+++ b/versioned_docs/version-v8/api/segment-view.md
@@ -2,12 +2,12 @@
 title: 'ion-segment-view'
 ---
 
-import Props from '@ionic-internal/component-api/v8/segment-view/props.md';
-import Events from '@ionic-internal/component-api/v8/segment-view/events.md';
-import Methods from '@ionic-internal/component-api/v8/segment-view/methods.md';
-import Parts from '@ionic-internal/component-api/v8/segment-view/parts.md';
+import Props from '@ionic-internal/component-api/v8/segment-view/props.mdx';
+import Events from '@ionic-internal/component-api/v8/segment-view/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/segment-view/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/segment-view/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/segment-view/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/segment-view/slots.md';
+import Slots from '@ionic-internal/component-api/v8/segment-view/slots.mdx';
 
 <head>
   <title>ion-segment-view: Controller element for swipeable segments</title>

--- a/versioned_docs/version-v8/api/segment.md
+++ b/versioned_docs/version-v8/api/segment.md
@@ -2,12 +2,12 @@
 title: 'ion-segment'
 ---
 
-import Props from '@ionic-internal/component-api/v8/segment/props.md';
-import Events from '@ionic-internal/component-api/v8/segment/events.md';
-import Methods from '@ionic-internal/component-api/v8/segment/methods.md';
-import Parts from '@ionic-internal/component-api/v8/segment/parts.md';
+import Props from '@ionic-internal/component-api/v8/segment/props.mdx';
+import Events from '@ionic-internal/component-api/v8/segment/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/segment/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/segment/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/segment/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/segment/slots.md';
+import Slots from '@ionic-internal/component-api/v8/segment/slots.mdx';
 
 <head>
   <title>ion-segment: API Documentation for Segmented Controls</title>

--- a/versioned_docs/version-v8/api/select-option.md
+++ b/versioned_docs/version-v8/api/select-option.md
@@ -2,12 +2,12 @@
 title: 'ion-select-option'
 ---
 
-import Props from '@ionic-internal/component-api/v8/select-option/props.md';
-import Events from '@ionic-internal/component-api/v8/select-option/events.md';
-import Methods from '@ionic-internal/component-api/v8/select-option/methods.md';
-import Parts from '@ionic-internal/component-api/v8/select-option/parts.md';
+import Props from '@ionic-internal/component-api/v8/select-option/props.mdx';
+import Events from '@ionic-internal/component-api/v8/select-option/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/select-option/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/select-option/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/select-option/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/select-option/slots.md';
+import Slots from '@ionic-internal/component-api/v8/select-option/slots.mdx';
 
 <head>
   <title>ion-select-option: Option For a Select Dialog</title>

--- a/versioned_docs/version-v8/api/select.md
+++ b/versioned_docs/version-v8/api/select.md
@@ -2,12 +2,12 @@
 title: 'ion-select'
 ---
 
-import Props from '@ionic-internal/component-api/v8/select/props.md';
-import Events from '@ionic-internal/component-api/v8/select/events.md';
-import Methods from '@ionic-internal/component-api/v8/select/methods.md';
-import Parts from '@ionic-internal/component-api/v8/select/parts.md';
+import Props from '@ionic-internal/component-api/v8/select/props.mdx';
+import Events from '@ionic-internal/component-api/v8/select/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/select/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/select/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/select/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/select/slots.md';
+import Slots from '@ionic-internal/component-api/v8/select/slots.mdx';
 
 <head>
   <title>ion-select: Select One or Multiple Value Boxes or Placeholders</title>

--- a/versioned_docs/version-v8/api/skeleton-text.md
+++ b/versioned_docs/version-v8/api/skeleton-text.md
@@ -2,12 +2,12 @@
 title: 'ion-skeleton-text'
 ---
 
-import Props from '@ionic-internal/component-api/v8/skeleton-text/props.md';
-import Events from '@ionic-internal/component-api/v8/skeleton-text/events.md';
-import Methods from '@ionic-internal/component-api/v8/skeleton-text/methods.md';
-import Parts from '@ionic-internal/component-api/v8/skeleton-text/parts.md';
+import Props from '@ionic-internal/component-api/v8/skeleton-text/props.mdx';
+import Events from '@ionic-internal/component-api/v8/skeleton-text/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/skeleton-text/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/skeleton-text/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/skeleton-text/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/skeleton-text/slots.md';
+import Slots from '@ionic-internal/component-api/v8/skeleton-text/slots.mdx';
 
 <head>
   <title>ion-skeleton-text: Skeleton Loading Placeholder for Text</title>

--- a/versioned_docs/version-v8/api/spinner.md
+++ b/versioned_docs/version-v8/api/spinner.md
@@ -2,12 +2,12 @@
 title: 'ion-spinner'
 ---
 
-import Props from '@ionic-internal/component-api/v8/spinner/props.md';
-import Events from '@ionic-internal/component-api/v8/spinner/events.md';
-import Methods from '@ionic-internal/component-api/v8/spinner/methods.md';
-import Parts from '@ionic-internal/component-api/v8/spinner/parts.md';
+import Props from '@ionic-internal/component-api/v8/spinner/props.mdx';
+import Events from '@ionic-internal/component-api/v8/spinner/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/spinner/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/spinner/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/spinner/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/spinner/slots.md';
+import Slots from '@ionic-internal/component-api/v8/spinner/slots.mdx';
 
 <head>
   <title>ion-spinner: Animated Spinner Icon Components and Properties</title>

--- a/versioned_docs/version-v8/api/split-pane.md
+++ b/versioned_docs/version-v8/api/split-pane.md
@@ -2,12 +2,12 @@
 title: 'ion-split-pane'
 ---
 
-import Props from '@ionic-internal/component-api/v8/split-pane/props.md';
-import Events from '@ionic-internal/component-api/v8/split-pane/events.md';
-import Methods from '@ionic-internal/component-api/v8/split-pane/methods.md';
-import Parts from '@ionic-internal/component-api/v8/split-pane/parts.md';
+import Props from '@ionic-internal/component-api/v8/split-pane/props.mdx';
+import Events from '@ionic-internal/component-api/v8/split-pane/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/split-pane/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/split-pane/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/split-pane/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/split-pane/slots.md';
+import Slots from '@ionic-internal/component-api/v8/split-pane/slots.mdx';
 
 <head>
   <title>ion-split-pane: Split Plane for Menus and Multi-View Layouts</title>

--- a/versioned_docs/version-v8/api/tab-bar.md
+++ b/versioned_docs/version-v8/api/tab-bar.md
@@ -5,12 +5,12 @@ title: 'ion-tab-bar'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v8/tab-bar/props.md';
-import Events from '@ionic-internal/component-api/v8/tab-bar/events.md';
-import Methods from '@ionic-internal/component-api/v8/tab-bar/methods.md';
-import Parts from '@ionic-internal/component-api/v8/tab-bar/parts.md';
+import Props from '@ionic-internal/component-api/v8/tab-bar/props.mdx';
+import Events from '@ionic-internal/component-api/v8/tab-bar/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/tab-bar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/tab-bar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/tab-bar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/tab-bar/slots.md';
+import Slots from '@ionic-internal/component-api/v8/tab-bar/slots.mdx';
 
 <head>
   <title>ion-tab-bar: Tab Bar Component with CSS Custom Properties</title>

--- a/versioned_docs/version-v8/api/tab-button.md
+++ b/versioned_docs/version-v8/api/tab-button.md
@@ -5,12 +5,12 @@ title: 'ion-tab-button'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v8/tab-button/props.md';
-import Events from '@ionic-internal/component-api/v8/tab-button/events.md';
-import Methods from '@ionic-internal/component-api/v8/tab-button/methods.md';
-import Parts from '@ionic-internal/component-api/v8/tab-button/parts.md';
+import Props from '@ionic-internal/component-api/v8/tab-button/props.mdx';
+import Events from '@ionic-internal/component-api/v8/tab-button/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/tab-button/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/tab-button/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/tab-button/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/tab-button/slots.md';
+import Slots from '@ionic-internal/component-api/v8/tab-button/slots.mdx';
 
 import EncapsulationPill from '@components/page/api/EncapsulationPill';
 

--- a/versioned_docs/version-v8/api/tab.md
+++ b/versioned_docs/version-v8/api/tab.md
@@ -2,12 +2,12 @@
 title: 'ion-tab'
 ---
 
-import Props from '@ionic-internal/component-api/v8/tab/props.md';
-import Events from '@ionic-internal/component-api/v8/tab/events.md';
-import Methods from '@ionic-internal/component-api/v8/tab/methods.md';
-import Parts from '@ionic-internal/component-api/v8/tab/parts.md';
+import Props from '@ionic-internal/component-api/v8/tab/props.mdx';
+import Events from '@ionic-internal/component-api/v8/tab/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/tab/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/tab/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/tab/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/tab/slots.md';
+import Slots from '@ionic-internal/component-api/v8/tab/slots.mdx';
 
 <head>
   <title>ion-tab: Ionic Framework Application Component</title>

--- a/versioned_docs/version-v8/api/tabs.md
+++ b/versioned_docs/version-v8/api/tabs.md
@@ -2,12 +2,12 @@
 title: 'ion-tabs'
 ---
 
-import Props from '@ionic-internal/component-api/v8/tabs/props.md';
-import Events from '@ionic-internal/component-api/v8/tabs/events.md';
-import Methods from '@ionic-internal/component-api/v8/tabs/methods.md';
-import Parts from '@ionic-internal/component-api/v8/tabs/parts.md';
+import Props from '@ionic-internal/component-api/v8/tabs/props.mdx';
+import Events from '@ionic-internal/component-api/v8/tabs/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/tabs/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/tabs/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/tabs/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/tabs/slots.md';
+import Slots from '@ionic-internal/component-api/v8/tabs/slots.mdx';
 
 <head>
   <title>ion-tabs: Tab-Based Component for App Top-Level Navigation</title>

--- a/versioned_docs/version-v8/api/text.md
+++ b/versioned_docs/version-v8/api/text.md
@@ -2,12 +2,12 @@
 title: 'ion-text'
 ---
 
-import Props from '@ionic-internal/component-api/v8/text/props.md';
-import Events from '@ionic-internal/component-api/v8/text/events.md';
-import Methods from '@ionic-internal/component-api/v8/text/methods.md';
-import Parts from '@ionic-internal/component-api/v8/text/parts.md';
+import Props from '@ionic-internal/component-api/v8/text/props.mdx';
+import Events from '@ionic-internal/component-api/v8/text/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/text/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/text/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/text/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/text/slots.md';
+import Slots from '@ionic-internal/component-api/v8/text/slots.mdx';
 
 <head>
   <title>ion-text: Ionic App Component to Style or Change Text Color</title>

--- a/versioned_docs/version-v8/api/textarea.md
+++ b/versioned_docs/version-v8/api/textarea.md
@@ -2,12 +2,12 @@
 title: 'ion-textarea'
 ---
 
-import Props from '@ionic-internal/component-api/v8/textarea/props.md';
-import Events from '@ionic-internal/component-api/v8/textarea/events.md';
-import Methods from '@ionic-internal/component-api/v8/textarea/methods.md';
-import Parts from '@ionic-internal/component-api/v8/textarea/parts.md';
+import Props from '@ionic-internal/component-api/v8/textarea/props.mdx';
+import Events from '@ionic-internal/component-api/v8/textarea/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/textarea/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/textarea/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/textarea/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/textarea/slots.md';
+import Slots from '@ionic-internal/component-api/v8/textarea/slots.mdx';
 
 <head>
   <title>Ionic Textarea Component and CSS Properties for Multi-Line Input</title>

--- a/versioned_docs/version-v8/api/thumbnail.md
+++ b/versioned_docs/version-v8/api/thumbnail.md
@@ -2,12 +2,12 @@
 title: 'ion-thumbnail'
 ---
 
-import Props from '@ionic-internal/component-api/v8/thumbnail/props.md';
-import Events from '@ionic-internal/component-api/v8/thumbnail/events.md';
-import Methods from '@ionic-internal/component-api/v8/thumbnail/methods.md';
-import Parts from '@ionic-internal/component-api/v8/thumbnail/parts.md';
+import Props from '@ionic-internal/component-api/v8/thumbnail/props.mdx';
+import Events from '@ionic-internal/component-api/v8/thumbnail/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/thumbnail/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/thumbnail/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/thumbnail/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/thumbnail/slots.md';
+import Slots from '@ionic-internal/component-api/v8/thumbnail/slots.mdx';
 
 <head>
   <title>ion-thumbnail: Thumbnail App Component for Images or Icons</title>

--- a/versioned_docs/version-v8/api/title.md
+++ b/versioned_docs/version-v8/api/title.md
@@ -2,12 +2,12 @@
 title: 'ion-title'
 ---
 
-import Props from '@ionic-internal/component-api/v8/title/props.md';
-import Events from '@ionic-internal/component-api/v8/title/events.md';
-import Methods from '@ionic-internal/component-api/v8/title/methods.md';
-import Parts from '@ionic-internal/component-api/v8/title/parts.md';
+import Props from '@ionic-internal/component-api/v8/title/props.mdx';
+import Events from '@ionic-internal/component-api/v8/title/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/title/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/title/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/title/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/title/slots.md';
+import Slots from '@ionic-internal/component-api/v8/title/slots.mdx';
 
 <head>
   <title>ion-title: Ionic Framework App Title Component for Toolbars</title>

--- a/versioned_docs/version-v8/api/toast.md
+++ b/versioned_docs/version-v8/api/toast.md
@@ -5,12 +5,12 @@ title: 'ion-toast'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import Props from '@ionic-internal/component-api/v8/toast/props.md';
-import Events from '@ionic-internal/component-api/v8/toast/events.md';
-import Methods from '@ionic-internal/component-api/v8/toast/methods.md';
-import Parts from '@ionic-internal/component-api/v8/toast/parts.md';
+import Props from '@ionic-internal/component-api/v8/toast/props.mdx';
+import Events from '@ionic-internal/component-api/v8/toast/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/toast/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/toast/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/toast/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/toast/slots.md';
+import Slots from '@ionic-internal/component-api/v8/toast/slots.mdx';
 
 <head>
   <title>ion-toast: A Dismissible App Notification Alert Component</title>

--- a/versioned_docs/version-v8/api/toggle.md
+++ b/versioned_docs/version-v8/api/toggle.md
@@ -2,12 +2,12 @@
 title: 'ion-toggle'
 ---
 
-import Props from '@ionic-internal/component-api/v8/toggle/props.md';
-import Events from '@ionic-internal/component-api/v8/toggle/events.md';
-import Methods from '@ionic-internal/component-api/v8/toggle/methods.md';
-import Parts from '@ionic-internal/component-api/v8/toggle/parts.md';
+import Props from '@ionic-internal/component-api/v8/toggle/props.mdx';
+import Events from '@ionic-internal/component-api/v8/toggle/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/toggle/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/toggle/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/toggle/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/toggle/slots.md';
+import Slots from '@ionic-internal/component-api/v8/toggle/slots.mdx';
 
 <head>
   <title>ion-toggle: Custom Toggle Button for Ionic Applications</title>

--- a/versioned_docs/version-v8/api/toolbar.md
+++ b/versioned_docs/version-v8/api/toolbar.md
@@ -2,12 +2,12 @@
 title: 'ion-toolbar'
 ---
 
-import Props from '@ionic-internal/component-api/v8/toolbar/props.md';
-import Events from '@ionic-internal/component-api/v8/toolbar/events.md';
-import Methods from '@ionic-internal/component-api/v8/toolbar/methods.md';
-import Parts from '@ionic-internal/component-api/v8/toolbar/parts.md';
+import Props from '@ionic-internal/component-api/v8/toolbar/props.mdx';
+import Events from '@ionic-internal/component-api/v8/toolbar/events.mdx';
+import Methods from '@ionic-internal/component-api/v8/toolbar/methods.mdx';
+import Parts from '@ionic-internal/component-api/v8/toolbar/parts.mdx';
 import CustomProps from '@ionic-internal/component-api/v8/toolbar/custom-props.mdx';
-import Slots from '@ionic-internal/component-api/v8/toolbar/slots.md';
+import Slots from '@ionic-internal/component-api/v8/toolbar/slots.mdx';
 
 <head>
   <title>ion-toolbar: Customize App Menu Toolbar Buttons and Icons</title>


### PR DESCRIPTION
Issue URL: internal

## What is the current behavior?

The component API plugin writes its generated partials with a `.md` extension: props, events, methods, parts and slots. Those files are MDX, not CommonMark, so the extension is inaccurate. The sixth partial, custom-props, is already `.mdx`, which suggests this was hit once before and fixed for a single file.

Each API page then imports them by explicit filename, so the extension is repeated across every page, for example importing Props from `@ionic-internal/component-api/v8/button/props.md`.

## What is the new behavior?

The plugin emits `.mdx` for the five remaining partials, and the import specifiers are updated to match.

- 5 lines in `plugins/docusaurus-plugin-ionic-component-api/index.js`
- 910 import specifiers across 181 pages in `docs/` (94) and `versioned_docs/version-v7` (87)

Every doc file change is a specifier swap; there are no other edits.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of the mdx migration.

### How to test

Check a page where all six partial types have content:

- **Current version:** https://ionic-docs-git-fw-6456-pt4b-ionic1.vercel.app/docs/api/modal
  - Scroll to the bottom and confirm **Properties**, **Events**, **Methods**, **CSS Shadow Parts**, **CSS Custom Properties** and **Slots** all render with real content
- **Versioned tree:** https://ionic-docs-git-fw-6456-pt4b-ionic1.vercel.app/docs/v7/api/select
  - Same six sections; this confirms the version-v7 specifiers were rewritten too

The content, datetime, popover and select pages also populate all six if you want another sample.