### PR TITLE
docs(v9): update demos and support info to use v9 version

### DIFF
--- a/_templates/README.md
+++ b/_templates/README.md
@@ -26,7 +26,7 @@ Once you've generated your playground, you need to add it to the main markdown f
 ```
 ## Feature
 
-import Feature from '@site/static/usage/v8/button/feature/index.md';
+import Feature from '@site/static/usage/v9/button/feature/index.md';
 
 <Feature />
 ```

--- a/_templates/playground/new/index.js
+++ b/_templates/playground/new/index.js
@@ -54,8 +54,8 @@ module.exports = {
               type: 'select',
               name: 'version',
               message: 'Select the Ionic Framework version for the playground',
-              initial: '8',
-              choices: ['6', '7', '8'],
+              initial: '9',
+              choices: ['6', '7', '8', '9'],
             },
             {
               type: 'toggle',

--- a/docs/angular/overview.md
+++ b/docs/angular/overview.md
@@ -18,7 +18,7 @@ import DocsCards from '@components/global/DocsCards';
 
 ## Angular Version Support
 
-Ionic Angular v9 supports Angular versions 18 through 21. For detailed information on supported versions and our support policy, refer to the [Ionic Angular Support Policy](/docs/reference/support#ionic-angular).
+Ionic Angular v9 supports Angular versions 18 through 22. For detailed information on supported versions and our support policy, refer to the [Ionic Angular Support Policy](/docs/reference/support#ionic-angular).
 
 ## Angular Tooling
 

--- a/docs/reference/support.md
+++ b/docs/reference/support.md
@@ -22,8 +22,8 @@ The current status of each Ionic Framework version is:
 
 | Version |     Status     |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :------------: | :----------: | :--------------: | :---------------: |
-|   V9    |   **Active**   |     TBD      |       TBD        |        TBD        |
-|   V8    |  Maintenance   | Apr 17, 2024 |       TBD        |        TBD        |
+|   V9    |   **Active**   | Aug 17, 2026 |       TBD        |        TBD        |
+|   V8    |  Maintenance   | Apr 17, 2024 |   Feb 17, 2027   |   Aug 17, 2027    |
 |   V7    | End of Support | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
 |   V6    | End of Support | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
 |   V5    | End of Support | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |

--- a/docs/vue/overview.md
+++ b/docs/vue/overview.md
@@ -18,7 +18,7 @@ import DocsCards from '@components/global/DocsCards';
 
 ## Vue Version Support
 
-Ionic Vue v8 supports Vue 3.x. For detailed information on supported versions and our support policy, refer to the [Ionic Vue Support Policy](/docs/reference/support#ionic-vue).
+Ionic Vue v9 supports Vue 3.5 and later. For detailed information on supported versions and our support policy, refer to the [Ionic Vue Support Policy](/docs/reference/support#ionic-vue).
 
 ## Vue Tooling
 

--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -54,9 +54,7 @@ module.exports = function (context, options) {
         await generateMarkdownForVersion(version, npmTag, context.i18n.currentLocale, false);
       }
 
-      // TODO(FW-7097): Replace this with `latest` when v9 is released.
-      // Dev build from the `major-9.0` branch of `ionic-framework` (sha a334b43).
-      let npmTag = '8.8.16-dev.11784913436.1a334b43';
+      let npmTag = 'latest';
       if (currentVersion.banner === 'unreleased') {
         npmTag = 'next';
       } else if (currentVersion.path !== undefined) {

--- a/static/code/stackblitz/v9/angular/package-lock.json
+++ b/static/code/stackblitz/v9/angular/package-lock.json
@@ -14,8 +14,8 @@
         "@angular/platform-browser": "^22.0.0",
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
-        "@ionic/angular": "8.8.16-dev.11785274070.1b3387c9",
-        "@ionic/core": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/angular": "9.0.0",
+        "@ionic/core": "9.0.0",
         "ionicons": "8.1.0",
         "rxjs": "^7.8.1",
         "tslib": "^2.5.0"
@@ -2578,10 +2578,10 @@
       }
     },
     "node_modules/@ionic/angular": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/core": "9.0.0",
         "ionicons": "^8.0.13",
         "jsonc-parser": "^3.0.0",
         "tslib": "^2.3.0"
@@ -2600,7 +2600,7 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.43.5",

--- a/static/code/stackblitz/v9/angular/package.json
+++ b/static/code/stackblitz/v9/angular/package.json
@@ -15,8 +15,8 @@
     "@angular/platform-browser": "^22.0.0",
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
-    "@ionic/angular": "8.8.16-dev.11785274070.1b3387c9",
-    "@ionic/core": "8.8.16-dev.11785274070.1b3387c9",
+    "@ionic/angular": "9.0.0",
+    "@ionic/core": "9.0.0",
     "ionicons": "8.1.0",
     "rxjs": "^7.8.1",
     "tslib": "^2.5.0"

--- a/static/code/stackblitz/v9/html/package-lock.json
+++ b/static/code/stackblitz/v9/html/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "html-starter",
       "dependencies": {
-        "@ionic/core": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/core": "9.0.0",
         "ionicons": "8.1.0"
       },
       "devDependencies": {
@@ -16,7 +16,7 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.43.5",

--- a/static/code/stackblitz/v9/html/package.json
+++ b/static/code/stackblitz/v9/html/package.json
@@ -9,7 +9,7 @@
     "start": "vite preview"
   },
   "dependencies": {
-    "@ionic/core": "8.8.16-dev.11785274070.1b3387c9",
+    "@ionic/core": "9.0.0",
     "ionicons": "8.1.0"
   },
   "devDependencies": {

--- a/static/code/stackblitz/v9/react/package-lock.json
+++ b/static/code/stackblitz/v9/react/package-lock.json
@@ -8,8 +8,8 @@
       "name": "vite-react-typescript",
       "version": "0.1.0",
       "dependencies": {
-        "@ionic/react": "8.8.16-dev.11785274070.1b3387c9",
-        "@ionic/react-router": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/react": "9.0.0",
+        "@ionic/react-router": "9.0.0",
         "@types/node": "^24.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -254,7 +254,7 @@
       "license": "MIT"
     },
     "node_modules/@ionic/core": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.43.5",
@@ -266,10 +266,10 @@
       }
     },
     "node_modules/@ionic/react": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/core": "9.0.0",
         "@stencil/react-output-target": "^1.5.2",
         "ionicons": "^8.0.13",
         "tslib": "*"
@@ -280,10 +280,10 @@
       }
     },
     "node_modules/@ionic/react-router": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ionic/react": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/react": "9.0.0",
         "tslib": "*"
       },
       "peerDependencies": {

--- a/static/code/stackblitz/v9/react/package.json
+++ b/static/code/stackblitz/v9/react/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ionic/react": "8.8.16-dev.11785274070.1b3387c9",
-    "@ionic/react-router": "8.8.16-dev.11785274070.1b3387c9",
+    "@ionic/react": "9.0.0",
+    "@ionic/react-router": "9.0.0",
     "@types/node": "^24.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/static/code/stackblitz/v9/vue/package-lock.json
+++ b/static/code/stackblitz/v9/vue/package-lock.json
@@ -8,8 +8,8 @@
       "name": "vite-vue-starter",
       "version": "0.0.0",
       "dependencies": {
-        "@ionic/vue": "8.8.16-dev.11785274070.1b3387c9",
-        "@ionic/vue-router": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/vue": "9.0.0",
+        "@ionic/vue-router": "9.0.0",
         "vue": "^3.2.25",
         "vue-router": "5.1.0"
       },
@@ -112,7 +112,7 @@
       }
     },
     "node_modules/@ionic/core": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^4.43.5",
@@ -124,19 +124,19 @@
       }
     },
     "node_modules/@ionic/vue": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ionic/core": "8.8.16-dev.11785274070.1b3387c9",
+        "@ionic/core": "9.0.0",
         "@stencil/vue-output-target": "0.13.1",
         "ionicons": "^8.0.13"
       }
     },
     "node_modules/@ionic/vue-router": {
-      "version": "8.8.16-dev.11785274070.1b3387c9",
+      "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ionic/vue": "8.8.16-dev.11785274070.1b3387c9"
+        "@ionic/vue": "9.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/static/code/stackblitz/v9/vue/package.json
+++ b/static/code/stackblitz/v9/vue/package.json
@@ -8,8 +8,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ionic/vue": "8.8.16-dev.11785274070.1b3387c9",
-    "@ionic/vue-router": "8.8.16-dev.11785274070.1b3387c9",
+    "@ionic/vue": "9.0.0",
+    "@ionic/vue-router": "9.0.0",
     "vue": "^3.2.25",
     "vue-router": "5.1.0"
   },

--- a/static/usage/v9/accordion/accessibility/animations/demo.html
+++ b/static/usage/v9/accordion/accessibility/animations/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/basic/demo.html
+++ b/static/usage/v9/accordion/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/customization/advanced-expansion-styles/demo.html
+++ b/static/usage/v9/accordion/customization/advanced-expansion-styles/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-accordion {
         margin: 0 auto;

--- a/static/usage/v9/accordion/customization/expansion-styles/demo.html
+++ b/static/usage/v9/accordion/customization/expansion-styles/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/customization/icons/demo.html
+++ b/static/usage/v9/accordion/customization/icons/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/customization/theming/demo.html
+++ b/static/usage/v9/accordion/customization/theming/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       :root {
         --ion-color-rose: #fecdd3;

--- a/static/usage/v9/accordion/disable/group/demo.html
+++ b/static/usage/v9/accordion/disable/group/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/disable/individual/demo.html
+++ b/static/usage/v9/accordion/disable/individual/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/listen-changes/demo.html
+++ b/static/usage/v9/accordion/listen-changes/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/multiple/demo.html
+++ b/static/usage/v9/accordion/multiple/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/readonly/group/demo.html
+++ b/static/usage/v9/accordion/readonly/group/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/readonly/individual/demo.html
+++ b/static/usage/v9/accordion/readonly/individual/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-accordion-group {

--- a/static/usage/v9/accordion/toggle/demo.html
+++ b/static/usage/v9/accordion/toggle/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .container {
         flex-direction: column;

--- a/static/usage/v9/action-sheet/controller/demo.html
+++ b/static/usage/v9/action-sheet/controller/demo.html
@@ -6,8 +6,8 @@
     <title>Action Sheet</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/action-sheet/inline/isOpen/demo.html
+++ b/static/usage/v9/action-sheet/inline/isOpen/demo.html
@@ -6,8 +6,8 @@
     <title>Action Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/action-sheet/inline/trigger/demo.html
+++ b/static/usage/v9/action-sheet/inline/trigger/demo.html
@@ -6,8 +6,8 @@
     <title>Action Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/action-sheet/role-info-on-dismiss/demo.html
+++ b/static/usage/v9/action-sheet/role-info-on-dismiss/demo.html
@@ -6,8 +6,8 @@
     <title>Action Sheet</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/action-sheet/theming/css-properties/demo.html
+++ b/static/usage/v9/action-sheet/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Action Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-action-sheet.my-custom-class {

--- a/static/usage/v9/action-sheet/theming/styling/demo.html
+++ b/static/usage/v9/action-sheet/theming/styling/demo.html
@@ -6,8 +6,8 @@
     <title>Action Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-action-sheet.my-custom-class .action-sheet-group {

--- a/static/usage/v9/alert/buttons/demo.html
+++ b/static/usage/v9/alert/buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Alert</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/alert/customization/demo.html
+++ b/static/usage/v9/alert/customization/demo.html
@@ -6,8 +6,8 @@
     <title>Alert</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-alert.custom-alert {

--- a/static/usage/v9/alert/inputs/radios/demo.html
+++ b/static/usage/v9/alert/inputs/radios/demo.html
@@ -6,8 +6,8 @@
     <title>Alert</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/alert/inputs/text-inputs/demo.html
+++ b/static/usage/v9/alert/inputs/text-inputs/demo.html
@@ -6,8 +6,8 @@
     <title>Alert</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/alert/presenting/controller/demo.html
+++ b/static/usage/v9/alert/presenting/controller/demo.html
@@ -6,8 +6,8 @@
     <title>Alert</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/alert/presenting/isOpen/demo.html
+++ b/static/usage/v9/alert/presenting/isOpen/demo.html
@@ -6,8 +6,8 @@
     <title>Alert</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/alert/presenting/trigger/demo.html
+++ b/static/usage/v9/alert/presenting/trigger/demo.html
@@ -6,8 +6,8 @@
     <title>Alert</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/animations/basic/demo.html
+++ b/static/usage/v9/animations/basic/demo.html
@@ -6,10 +6,10 @@
     <title>Animation</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
 
       const animation = createAnimation()

--- a/static/usage/v9/animations/before-and-after-hooks/demo.html
+++ b/static/usage/v9/animations/before-and-after-hooks/demo.html
@@ -6,11 +6,11 @@
     <title>Animations</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
 
       const card = createAnimation()

--- a/static/usage/v9/animations/chain/demo.html
+++ b/static/usage/v9/animations/chain/demo.html
@@ -6,10 +6,10 @@
     <title>Animation</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
 
       const cardA = createAnimation()

--- a/static/usage/v9/animations/gesture/demo.html
+++ b/static/usage/v9/animations/gesture/demo.html
@@ -6,13 +6,13 @@
     <title>Animation</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
       import {
         createAnimation,
         createGesture,
-      } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
       window.createGesture = createGesture;
 

--- a/static/usage/v9/animations/group/demo.html
+++ b/static/usage/v9/animations/group/demo.html
@@ -6,10 +6,10 @@
     <title>Animation</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
 
       const cardA = createAnimation()

--- a/static/usage/v9/animations/keyframes/demo.html
+++ b/static/usage/v9/animations/keyframes/demo.html
@@ -6,10 +6,10 @@
     <title>Keyframe Animations</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
 
       const animation = createAnimation()
         .addElement(document.querySelector('#card'))

--- a/static/usage/v9/animations/modal-override/demo.html
+++ b/static/usage/v9/animations/modal-override/demo.html
@@ -6,10 +6,10 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
     </script>
   </head>

--- a/static/usage/v9/animations/preference-based/demo.html
+++ b/static/usage/v9/animations/preference-based/demo.html
@@ -6,10 +6,10 @@
     <title>Animation</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
 
       const animation = createAnimation()

--- a/static/usage/v9/app/set-focus/demo.html
+++ b/static/usage/v9/app/set-focus/demo.html
@@ -6,8 +6,8 @@
     <title>App</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/avatar/basic/demo.html
+++ b/static/usage/v9/avatar/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Avatar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/avatar/chip/demo.html
+++ b/static/usage/v9/avatar/chip/demo.html
@@ -6,8 +6,8 @@
     <title>Avatar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/avatar/item/demo.html
+++ b/static/usage/v9/avatar/item/demo.html
@@ -6,8 +6,8 @@
     <title>Avatar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/avatar/theming/css-properties/demo.html
+++ b/static/usage/v9/avatar/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Avatar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-avatar {

--- a/static/usage/v9/back-button/basic/demo.html
+++ b/static/usage/v9/back-button/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Back Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/back-button/custom/demo.html
+++ b/static/usage/v9/back-button/custom/demo.html
@@ -6,8 +6,8 @@
     <title>Back Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/backdrop/basic/demo.html
+++ b/static/usage/v9/backdrop/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Backdrop</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-backdrop {

--- a/static/usage/v9/backdrop/styling/demo.html
+++ b/static/usage/v9/backdrop/styling/demo.html
@@ -6,8 +6,8 @@
     <title>Backdrop</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-backdrop {
         opacity: 0.9;

--- a/static/usage/v9/badge/basic/demo.html
+++ b/static/usage/v9/badge/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Badge</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/badge/inside-tab-bar/demo.html
+++ b/static/usage/v9/badge/inside-tab-bar/demo.html
@@ -6,8 +6,8 @@
     <title>Badge</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-tab-bar {

--- a/static/usage/v9/badge/theming/colors/demo.html
+++ b/static/usage/v9/badge/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Badge</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/badge/theming/css-properties/demo.html
+++ b/static/usage/v9/badge/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Styling the Select</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/breadcrumbs/basic/demo.html
+++ b/static/usage/v9/breadcrumbs/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Breadcrumbs</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/breadcrumbs/collapsing-items/expand-on-click/demo.html
+++ b/static/usage/v9/breadcrumbs/collapsing-items/expand-on-click/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/breadcrumbs/collapsing-items/items-before-after/demo.html
+++ b/static/usage/v9/breadcrumbs/collapsing-items/items-before-after/demo.html
@@ -6,8 +6,8 @@
     <title>Breadcrumbs</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/breadcrumbs/collapsing-items/max-items/demo.html
+++ b/static/usage/v9/breadcrumbs/collapsing-items/max-items/demo.html
@@ -6,8 +6,8 @@
     <title>Breadcrumbs</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/breadcrumbs/collapsing-items/popover-on-click/demo.html
+++ b/static/usage/v9/breadcrumbs/collapsing-items/popover-on-click/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/breadcrumbs/icons/custom-separators/demo.html
+++ b/static/usage/v9/breadcrumbs/icons/custom-separators/demo.html
@@ -6,8 +6,8 @@
     <title>Breadcrumbs</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/breadcrumbs/icons/icons-on-items/demo.html
+++ b/static/usage/v9/breadcrumbs/icons/icons-on-items/demo.html
@@ -6,8 +6,8 @@
     <title>Breadcrumbs</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/breadcrumbs/theming/colors/demo.html
+++ b/static/usage/v9/breadcrumbs/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Breadcrumbs</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/breadcrumbs/theming/css-properties/demo.html
+++ b/static/usage/v9/breadcrumbs/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Breadcrumbs</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-breadcrumb {

--- a/static/usage/v9/button/basic/demo.html
+++ b/static/usage/v9/button/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/button/expand/demo.html
+++ b/static/usage/v9/button/expand/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/button/fill/demo.html
+++ b/static/usage/v9/button/fill/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/button/icons/demo.html
+++ b/static/usage/v9/button/icons/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/button/shape/demo.html
+++ b/static/usage/v9/button/shape/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/button/size/demo.html
+++ b/static/usage/v9/button/size/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/button/text-wrapping/demo.html
+++ b/static/usage/v9/button/text-wrapping/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/button/theming/colors/demo.html
+++ b/static/usage/v9/button/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/button/theming/css-properties/demo.html
+++ b/static/usage/v9/button/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Button</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-button {

--- a/static/usage/v9/buttons/basic/demo.html
+++ b/static/usage/v9/buttons/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Buttons</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/buttons/placement/demo.html
+++ b/static/usage/v9/buttons/placement/demo.html
@@ -6,8 +6,8 @@
     <title>Buttons</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/buttons/types/demo.html
+++ b/static/usage/v9/buttons/types/demo.html
@@ -6,8 +6,8 @@
     <title>Buttons</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/card/basic/demo.html
+++ b/static/usage/v9/card/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Card</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/card/buttons/demo.html
+++ b/static/usage/v9/card/buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Card</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/card/list/demo.html
+++ b/static/usage/v9/card/list/demo.html
@@ -6,8 +6,8 @@
     <title>Card</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/card/media/demo.html
+++ b/static/usage/v9/card/media/demo.html
@@ -6,8 +6,8 @@
     <title>Card</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/card/theming/colors/demo.html
+++ b/static/usage/v9/card/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Card</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/card/theming/css-properties/demo.html
+++ b/static/usage/v9/card/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Card</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/checkbox/alignment/demo.html
+++ b/static/usage/v9/checkbox/alignment/demo.html
@@ -6,8 +6,8 @@
     <title>Checkbox</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
   <body>
     <ion-app>

--- a/static/usage/v9/checkbox/basic/demo.html
+++ b/static/usage/v9/checkbox/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Checkbox</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/checkbox/helper-error/demo.html
+++ b/static/usage/v9/checkbox/helper-error/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/checkbox/indeterminate/demo.html
+++ b/static/usage/v9/checkbox/indeterminate/demo.html
@@ -6,8 +6,8 @@
     <title>Checkbox</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/checkbox/justify/demo.html
+++ b/static/usage/v9/checkbox/justify/demo.html
@@ -6,8 +6,8 @@
     <title>Checkbox</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/checkbox/label-link/demo.html
+++ b/static/usage/v9/checkbox/label-link/demo.html
@@ -6,8 +6,8 @@
     <title>Checkbox</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/checkbox/label-placement/demo.html
+++ b/static/usage/v9/checkbox/label-placement/demo.html
@@ -6,8 +6,8 @@
     <title>Checkbox</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/checkbox/theming/css-properties/demo.html
+++ b/static/usage/v9/checkbox/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Checkbox</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-checkbox {
         --size: 32px;

--- a/static/usage/v9/chip/basic/demo.html
+++ b/static/usage/v9/chip/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Chip</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/chip/slots/demo.html
+++ b/static/usage/v9/chip/slots/demo.html
@@ -6,8 +6,8 @@
     <title>Chip</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/chip/theming/colors/demo.html
+++ b/static/usage/v9/chip/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Chip</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .flex-items {

--- a/static/usage/v9/chip/theming/css-properties/demo.html
+++ b/static/usage/v9/chip/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Chip</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-chip {

--- a/static/usage/v9/common.js
+++ b/static/usage/v9/common.js
@@ -1,7 +1,7 @@
 const linkElement = document.createElement('link');
 
 linkElement.rel = 'stylesheet';
-linkElement.href = 'https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/dark.class.css';
+linkElement.href = 'https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/dark.class.css';
 
 document.head.appendChild(linkElement);
 

--- a/static/usage/v9/config/mode/demo.html
+++ b/static/usage/v9/config/mode/demo.html
@@ -6,8 +6,8 @@
     <title>Ionic Config Mode</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .mode-value {
         margin-top: 16px;

--- a/static/usage/v9/content/basic/demo.html
+++ b/static/usage/v9/content/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/content/fixed/demo.html
+++ b/static/usage/v9/content/fixed/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-button[slot='fixed'] {

--- a/static/usage/v9/content/fullscreen/demo.html
+++ b/static/usage/v9/content/fullscreen/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-toolbar {

--- a/static/usage/v9/content/header-footer/demo.html
+++ b/static/usage/v9/content/header-footer/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/content/scroll-events/demo.html
+++ b/static/usage/v9/content/scroll-events/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/content/scroll-methods/demo.html
+++ b/static/usage/v9/content/scroll-methods/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/content/theming/colors/demo.html
+++ b/static/usage/v9/content/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/content/theming/css-properties/demo.html
+++ b/static/usage/v9/content/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-content {

--- a/static/usage/v9/content/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/content/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-content::part(background) {

--- a/static/usage/v9/content/theming/safe-area/demo.html
+++ b/static/usage/v9/content/theming/safe-area/demo.html
@@ -6,8 +6,8 @@
     <title>Content</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-content {

--- a/static/usage/v9/datetime-button/basic/demo.html
+++ b/static/usage/v9/datetime-button/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-modal {
         --border-radius: 8px;

--- a/static/usage/v9/datetime-button/format-options/demo.html
+++ b/static/usage/v9/datetime-button/format-options/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/datetime/basic/demo.html
+++ b/static/usage/v9/datetime/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/buttons/customizing-button-texts/demo.html
+++ b/static/usage/v9/datetime/buttons/customizing-button-texts/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/buttons/customizing-buttons/demo.html
+++ b/static/usage/v9/datetime/buttons/customizing-buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/buttons/showing-confirmation-buttons/demo.html
+++ b/static/usage/v9/datetime/buttons/showing-confirmation-buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/date-constraints/advanced/demo.html
+++ b/static/usage/v9/datetime/date-constraints/advanced/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/date-constraints/max-min/demo.html
+++ b/static/usage/v9/datetime/date-constraints/max-min/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/date-constraints/values/demo.html
+++ b/static/usage/v9/datetime/date-constraints/values/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/format-options/demo.html
+++ b/static/usage/v9/datetime/format-options/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/highlightedDates/array/demo.html
+++ b/static/usage/v9/datetime/highlightedDates/array/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/highlightedDates/callback/demo.html
+++ b/static/usage/v9/datetime/highlightedDates/callback/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/localization/custom-locale/demo.html
+++ b/static/usage/v9/datetime/localization/custom-locale/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/localization/first-day-of-week/demo.html
+++ b/static/usage/v9/datetime/localization/first-day-of-week/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/localization/hour-cycle/demo.html
+++ b/static/usage/v9/datetime/localization/hour-cycle/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/localization/locale-extension-tags/demo.html
+++ b/static/usage/v9/datetime/localization/locale-extension-tags/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/localization/time-label/demo.html
+++ b/static/usage/v9/datetime/localization/time-label/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/multiple/demo.html
+++ b/static/usage/v9/datetime/multiple/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/presentation/date/demo.html
+++ b/static/usage/v9/datetime/presentation/date/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/presentation/month-and-year/demo.html
+++ b/static/usage/v9/datetime/presentation/month-and-year/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/presentation/time/demo.html
+++ b/static/usage/v9/datetime/presentation/time/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/presentation/wheel/demo.html
+++ b/static/usage/v9/datetime/presentation/wheel/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/show-adjacent-days/demo.html
+++ b/static/usage/v9/datetime/show-adjacent-days/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/styling/calendar-days/demo.html
+++ b/static/usage/v9/datetime/styling/calendar-days/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       /*

--- a/static/usage/v9/datetime/styling/calendar-header/demo.html
+++ b/static/usage/v9/datetime/styling/calendar-header/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       /*

--- a/static/usage/v9/datetime/styling/datetime-header/demo.html
+++ b/static/usage/v9/datetime/styling/datetime-header/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       /*

--- a/static/usage/v9/datetime/styling/global-theming/demo.html
+++ b/static/usage/v9/datetime/styling/global-theming/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       :root,
       .ios body.dark,

--- a/static/usage/v9/datetime/styling/wheel-styling/demo.html
+++ b/static/usage/v9/datetime/styling/wheel-styling/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-datetime {

--- a/static/usage/v9/datetime/title/customizing-title/demo.html
+++ b/static/usage/v9/datetime/title/customizing-title/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/datetime/title/showing-default-title/demo.html
+++ b/static/usage/v9/datetime/title/showing-default-title/demo.html
@@ -6,8 +6,8 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-datetime {
         width: 350px;

--- a/static/usage/v9/fab/basic/demo.html
+++ b/static/usage/v9/fab/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/fab/before-content/demo.html
+++ b/static/usage/v9/fab/before-content/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/fab/button-sizing/demo.html
+++ b/static/usage/v9/fab/button-sizing/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/fab/list-side/demo.html
+++ b/static/usage/v9/fab/list-side/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/fab/positioning/demo.html
+++ b/static/usage/v9/fab/positioning/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/fab/safe-area/demo.html
+++ b/static/usage/v9/fab/safe-area/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-fab {

--- a/static/usage/v9/fab/theming/colors/demo.html
+++ b/static/usage/v9/fab/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/fab/theming/css-custom-properties/demo.html
+++ b/static/usage/v9/fab/theming/css-custom-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-fab-button {

--- a/static/usage/v9/fab/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/fab/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Fab</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-fab-button::part(native) {

--- a/static/usage/v9/footer/basic/demo.html
+++ b/static/usage/v9/footer/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Footer</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/footer/custom-scroll-target/demo.html
+++ b/static/usage/v9/footer/custom-scroll-target/demo.html
@@ -6,8 +6,8 @@
     <title>Footer</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .ion-content-scroll-host {

--- a/static/usage/v9/footer/fade/demo.html
+++ b/static/usage/v9/footer/fade/demo.html
@@ -6,8 +6,8 @@
     <title>Footer</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/footer/no-border/demo.html
+++ b/static/usage/v9/footer/no-border/demo.html
@@ -6,8 +6,8 @@
     <title>Footer</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/footer/translucent/demo.html
+++ b/static/usage/v9/footer/translucent/demo.html
@@ -6,8 +6,8 @@
     <title>Footer</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/gestures/basic/demo.html
+++ b/static/usage/v9/gestures/basic/demo.html
@@ -6,10 +6,10 @@
     <title>Gesture</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createGesture } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createGesture } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createGesture = createGesture;
 
       const p = document.querySelector('#debug');

--- a/static/usage/v9/gestures/double-click/demo.html
+++ b/static/usage/v9/gestures/double-click/demo.html
@@ -6,11 +6,11 @@
     <title>Double-Click Gestures</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <script type="module">
-      import { createGesture } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createGesture } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createGesture = createGesture;
 
       const DOUBLE_CLICK_THRESHOLD = 500;

--- a/static/usage/v9/grid/basic/demo.html
+++ b/static/usage/v9/grid/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/customizing/column-number/demo.html
+++ b/static/usage/v9/grid/customizing/column-number/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/customizing/padding/demo.html
+++ b/static/usage/v9/grid/customizing/padding/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/customizing/width/demo.html
+++ b/static/usage/v9/grid/customizing/width/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/fixed/demo.html
+++ b/static/usage/v9/grid/fixed/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/horizontal-alignment/demo.html
+++ b/static/usage/v9/grid/horizontal-alignment/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/offset-responsive/demo.html
+++ b/static/usage/v9/grid/offset-responsive/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/offset/demo.html
+++ b/static/usage/v9/grid/offset/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/push-pull-responsive/demo.html
+++ b/static/usage/v9/grid/push-pull-responsive/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/push-pull/demo.html
+++ b/static/usage/v9/grid/push-pull/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/size-auto/demo.html
+++ b/static/usage/v9/grid/size-auto/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/size-responsive/demo.html
+++ b/static/usage/v9/grid/size-responsive/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/size/demo.html
+++ b/static/usage/v9/grid/size/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/grid/vertical-alignment/demo.html
+++ b/static/usage/v9/grid/vertical-alignment/demo.html
@@ -6,8 +6,8 @@
     <title>Grid</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/header/basic/demo.html
+++ b/static/usage/v9/header/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/header/condense/demo.html
+++ b/static/usage/v9/header/condense/demo.html
@@ -6,8 +6,8 @@
     <title>Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/header/custom-scroll-target/demo.html
+++ b/static/usage/v9/header/custom-scroll-target/demo.html
@@ -6,8 +6,8 @@
     <title>Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .ion-content-scroll-host {

--- a/static/usage/v9/header/fade/demo.html
+++ b/static/usage/v9/header/fade/demo.html
@@ -6,8 +6,8 @@
     <title>Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/header/no-border/demo.html
+++ b/static/usage/v9/header/no-border/demo.html
@@ -6,8 +6,8 @@
     <title>Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/header/translucent/demo.html
+++ b/static/usage/v9/header/translucent/demo.html
@@ -6,8 +6,8 @@
     <title>Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/icon/basic/demo.html
+++ b/static/usage/v9/icon/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Icon</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/icon/custom-svgs/demo.html
+++ b/static/usage/v9/icon/custom-svgs/demo.html
@@ -6,8 +6,8 @@
     <title>Custom SVGs</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/icon/font-icons/demo.html
+++ b/static/usage/v9/icon/font-icons/demo.html
@@ -6,8 +6,8 @@
     <title>Font Icons</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />

--- a/static/usage/v9/img/basic/demo.html
+++ b/static/usage/v9/img/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Image</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-img {

--- a/static/usage/v9/infinite-scroll/basic/demo.html
+++ b/static/usage/v9/infinite-scroll/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Infinite Scroll</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/infinite-scroll/custom-infinite-scroll-content/demo.html
+++ b/static/usage/v9/infinite-scroll/custom-infinite-scroll-content/demo.html
@@ -6,8 +6,8 @@
     <title>Infinite Scroll</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       svg {
         width: 20px;

--- a/static/usage/v9/infinite-scroll/infinite-scroll-content/demo.html
+++ b/static/usage/v9/infinite-scroll/infinite-scroll-content/demo.html
@@ -6,8 +6,8 @@
     <title>Infinite Scroll</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/input-otp/basic/demo.html
+++ b/static/usage/v9/input-otp/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Input OTP</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/fill/demo.html
+++ b/static/usage/v9/input-otp/fill/demo.html
@@ -6,8 +6,8 @@
     <title>Input OTP</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/pattern/demo.html
+++ b/static/usage/v9/input-otp/pattern/demo.html
@@ -6,8 +6,8 @@
     <title>Input OTP</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/separators/demo.html
+++ b/static/usage/v9/input-otp/separators/demo.html
@@ -6,8 +6,8 @@
     <title>Input OTP</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/shape/demo.html
+++ b/static/usage/v9/input-otp/shape/demo.html
@@ -6,8 +6,8 @@
     <title>Input OTP</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/size/demo.html
+++ b/static/usage/v9/input-otp/size/demo.html
@@ -6,8 +6,8 @@
     <title>Input OTP</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/states/demo.html
+++ b/static/usage/v9/input-otp/states/demo.html
@@ -6,8 +6,8 @@
     <title>Input OTP</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/theming/colors/demo.html
+++ b/static/usage/v9/input-otp/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Badge</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/theming/css-properties/demo.html
+++ b/static/usage/v9/input-otp/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Styling the Select</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-otp/type/demo.html
+++ b/static/usage/v9/input-otp/type/demo.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
 
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input-password-toggle/basic/demo.html
+++ b/static/usage/v9/input-password-toggle/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-input.custom-input {

--- a/static/usage/v9/input/basic/demo.html
+++ b/static/usage/v9/input/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/input/clear/demo.html
+++ b/static/usage/v9/input/clear/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/input/counter-alignment/demo.html
+++ b/static/usage/v9/input/counter-alignment/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/input/counter/demo.html
+++ b/static/usage/v9/input/counter/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input/fill/demo.html
+++ b/static/usage/v9/input/fill/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input/filtering/demo.html
+++ b/static/usage/v9/input/filtering/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/input/helper-error/demo.html
+++ b/static/usage/v9/input/helper-error/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .container ion-input {
         width: 300px;

--- a/static/usage/v9/input/label-placement/demo.html
+++ b/static/usage/v9/input/label-placement/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/input/label-slot/demo.html
+++ b/static/usage/v9/input/label-slot/demo.html
@@ -6,8 +6,8 @@
     <title>input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/input/mask/demo.html
+++ b/static/usage/v9/input/mask/demo.html
@@ -6,13 +6,13 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
     <script type="module">
       import { Maskito, maskitoTransform } from 'https://cdn.jsdelivr.net/npm/@maskito/core/index.esm.js';
       window.Maskito = Maskito;
       window.maskitoTransform = maskitoTransform;
     </script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/input/no-visible-label/demo.html
+++ b/static/usage/v9/input/no-visible-label/demo.html
@@ -6,8 +6,8 @@
     <title>input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/input/set-focus/demo.html
+++ b/static/usage/v9/input/set-focus/demo.html
@@ -6,8 +6,8 @@
     <title>setFocus</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/input/start-end-slots/demo.html
+++ b/static/usage/v9/input/start-end-slots/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/input/theming/colors/demo.html
+++ b/static/usage/v9/input/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input/theming/css-properties/demo.html
+++ b/static/usage/v9/input/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/input/types/demo.html
+++ b/static/usage/v9/input/types/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/item-divider/basic/demo.html
+++ b/static/usage/v9/item-divider/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Item Divider</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item-divider/theming/colors/demo.html
+++ b/static/usage/v9/item-divider/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Item Divider</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item-divider/theming/css-properties/demo.html
+++ b/static/usage/v9/item-divider/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Item Divider</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-item-divider {

--- a/static/usage/v9/item-group/basic/demo.html
+++ b/static/usage/v9/item-group/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Item Group</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item-group/sliding-items/demo.html
+++ b/static/usage/v9/item-group/sliding-items/demo.html
@@ -6,8 +6,8 @@
     <title>Item Group</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item-sliding/basic/demo.html
+++ b/static/usage/v9/item-sliding/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Item Sliding</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item-sliding/expandable/demo.html
+++ b/static/usage/v9/item-sliding/expandable/demo.html
@@ -6,8 +6,8 @@
     <title>Item Sliding</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item-sliding/icons/demo.html
+++ b/static/usage/v9/item-sliding/icons/demo.html
@@ -6,8 +6,8 @@
     <title>Item Sliding</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/basic/demo.html
+++ b/static/usage/v9/item/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/buttons/demo.html
+++ b/static/usage/v9/item/buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/clickable/demo.html
+++ b/static/usage/v9/item/clickable/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/content-types/actions/demo.html
+++ b/static/usage/v9/item/content-types/actions/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/item/content-types/controls/demo.html
+++ b/static/usage/v9/item/content-types/controls/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/item/content-types/metadata/demo.html
+++ b/static/usage/v9/item/content-types/metadata/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .unread-indicator {
         background: var(--ion-color-primary);

--- a/static/usage/v9/item/content-types/supporting-visuals/demo.html
+++ b/static/usage/v9/item/content-types/supporting-visuals/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/item/content-types/text/demo.html
+++ b/static/usage/v9/item/content-types/text/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-note {
         display: block;

--- a/static/usage/v9/item/detail-arrows/demo.html
+++ b/static/usage/v9/item/detail-arrows/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/inputs/demo.html
+++ b/static/usage/v9/item/inputs/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/lines/demo.html
+++ b/static/usage/v9/item/lines/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/media/demo.html
+++ b/static/usage/v9/item/media/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/theming/colors/demo.html
+++ b/static/usage/v9/item/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/theming/css-properties/demo.html
+++ b/static/usage/v9/item/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/item/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/item/theming/input-highlight/demo.html
+++ b/static/usage/v9/item/theming/input-highlight/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/keyboard/enterkeyhint/demo.html
+++ b/static/usage/v9/keyboard/enterkeyhint/demo.html
@@ -6,8 +6,8 @@
     <title>Keyboard</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/keyboard/inputmode/demo.html
+++ b/static/usage/v9/keyboard/inputmode/demo.html
@@ -6,8 +6,8 @@
     <title>Keyboard</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/label/basic/demo.html
+++ b/static/usage/v9/label/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Label</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/label/input/demo.html
+++ b/static/usage/v9/label/input/demo.html
@@ -6,8 +6,8 @@
     <title>Label</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/label/item/demo.html
+++ b/static/usage/v9/label/item/demo.html
@@ -6,8 +6,8 @@
     <title>Label</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/label/theming/colors/demo.html
+++ b/static/usage/v9/label/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Label</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-label {

--- a/static/usage/v9/layout/dynamic-font-scaling/demo.html
+++ b/static/usage/v9/layout/dynamic-font-scaling/demo.html
@@ -6,8 +6,8 @@
     <title>Dynamic Font Scaling</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/list-header/basic/demo.html
+++ b/static/usage/v9/list-header/basic/demo.html
@@ -6,8 +6,8 @@
     <title>List Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/list-header/buttons/demo.html
+++ b/static/usage/v9/list-header/buttons/demo.html
@@ -6,8 +6,8 @@
     <title>List Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/list-header/lines/demo.html
+++ b/static/usage/v9/list-header/lines/demo.html
@@ -6,8 +6,8 @@
     <title>List Header</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/list-header/theming/colors/demo.html
+++ b/static/usage/v9/list-header/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>List Header</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/list-header/theming/css-properties/demo.html
+++ b/static/usage/v9/list-header/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>List Header</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list-header {

--- a/static/usage/v9/list/basic/demo.html
+++ b/static/usage/v9/list/basic/demo.html
@@ -6,8 +6,8 @@
     <title>List</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/list/inset/demo.html
+++ b/static/usage/v9/list/inset/demo.html
@@ -6,8 +6,8 @@
     <title>List</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/list/lines/demo.html
+++ b/static/usage/v9/list/lines/demo.html
@@ -6,8 +6,8 @@
     <title>List</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/loading/controller/demo.html
+++ b/static/usage/v9/loading/controller/demo.html
@@ -6,10 +6,10 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { loadingController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { loadingController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.loadingController = loadingController;
     </script>
   </head>

--- a/static/usage/v9/loading/inline/demo.html
+++ b/static/usage/v9/loading/inline/demo.html
@@ -6,8 +6,8 @@
     <title>Loading</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/loading/spinners/demo.html
+++ b/static/usage/v9/loading/spinners/demo.html
@@ -6,8 +6,8 @@
     <title>Loading</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/loading/theming/demo.html
+++ b/static/usage/v9/loading/theming/demo.html
@@ -6,10 +6,10 @@
     <title>Datetime</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { loadingController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { loadingController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.loadingController = loadingController;
     </script>
     <style>

--- a/static/usage/v9/menu/basic/demo.html
+++ b/static/usage/v9/menu/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Menu</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/menu/multiple/demo.html
+++ b/static/usage/v9/menu/multiple/demo.html
@@ -6,11 +6,11 @@
     <title>Menu</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <script type="module">
-      import { menuController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { menuController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.menuController = menuController;
     </script>
   </head>

--- a/static/usage/v9/menu/sides/demo.html
+++ b/static/usage/v9/menu/sides/demo.html
@@ -6,8 +6,8 @@
     <title>Menu</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/menu/theming/demo.html
+++ b/static/usage/v9/menu/theming/demo.html
@@ -6,8 +6,8 @@
     <title>Menu</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-menu::part(backdrop) {
         background-color: rgba(255, 0, 255, 0.5);

--- a/static/usage/v9/menu/toggle/demo.html
+++ b/static/usage/v9/menu/toggle/demo.html
@@ -6,8 +6,8 @@
     <title>Menu - Toggle</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/menu/type/demo.html
+++ b/static/usage/v9/menu/type/demo.html
@@ -6,8 +6,8 @@
     <title>Menu - Type</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/can-dismiss/boolean/demo.html
+++ b/static/usage/v9/modal/can-dismiss/boolean/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Can Dismiss</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/can-dismiss/child-state/demo.html
+++ b/static/usage/v9/modal/can-dismiss/child-state/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Can Dismiss</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/can-dismiss/function/demo.html
+++ b/static/usage/v9/modal/can-dismiss/function/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Can Dismiss</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/can-dismiss/prevent-swipe-to-close/demo.html
+++ b/static/usage/v9/modal/can-dismiss/prevent-swipe-to-close/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Can Dismiss</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/card/basic/demo.html
+++ b/static/usage/v9/modal/card/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Card</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/controller/demo.html
+++ b/static/usage/v9/modal/controller/demo.html
@@ -6,10 +6,10 @@
     <title>Modal | Controller</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { modalController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.modalController = modalController;
     </script>
   </head>

--- a/static/usage/v9/modal/custom-dialogs/demo.html
+++ b/static/usage/v9/modal/custom-dialogs/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Custom Dialog</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-modal {
         --width: fit-content;

--- a/static/usage/v9/modal/drag-move-event/demo.html
+++ b/static/usage/v9/modal/drag-move-event/demo.html
@@ -6,8 +6,8 @@
     <title>Modal</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/drag-start-end-events/demo.html
+++ b/static/usage/v9/modal/drag-start-end-events/demo.html
@@ -6,8 +6,8 @@
     <title>Modal</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/inline/basic/demo.html
+++ b/static/usage/v9/modal/inline/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Inline</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/inline/is-open/demo.html
+++ b/static/usage/v9/modal/inline/is-open/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Inline</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/performance/mount/demo.html
+++ b/static/usage/v9/modal/performance/mount/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Performance</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/sheet/auto-height/demo.html
+++ b/static/usage/v9/modal/sheet/auto-height/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .block {
         width: 100%;

--- a/static/usage/v9/modal/sheet/background-content/demo.html
+++ b/static/usage/v9/modal/sheet/background-content/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .counter__section {
         display: flex;

--- a/static/usage/v9/modal/sheet/basic/demo.html
+++ b/static/usage/v9/modal/sheet/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/sheet/expand-to-scroll/demo.html
+++ b/static/usage/v9/modal/sheet/expand-to-scroll/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/sheet/handle-behavior/demo.html
+++ b/static/usage/v9/modal/sheet/handle-behavior/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/modal/styling/animations/demo.html
+++ b/static/usage/v9/modal/styling/animations/demo.html
@@ -6,10 +6,10 @@
     <title>Modal | Animations</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <script type="module">
-      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { createAnimation } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.createAnimation = createAnimation;
     </script>
   </head>

--- a/static/usage/v9/modal/styling/theming/demo.html
+++ b/static/usage/v9/modal/styling/theming/demo.html
@@ -6,8 +6,8 @@
     <title>Modal | Theming</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-modal {
         --height: 50%;

--- a/static/usage/v9/nav/modal-navigation/demo.html
+++ b/static/usage/v9/nav/modal-navigation/demo.html
@@ -7,8 +7,8 @@
     <title>Nav | Modal Navigation</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/nav/nav-link/demo.html
+++ b/static/usage/v9/nav/nav-link/demo.html
@@ -7,8 +7,8 @@
     <title>Nav | NavLink</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/navigation/demo.html
+++ b/static/usage/v9/navigation/demo.html
@@ -6,8 +6,8 @@
     <title>Navigation</title>
     <link rel="stylesheet" href="../common.css" />
     <script src="../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/note/basic/demo.html
+++ b/static/usage/v9/note/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Note</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/note/item/demo.html
+++ b/static/usage/v9/note/item/demo.html
@@ -6,8 +6,8 @@
     <title>Note</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/note/theming/colors/demo.html
+++ b/static/usage/v9/note/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Note</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .flex-items {

--- a/static/usage/v9/note/theming/css-properties/demo.html
+++ b/static/usage/v9/note/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Note</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-note {

--- a/static/usage/v9/picker/basic/demo.html
+++ b/static/usage/v9/picker/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Picker | Basic</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/picker/modal/demo.html
+++ b/static/usage/v9/picker/modal/demo.html
@@ -6,8 +6,8 @@
     <title>Picker | Basic</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-modal {
         --height: auto;

--- a/static/usage/v9/picker/prefix-suffix/demo.html
+++ b/static/usage/v9/picker/prefix-suffix/demo.html
@@ -6,8 +6,8 @@
     <title>Picker | Slot</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/picker/theming/css-properties/demo.html
+++ b/static/usage/v9/picker/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Picker | CSS Variables</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-picker {

--- a/static/usage/v9/popover/customization/positioning/demo.html
+++ b/static/usage/v9/popover/customization/positioning/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/popover/customization/sizing/demo.html
+++ b/static/usage/v9/popover/customization/sizing/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/popover/customization/styling/demo.html
+++ b/static/usage/v9/popover/customization/styling/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-popover {

--- a/static/usage/v9/popover/nested/demo.html
+++ b/static/usage/v9/popover/nested/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/popover/performance/mount/demo.html
+++ b/static/usage/v9/popover/performance/mount/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/popover/presenting/controller/demo.html
+++ b/static/usage/v9/popover/presenting/controller/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/popover/presenting/inline-isopen/demo.html
+++ b/static/usage/v9/popover/presenting/inline-isopen/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/popover/presenting/inline-trigger/demo.html
+++ b/static/usage/v9/popover/presenting/inline-trigger/demo.html
@@ -6,8 +6,8 @@
     <title>Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/progress-bar/buffer/demo.html
+++ b/static/usage/v9/progress-bar/buffer/demo.html
@@ -6,8 +6,8 @@
     <title>Progress Bar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/progress-bar/determinate/demo.html
+++ b/static/usage/v9/progress-bar/determinate/demo.html
@@ -6,8 +6,8 @@
     <title>Progress Bar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/progress-bar/indeterminate/demo.html
+++ b/static/usage/v9/progress-bar/indeterminate/demo.html
@@ -6,8 +6,8 @@
     <title>Progress Bar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/progress-bar/theming/colors/demo.html
+++ b/static/usage/v9/progress-bar/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Progress Bar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/progress-bar/theming/css-properties/demo.html
+++ b/static/usage/v9/progress-bar/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Progress Bar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/progress-bar/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/progress-bar/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Progress Bar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/radio/alignment/demo.html
+++ b/static/usage/v9/radio/alignment/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/radio/basic/demo.html
+++ b/static/usage/v9/radio/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/radio/empty-selection/demo.html
+++ b/static/usage/v9/radio/empty-selection/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/radio/helper-error/demo.html
+++ b/static/usage/v9/radio/helper-error/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-radio-group {

--- a/static/usage/v9/radio/justify/demo.html
+++ b/static/usage/v9/radio/justify/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/radio/label-placement/demo.html
+++ b/static/usage/v9/radio/label-placement/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/radio/label-wrap/demo.html
+++ b/static/usage/v9/radio/label-wrap/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/radio/theming/colors/demo.html
+++ b/static/usage/v9/radio/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/radio/theming/css-properties/demo.html
+++ b/static/usage/v9/radio/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-radio {

--- a/static/usage/v9/radio/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/radio/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-radio::part(container) {

--- a/static/usage/v9/radio/using-comparewith/demo.html
+++ b/static/usage/v9/radio/using-comparewith/demo.html
@@ -6,8 +6,8 @@
     <title>Radio</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/range/basic/demo.html
+++ b/static/usage/v9/range/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         max-width: 320px;

--- a/static/usage/v9/range/dual-knobs/demo.html
+++ b/static/usage/v9/range/dual-knobs/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         max-width: 320px;

--- a/static/usage/v9/range/ion-change-event/demo.html
+++ b/static/usage/v9/range/ion-change-event/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .demo {
         max-width: 320px;

--- a/static/usage/v9/range/ion-knob-move-event/demo.html
+++ b/static/usage/v9/range/ion-knob-move-event/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .demo {
         max-width: 320px;

--- a/static/usage/v9/range/label-slot/demo.html
+++ b/static/usage/v9/range/label-slot/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         max-width: 400px;

--- a/static/usage/v9/range/labels/demo.html
+++ b/static/usage/v9/range/labels/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .wrapper {
         width: calc(100% - 100px);

--- a/static/usage/v9/range/no-visible-label/demo.html
+++ b/static/usage/v9/range/no-visible-label/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         max-width: 320px;

--- a/static/usage/v9/range/pins/demo.html
+++ b/static/usage/v9/range/pins/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         max-width: 320px;

--- a/static/usage/v9/range/slots/demo.html
+++ b/static/usage/v9/range/slots/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         max-width: 320px;

--- a/static/usage/v9/range/snapping-ticks/demo.html
+++ b/static/usage/v9/range/snapping-ticks/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         max-width: 320px;

--- a/static/usage/v9/range/theming/css-properties/demo.html
+++ b/static/usage/v9/range/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-range {
         --bar-background: #a2d2ff;

--- a/static/usage/v9/range/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/range/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Range</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .container {
         flex-direction: column;

--- a/static/usage/v9/refresher/advanced/demo.html
+++ b/static/usage/v9/refresher/advanced/demo.html
@@ -6,8 +6,8 @@
     <title>Refresher</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-item {

--- a/static/usage/v9/refresher/basic/demo.html
+++ b/static/usage/v9/refresher/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Refresher</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/refresher/custom-content/demo.html
+++ b/static/usage/v9/refresher/custom-content/demo.html
@@ -6,8 +6,8 @@
     <title>Refresher</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/refresher/custom-scroll-target/demo.html
+++ b/static/usage/v9/refresher/custom-scroll-target/demo.html
@@ -6,8 +6,8 @@
     <title>Refresher</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .ion-content-scroll-host {

--- a/static/usage/v9/refresher/pull-properties/demo.html
+++ b/static/usage/v9/refresher/pull-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Refresher</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/refresher/pull-start-end-events/demo.html
+++ b/static/usage/v9/refresher/pull-start-end-events/demo.html
@@ -6,8 +6,8 @@
     <title>Refresher</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/reorder/basic/demo.html
+++ b/static/usage/v9/reorder/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/reorder/custom-icon/demo.html
+++ b/static/usage/v9/reorder/custom-icon/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/reorder/custom-scroll-target/demo.html
+++ b/static/usage/v9/reorder/custom-scroll-target/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/reorder/reorder-move-event/demo.html
+++ b/static/usage/v9/reorder/reorder-move-event/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/reorder/reorder-start-end-events/demo.html
+++ b/static/usage/v9/reorder/reorder-start-end-events/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/reorder/toggling-disabled/demo.html
+++ b/static/usage/v9/reorder/toggling-disabled/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/reorder/updating-data/demo.html
+++ b/static/usage/v9/reorder/updating-data/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/reorder/wrapper/demo.html
+++ b/static/usage/v9/reorder/wrapper/demo.html
@@ -6,8 +6,8 @@
     <title>Reorder</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/ripple-effect/basic/demo.html
+++ b/static/usage/v9/ripple-effect/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Ripple Effect</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .wrapper {

--- a/static/usage/v9/ripple-effect/customizing/demo.html
+++ b/static/usage/v9/ripple-effect/customizing/demo.html
@@ -6,8 +6,8 @@
     <title>Ripple Effect</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .wrapper {

--- a/static/usage/v9/ripple-effect/type/demo.html
+++ b/static/usage/v9/ripple-effect/type/demo.html
@@ -6,8 +6,8 @@
     <title>Ripple Effect</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .wrapper {

--- a/static/usage/v9/router/basic/demo.html
+++ b/static/usage/v9/router/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Router</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/router/nav-within-page/demo.html
+++ b/static/usage/v9/router/nav-within-page/demo.html
@@ -6,14 +6,8 @@
     <title>Router | ion-nav within a Routed Page</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script
-      type="module"
-      src="https://cdn.jsdelivr.net/npm/@ionic/core@9.8.14-dev.11784216165.1ecbf364/dist/ionic/ionic.esm.js"
-    ></script>
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@ionic/core@9.8.14-dev.11784216165.1ecbf364/css/ionic.bundle.css"
-    />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/router/nav-within-page/demo.html
+++ b/static/usage/v9/router/nav-within-page/demo.html
@@ -8,11 +8,11 @@
     <script src="../../common.js"></script>
     <script
       type="module"
-      src="https://cdn.jsdelivr.net/npm/@ionic/core@8.8.14-dev.11784216165.1ecbf364/dist/ionic/ionic.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@ionic/core@9.8.14-dev.11784216165.1ecbf364/dist/ionic/ionic.esm.js"
     ></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@ionic/core@8.8.14-dev.11784216165.1ecbf364/css/ionic.bundle.css"
+      href="https://cdn.jsdelivr.net/npm/@ionic/core@9.8.14-dev.11784216165.1ecbf364/css/ionic.bundle.css"
     />
   </head>
 

--- a/static/usage/v9/searchbar/basic/demo.html
+++ b/static/usage/v9/searchbar/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Searchbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/searchbar/cancel-button/demo.html
+++ b/static/usage/v9/searchbar/cancel-button/demo.html
@@ -6,8 +6,8 @@
     <title>Searchbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/searchbar/clear-button/demo.html
+++ b/static/usage/v9/searchbar/clear-button/demo.html
@@ -6,8 +6,8 @@
     <title>Searchbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/searchbar/debounce/demo.html
+++ b/static/usage/v9/searchbar/debounce/demo.html
@@ -6,8 +6,8 @@
     <title>Searchbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/searchbar/search-icon/demo.html
+++ b/static/usage/v9/searchbar/search-icon/demo.html
@@ -6,8 +6,8 @@
     <title>Searchbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/searchbar/theming/colors/demo.html
+++ b/static/usage/v9/searchbar/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Searchbar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/searchbar/theming/css-properties/demo.html
+++ b/static/usage/v9/searchbar/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Searchbar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment-button/basic/demo.html
+++ b/static/usage/v9/segment-button/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Segment Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment-button/layout/demo.html
+++ b/static/usage/v9/segment-button/layout/demo.html
@@ -6,8 +6,8 @@
     <title>Segment Button</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment-button/theming/css-properties/demo.html
+++ b/static/usage/v9/segment-button/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Segment Button</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment-button/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/segment-button/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Segment Button</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment/basic/demo.html
+++ b/static/usage/v9/segment/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Segment</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment/scrollable/demo.html
+++ b/static/usage/v9/segment/scrollable/demo.html
@@ -6,8 +6,8 @@
     <title>Segment</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment/swipeable/demo.html
+++ b/static/usage/v9/segment/swipeable/demo.html
@@ -6,8 +6,8 @@
     <title>Segment - Swipeable</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-segment-view {

--- a/static/usage/v9/segment/theming/colors/demo.html
+++ b/static/usage/v9/segment/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Segment</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/segment/theming/css-properties/demo.html
+++ b/static/usage/v9/segment/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Note</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/select/basic/multiple-selection/demo.html
+++ b/static/usage/v9/select/basic/multiple-selection/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Multiple Selection</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/basic/responding-to-interaction/demo.html
+++ b/static/usage/v9/select/basic/responding-to-interaction/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Responding to Interaction</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/basic/single-selection/demo.html
+++ b/static/usage/v9/select/basic/single-selection/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Single Selection</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/customization/button-text/demo.html
+++ b/static/usage/v9/select/customization/button-text/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Button Text</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/customization/custom-toggle-icons/demo.html
+++ b/static/usage/v9/select/customization/custom-toggle-icons/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Custom Toggle Icons</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/customization/icon-flip-behavior/demo.html
+++ b/static/usage/v9/select/customization/icon-flip-behavior/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Icon Flip Behavior</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-select.always-flip::part(icon) {

--- a/static/usage/v9/select/customization/interface-options/demo.html
+++ b/static/usage/v9/select/customization/interface-options/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Interface Options</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container > ion-list {

--- a/static/usage/v9/select/customization/styling-select/demo.html
+++ b/static/usage/v9/select/customization/styling-select/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Styling the Select</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-select {

--- a/static/usage/v9/select/fill/demo.html
+++ b/static/usage/v9/select/fill/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/select/helper-error/demo.html
+++ b/static/usage/v9/select/helper-error/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/interfaces/action-sheet/demo.html
+++ b/static/usage/v9/select/interfaces/action-sheet/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Action Sheet</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/interfaces/modal/demo.html
+++ b/static/usage/v9/select/interfaces/modal/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Modal</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/interfaces/popover/demo.html
+++ b/static/usage/v9/select/interfaces/popover/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Popover</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/justify/demo.html
+++ b/static/usage/v9/select/justify/demo.html
@@ -6,8 +6,8 @@
     <title>select</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/select/label-placement/demo.html
+++ b/static/usage/v9/select/label-placement/demo.html
@@ -6,8 +6,8 @@
     <title>select</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/select/label-slot/demo.html
+++ b/static/usage/v9/select/label-slot/demo.html
@@ -6,8 +6,8 @@
     <title>select</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/no-visible-label/demo.html
+++ b/static/usage/v9/select/no-visible-label/demo.html
@@ -6,8 +6,8 @@
     <title>select</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/objects-as-values/multiple-selection/demo.html
+++ b/static/usage/v9/select/objects-as-values/multiple-selection/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Object Values and Multiple Selection</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/objects-as-values/using-comparewith/demo.html
+++ b/static/usage/v9/select/objects-as-values/using-comparewith/demo.html
@@ -6,8 +6,8 @@
     <title>Select - Using compareWith</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/select/rich-content-options/demo.html
+++ b/static/usage/v9/select/rich-content-options/demo.html
@@ -17,8 +17,8 @@
         },
       };
     </script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container > ion-list {

--- a/static/usage/v9/select/start-end-slots/demo.html
+++ b/static/usage/v9/select/start-end-slots/demo.html
@@ -6,8 +6,8 @@
     <title>Select</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/select/typeahead/demo.html
+++ b/static/usage/v9/select/typeahead/demo.html
@@ -6,8 +6,8 @@
     <title>Select</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/skeleton-text/basic/demo.html
+++ b/static/usage/v9/skeleton-text/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/skeleton-text/theming/css-properties/demo.html
+++ b/static/usage/v9/skeleton-text/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Accordion</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/spinner/basic/demo.html
+++ b/static/usage/v9/spinner/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Spinner</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/spinner/theming/colors/demo.html
+++ b/static/usage/v9/spinner/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Spinner</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/spinner/theming/css-properties/demo.html
+++ b/static/usage/v9/spinner/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Spinner</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-spinner {

--- a/static/usage/v9/spinner/theming/resizing/demo.html
+++ b/static/usage/v9/spinner/theming/resizing/demo.html
@@ -6,8 +6,8 @@
     <title>Spinner</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-spinner {

--- a/static/usage/v9/split-pane/basic/demo.html
+++ b/static/usage/v9/split-pane/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Spinner</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/split-pane/theming/css-properties/demo.html
+++ b/static/usage/v9/split-pane/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Spinner</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       ion-split-pane {
         --side-width: 350px;

--- a/static/usage/v9/tabs/basic/demo.html
+++ b/static/usage/v9/tabs/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Tabs</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .example-content {
         display: flex;

--- a/static/usage/v9/tabs/router/demo.html
+++ b/static/usage/v9/tabs/router/demo.html
@@ -6,8 +6,8 @@
     <title>Tabs</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .example-content {
         display: flex;

--- a/static/usage/v9/tabs/select-method/demo.html
+++ b/static/usage/v9/tabs/select-method/demo.html
@@ -6,8 +6,8 @@
     <title>Tabs</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .example-content {
         display: flex;

--- a/static/usage/v9/text/basic/demo.html
+++ b/static/usage/v9/text/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Text</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/textarea/autogrow/demo.html
+++ b/static/usage/v9/textarea/autogrow/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea - Autogrow</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/textarea/basic/demo.html
+++ b/static/usage/v9/textarea/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea - Basic Usage</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/textarea/clear-on-edit/demo.html
+++ b/static/usage/v9/textarea/clear-on-edit/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea - Clear on Edit</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/textarea/counter/demo.html
+++ b/static/usage/v9/textarea/counter/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/textarea/fill/demo.html
+++ b/static/usage/v9/textarea/fill/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/textarea/helper-error/demo.html
+++ b/static/usage/v9/textarea/helper-error/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .container ion-textarea {
         width: 300px;

--- a/static/usage/v9/textarea/label-placement/demo.html
+++ b/static/usage/v9/textarea/label-placement/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/textarea/label-slot/demo.html
+++ b/static/usage/v9/textarea/label-slot/demo.html
@@ -6,8 +6,8 @@
     <title>textarea</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/textarea/no-visible-label/demo.html
+++ b/static/usage/v9/textarea/no-visible-label/demo.html
@@ -6,8 +6,8 @@
     <title>textarea</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/textarea/start-end-slots/demo.html
+++ b/static/usage/v9/textarea/start-end-slots/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/textarea/theming/demo.html
+++ b/static/usage/v9/textarea/theming/demo.html
@@ -6,8 +6,8 @@
     <title>Textarea - Theming</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
     <style>
       .container {
         padding: 0 40px;

--- a/static/usage/v9/theming/always-dark-mode/demo.html
+++ b/static/usage/v9/theming/always-dark-mode/demo.html
@@ -6,9 +6,9 @@
     <title>Theming</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/dark.always.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/dark.always.css" />
   </head>
 
   <body>

--- a/static/usage/v9/theming/always-high-contrast-mode/demo.html
+++ b/static/usage/v9/theming/always-high-contrast-mode/demo.html
@@ -6,9 +6,9 @@
     <title>Theming</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/high-contrast.always.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/high-contrast.always.css" />
   </head>
 
   <body>

--- a/static/usage/v9/theming/class-dark-mode/demo.html
+++ b/static/usage/v9/theming/class-dark-mode/demo.html
@@ -6,9 +6,9 @@
     <title>Theming</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/dark.class.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/dark.class.css" />
   </head>
 
   <body>

--- a/static/usage/v9/theming/class-high-contrast-mode/demo.html
+++ b/static/usage/v9/theming/class-high-contrast-mode/demo.html
@@ -6,13 +6,13 @@
     <title>Theming</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/dark.class.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/high-contrast.class.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/dark.class.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/high-contrast.class.css" />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/high-contrast-dark.class.css"
+      href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/high-contrast-dark.class.css"
     />
   </head>
 

--- a/static/usage/v9/theming/system-dark-mode/demo.html
+++ b/static/usage/v9/theming/system-dark-mode/demo.html
@@ -6,9 +6,9 @@
     <title>Theming</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/dark.system.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/dark.system.css" />
   </head>
 
   <body>

--- a/static/usage/v9/theming/system-high-contrast-mode/demo.html
+++ b/static/usage/v9/theming/system-high-contrast-mode/demo.html
@@ -6,16 +6,16 @@
     <title>Theming</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/dark.system.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/dark.system.css" />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/high-contrast-light.system.css"
+      href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/high-contrast-light.system.css"
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/palettes/high-contrast-dark.system.css"
+      href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/palettes/high-contrast-dark.system.css"
     />
   </head>
 

--- a/static/usage/v9/thumbnail/basic/demo.html
+++ b/static/usage/v9/thumbnail/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Thumbnail</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/thumbnail/item/demo.html
+++ b/static/usage/v9/thumbnail/item/demo.html
@@ -6,8 +6,8 @@
     <title>Thumbnail</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/thumbnail/theming/css-properties/demo.html
+++ b/static/usage/v9/thumbnail/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Thumbnail</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-thumbnail {

--- a/static/usage/v9/title/basic/demo.html
+++ b/static/usage/v9/title/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Title</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/title/collapsible-large-title/basic/demo.html
+++ b/static/usage/v9/title/collapsible-large-title/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Title</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/title/collapsible-large-title/buttons/demo.html
+++ b/static/usage/v9/title/collapsible-large-title/buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Title</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/title/theming/css-properties/demo.html
+++ b/static/usage/v9/title/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Title</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-title.title-large {

--- a/static/usage/v9/toast/buttons/demo.html
+++ b/static/usage/v9/toast/buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Toast</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toast/icon/demo.html
+++ b/static/usage/v9/toast/icon/demo.html
@@ -6,8 +6,8 @@
     <title>Toast</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toast/inline/basic/demo.html
+++ b/static/usage/v9/toast/inline/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Toast | Inline</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toast/inline/is-open/demo.html
+++ b/static/usage/v9/toast/inline/is-open/demo.html
@@ -6,8 +6,8 @@
     <title>Toast | Inline</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toast/layout/demo.html
+++ b/static/usage/v9/toast/layout/demo.html
@@ -6,8 +6,8 @@
     <title>Toast</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toast/position-anchor/demo.html
+++ b/static/usage/v9/toast/position-anchor/demo.html
@@ -6,8 +6,8 @@
     <title>Toast</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/toast/presenting/controller/demo.html
+++ b/static/usage/v9/toast/presenting/controller/demo.html
@@ -6,8 +6,8 @@
     <title>Toast</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {
@@ -33,7 +33,7 @@
     </ion-app>
 
     <script type="module">
-      import { toastController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/index.esm.js';
+      import { toastController } from 'https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/index.esm.js';
       window.toastController = toastController;
     </script>
 

--- a/static/usage/v9/toast/swipe-gesture/demo.html
+++ b/static/usage/v9/toast/swipe-gesture/demo.html
@@ -6,8 +6,8 @@
     <title>Toast</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toast/theming/demo.html
+++ b/static/usage/v9/toast/theming/demo.html
@@ -6,8 +6,8 @@
     <title>Toast</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-toast.custom-toast {

--- a/static/usage/v9/toggle/alignment/demo.html
+++ b/static/usage/v9/toggle/alignment/demo.html
@@ -6,8 +6,8 @@
     <title>Toggle</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toggle/basic/demo.html
+++ b/static/usage/v9/toggle/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Toggle</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toggle/helper-error/demo.html
+++ b/static/usage/v9/toggle/helper-error/demo.html
@@ -6,8 +6,8 @@
     <title>Input</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toggle/justify/demo.html
+++ b/static/usage/v9/toggle/justify/demo.html
@@ -6,8 +6,8 @@
     <title>Toggle</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-list {

--- a/static/usage/v9/toggle/label-placement/demo.html
+++ b/static/usage/v9/toggle/label-placement/demo.html
@@ -6,8 +6,8 @@
     <title>Toggle</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toggle/list/demo.html
+++ b/static/usage/v9/toggle/list/demo.html
@@ -6,8 +6,8 @@
     <title>Toggle</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toggle/on-off/demo.html
+++ b/static/usage/v9/toggle/on-off/demo.html
@@ -6,8 +6,8 @@
     <title>Toggle</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toggle/theming/colors/demo.html
+++ b/static/usage/v9/toggle/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Toggle</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toggle/theming/css-properties/demo.html
+++ b/static/usage/v9/toggle/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-toggle {

--- a/static/usage/v9/toggle/theming/css-shadow-parts/demo.html
+++ b/static/usage/v9/toggle/theming/css-shadow-parts/demo.html
@@ -6,8 +6,8 @@
     <title>Item</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       ion-toggle {

--- a/static/usage/v9/toolbar/basic/demo.html
+++ b/static/usage/v9/toolbar/basic/demo.html
@@ -6,8 +6,8 @@
     <title>Toolbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toolbar/buttons/demo.html
+++ b/static/usage/v9/toolbar/buttons/demo.html
@@ -6,8 +6,8 @@
     <title>Toolbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/toolbar/progress-bars/demo.html
+++ b/static/usage/v9/toolbar/progress-bars/demo.html
@@ -6,8 +6,8 @@
     <title>Toolbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toolbar/searchbars/demo.html
+++ b/static/usage/v9/toolbar/searchbars/demo.html
@@ -6,8 +6,8 @@
     <title>Toolbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toolbar/segments/demo.html
+++ b/static/usage/v9/toolbar/segments/demo.html
@@ -6,8 +6,8 @@
     <title>Toolbar</title>
     <link rel="stylesheet" href="../../common.css" />
     <script src="../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
   </head>
 
   <body>

--- a/static/usage/v9/toolbar/theming/colors/demo.html
+++ b/static/usage/v9/toolbar/theming/colors/demo.html
@@ -6,8 +6,8 @@
     <title>Toolbar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/static/usage/v9/toolbar/theming/css-properties/demo.html
+++ b/static/usage/v9/toolbar/theming/css-properties/demo.html
@@ -6,8 +6,8 @@
     <title>Toolbar</title>
     <link rel="stylesheet" href="../../../common.css" />
     <script src="../../../common.js"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@8/dist/ionic/ionic.esm.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@8/css/ionic.bundle.css" />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core@9/dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core@9/css/ionic.bundle.css" />
 
     <style>
       .container {

--- a/vercel.json
+++ b/vercel.json
@@ -41,13 +41,13 @@
       "source": "/docs/ja/",
       "destination": "/docs/ja"
     },
-    { "source": "/docs/ja/v8/:match*", "destination": "/docs/ja/:match*" },
+    { "source": "/docs/ja/v9/:match*", "destination": "/docs/ja/:match*" },
     {
       "source": "/docs/(v5|next)?/developer-resources/:path*",
       "destination": "https://ionic.io/resources"
     },
     { "source": "/docs/next/:match*", "destination": "/docs/:match*" },
-    { "source": "/docs/v8/:match*", "destination": "/docs/:match*" },
+    { "source": "/docs/v9/:match*", "destination": "/docs/:match*" },
     {
       "source": "/docs/react",
       "destination": "/docs/react/overview"

--- a/versioned_docs/version-v8/reference/support.md
+++ b/versioned_docs/version-v8/reference/support.md
@@ -22,7 +22,7 @@ The current status of each Ionic Framework version is:
 
 | Version |     Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------: | :----------: | :--------------: | :---------------: |
-|   V8    | **Maintenance** | Apr 17, 2024 |   Feb 17, 2026   |   Aug 17, 2027    |
+|   V8    | **Maintenance** | Apr 17, 2024 |   Feb 17, 2027   |   Aug 17, 2027    |
 |   V7    | End of Support  | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
 |   V6    | End of Support  | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
 |   V5    | End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |

--- a/versioned_docs/version-v8/reference/support.md
+++ b/versioned_docs/version-v8/reference/support.md
@@ -22,7 +22,7 @@ The current status of each Ionic Framework version is:
 
 | Version |     Status      |   Released   | Maintenance Ends | Ext. Support Ends |
 | :-----: | :-------------: | :----------: | :--------------: | :---------------: |
-|   V8    | **Maintenance** | Apr 17, 2024 |       TBD        |        TBD        |
+|   V8    | **Maintenance** | Apr 17, 2024 |   Feb 17, 2026   |   Aug 17, 2027    |
 |   V7    | End of Support  | Mar 29, 2023 |   Oct 17, 2024   |   Apr 17, 2025    |
 |   V6    | End of Support  | Dec 8, 2021  |   Sep 29, 2023   |   Mar 29, 2024    |
 |   V5    | End of Support  | Feb 11, 2020 |   June 8, 2022   |    Dec 8, 2022    |


### PR DESCRIPTION
- Updates all demos to point to v9
- Updates StackBlitz versions to v9
- Changes the npm tag to use `latest` for the docusaurus build
- Updates support table with v9 release date & v8 maintenance/support end dates
- Updates playground template to include v9
- Updates old references to v8