### PR TITLE
chore(archive): add missing lint ignores and document archiving

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -27,6 +27,9 @@ versioned_docs/version-v*/reference/glossary.md
 # Archived versions
 versioned_docs/version-v5
 versioned_docs/version-v6
+versioned_docs/version-v7
+static/usage/v6
+static/usage/v7
 
 static/code/stackblitz
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,10 +221,25 @@ Archived versions are served from a frozen Vercel deployment instead of being re
 
 The archived URL has to point at a build that _included_ the version, so you build it first, then move it to `versionsArchived.json`:
 
-1. **Build the version.** Make sure it is in `versions.json`. If you are refreshing an already-archived version, move it out of `versionsArchived.json` and back into `versions.json`. Commit, push and let Vercel deploy.
-2. **Promote the deployment.** In the Vercel dashboard, open that deployment and **Promote to Production** so it does not get cleaned up. Wait for the build to finish before pushing again, or it may get canceled.
-3. **Copy its URL.** Use the deployment's unique `ionic-docs-<hash>-ionic1.vercel.app` URL, not the branch or production alias.
-4. **Archive it.** Remove the version from `versions.json`, then add it to `versionsArchived.json` with `/docs/<version>` appended and no trailing slash (a trailing slash causes a brief 404 flash):
+1. **Add the version to the `vercel.json` redirects.** The frozen deployment serves its own copy of [`vercel.json`](./vercel.json), so a version scoped redirect has to be in place _before_ the build in the next step, or it will be missing from the archive for good. Add the version to each `:version(...)` group that applies to it. The `angular`, `react`, `vue` and `javascript` landing pages all need this, since no version ships an index page for them:
+
+   ```json
+   {
+     "source": "/docs/:version(v6|v7|v8|v<version>)/angular",
+     "destination": "/docs/:version/angular/overview"
+   },
+   {
+     "source": "/docs/:version(v8|v<version>)/javascript",
+     "destination": "/docs/:version/javascript/overview"
+   }
+   ```
+
+   The `javascript` group only goes back to v8, since v6 and v7 have no `javascript/` section.
+
+2. **Build the version.** Make sure it is in `versions.json`. If you are refreshing an already-archived version, move it out of `versionsArchived.json` and back into `versions.json`. Commit, push and let Vercel deploy.
+3. **Promote the deployment.** In the Vercel dashboard, open that deployment and **Promote to Production** so it does not get cleaned up. Wait for the build to finish before pushing again, or it may get canceled.
+4. **Copy its URL.** Use the deployment's unique `ionic-docs-<hash>-ionic1.vercel.app` URL, not the branch or production alias.
+5. **Archive it.** Remove the version from `versions.json`, then add it to `versionsArchived.json` with `/docs/<version>` appended and no trailing slash (a trailing slash causes a brief 404 flash):
 
    ```json
    {
@@ -232,7 +247,28 @@ The archived URL has to point at a build that _included_ the version, so you bui
    }
    ```
 
-5. **Open a PR.** Once merged, the version picker links to the archive and `main` stops building that version.
+6. **Update `.prettierignore`.** Add the archived version folders to the archived versions group to keep Prettier from formatting generated files:
+
+   ```
+   static/usage/v<version>
+   versioned_docs/version-v<version>
+   ```
+
+7. **Update `cspell.json`.** Add the archived version to the `ignorePaths` array so the spell checker skips generated files:
+
+   ```json
+   "versioned_docs/version-v<version>"
+   ```
+
+8. **Update `renovate.json`.** Add the version's StackBlitz examples to `ignorePaths` so Renovate stops opening dependency PRs against frozen examples:
+
+   ```json
+   "ignorePaths": ["static/code/stackblitz/v<version>/**"]
+   ```
+
+   Then remove that version's `@ionic/` `allowedVersions` rule from `packageRules`, since it no longer has anything to match.
+
+9. **Open a PR.** Once merged, the version picker links to the archive and `main` stops building that version.
 
 Removed versions keep their `versioned_docs/` and `versioned_sidebars/` content, so they can be rebuilt anytime by adding them back to `versions.json`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,56 +219,87 @@ Archived versions are served from a frozen Vercel deployment instead of being re
 - [`versions.json`](./versions.json): lists the older versions Docusaurus rebuilds on every deploy. It does not include the current version, which is built from `docs/` and takes its label from `versions.current` in `docusaurus.config.js`.
 - [`versionsArchived.json`](./versionsArchived.json): maps each archived version to the frozen deployment URL the version picker links to.
 
-The archived URL has to point at a build that _included_ the version, so you build it first, then move it to `versionsArchived.json`:
+The docs keep the current version plus one older version rebuildable, so each major release archives one version and involves two different version numbers. The steps below refer to them as:
 
-1. **Check the `vercel.json` redirects.** Any `:version(...)` group missing a version at build time stays broken on that host for good. Add the version that most recently stopped being current, since it is the one most likely to be missing. The `angular`, `react`, `vue` and `javascript` landing pages each need a group, as no version ships an index page for them:
+- `<archiving>`: the version being frozen and removed from `versions.json`.
+- `<last-current>`: the version that just stopped being current and moved into `versions.json`. It is not being archived, but step 1 has to account for it.
+
+For example, when `v9` becomes current: `v8` is `<last-current>` and `v7` is `<archiving>`.
+
+The archived URL has to point at a build that _included_ `<archiving>`, so you build it first, then move it to `versionsArchived.json`:
+
+1. **Check the `vercel.json` redirects.** The frozen deployment bakes in whatever `vercel.json` looked like at build time, and it serves every version in that build. Any `:version(...)` group missing a version therefore stays broken on that host for good. Make sure the groups already list `<last-current>`, which is the one most likely to be missing since it only just moved into `versions.json`. The `angular`, `react`, `vue` and `javascript` landing pages each need a group, as no version ships an index page for them:
 
    ```json
    {
-     "source": "/docs/:version(v6|v7|v<version>)/angular",
+     "source": "/docs/:version(v6|v7|<last-current>)/angular",
      "destination": "/docs/:version/angular/overview"
    },
    {
-     "source": "/docs/:version(v<version>)/javascript",
+     "source": "/docs/:version(<last-current>)/javascript",
      "destination": "/docs/:version/javascript/overview"
    }
    ```
 
-   The `javascript` group only covers versions that have a `javascript/` section.
+   The groups accumulate, so existing entries stay in place whether or not that version is archived and you are only ever adding to them. The `javascript` group only covers versions that have a `javascript/` section.
 
-2. **Build the version.** Make sure it is in `versions.json`. If you are refreshing an already-archived version, move it out of `versionsArchived.json` and back into `versions.json`. Commit, push and let Vercel deploy.
+Everything from here on refers to `<archiving>`:
+
+2. **Build `<archiving>`.** Make sure it is in `versions.json`. If you are refreshing an already-archived version, move it out of `versionsArchived.json` and back into `versions.json`. Commit, push and let Vercel deploy.
 3. **Promote the deployment.** In the Vercel dashboard, open that deployment and **Promote to Production** so it does not get cleaned up. Wait for the build to finish before pushing again, or it may get canceled.
 4. **Copy its URL.** Use the deployment's unique `ionic-docs-<hash>-ionic1.vercel.app` URL, not the branch or production alias.
-5. **Archive it.** Remove the version from `versions.json`, then add it to `versionsArchived.json` with `/docs/<version>` appended and no trailing slash (a trailing slash causes a brief 404 flash):
+5. **Archive it.** Remove `<archiving>` from `versions.json`, then add it to `versionsArchived.json` with `/docs/<archiving>` appended and no trailing slash (a trailing slash causes a brief 404 flash):
+
+   _`versions.json`_
+
+   ```diff
+    [
+   -  "v8",
+   -  "<archiving>"
+   +  "v8"
+    ]
+   ```
+
+   _`versionsArchived.json`_
 
    ```json
    {
-     "v6": "https://ionic-docs-<hash>-ionic1.vercel.app/docs/v6"
+     "<archiving>": "https://ionic-docs-<hash>-ionic1.vercel.app/docs/<archiving>",
+     "v6": "https://ionic-docs-lq0if04rc-ionic1.vercel.app/docs/v6",
+     "v5": "https://ionic-docs-5utg8ms4c-ionic1.vercel.app/docs/v5"
    }
    ```
 
 6. **Update `.prettierignore`.** Add the archived version folders to the archived versions group to keep Prettier from formatting generated files:
 
    ```
-   static/usage/v<version>
-   versioned_docs/version-v<version>
+   static/usage/<archiving>
+   versioned_docs/version-<archiving>
    ```
 
 7. **Update `cspell.json`.** Add the archived version to the `ignorePaths` array so the spell checker skips generated files:
 
-   ```json
-   "versioned_docs/version-v<version>"
+   ```diff
+   "ignorePaths": [
+     ...
+     "versioned_docs/version-v5",
+     "versioned_docs/version-v6",
+   + "versioned_docs/version-<archiving>"
+   ]
    ```
 
-8. **Update `renovate.json`.** Add the version's StackBlitz examples to `ignorePaths` so Renovate stops opening dependency PRs against frozen examples:
+8. **Update `renovate.json`.** Add the archived version's StackBlitz examples to `ignorePaths` so Renovate stops opening dependency PRs against frozen examples:
 
-   ```json
-   "ignorePaths": ["static/code/stackblitz/v<version>/**"]
+   ```diff
+   "ignorePaths": [
+     "static/code/stackblitz/v6/**",
+   + "static/code/stackblitz/<archiving>/**"
+   ]
    ```
 
    Then remove that version's `@ionic/` `allowedVersions` rule from `packageRules`, since it no longer has anything to match.
 
-9. **Open a PR.** Once merged, the version picker links to the archive and `main` stops building that version.
+9. **Open a PR.** Once merged, the version picker links to the archive and `main` stops building `<archiving>`.
 
 Removed versions keep their `versioned_docs/` and `versioned_sidebars/` content, so they can be rebuilt anytime by adding them back to `versions.json`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ The Ionic documentation's `main` branch is deployed automatically and separately
 
 Archived versions are served from a frozen Vercel deployment instead of being rebuilt on every `main` deploy, which keeps build times and memory usage low. Two files control this:
 
-- [`versions.json`](./versions.json): lists the versions Docusaurus rebuilds on every deploy.
+- [`versions.json`](./versions.json): lists the older versions Docusaurus rebuilds on every deploy. It does not include the current version, which is built from `docs/` and takes its label from `versions.current` in `docusaurus.config.js`.
 - [`versionsArchived.json`](./versionsArchived.json): maps each archived version to the frozen deployment URL the version picker links to.
 
 The archived URL has to point at a build that _included_ the version, so you build it first, then move it to `versionsArchived.json`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,27 +214,27 @@ The Ionic documentation's `main` branch is deployed automatically and separately
 
 ### Archiving a Version
 
-Archived versions are served from a frozen Vercel deployment instead of being rebuilt on every `main` deploy, which keeps build times and memory usage low. Two files control this:
+Archived versions are served from a frozen Vercel deployment instead of being rebuilt on every `main` deploy, which keeps build times and memory usage low. That deployment is a full snapshot of the site, so it serves every version that was in the build. Two files control this:
 
 - [`versions.json`](./versions.json): lists the older versions Docusaurus rebuilds on every deploy. It does not include the current version, which is built from `docs/` and takes its label from `versions.current` in `docusaurus.config.js`.
 - [`versionsArchived.json`](./versionsArchived.json): maps each archived version to the frozen deployment URL the version picker links to.
 
 The archived URL has to point at a build that _included_ the version, so you build it first, then move it to `versionsArchived.json`:
 
-1. **Add the version to the `vercel.json` redirects.** The frozen deployment serves its own copy of [`vercel.json`](./vercel.json), so a version scoped redirect has to be in place _before_ the build in the next step, or it will be missing from the archive for good. Add the version to each `:version(...)` group that applies to it. The `angular`, `react`, `vue` and `javascript` landing pages all need this, since no version ships an index page for them:
+1. **Check the `vercel.json` redirects.** Any `:version(...)` group missing a version at build time stays broken on that host for good. Add the version that most recently stopped being current, since it is the one most likely to be missing. The `angular`, `react`, `vue` and `javascript` landing pages each need a group, as no version ships an index page for them:
 
    ```json
    {
-     "source": "/docs/:version(v6|v7|v8|v<version>)/angular",
+     "source": "/docs/:version(v6|v7|v<version>)/angular",
      "destination": "/docs/:version/angular/overview"
    },
    {
-     "source": "/docs/:version(v8|v<version>)/javascript",
+     "source": "/docs/:version(v<version>)/javascript",
      "destination": "/docs/:version/javascript/overview"
    }
    ```
 
-   The `javascript` group only goes back to v8, since v6 and v7 have no `javascript/` section.
+   The `javascript` group only covers versions that have a `javascript/` section.
 
 2. **Build the version.** Make sure it is in `versions.json`. If you are refreshing an already-archived version, move it out of `versionsArchived.json` and back into `versions.json`. Commit, push and let Vercel deploy.
 3. **Promote the deployment.** In the Vercel dashboard, open that deployment and **Promote to Production** so it does not get cleaned up. Wait for the build to finish before pushing again, or it may get canceled.

--- a/cspell.json
+++ b/cspell.json
@@ -20,6 +20,7 @@
     "versioned_docs/**/native",
     "versioned_docs/version-v5",
     "versioned_docs/version-v6",
+    "versioned_docs/version-v7",
     "node_modules"
   ],
   "flagWords": [

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
       "destination": "/docs/angular/overview"
     },
     {
-      "source": "/docs/:version(v6|v7)/angular",
+      "source": "/docs/:version(v6|v7|v8)/angular",
       "destination": "/docs/:version/angular/overview"
     },
     {
@@ -38,6 +38,10 @@
       "destination": "/docs/javascript/overview"
     },
     {
+      "source": "/docs/:version(v8)/javascript",
+      "destination": "/docs/:version/javascript/overview"
+    },
+    {
       "source": "/docs/ja/",
       "destination": "/docs/ja"
     },
@@ -53,7 +57,7 @@
       "destination": "/docs/react/overview"
     },
     {
-      "source": "/docs/:version(v6|v7)/react",
+      "source": "/docs/:version(v6|v7|v8)/react",
       "destination": "/docs/:version/react/overview"
     },
     {
@@ -82,7 +86,7 @@
       "destination": "/docs/vue/overview"
     },
     {
-      "source": "/docs/:version(v6|v7)/vue",
+      "source": "/docs/:version(v6|v7|v8)/vue",
       "destination": "/docs/:version/vue/overview"
     },
     { "source": "/docs/vue/your-first-app/2-taking-photos", "destination": "/docs/vue/your-first-app/taking-photos" },


### PR DESCRIPTION
Issue URL: N/A

## What is the current behavior?

v7 was archived in #4647, but it was never added to `.prettierignore` or `cspell.json`, so Prettier and cspell still walk archived v7 content. The `static/usage/v6` and `v7` playground folders were never ignored either.

Separately, the framework landing redirects in `vercel.json` cover v6 and v7 but not v8. No version ships an index page for those routes, so `/docs/v8/angular`, `/docs/v8/react`, and `/docs/v8/vue` currently fail to redirect to their overview pages, and `/docs/v8/javascript` has no versioned redirect at all.

The archiving instructions in `CONTRIBUTING.md` only covered `versions.json` and `versionsArchived.json`, which is how the v7 lint ignores were missed in the first place.

## What is the new behavior?

Config catch up:

- `.prettierignore`: adds `versioned_docs/version-v7`, `static/usage/v6`, and `static/usage/v7`
- `cspell.json`: adds `versioned_docs/version-v7`
- `vercel.json`: adds v8 to the `angular`, `react`, and `vue` landing redirects, and adds a v8 scoped `javascript` redirect

The archiving steps in `CONTRIBUTING.md` now also cover `vercel.json`, `.prettierignore`, `cspell.json`, and `renovate.json`, so the next archive has a complete checklist.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**Why the `vercel.json` step is ordered first.** An archived version is served from a frozen Vercel deployment that ships its own copy of `vercel.json`. A version scoped redirect therefore has to exist *before* the archive build, or it never reaches the archive and those links 404 there permanently. This is not hypothetical: v6 and v7 both work today only because the redirect pattern predates their most recent promoted builds.

**The v8 redirects fix a live issue.** They are not only preparation for archiving v8. Those routes are broken on `main` right now, and archiving would have frozen the breakage in place.