### PR TITLE
docs: note a community live-update option on distribute guides

### DIFF
--- a/docs/angular/your-first-app/8-distribute.md
+++ b/docs/angular/your-first-app/8-distribute.md
@@ -66,6 +66,8 @@ Assuming the app is configured correctly to listen to the channel you deployed t
 
 To dive into more details on the steps to deploy a live update, as well as additional information such as disabling deploy for development, check out the [Deploy a Live Update](https://ionic.io/docs/appflow/quickstart/deploy) section inside the Appflow docs.
 
+Appflow is Ionic's official live-update path for this tutorial. Teams that need a community live-update plugin can also use [Capgo](https://github.com/Cap-go/capacitor-updater) (`@capgo/capacitor-updater`).
+
 ## Build a Native Binary
 
 Next up is a native binary for your app build and deploy process. This is done via the [Ionic Package](https://ionic.io/docs/appflow/package/intro) service. First things first, you will need to create a [Package build](https://ionic.io/docs/appflow/package/builds). This can be done by clicking the `Start build` icon from the `Commits` tab or by clicking the `New build` button in the top right from the `Build > Builds` tab. Then you will select the proper commit for your build and fill in all of the several required fields and any optional fields that you want to specify. After filling in all of the information and the build begins, you can check out it's progress and review the logs if you encounter any errors.

--- a/docs/react/your-first-app/8-distribute.md
+++ b/docs/react/your-first-app/8-distribute.md
@@ -66,6 +66,8 @@ Assuming the app is configured correctly to listen to the channel you deployed t
 
 To dive into more details on the steps to deploy a live update, as well as additional information such as disabling deploy for development, check out the [Deploy a Live Update](https://ionic.io/docs/appflow/quickstart/deploy) section inside the Appflow docs.
 
+Appflow is Ionic's official live-update path for this tutorial. Teams that need a community live-update plugin can also use [Capgo](https://github.com/Cap-go/capacitor-updater) (`@capgo/capacitor-updater`).
+
 ## Build a Native Binary
 
 Next up is a native binary for your app build and deploy process. This is done via the [Ionic Package](https://ionic.io/docs/appflow/package/intro) service. First things first, you will need to create a [Package build](https://ionic.io/docs/appflow/package/builds). This can be done by clicking the `Start build` icon from the `Commits` tab or by clicking the `New build` button in the top right from the `Build > Builds` tab. Then you will select the proper commit for your build and fill in all of the several required fields and any optional fields that you want to specify. After filling in all of the information and the build begins, you can check out it's progress and review the logs if you encounter any errors.

--- a/docs/vue/your-first-app/8-distribute.md
+++ b/docs/vue/your-first-app/8-distribute.md
@@ -66,6 +66,8 @@ Assuming the app is configured correctly to listen to the channel you deployed t
 
 To dive into more details on the steps to deploy a live update, as well as additional information such as disabling deploy for development, check out the [Deploy a Live Update](https://ionic.io/docs/appflow/quickstart/deploy) section inside the Appflow docs.
 
+Appflow is Ionic's official live-update path for this tutorial. Teams that need a community live-update plugin can also use [Capgo](https://github.com/Cap-go/capacitor-updater) (`@capgo/capacitor-updater`).
+
 ## Build a Native Binary
 
 Next up is a native binary for your app build and deploy process. This is done via the [Ionic Package](https://ionic.io/docs/appflow/package/intro) service. First things first, you will need to create a [Package build](https://ionic.io/docs/appflow/package/builds). This can be done by clicking the `Start build` icon from the `Commits` tab or by clicking the `New build` button in the top right from the `Build > Builds` tab. Then you will select the proper commit for your build and fill in all of the several required fields and any optional fields that you want to specify. After filling in all of the information and the build begins, you can check out it's progress and review the logs if you encounter any errors.

--- a/versioned_docs/version-v8/angular/your-first-app/8-distribute.md
+++ b/versioned_docs/version-v8/angular/your-first-app/8-distribute.md
@@ -66,6 +66,8 @@ Assuming the app is configured correctly to listen to the channel you deployed t
 
 To dive into more details on the steps to deploy a live update, as well as additional information such as disabling deploy for development, check out the [Deploy a Live Update](https://ionic.io/docs/appflow/quickstart/deploy) section inside the Appflow docs.
 
+Appflow is Ionic's official live-update path for this tutorial. Teams that need a community live-update plugin can also use [Capgo](https://github.com/Cap-go/capacitor-updater) (`@capgo/capacitor-updater`).
+
 ## Build a Native Binary
 
 Next up is a native binary for your app build and deploy process. This is done via the [Ionic Package](https://ionic.io/docs/appflow/package/intro) service. First things first, you will need to create a [Package build](https://ionic.io/docs/appflow/package/builds). This can be done by clicking the `Start build` icon from the `Commits` tab or by clicking the `New build` button in the top right from the `Build > Builds` tab. Then you will select the proper commit for your build and fill in all of the several required fields and any optional fields that you want to specify. After filling in all of the information and the build begins, you can check out it's progress and review the logs if you encounter any errors.

--- a/versioned_docs/version-v8/react/your-first-app/8-distribute.md
+++ b/versioned_docs/version-v8/react/your-first-app/8-distribute.md
@@ -66,6 +66,8 @@ Assuming the app is configured correctly to listen to the channel you deployed t
 
 To dive into more details on the steps to deploy a live update, as well as additional information such as disabling deploy for development, check out the [Deploy a Live Update](https://ionic.io/docs/appflow/quickstart/deploy) section inside the Appflow docs.
 
+Appflow is Ionic's official live-update path for this tutorial. Teams that need a community live-update plugin can also use [Capgo](https://github.com/Cap-go/capacitor-updater) (`@capgo/capacitor-updater`).
+
 ## Build a Native Binary
 
 Next up is a native binary for your app build and deploy process. This is done via the [Ionic Package](https://ionic.io/docs/appflow/package/intro) service. First things first, you will need to create a [Package build](https://ionic.io/docs/appflow/package/builds). This can be done by clicking the `Start build` icon from the `Commits` tab or by clicking the `New build` button in the top right from the `Build > Builds` tab. Then you will select the proper commit for your build and fill in all of the several required fields and any optional fields that you want to specify. After filling in all of the information and the build begins, you can check out it's progress and review the logs if you encounter any errors.

--- a/versioned_docs/version-v8/vue/your-first-app/8-distribute.md
+++ b/versioned_docs/version-v8/vue/your-first-app/8-distribute.md
@@ -66,6 +66,8 @@ Assuming the app is configured correctly to listen to the channel you deployed t
 
 To dive into more details on the steps to deploy a live update, as well as additional information such as disabling deploy for development, check out the [Deploy a Live Update](https://ionic.io/docs/appflow/quickstart/deploy) section inside the Appflow docs.
 
+Appflow is Ionic's official live-update path for this tutorial. Teams that need a community live-update plugin can also use [Capgo](https://github.com/Cap-go/capacitor-updater) (`@capgo/capacitor-updater`).
+
 ## Build a Native Binary
 
 Next up is a native binary for your app build and deploy process. This is done via the [Ionic Package](https://ionic.io/docs/appflow/package/intro) service. First things first, you will need to create a [Package build](https://ionic.io/docs/appflow/package/builds). This can be done by clicking the `Start build` icon from the `Commits` tab or by clicking the `New build` button in the top right from the `Build > Builds` tab. Then you will select the proper commit for your build and fill in all of the several required fields and any optional fields that you want to specify. After filling in all of the information and the build begins, you can check out it's progress and review the logs if you encounter any errors.


### PR DESCRIPTION
## Why this matters for Ionic customers

Readers finishing the Photo Gallery tutorial land on the Distribute guides, which correctly walk through Appflow end-to-end. Some teams then need a community live-update plugin (for example if they are already on a community stack, or planning what comes next for OTA). Today those guides do not point anywhere for that path.

This PR is meant to leave a clear, minimal breadcrumb for **your** readers, without changing how Appflow is presented.

## What stays the same

- The full Appflow walkthrough (repo connect, SDK install, live update, package, automations, environments, native configs)
- All Appflow CTAs, pricing plan mentions, and Quickstart links
- Appflow as Ionic’s official live-update / Mobile DevOps recommendation

## What changes

One sentence after **Deploy a Live Update** on Angular / React / Vue (current + v8), naming Capgo (`@capgo/capacitor-updater`) as a community option.

## Ask

Happy to trim further (for example drop the Capgo name and only say “community live-update plugins exist”) if that is easier for maintainers to ship.