### PR TITLE
chore(renovate): update syntax and ignore specific versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,49 +1,60 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+  "extends": [
+    "config:recommended", 
+    ":semanticCommitTypeAll(chore)"
+  ],
+  "description": "Renovate may only open or update PRs on weekdays, 6-10am ET.",
+  "timezone": "America/New_York",
+  "minimumReleaseAge": "3 days",
+  "schedule": ["* 6-10 * * 1-5"],
+  "semanticCommits": "enabled",
+  "rebaseWhen": "never",
+  "includePaths": [
+    "static/code/stackblitz/**/*/package.json", 
+    ".github/workflows/**"
+  ],
+  "ignorePaths": [
+    "static/code/stackblitz/v6/**", 
+    "static/code/stackblitz/v7/**"
+  ],
   "packageRules": [
     {
-      "matchPackagePatterns": ["@ionic/"],
+      "matchPackageNames": ["@ionic/**"],
       "minimumReleaseAge": "0 days",
-      "groupName": "ionic",
-      "schedule": ["every weekday before 11am"]
+      "groupName": "ionic"
     },
     {
-      "matchPackagePatterns": ["@angular/",  "@angular-devkit/"],
+      "description": "Angular majors land on a fixed cadence, so this group is restricted to the 1st of each month, 6-10am ET.",
+      "matchPackageNames": ["@angular/**", "@angular-devkit/**"],
       "groupName": "angular",
-      "schedule": ["on the first day of the month"]
-    },
-    {
-      "matchPackageNames": ["react-router", "react-router-dom"],
-      "groupName": "react-router",
-      "allowedVersions": "^5.0.0"
+      "schedule": ["* 6-10 1 * *"]
     },
     {
       "matchPackageNames": ["react", "react-dom"],
       "groupName": "react"
     },
     {
+      "matchPackageNames": ["react-router", "react-router-dom"],
+      "groupName": "react-router"
+    },
+    {
       "matchPackageNames": ["vite", "vite-plugin-static-copy"],
       "groupName": "vite-html",
-      "matchFileNames": [
-        "static/code/stackblitz/**/html/package.json"
-      ]
+      "matchFileNames": ["static/code/stackblitz/**/html/package.json"]
     },
     {
       "matchPackageNames": ["vite", "@vitejs/plugin-react"],
       "groupName": "vite-react",
-      "matchFileNames": [
-        "static/code/stackblitz/**/react/package.json"
-      ]
+      "matchFileNames": ["static/code/stackblitz/**/react/package.json"]
     },
     {
       "matchPackageNames": ["vite", "@vitejs/plugin-vue"],
       "groupName": "vite-vue",
-      "matchFileNames": [
-        "static/code/stackblitz/**/vue/package.json"
-      ]
+      "matchFileNames": ["static/code/stackblitz/**/vue/package.json"]
     },
     {
+      "description": "The examples pin Vite 7. Raise this when they move to Vite 8.",
       "matchPackageNames": ["vite"],
       "allowedVersions": "^7.0.0",
       "matchFileNames": [
@@ -53,14 +64,49 @@
       ]
     },
     {
+      "description": "The examples pin @vitejs/plugin-react 5. Raise this when they move to 6.",
       "matchPackageNames": ["@vitejs/plugin-react"],
       "allowedVersions": "^5.0.0",
-      "matchFileNames": [
-        "static/code/stackblitz/**/react/package.json"
-      ]
+      "matchFileNames": ["static/code/stackblitz/**/react/package.json"]
     },
     {
-      "matchPackagePatterns": ["@ionic/"],
+      "description": "Ionic 8 supports React Router 5.",
+      "matchPackageNames": ["react-router", "react-router-dom"],
+      "allowedVersions": "^5.0.0",
+      "matchFileNames": ["static/code/stackblitz/v8/react/package.json"]
+    },
+    {
+      "description": "Ionic 9 supports React Router 6.",
+      "matchPackageNames": ["react-router", "react-router-dom"],
+      "allowedVersions": "^6.0.0",
+      "matchFileNames": ["static/code/stackblitz/v9/react/package.json"]
+    },
+    {
+      "description": "Ionic 8 supports Angular v16 through v20.x.",
+      "matchPackageNames": ["@angular/**", "@angular-devkit/**"],
+      "allowedVersions": "<21.0.0",
+      "matchFileNames": ["static/code/stackblitz/v8/angular/package.json"]
+    },
+    {
+      "description": "Ionic 9 supports Angular v18 through v22.x.",
+      "matchPackageNames": ["@angular/**", "@angular-devkit/**"],
+      "allowedVersions": "<23.0.0",
+      "matchFileNames": ["static/code/stackblitz/v9/angular/package.json"]
+    },
+    {
+      "description": "Angular 20 requires typescript >=5.8 <6.0.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<6.0.0",
+      "matchFileNames": ["static/code/stackblitz/v8/angular/package.json"]
+    },
+    {
+      "description": "Angular 22 requires typescript >=6.0 <6.1.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7.0.0",
+      "matchFileNames": ["static/code/stackblitz/v9/angular/package.json"]
+    },
+    {
+      "matchPackageNames": ["@ionic/**"],
       "minimumReleaseAge": "0 days",
       "allowedVersions": "^8.0.0",
       "groupName": "ionic",
@@ -72,7 +118,7 @@
       ]
     },
     {
-      "matchPackagePatterns": ["@ionic/"],
+      "matchPackageNames": ["@ionic/**"],
       "minimumReleaseAge": "0 days",
       "allowedVersions": "^9.0.0",
       "groupName": "ionic",
@@ -83,18 +129,5 @@
         "static/code/stackblitz/v9/vue/package.json"
       ]
     }
-  ],
-  "dependencyDashboard": true,
-  "minimumReleaseAge": "3 days",
-  "rebaseWhen": "never",
-  "schedule": ["every weekday before 11am"],
-  "semanticCommits": "enabled",
-  "includePaths": [
-    "static/code/stackblitz/**/*/package.json",
-    ".github/workflows/**"
-  ],
-  "ignorePaths": [
-    "static/code/stackblitz/v6/**",
-    "static/code/stackblitz/v7/**"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,6 @@
       "matchFileNames": ["static/code/stackblitz/**/vue/package.json"]
     },
     {
-      "description": "The examples pin Vite 7. Raise this when they move to Vite 8.",
       "matchPackageNames": ["vite"],
       "allowedVersions": "^7.0.0",
       "matchFileNames": [
@@ -64,7 +63,6 @@
       ]
     },
     {
-      "description": "The examples pin @vitejs/plugin-react 5. Raise this when they move to 6.",
       "matchPackageNames": ["@vitejs/plugin-react"],
       "allowedVersions": "^5.0.0",
       "matchFileNames": ["static/code/stackblitz/**/react/package.json"]


### PR DESCRIPTION
This reconfigures `renovate.json` to update the following:
- Use the latest cron syntax for scheduling
- Use the latest syntax for matching package names
- Restrict the version of Angular to less than 21 for v8 and less than 23 for v9
- Restrict the version of React Router to v5 for Ionic 8 and v6 for Ionic 9

See the comment by renovate for the expected results of the reconfigure.