### PR TITLE
chore(docs): pad admonitions with blank lines

### DIFF
--- a/docs/angular/build-options.md
+++ b/docs/angular/build-options.md
@@ -10,7 +10,9 @@ The Standalone approach uses modern Angular APIs and is the recommended way to b
 ## Standalone
 
 :::info
+
 Ionic UI components as Angular standalone components is supported starting in Ionic v7.5.
+
 :::
 
 ### Overview
@@ -30,13 +32,17 @@ Refer to the [Standalone Migration Guide](#migrating-from-modules-to-standalone)
 1. Ionic components need to be imported into every Angular component they are used in which can be time consuming to set up.
 
 :::info[Code splitting]
+
 Ionic ships standalone components from a single entry point (`@ionic/angular`). Bundlers such as Webpack and esbuild cannot split code from a single entry point across separate chunks, so the Ionic components you import are included in the main bundle rather than in the chunk for the route or component where they are used. Unused components are still tree-shaken out of the build.
+
 :::
 
 ### Usage with Standalone-based Applications
 
 :::warning
+
 All Ionic imports should be imported from the `@ionic/angular` submodule. This includes imports such as components, directives, providers, and types. Importing from `@ionic/angular/lazy` may pull in lazy loaded Ionic code which can interfere with treeshaking.
+
 :::
 
 **Bootstrapping and Configuration**
@@ -203,7 +209,9 @@ Ionic Angular's standalone components use ES Modules. As a result, developers us
 ### Usage with NgModule-based Applications
 
 :::warning
+
 All Ionic imports should be imported from the `@ionic/angular` submodule. This includes imports such as components, directives, providers, and types. Importing from `@ionic/angular/lazy` may pull in lazy loaded Ionic code which can interfere with treeshaking.
+
 :::
 
 **Bootstrapping and Configuration**
@@ -366,7 +374,9 @@ Ionic Angular's standalone components use ES Modules. As a result, developers us
 ## Modules
 
 :::warning[Deprecation Notice]
+
 The Modules approach, including `IonicModule`, is **deprecated** and will be removed in a future major release. Existing applications will continue to work during the deprecation period but should migrate using the [Standalone migration guide](#migrating-from-modules-to-standalone). New applications should use the [Standalone](#standalone) approach.
+
 :::
 
 ### Overview
@@ -405,9 +415,11 @@ export class AppModule {}
 ## Migrating from Modules to Standalone
 
 :::tip
+
 Try our automated utility for migrating to standalone!
 
 Refer to the [standalone migration codemods](https://github.com/ionic-team/ionic-angular-standalone-codemods) for instructions on how to get started. All issues related to the migration utility should be filed on the linked repo.
+
 :::
 
 The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate.

--- a/docs/angular/lifecycle.md
+++ b/docs/angular/lifecycle.md
@@ -27,7 +27,9 @@ Ionic embraces the life cycle events provided by Angular. The two Angular events
 For more info on the Angular Component Life Cycle events, visit their [component lifecycle docs](https://angular.io/guide/lifecycle-hooks).
 
 :::note
+
 Components that use `ion-nav` or `ion-router-outlet` should not use the `OnPush` change detection strategy. Doing so will prevent lifecycle hooks such as `ngOnInit` from firing. Additionally, asynchronous state changes may not render properly.
+
 :::
 
 ## Ionic Page Events

--- a/docs/angular/navigation.md
+++ b/docs/angular/navigation.md
@@ -168,7 +168,9 @@ import { LoginComponent } from './login.component';
 ```
 
 :::note
+
 We're excluding some additional content and only including the necessary parts.
+
 :::
 
 Here, we have a typical Angular Module setup, along with a RouterModule import, but we're now using `forChild` and declaring the component in that setup. With this setup, when we run our build, we will produce separate chunks for both the app component, the login component, and the detail component.
@@ -194,7 +196,9 @@ export class AppRoutingModule {}
 ```
 
 :::tip
+
 If you are using `routerLink`, `routerDirection`, or `routerAction` be sure to also import the `IonRouterLink` directive for Ionic components or the `IonRouterLinkWithHref` directive for `<a>` elements. An example of this is available in the [Ionic Angular Build Options docs](./build-options.md#migrating-from-modules-to-standalone).
+
 :::
 
 To get started with standalone components [visit Angular's official docs](https://angular.io/guide/standalone-components).

--- a/docs/angular/performance.md
+++ b/docs/angular/performance.md
@@ -69,5 +69,7 @@ For more information, refer to the [Angular NgForOf change propagation documenta
 {/* cspell:enable */}
 
 :::note
+
 Do you have a guide you'd like to share? Click the _Edit this page_ button below.
+
 :::

--- a/docs/angular/pwa.md
+++ b/docs/angular/pwa.md
@@ -25,11 +25,15 @@ ng add @angular/pwa
 Once this package has been added run `ionic build --prod` and the `www` directory will be ready to deploy as a PWA.
 
 :::note
+
 By default, the `@angular/pwa` package comes with the Angular logo for the app icons. Be sure to update the manifest to use the correct app name and also replace the icons.
+
 :::
 
 :::note
+
 Features like Service Workers and many JavaScript APIs (such as geolocation) require the app be hosted in a secure context. When deploying an app through a hosting service, be aware that HTTPS will be required to take full advantage of Service Workers.
+
 :::
 
 ## Service Worker configuration
@@ -77,7 +81,9 @@ npm install -g firebase-tools
 ```
 
 :::note
+
 If it's the first time you use firebase-tools, login to your Google account with `firebase login` command.
+
 :::
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -91,7 +97,9 @@ Create a new Firebase project or select an existing one.
 **"What do you want to use as your public directory?"** Enter "www".
 
 :::note
+
 Answering this next question will ensure that routing, hard reload, and deep linking work in the app:
+
 :::
 
 **Configure as a single-page app (rewrite all urls to /index.html)?"** Enter "Yes".

--- a/docs/angular/quickstart.md
+++ b/docs/angular/quickstart.md
@@ -72,7 +72,9 @@ Your new app's directory will look like this:
 ```
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's walk through these files to understand the app's structure.
@@ -175,7 +177,9 @@ And the template, in the `home.page.html` file, uses those components:
 This creates a page with a header and scrollable content area. The second header shows a [collapsible large title](/docs/api/title.md#collapsible-large-titles) that displays on iOS devices when at the top of the content, then condenses to show the smaller title in the first header when scrolling down.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 ## Add an Ionic Component
@@ -257,7 +261,9 @@ import { RouterLink } from '@angular/router';
 ```
 
 :::info
+
 Navigating can also be performed using Angular's Router service. Refer to the [Angular Navigation documentation](/docs/angular/navigation.md#navigating-to-different-routes) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/docs/angular/slides.md
+++ b/docs/angular/slides.md
@@ -14,7 +14,9 @@ import TabItem from '@theme/TabItem';
 </head>
 
 :::warning[Looking for `ion-slides`?]
+
 `ion-slides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
+
 :::
 
 We recommend [Swiper.js](http://swiperjs.com/) if you need a modern touch slider component. Swiper 9 introduced [Swiper Element](https://swiperjs.com/element) as a replacement for its Angular component, so this guide will go over how to get Swiper Element set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to Swiper Element.
@@ -191,7 +193,9 @@ export class HomePage {
 ```
 
 :::note
+
 If you are using the Core version of Swiper and have installed additional modules, ensure that `IonicSlides` is the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+
 :::
 
 ## Properties
@@ -227,7 +231,9 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | pager   | Use the `pagination` property instead.                                                                                                  |
 
 :::note
+
 All properties available in Swiper Element can be found in the [Swiper API parameters documentation](https://swiperjs.com/swiper-api#parameters).
+
 :::
 
 ## Events
@@ -276,7 +282,9 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `swiperinit`                       |
 
 :::note
+
 All events available in Swiper Element can be found in the [Swiper API events documentation](https://swiperjs.com/swiper-api#events) and should be lowercased and prefixed with the word `swiper`.
+
 :::
 
 ## Methods
@@ -328,7 +336,9 @@ Below is a full list of method changes when going from `ion-slides` to Swiper El
 | `stopAutoplay()`     | Use the `autoplay` property instead.                                                 |
 
 :::note
+
 All methods and properties available on the Swiper instance can be found in the [Swiper API methods and properties documentation](https://swiperjs.com/swiper-api#methods-and-properties).
+
 :::
 
 ## Effects
@@ -340,7 +350,9 @@ Effects such as Cube or Fade can be used in Swiper Element with no additional im
 ```
 
 :::note
+
 For more information on effects in Swiper, please refer to the [Swiper API fade effect documentation](https://swiperjs.com/swiper-api#fade-effect).
+
 :::
 
 ## Wrap Up

--- a/docs/angular/storage.md
+++ b/docs/angular/storage.md
@@ -14,7 +14,9 @@ sidebar_label: Storage
 There are a variety of options available for storing data within an Ionic application. It is best to choose options that best fit the needs of your application. A single application may have requirements that span multiple options.
 
 :::info
+
 Some storage options involve third-party plugins or products. In such cases, we neither endorse nor support those plugins or products. We are mentioning them here for informational purposes only.
+
 :::
 
 Here are some common use cases and solutions:

--- a/docs/angular/your-first-app.md
+++ b/docs/angular/your-first-app.md
@@ -25,7 +25,9 @@ Here’s the finished app running on all 3 platforms:
 ></iframe>
 
 :::note
+
 Looking for the previous version of this guide that covered Ionic 4 and Cordova? Refer to the [Ionic 4 and Cordova guide](../developer-resources/guides/first-app-v4/intro.md).
+
 :::
 
 ## What We'll Build
@@ -55,7 +57,9 @@ Download and install these right away to ensure an optimal Ionic development exp
 Run the following in the command line terminal to install the Ionic CLI (`ionic`), `native-run`, used to run native binaries on devices and simulators/emulators, and `cordova-res`, used to generate native app icons and splash screens:
 
 :::note
+
 To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
+
 :::
 
 ```shell
@@ -63,9 +67,11 @@ npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/docs/angular/your-first-app/2-taking-photos.md
+++ b/docs/angular/your-first-app/2-taking-photos.md
@@ -105,7 +105,9 @@ export class Tab2Page {
 ```
 
 :::note
+
 In a standalone app there is no global icon registry, so each icon you reference by name (like `camera`) must be registered with `addIcons`. Import the specific Ionic components a page uses from `@ionic/angular` and list them in the component's `imports` array.
+
 :::
 
 Then, open `tab2.page.html` and call the `addPhotoToGallery()` method when the FAB is tapped/clicked:

--- a/docs/angular/your-first-app/4-loading-photos.md
+++ b/docs/angular/your-first-app/4-loading-photos.md
@@ -265,9 +265,11 @@ export class Tab2Page implements OnInit {
 ```
 
 :::note
+
 If you encounter broken image links or missing photos after following these steps, you may need to open your browser's dev tools and clear both [localStorage](https://developer.chrome.com/docs/devtools/storage/localstorage) and [IndexedDB](https://developer.chrome.com/docs/devtools/storage/indexeddb).
 
 In localStorage, look for domain `http://localhost:8100` and key `CapacitorStorage.photos`. In IndexedDB, find a store called "FileStorage". Your photos will have a key like `/DATA/123456789012.jpeg`.
+
 :::
 
 That’s it! We’ve built a complete Photo Gallery feature in our Ionic app that works on the web. Next up, we’ll transform it into a mobile app for iOS and Android!

--- a/docs/angular/your-first-app/6-deploying-mobile.md
+++ b/docs/angular/your-first-app/6-deploying-mobile.md
@@ -47,7 +47,9 @@ ionic cap sync
 ## iOS Deployment
 
 :::important
+
 To build an iOS app, you’ll need a Mac computer.
+
 :::
 
 Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac IDE), with dependencies managed by [CocoaPods](https://cocoapods.org/). Before running this app on an iOS device, there's a couple of steps to complete.

--- a/docs/angular/your-first-app/7-live-reload.md
+++ b/docs/angular/your-first-app/7-live-reload.md
@@ -217,7 +217,9 @@ button img {
 Tap on a photo again and choose the “Delete” option. The photo is deleted! Implemented much faster using Live Reload. 💪
 
 :::note
+
 Remember, you can find the [complete source code for this app](https://github.com/ionic-team/tutorial-photo-gallery-angular) on GitHub.
+
 :::
 
 In the final portion of this tutorial, we’ll walk you through the basics of the Appflow product used to build and deploy your application to users' devices.

--- a/docs/angular/zoneless.md
+++ b/docs/angular/zoneless.md
@@ -27,7 +27,9 @@ You do not need to change these. Angular schedules change detection for them in 
 - Navigation, route transitions, and tab switching.
 
 :::note[Angular 22]
+
 Angular 22 also makes `OnPush` the default change detection strategy. Under `OnPush`, synchronous state set as a plain field (including in the lifecycle hooks above) no longer re-renders on its own, even though Ionic notifies Angular. Signals still update the view. For the migration path, refer to the [OnPush Change Detection section of the Ionic 9 upgrade guide](/docs/updating/9-0.md#onpush-change-detection-on-angular-22).
+
 :::
 
 ## What needs a notification

--- a/docs/api/accordion.md
+++ b/docs/api/accordion.md
@@ -40,9 +40,11 @@ import Toggle from '@site/static/usage/v9/accordion/toggle/index.mdx';
 ## Listen for Accordion State Changes
 
 :::caution
+
 Most `ionChange` events emitted by other components such as [Input](./input) and [Textarea](./textarea) bubble. As a result, these events will bubble up and cause your `ionChange` listener on the Accordion Group to fire if the associated components are used inside of an Accordion.
 
 When using other components that emit `ionChange` inside of Accordion it is recommended to have the `ionChange` callback on Accordion Group check the `target` key on the event passed to the callback to verify that `ionChange` is coming from the Accordion Group and not any descendants.
+
 :::
 
 Developers can listen for the `ionChange` event to be notified when accordions expand or collapse.

--- a/docs/api/alert.md
+++ b/docs/api/alert.md
@@ -109,7 +109,9 @@ import Customization from '@site/static/usage/v9/alert/customization/index.mdx';
 <Customization />
 
 :::note
+
 If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file.
+
 :::
 
 ## Accessibility

--- a/docs/api/badge.md
+++ b/docs/api/badge.md
@@ -34,7 +34,9 @@ import Basic from '@site/static/usage/v9/badge/basic/index.mdx';
 Badges can be added inside a tab button, often used to indicate notifications or highlight additional items associated with the element.
 
 :::info
+
 Empty badges are only available for `md` mode.
+
 :::
 
 import InsideTabBar from '@site/static/usage/v9/badge/inside-tab-bar/index.mdx';

--- a/docs/api/button.md
+++ b/docs/api/button.md
@@ -92,7 +92,9 @@ There are many cases where a button's text content may overflow the container. I
 The button text does not automatically wrap to the next line when the text is too long to fit. In order to make the text wrap, the `ion-text-wrap` class can be added, which will set the `white-space` property to `"normal"`. This will become the default in a future major release.
 
 :::info
+
 The `max-width` style is set on the button below for demo purposes only. Text wrapping will work with a dynamic button width.
+
 :::
 
 import TextWrapping from '@site/static/usage/v9/button/text-wrapping/index.mdx';

--- a/docs/api/checkbox.md
+++ b/docs/api/checkbox.md
@@ -42,7 +42,9 @@ import LabelPlacement from '@site/static/usage/v9/checkbox/label-placement/index
 Developers can use the `alignment` property to control how the label and control are aligned on the cross axis. This property mirrors the flexbox `align-items` property.
 
 :::note
+
 Stacked checkboxes can be aligned using the `alignment` property. This can be useful when the label and control need to be centered horizontally.
+
 :::
 
 import Alignment from '@site/static/usage/v9/checkbox/alignment/index.mdx';
@@ -58,7 +60,9 @@ import Justify from '@site/static/usage/v9/checkbox/justify/index.mdx';
 <Justify />
 
 :::note
+
 `ion-item` is only used in the demos to emphasize how `justify` works. It is not needed in order for `justify` to function correctly.
+
 :::
 
 ## Indeterminate Checkboxes

--- a/docs/api/datetime.md
+++ b/docs/api/datetime.md
@@ -98,7 +98,9 @@ always in the 24-hour format, so `00` is `12am` on a 12-hour clock, `13` means
 `1pm`, and `23` means `11pm`.
 
 :::note
+
 While seconds, milliseconds, and time zone can be specified using the ISO 8601 datetime format, `ion-datetime` does not provide an interface for second, millisecond, and time zone selection. Any second, millisecond, or time zone values provided will be ignored.
+
 :::
 
 ## Basic Usage
@@ -153,7 +155,9 @@ The following example shows how to set the locale to Spanish (Spain).
 <CustomLocale />
 
 :::note
+
 The time label is not automatically localized. Refer to [Time Label](#time-label) for more information.
+
 :::
 
 ### Hour Cycle
@@ -170,7 +174,9 @@ There are 4 primary hour cycle types:
 | `'h24'`         | Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00.     |
 
 :::note
+
 Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle
+
 :::
 
 There may be scenarios where you need to have more control over which hour cycle is used. This is where the `hourCycle` property can help.
@@ -200,7 +206,9 @@ For example, if you wanted to use a 12 hour cycle with the `en-GB` locale, you c
 <LocaleExtensionTags />
 
 :::note
+
 Be sure to check the [Browser Compatibility Chart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale#browser_compatibility) for `Intl.Locale` before using it in your app.
+
 :::
 
 ## Presentation
@@ -262,7 +270,9 @@ If the `showAdjacentDays` property is set to `true`, days from the previous and 
 The calendar view always displays 6 rows when `showAdjacentDays` is enabled, so days from the previous or next month will be shown as needed to fill the grid. For example, even if a month starts on the first day of the week and ends within the fifth row, days from the next month will appear at the end to complete the sixth row.
 
 :::note
+
 This property is only supported when using `presentation="date"` and `preferWheel="false"`.
+
 :::
 
 <ShowAdjacentDays />
@@ -272,7 +282,9 @@ This property is only supported when using `presentation="date"` and `preferWhee
 If the `multiple` property is set to `true`, multiple dates can be selected from the calendar picker. Clicking a selected date will deselect it.
 
 :::note
+
 This property is only supported when using `presentation="date"` and `preferWheel="false"`.
+
 :::
 
 <MultipleDateSelection />
@@ -332,7 +344,9 @@ When specifying colors, any valid CSS color format can be used. This includes he
 To maintain a consistent user experience, the style of selected date(s) will always override custom highlights.
 
 :::note
+
 This property is only supported when `preferWheel="false"`, and using a `presentation` of either `"date"`, `"date-time"`, or `"time-date"`.
+
 :::
 
 ### Using Array
@@ -362,7 +376,9 @@ The benefit of this approach is that every component, not just `ion-datetime`, c
 The datetime header manages the content for the `title` slot and the selected date.
 
 :::note
+
 The selected date will not render if `preferWheel` is set to `true`.
+
 :::
 
 <DatetimeHeaderStyling />
@@ -380,7 +396,9 @@ The header can be styled using CSS shadow parts.
 The calendar days in a grid-style `ion-datetime` can be styled using CSS shadow parts.
 
 :::note
+
 The example below selects the day 2 days ago, unless that day is in the previous month, then it selects a day 2 days in the future. This is done for demo purposes in order to show how to apply custom styling to all days, the current day, and the selected day.
+
 :::
 
 <CalendarDaysStyling />

--- a/docs/api/img.md
+++ b/docs/api/img.md
@@ -22,7 +22,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 <EncapsulationPill type="shadow" />
 
 :::warning[Deprecated]
+
 `ion-img` is deprecated and will be removed in Ionic 10. Use a native `<img>` tag with [loading="lazy"](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading) instead. Refer to the [migration guide](../updating/9-0.md#img) for details on replacing events and styling.
+
 :::
 
 Img is a tag that will lazily load an image whenever the tag is in the viewport. This is extremely useful when generating a large list as images are only loaded when they're visible. The component uses [Intersection Observer](https://caniuse.com/#feat=intersectionobserver) internally, which is supported in most modern browsers, but falls back to a `setTimeout` when it is not supported.

--- a/docs/api/input-otp.md
+++ b/docs/api/input-otp.md
@@ -113,11 +113,13 @@ The `pattern` property enables custom validation using regular expressions. It a
 The component will prevent users from entering any characters that don't match the specified pattern. Developers can override these defaults by providing their own pattern string to match specific input requirements.
 
 :::tip
+
 When using a custom `pattern`, remember that the `type` property controls which keyboard appears on mobile devices:
 
 - Use `type="number"` for numeric-only patterns to show the numeric keyboard
 - Use `type="text"` for patterns that include letters to show the alphanumeric keyboard
-  :::
+
+:::
 
 import Pattern from '@site/static/usage/v9/input-otp/pattern/index.mdx';
 
@@ -130,7 +132,9 @@ import Pattern from '@site/static/usage/v9/input-otp/pattern/index.mdx';
 The `color` property changes the color palette for input boxes. For `outline` fills, this property changes the caret color, highlight color and border color. For `solid` fills, this property changes the caret color and highlight color.
 
 :::note
+
 The `color` property does _not_ change the text color of the input OTP. For that, use the [`--color` CSS property](#css-custom-properties-1).
+
 :::
 
 import Colors from '@site/static/usage/v9/input-otp/theming/colors/index.mdx';

--- a/docs/api/input-password-toggle.md
+++ b/docs/api/input-password-toggle.md
@@ -26,9 +26,11 @@ The InputPasswordToggle component is a companion component to [Input](./input). 
 ## Basic Usage
 
 :::info
+
 InputPasswordToggle must be used with an [Input](./input) that has its [`type`](./input/#type) property set to either `'text'` or `'password'`.
 
 Using any other `type` will cause a warning to be logged.
+
 :::
 
 import Basic from '@site/static/usage/v9/input-password-toggle/basic/index.mdx';

--- a/docs/api/input.md
+++ b/docs/api/input.md
@@ -86,7 +86,9 @@ Material Design offers filled styles for an input. The `fill` property on the in
 Filled inputs can be used on iOS by setting the input's `mode` to `md`.
 
 :::warning
+
 Inputs that use `fill` should not be used in an `ion-item` due to styling conflicts between the components.
+
 :::
 
 import Fill from '@site/static/usage/v9/input/fill/index.mdx';
@@ -156,9 +158,11 @@ The `start` and `end` slots can be used to place icons, buttons, or prefix/suffi
 Note that this feature is considered experimental because it relies on a simulated version of [Web Component slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots). As a result, the simulated behavior may not exactly match the native slot behavior.
 
 :::note
+
 In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. Refer to the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
 
 If slot content is meant to be interacted with, it should be wrapped in an interactive element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
 :::
 
 import StartEndSlots from '@site/static/usage/v9/input/start-end-slots/index.mdx';
@@ -172,7 +176,9 @@ import StartEndSlots from '@site/static/usage/v9/input/start-end-slots/index.mdx
 Setting the `color` property changes the color palette for each input. On `ios` mode, this property changes the caret color. On `md` mode, this property changes the caret color and the highlight/underline color.
 
 :::note
+
 The `color` property does _not_ change the text color of the input. For that, use the [`--color` CSS property](#css-custom-properties-1).
+
 :::
 
 import Colors from '@site/static/usage/v9/input/theming/colors/index.mdx';

--- a/docs/api/loading.md
+++ b/docs/api/loading.md
@@ -62,7 +62,9 @@ import Theming from '@site/static/usage/v9/loading/theming/index.mdx';
 <Theming />
 
 :::note
+
 `ion-loading` is presented at the root of your application, so we recommend placing any `ion-loading` styles in a global stylesheet.
+
 :::
 
 ## Accessibility

--- a/docs/api/modal.md
+++ b/docs/api/modal.md
@@ -58,7 +58,9 @@ When entering data into a modal, it is often desirable to have a way of preventi
 There are two different ways of using the `canDismiss` property: setting a boolean value or setting a callback function.
 
 :::note
+
 Note: When using a sheet modal, `canDismiss` will not be checked on swipe if there is no `0` breakpoint set. However, it will still be checked when pressing `Esc` or the hardware back button.
+
 :::
 
 ### Setting a boolean value
@@ -112,7 +114,9 @@ The `presentingElement` property accepts a reference to the element that should 
 The `canDismiss` property can be used to control whether or not the card modal can be swiped to close.
 
 :::note
+
 The card display style is only available on iOS.
+
 :::
 
 import CardExample from '@site/static/usage/v9/modal/card/basic/index.mdx';
@@ -122,7 +126,9 @@ import CardExample from '@site/static/usage/v9/modal/card/basic/index.mdx';
 ## Sheet Modal
 
 :::info
+
 [Content](./content) should be used inside of the sheet modal if you want your modal content to be scrollable.
+
 :::
 
 Developers can create a sheet modal effect similar to the drawer components available in maps applications. To create a sheet modal, developers need to set the `breakpoints` and `initialBreakpoint` properties on `ion-modal`.
@@ -174,11 +180,15 @@ import SheetScrollingContentExample from '@site/static/usage/v9/modal/sheet/expa
 Modals are presented at the root of your application so they overlay your entire app. This behavior applies to both inline modals and modals presented from a controller. As a result, custom modal styles can not be scoped to a particular component as they will not apply to the modal. Instead, styles must be applied globally. For most developers, placing the custom styles in `global.css` is sufficient.
 
 :::note
+
 If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file. Read [Style Placement](#style-placement) in the Angular section below for more information.
+
 :::
 
 :::note
+
 `ion-modal` works under the assumption that stacked modals are the same size. As a result, each subsequent modal will have no box shadow and a backdrop opacity of `0`. This is to avoid the effect of shadows and backdrops getting darker with each added modal. This can be changed by setting the `--box-shadow` and `--backdrop-opacity` CSS variables:
+
 :::
 
 ```

--- a/docs/api/nav.md
+++ b/docs/api/nav.md
@@ -26,7 +26,9 @@ Nav is a standalone component for loading arbitrary components and pushing new c
 Unlike Router Outlet, Nav is not tied to a particular router. This means that if we load a Nav component, and push other components to the stack, they will not affect the app's overall router. For example, you should not push a new component to `ion-nav` and expect the URL to update. This fits use cases where you could have a modal, which needs its own sub-navigation, without making it tied to the apps URL.
 
 :::note
+
 `ion-nav` is not meant to be used for routing. Instead, refer to the routing guides for [Angular](../angular/navigation), [React](../react/navigation), and [Vue](../vue/navigation), or [`ion-router`](./router) for vanilla JavaScript projects.
+
 :::
 
 ## Using NavLink

--- a/docs/api/picker.md
+++ b/docs/api/picker.md
@@ -65,7 +65,9 @@ Picker supports navigation using a screen reader by implementing the [`slider` r
 | Double Tap and Slide Up/Down | Adjust the selected option in the Picker Column. Can be used as an alternative to swiping up and down. |
 
 :::caution
+
 The Swipe Up and Swipe Down gestures rely on the correct key events being synthesized as noted on the [`slider` documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role). [Chromium-based browsers do not synthesize keyboard events correctly](https://issues.chromium.org/issues/40816094), but the "Double Tap and Slide Up/Down" gesture can be used as an alternative until this has been implemented in Chromium-based browsers.
+
 :::
 
 ### Keyboard Interactions

--- a/docs/api/popover.md
+++ b/docs/api/popover.md
@@ -54,7 +54,9 @@ Since the component you passed in needs to be created when the popover is presen
 A trigger for an inline `ion-popover` is the element that will open a popover when interacted with. The interaction behavior can be customized by setting the `trigger-action` property. Note that `trigger-action="context-menu"` will prevent your system's default context menu from opening.
 
 :::note
+
 Triggers are not applicable when using the `popoverController` because the `ion-popover` is not created ahead of time.
+
 :::
 
 import InlineTrigger from '@site/static/usage/v9/popover/presenting/inline-trigger/index.mdx';
@@ -94,7 +96,9 @@ import ControllerExample from '@site/static/usage/v9/popover/presenting/controll
 Popovers are presented at the root of your application so they overlay your entire app. This behavior applies to both inline popovers and popovers presented from a controller. As a result, custom popover styles can not be scoped to a particular component as they will not apply to the popover. Instead, styles must be applied globally. For most developers, placing the custom styles in `global.css` is sufficient.
 
 :::note
+
 If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file.
+
 :::
 
 import Styling from '@site/static/usage/v9/popover/customization/styling/index.mdx';
@@ -142,7 +146,9 @@ When using `ion-popover` inline, you can nested popovers to create nested dropdo
 You can use the `dismissOnSelect` property to automatically close the popover when the popover content has been clicked. This behavior does not apply when clicking a trigger element for another popover.
 
 :::note
+
 Nested popovers cannot be created when using the `popoverController` because the popover is automatically added to the root of your application when the `create` method is called.
+
 :::
 
 import NestedPopover from '@site/static/usage/v9/popover/nested/index.mdx';

--- a/docs/api/radio.md
+++ b/docs/api/radio.md
@@ -60,7 +60,9 @@ import UsingComparewith from '@site/static/usage/v9/radio/using-comparewith/inde
 Developers can use the `alignment` property to control how the label and control are aligned on the cross axis. This property mirrors the flexbox `align-items` property.
 
 :::note
+
 Stacked radios can be aligned using the `alignment` property. This can be useful when the label and control need to be centered horizontally.
+
 :::
 
 import Alignment from '@site/static/usage/v9/radio/alignment/index.mdx';
@@ -76,7 +78,9 @@ import Justify from '@site/static/usage/v9/radio/justify/index.mdx';
 <Justify />
 
 :::note
+
 `ion-item` is only used in the demos to emphasize how `justify` works. It is not needed in order for `justify` to function correctly.
+
 :::
 
 ## Deselecting Radios

--- a/docs/api/reorder.md
+++ b/docs/api/reorder.md
@@ -88,7 +88,9 @@ import ReorderStartEndEvents from '@site/static/usage/v9/reorder/reorder-start-e
 The `ionReorderMove` event is emitted continuously during the reorder gesture as the user drags an item. The event includes the `from` and `to` indices of the item. Unlike `ionReorderEnd`, the `from` index in this event represents the last known position of the item (which updates as the item moves), while the `to` index represents its current position. If the item has not changed position since the last event, the `from` and `to` indices will be the same. This event is useful for tracking position changes during the drag operation. For example, the ranking or numbering of items can be updated in real-time as they are being dragged to maintain a logical ascending order.
 
 :::warning
+
 Do not call the `complete` method during the `ionReorderMove` event as it can break the gesture.
+
 :::
 
 import ReorderMoveEvent from '@site/static/usage/v9/reorder/reorder-move-event/index.mdx';

--- a/docs/api/route-redirect.md
+++ b/docs/api/route-redirect.md
@@ -22,7 +22,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 A route redirect can only be used with an `ion-router` as a direct child of it.
 
 :::note
+
 Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use [`ion-router-outlet`](router-outlet.md) and the Angular router.
+
 :::
 
 The route redirect has two configurable properties:

--- a/docs/api/route.md
+++ b/docs/api/route.md
@@ -25,7 +25,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The route component takes a component and renders it when the Browser URL matches the url property.
 
 :::note
+
 Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use [`ion-router-outlet`](router-outlet.md) and the Angular router.
+
 :::
 
 ## Navigation Hooks

--- a/docs/api/router-link.md
+++ b/docs/api/router-link.md
@@ -24,7 +24,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The router link component is used for navigating to a specified link. Similar to the browser's anchor tag, it can accept a href for the location, and a direction for the transition animation.
 
 :::note
+
 Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use an `<a>` and `routerLink` with the Angular router.
+
 :::
 
 Refer to the [Router](./router) documentation for more information.

--- a/docs/api/router.md
+++ b/docs/api/router.md
@@ -22,7 +22,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The router is a component for handling routing inside vanilla and Stencil JavaScript projects.
 
 :::note
+
 Note: This component should only be used with vanilla and Stencil JavaScript projects. See the routing guides for [Angular](../angular/navigation), [React](../react/navigation), and [Vue](../vue/navigation) for framework-specific routing solutions.
+
 :::
 
 Apps should have a single `ion-router` component in the codebase.

--- a/docs/api/segment.md
+++ b/docs/api/segment.md
@@ -55,9 +55,11 @@ when the segment is active. With this approach, each segment's content can be sw
 to reflect the currently visible content.
 
 :::warning
+
 If no initial `value` is assigned to the `ion-segment` when using swipeable segments, the segment will default to the value of the first segment button.
 
 Segment buttons cannot be disabled when used with swipeable segments.
+
 :::
 
 import Swipeable from '@site/static/usage/v9/segment/swipeable/index.mdx';

--- a/docs/api/select.md
+++ b/docs/api/select.md
@@ -156,7 +156,9 @@ Material Design offers filled styles for a select. The `fill` property on the se
 Filled selects can be used on iOS by setting the select's `mode` to `md`.
 
 :::warning
+
 Selects that use `fill` should not be used in an `ion-item` due to styling conflicts between the components.
+
 :::
 
 import FillExample from '@site/static/usage/v9/select/fill/index.mdx';
@@ -194,9 +196,11 @@ import InterfaceOptionsExample from '@site/static/usage/v9/select/customization/
 The `start` and `end` slots can be used to place icons, buttons, or prefix/suffix text on either side of the select. If the slot content is clicked, the select will not open.
 
 :::note
+
 In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. Refer to the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
 
 If slot content is meant to be interacted with, it should be wrapped in an interactive element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
 :::
 
 import StartEndSlots from '@site/static/usage/v9/select/start-end-slots/index.mdx';
@@ -206,7 +210,9 @@ import StartEndSlots from '@site/static/usage/v9/select/start-end-slots/index.md
 ## Rich Content Options
 
 :::important
+
 Rich content in select options is disabled by default. Set [`innerHTMLTemplatesEnabled`](/docs/developing/config.md#ionicconfig) to `true` in your [global Ionic config](/docs/developing/config.md#global-config). Markup inside options is treated as plain text when it is disabled. Refer to [Security](/docs/techniques/security.md) for sanitization guidance when enabling custom HTML.
+
 :::
 
 In addition to single text labels, [Select Options](./select-option.md) can include HTML rich content in the select interface. Elements added inside of an option without a named slot will go into the default slot. The `start` and `end` slots will place elements on either side of the default slot. The `description` attribute can be used for additional supporting text displayed under the label.

--- a/docs/api/split-pane.md
+++ b/docs/api/split-pane.md
@@ -29,7 +29,9 @@ If the device's screen width is below a certain size, the split pane will collap
 ## Basic Usage
 
 :::note
+
 This demo sets the `when` property to `'xs'` so the split pane always shows up. Your Ionic application does not need this if you want the split pane to collapse on smaller viewports. Refer to [Setting Breakpoints](#setting-breakpoints) for more information.
+
 :::
 
 import Basic from '@site/static/usage/v9/split-pane/basic/index.mdx';

--- a/docs/api/tab-bar.md
+++ b/docs/api/tab-bar.md
@@ -141,7 +141,9 @@ export const TabBarExample: React.FC = () => (
 Badges can be added inside a tab button, often used to indicate notifications or highlight additional items associated with the element.
 
 :::info
+
 Empty badges are only available for `md` mode.
+
 :::
 
 import InsideTabBar from '@site/static/usage/v9/badge/inside-tab-bar/index.mdx';

--- a/docs/api/tab.md
+++ b/docs/api/tab.md
@@ -24,9 +24,11 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The tab component is a child component of [tabs](tabs.md). Each tab can contain a top level navigation stack for an app or a single view. An app can have many tabs, all with their own independent navigation.
 
 :::note
+
 Angular, React, and Vue can only use this component when the `ion-tabs` component is configured for [basic usage](./tabs.md#basic-usage). When setting up tabs with routing, the `ion-tab` component cannot be used.
 
 In JavaScript, this component can be used with the `ion-tabs` component configured for either [basic usage](./tabs.md#basic-usage) or [usage with router](./tabs.md#usage-with-router).
+
 :::
 
 Refer to the [tabs documentation](tabs.md) for more details on configuring tabs.

--- a/docs/api/textarea.md
+++ b/docs/api/textarea.md
@@ -74,7 +74,9 @@ Material Design offers filled styles for a textarea. The `fill` property on the 
 Filled textareas can be used on iOS by setting the textarea's `mode` to `md`.
 
 :::warning
+
 Textareas that use `fill` should not be used in an `ion-item` due to styling conflicts between the components.
+
 :::
 
 import Fill from '@site/static/usage/v9/textarea/fill/index.mdx';
@@ -122,9 +124,11 @@ The `start` and `end` slots can be used to place icons, buttons, or prefix/suffi
 Note that this feature is considered experimental because it relies on a simulated version of [Web Component slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots). As a result, the simulated behavior may not exactly match the native slot behavior.
 
 :::note
+
 In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. Refer to the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
 
 If slot content is meant to be interacted with, it should be wrapped in an interactive element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
 :::
 
 import StartEndSlots from '@site/static/usage/v9/textarea/start-end-slots/index.mdx';

--- a/docs/api/toggle.md
+++ b/docs/api/toggle.md
@@ -58,7 +58,9 @@ import LabelPlacement from '@site/static/usage/v9/toggle/label-placement/index.m
 Developers can use the `alignment` property to control how the label and control are aligned on the cross axis. This property mirrors the flexbox `align-items` property.
 
 :::note
+
 Stacked toggles can be aligned using the `alignment` property. This can be useful when the label and control need to be centered horizontally.
+
 :::
 
 import Alignment from '@site/static/usage/v9/toggle/alignment/index.mdx';

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,9 +32,11 @@ $ ionic <command> <subcommand> --help
 ```
 
 :::note
+
 Be sure to run `ionic <command> --help` in your project directory.
 
 For some commands, such as `ionic serve`, the help documentation is contextual to the type of your project, e.g. React vs Angular.
+
 :::
 
 ## Architecture

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -124,9 +124,11 @@ module.exports = function (ctx) {
 The Ionic CLI supports a multi-app configuration setup, which involves multiple Ionic apps and shared code within a single repository, or [monorepo](../reference/glossary.md#monorepo).
 
 :::note
+
 These docs give an overview of the multi-app feature of the Ionic CLI, but don't really go into details for each framework.
 
 If you're using Angular, please refer to [the Angular monorepo guide](https://github.com/ionic-team/ionic-cli/wiki/Angular-Monorepo) for examples.
+
 :::
 
 ### Setup Steps
@@ -207,7 +209,9 @@ $ ionic start "My New App" --no-deps
 If an app was created in a way other than `ionic start`, for example by using a prebuilt template, use `ionic init` to register the existing app with the multi-app project.
 
 :::note
+
 Make sure the app doesn't have an existing `ionic.config.json`.
+
 :::
 
 ```shell

--- a/docs/cli/livereload.md
+++ b/docs/cli/livereload.md
@@ -22,7 +22,9 @@ $ ionic capacitor run android -l --external
 ```
 
 :::note
+
 Remember, with the `--external` option, others on your Wi-Fi network will be able to access your app.
+
 :::
 
 ### Cordova
@@ -50,7 +52,9 @@ ionic cordova run ios -l --external
 ```
 
 :::note
+
 Remember, with the `--external` option, others on your Wi-Fi network will be able to access your app.
+
 :::
 
 ## Tips

--- a/docs/deployment/app-store.md
+++ b/docs/deployment/app-store.md
@@ -84,7 +84,9 @@ This will generate the minified code for the web portion of an app and copy it o
 From here, open the `.xcworkspace` file in `./platforms/ios/` to start Xcode.
 
 :::tip
+
 You can also have a release build generated automatically by using the `--release` flag.
+
 :::
 
 </TabItem>
@@ -119,5 +121,7 @@ An app can be updated by either submitting a new version to Apple, or by using a
 With <strong>Live Updates</strong>, app changes can be pushed in realtime directly to users from the Appflow dashboard, without waiting for App Store approvals.
 
 :::note
+
 In order for the iOS App Store to accept the updated build, the config.xml file will need to be edited to increment the version value, then rebuild the app for release following the same instructions above.
+
 :::

--- a/docs/deployment/play-store.mdx
+++ b/docs/deployment/play-store.mdx
@@ -91,7 +91,9 @@ To opt into app signing, you'll need to upload the app signing key used to sign 
 ![The opt-in options for Play App Signing in the Google Play Console.](https://blog.ionicframework.com/wp-content/uploads/2021/12/existingapps-optin.png 'Google Play Console Opt-in to Play App Signing')
 
 :::tip
+
 With smaller app sizes, improved performance, and enhanced security, the AAB binary format is a win for app developers and users alike. If you have an existing Android app using the APK format, consider migrating to AAB to take advantage of all the great features it provides.
+
 :::
 
 </TabItem>
@@ -106,7 +108,9 @@ keytool -genkey -v -keystore my-release-key.keystore -alias alias_name -keyalg R
 Once that command has been ran and its prompts have been answered a file called `my-release-key.keystore` will be created in the current directory.
 
 :::warning
+
 Save this file and keep it somewhere safe. If it is lost the Google Play Store will not accept updates for this app!
+
 :::
 
 To sign the unsigned APK, run the jarsigner tool which is also included in the Android SDK:
@@ -135,7 +139,9 @@ Now that a release AAB/APK has been generated, a Play Store listing can be writt
 To start, visit the [Google Play Store Developer Console](https://play.google.com/apps/publish) and create a new developer account.
 
 :::note
+
 Making a developer account with Google Play costs $25 USD.
+
 :::
 
 Once a developer account has been created, go ahead and click the `Create an Application`
@@ -153,14 +159,18 @@ As an app evolves, it will need to be updated with new features and fixes. An ap
 <TabItem value="capacitor" label="Capacitor" default>
 
 :::note
+
 In order for the Google Play Store to accept updated AAB/APK, the `android/app/build.gradle` file will need to be edited to increment the `versionCode` value, then rebuild the app for release following the instructions above.
+
 :::
 
 </TabItem>
 <TabItem value="cordova" label="Cordova">
 
 :::note
+
 In order for the Google Play Store to accept updated AAB/APK, the config.xml file will need to be edited to increment the version value, then rebuild the app for release following the instructions above.
+
 :::
 
 </TabItem>

--- a/docs/developer-resources/guides/first-app-v4/intro.md
+++ b/docs/developer-resources/guides/first-app-v4/intro.md
@@ -28,9 +28,11 @@ npm install -g @ionic/cli cordova
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../../../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/docs/developing/config/per-platform/index.md
+++ b/docs/developing/config/per-platform/index.md
@@ -14,9 +14,11 @@ import TabItem from '@theme/TabItem';
 <TabItem value="angular">
 
 :::note
+
 Since the config is set at runtime, you will not have access to the Platform Dependency Injection. Instead, you can use the underlying functions that the provider uses directly.
 
 Refer to the [Angular Platform Documentation](../angular/platform) for the types of platforms you can detect.
+
 :::
 
 ```ts title="app.module.ts"
@@ -41,9 +43,11 @@ import { isPlatform, IonicModule } from '@ionic/angular/lazy';
 <TabItem value="angular-standalone">
 
 :::note
+
 Since the config is set at runtime, you will not have access to the Platform Dependency Injection. Instead, you can use the underlying functions that the provider uses directly.
 
 Refer to the [Angular Platform Documentation](../angular/platform) for the types of platforms you can detect.
+
 :::
 
 ```ts title="main.ts"
@@ -63,7 +67,9 @@ bootstrapApplication(AppComponent, {
 <TabItem value="react">
 
 :::note
+
 Refer to the [React Platform Documentation](../react/platform) for the types of platforms you can detect.
+
 :::
 
 ```tsx title="App.tsx"
@@ -78,7 +84,9 @@ setupIonicReact({
 <TabItem value="vue">
 
 :::note
+
 Refer to the [Vue Platform Documentation](../vue/platform) for the types of platforms you can detect.
+
 :::
 
 ```ts title="main.ts"

--- a/docs/developing/hardware-back-button.md
+++ b/docs/developing/hardware-back-button.md
@@ -16,7 +16,9 @@ import TabItem from '@theme/TabItem';
 The hardware back button is found on most Android devices. In native applications it can be used to close modals, navigate to the previous view, exit an app, and more. By default in Ionic, when the back button is pressed, the current view will be popped off the navigation stack, and the previous view will be displayed. If no previous view exists in the navigation stack, nothing will happen. This guide will show how to customize the behavior of the hardware back button.
 
 :::note
+
 The hardware back button refers to the physical back button on an Android device and should not be confused with either the browser back button or `ion-back-button`. The information in this guide only applies to Android devices.
+
 :::
 
 ## Overview
@@ -47,7 +49,9 @@ Chrome has support for Close Watcher starting in [Chrome 120](https://developer.
 For complete hardware back button support, we recommend using Capacitor or Cordova.
 
 :::note
+
 The `ionBackButton` event will not be emitted when running an app in a browser or as a PWA if Close Watcher is unsupported or `experimentalCloseWatcher` is `false`.
+
 :::
 
 ## Basic Usage

--- a/docs/developing/keyboard.md
+++ b/docs/developing/keyboard.md
@@ -32,7 +32,9 @@ import Inputmode from '@site/static/usage/v9/keyboard/inputmode/index.mdx';
 <Inputmode />
 
 :::note
+
 The `inputmode` attribute is supported on devices running Chrome 66+ and iOS Safari 12.2+: https://caniuse.com/#search=inputmode
+
 :::
 
 ## enterkeyhint
@@ -50,7 +52,9 @@ import Enterkeyhint from '@site/static/usage/v9/keyboard/enterkeyhint/index.mdx'
 <Enterkeyhint />
 
 :::note
+
 The `enterkeyhint` attribute is supported on devices running Chrome 77+ and iOS Safari 13.4+.
+
 :::
 
 ## Dark Mode
@@ -171,5 +175,7 @@ watch(keyboardHeight, () => {
 ````
 
 :::note
+
 For apps running in a mobile web browser or as a PWA, Keyboard Lifecycle Events are only supported on Chrome 62+ and iOS Safari 13.0+.
+
 :::

--- a/docs/developing/managing-focus.md
+++ b/docs/developing/managing-focus.md
@@ -264,7 +264,9 @@ The following table explains what each content type represents:
 | `banner`  | The header of the view.       | [Header](../api/header)   | [`header`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) | [`role="banner"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_Role)                                                                                                                  |
 
 :::important
+
 Developers should assign `role="heading"` and `aria-level="1"` to the primary [Title](../api/title) on each view. Since multiple [Title](../api/title) components can be used in a single view, Ionic does not automatically assign these attributes.
+
 :::
 
 ### Specifying Priority

--- a/docs/developing/scaffolding.md
+++ b/docs/developing/scaffolding.md
@@ -45,7 +45,9 @@ The `src/app/` directory contains the root app component and module as well as a
 ## Generating New Features
 
 :::note
+
 This command is only supported in Ionic Angular.
+
 :::
 
 The Ionic CLI can generate new app features with the [`ionic generate`](../cli/commands/generate.md) command. By running `ionic generate` in the command line, a selection prompt is displayed which lists the available features that can be generated.
@@ -65,7 +67,9 @@ $ ionic generate
 After a selection is made, the Ionic CLI will prompt for a name. The name can be a path, allowing easy generation of features within an organized project structure.
 
 :::note
+
 Any level of nesting is allowed, such as `portfolio/intro`. You can easily scope components to pages by using `ionic g component "portfolio/intro/About Me"`, for example.
+
 :::
 
 ```shell-session

--- a/docs/developing/tips.md
+++ b/docs/developing/tips.md
@@ -15,7 +15,9 @@ title: Development Tips
 `EACCES` permission errors can occur when packages are installed globally. If this is the case, npm may need to be set up to operate without elevated permissions.
 
 :::note
+
 Using `sudo` with npm is **not recommended** because it can lead to further complications.
+
 :::
 
 This guide offers two options for resolving permission issues. Refer to the [npm docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) for full documentation and additional options.
@@ -118,7 +120,9 @@ When an app runs, it will pause at this function. From there, the developer tool
 By default, when an app is viewed in the browser, Ionic will apply the `md` mode. However, since Ionic components adapt according to their platform, it is helpful to be able to view what the app will look like on iOS. To do this, add `?ionic:mode=ios` to the URL where the app is being served. For example, if the app is served on port `8100`, the url would be: `http://localhost:8100/?ionic:mode=ios`.
 
 :::note
+
 This will not change which platform the browser detects. The platform is determined by device detection and inspecting the user-agent. To change the platform, the user-agent must be changed. To do this, open up Chrome DevTools with <kbd>Ctrl+Shift+I</kbd>(<kbd>Cmd+Option+I</kbd> on Mac), and then toggle device mode on with <kbd>Ctrl+Shift+M</kbd>(<kbd>Cmd+Option+M</kbd> on Mac).
+
 :::
 
 ![Chrome DevTools showing the device mode with iPhone X selected.](/img/faq/tips/change-device-platform.png 'Chrome DevTools Device Mode')

--- a/docs/intro/cli.md
+++ b/docs/intro/cli.md
@@ -36,8 +36,10 @@ $ npm install -g @ionic/cli
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Start an App

--- a/docs/intro/environment.md
+++ b/docs/intro/environment.md
@@ -17,7 +17,9 @@ Of course, a code editor is also required. [Visual Studio Code](https://code.vis
 ## Terminal
 
 :::note
+
 Much of Ionic development requires familiarity with the command line. If you're new to the command line, refer to the [New to the Command Line](https://ionicframework.com/blog/new-to-the-command-line/) blog post for a quick introduction.
+
 :::
 
 In general, we recommend using the built-in terminals. Many third-party terminals work well with Ionic, but may not be supported.
@@ -41,7 +43,9 @@ $ npm --version
 ```
 
 :::note
+
 Permission errors are common on macOS when installing global packages with `npm`. If you get an `EACCES` error, refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors).
+
 :::
 
 ## Git

--- a/docs/javascript/quickstart.md
+++ b/docs/javascript/quickstart.md
@@ -68,11 +68,15 @@ Your new app's directory will look like this:
 ```
 
 :::warning[Delete files]
+
 The `counter.js` and `style.css` files can be deleted. We will not be using them.
+
 :::
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's configure the project, initialize Ionic, and add components to create our app.
@@ -227,7 +231,9 @@ customElements.define('home-page', HomePage);
 This creates a custom element called `home-page` that contains the layout for your Home page. The page uses Ionic's layout components to create a header with a toolbar and scrollable content area.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 Next, add a `<script>` tag before the `main.js` import in `index.html` to import the Home page:
@@ -325,7 +331,9 @@ To navigate to the new page, update the button in `HomePage.js` to be inside of 
 When the button is clicked, Ionic's router will automatically navigate to the `/new` route and display the `new-page` component.
 
 :::info
+
 Navigating can also be performed programmatically using `document.querySelector('ion-router').push('/new')`. Refer to the [Ionic Router documentation](/docs/api/router.md) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/docs/layout/css-utilities.md
+++ b/docs/layout/css-utilities.md
@@ -13,7 +13,9 @@ title: CSS Utilities
 Ionic Framework provides a set of CSS utility classes that can be used on any element in order to modify the text, element placement or adjust the padding and margin.
 
 :::important
+
 If your app was not started using an available Ionic Framework starter, the stylesheets listed in the [optional section of the global stylesheets](global-stylesheets.md#optional) will need to be included in order for these styles to work.
+
 :::
 
 ## Text Modification

--- a/docs/layout/dynamic-font-scaling.md
+++ b/docs/layout/dynamic-font-scaling.md
@@ -5,9 +5,11 @@ Dynamic Font Scaling is a feature that allows users to choose the size of the te
 ## Try It Out
 
 :::tip
+
 Be sure to try this on an Android, iOS, or iPadOS device.
 
 If you are testing on Chrome for Android, make sure ["Accessibility Page Zoom"](#chrome-for-android) is enabled.
+
 :::
 
 Follow the [Changing the Font Size on a Device](#changing-the-font-size-on-a-device) guide to set your preferred font size, and watch the text in the demo below grow or shrink according to your preferences.
@@ -156,7 +158,9 @@ Refer to [Apple Support](https://support.apple.com/en-us/102453) for more inform
 Where users access the font scaling configuration varies across devices, but it is typically found in the "Accessibility" page in the Settings app.
 
 :::info
+
 The Chrome Web Browser on Android has some limitations with respecting system-level font scales. Refer to [Chrome for Android](#chrome-for-android) for more information.
+
 :::
 
 ## Troubleshooting
@@ -190,5 +194,7 @@ Certain native iOS components such as the Action Sheet make use of private font 
 The root element's default font size is typically `16px`. However, Dynamic Font Scaling on iOS devices make use of the ["Body" text style](https://developer.apple.com/design/human-interface-guidelines/typography#Specifications) which has a default font size of `17px`. Since the text in Ionic components is scaled relative to the root element's font size, some text may get larger or smaller when Dynamic Font Scaling is enabled, even if the system-level text scale did not change.
 
 :::info
+
 iOS provides a "Callout" text style which has a default font size of `16px`. However, this font style is currently not exposed to web content. Refer to [the supported text styles in WebKit](https://webkit.org/blog/3709/using-the-system-font-in-web-content/) for more information.
+
 :::

--- a/docs/react/lifecycle.md
+++ b/docs/react/lifecycle.md
@@ -37,7 +37,9 @@ export default withIonLifeCycle(HomePage);
 ```
 
 :::note
+
 `withIonLifeCycle` is imported from `@ionic/react`
+
 :::
 
 You can then create the appropriate lifecycle method on your class component, and the HOC calls that method when the event happens. Below is the entire component with each of the lifecycle methods implemented:
@@ -130,7 +132,9 @@ export default HomePage;
 ```
 
 :::note
+
 Functional components don't need to be wrapped with the `withIonLifeCycle` HOC as class components do.
+
 :::
 
 Developers can also optionally pass reactive dependencies to each lifecycle hook. These are then passed to the underlying [React useEffect hook](https://react.dev/reference/react/useEffect#useeffect):

--- a/docs/react/navigation.md
+++ b/docs/react/navigation.md
@@ -420,7 +420,9 @@ export default Tabs;
 If you have worked with Ionic Framework before, this should feel familiar. We create an `IonTabs` component and provide an `IonTabBar`. The `IonTabBar` provides `IonTabButton` components, each with a `tab` property that is associated with its corresponding tab in the router config. We also provide an `IonRouterOutlet` to give `IonTabs` an outlet to render the different tab views in. Note how the `Route` paths are relative (e.g., `"tab1"` instead of `"/tabs/tab1"`) since the parent route already matches `/tabs/*`.
 
 :::tip
+
 `IonTabs` renders an `IonPage` for you, so you do not need to add `IonPage` manually here.
+
 :::
 
 ### How Tabs in Ionic Work

--- a/docs/react/overlays.md
+++ b/docs/react/overlays.md
@@ -23,7 +23,9 @@ const [showAlert, hideAlert] = useIonAlert();
 ```
 
 :::note
+
 Overlays often dismiss themselves when the user is done interacting with them, so you might not need to use dismiss/hide method.
+
 :::
 
 To display the overlay, you use the present method, which we destructured to the name `showAlert`. The method takes in a set of parameters that vary depending on each overlay, but generally, they can either take in a simple set of common parameters or an object to specify additional options.
@@ -85,7 +87,9 @@ For overlays that display custom components, such as [modals](https://ionicframe
 ```
 
 :::note
+
 The Overlay Components are still a valid way of displaying overlays and are in no way a deprecated method. Use whichever method best fits your application.
+
 :::
 
 ## Docs for Overlays in Ionic

--- a/docs/react/pwa.md
+++ b/docs/react/pwa.md
@@ -42,7 +42,9 @@ Refer to the [Vite PWA "Deploy" Guide](https://vite-pwa-org.netlify.app/deployme
 ## Making your React app a PWA with Create React App
 
 :::note
+
 As of Ionic CLI v7, Ionic React starter apps ship with Vite instead of Create React App. Refer to [Making your React app a PWA with Vite](#making-your-react-app-a-pwa-with-vite) for Vite instructions.
+
 :::
 
 The two main requirements of a PWA are a [Service Worker](https://developers.google.com/web/fundamentals/primers/service-workers/) and a [Web Application Manifest](https://developers.google.com/web/fundamentals/web-app-manifest/). While it's possible to add both of these to an app manually, a base project from Create React App (CRA) and the Ionic CLI provides this already.
@@ -72,11 +74,15 @@ serviceWorkerRegistration.register();
 Once this package has been added, run `ionic build` and the `build` directory will be ready to deploy as a PWA.
 
 :::note
+
 By default, react apps package comes with the Ionic logo for the app icons. Be sure to update the manifest to use the correct app name and also replace the icons.
+
 :::
 
 :::note
+
 Features like Service Workers and many JavaScript APIs (such as geolocation) require the app to be hosted in a secure context. When deploying an app through a hosting service, be aware that HTTPS will be required to take full advantage of Service Workers.
+
 :::
 
 ### Service Worker configuration
@@ -100,7 +106,9 @@ npm install -g firebase-tools
 ```
 
 :::note
+
 If it's the first time you use firebase-tools, login to your Google account with `firebase login` command.
+
 :::
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -114,7 +122,9 @@ Create a new Firebase project or select an existing one.
 **"What do you want to use as your public directory?"** Enter "dist".
 
 :::note
+
 Answering this next question will ensure that routing, hard reload, and deep linking work in the app:
+
 :::
 
 **Configure as a single-page app (rewrite all urls to /index.html)?"** Enter "Yes".

--- a/docs/react/quickstart.md
+++ b/docs/react/quickstart.md
@@ -68,7 +68,9 @@ Your new app's directory will look like this:
 ```
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's walk through these files to understand the app's structure.
@@ -151,7 +153,9 @@ export default Home;
 This creates a page with a header and scrollable content area. The `IonPage` component provides the basic page structure and must be used on every page. The second header shows a [collapsible large title](/docs/api/title.md#collapsible-large-titles) that displays on iOS devices when at the top of the content, then condenses to show the smaller title in the first header when scrolling down.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 ## Add an Ionic Component
@@ -217,7 +221,9 @@ export default New;
 This creates a page with a [Back Button](/docs/api/back-button.md) in the [Toolbar](/docs/api/toolbar.md). The back button will automatically handle navigation back to the previous page, or to `/` if there is no history.
 
 :::warning
+
 When creating your own pages, always use `IonPage` as the root component. This is essential for proper transitions between pages, base CSS styling that Ionic components depend on, and consistent layout behavior across your app.
+
 :::
 
 ## Navigate to the New Page
@@ -245,7 +251,9 @@ Once that is done, update the button in `Home.tsx`:
 ```
 
 :::info
+
 Navigating can also be performed programmatically using the `useIonRouter` hook. See the [React Navigation documentation](/docs/react/navigation.md#useionrouter) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/docs/react/slides.md
+++ b/docs/react/slides.md
@@ -19,9 +19,11 @@ title: Migrating From IonSlides to Swiper.js
 We recommend [Swiper.js](http://swiperjs.com/) if you need a modern touch slider component. This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
 :::note
+
 Swiper's React component is set to be removed in a future release of Swiper, with [Swiper Element](https://swiperjs.com/element) as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for Web Components yet.
 
 Using Swiper's React component is **not** required to use Swiper.js with Ionic Framework.
+
 :::
 
 ## Getting Started
@@ -39,7 +41,9 @@ npm install swiper@latest
 ```
 
 :::note
+
 Developers using Create React App must use `react-scripts` v5.0.0+ with the latest version of Swiper.
+
 :::
 
 ## Swiping with Style
@@ -65,7 +69,9 @@ export default Home;
 ```
 
 :::note
+
 Importing `@ionic/react/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+
 :::
 
 ### Updating Selectors
@@ -257,7 +263,9 @@ export default Home;
 ```
 
 :::note
+
 Refer to [Swiper's React usage documentation](https://swiperjs.com/react#usage) for a full list of modules.
+
 :::
 
 ## The IonicSlides Module
@@ -306,7 +314,9 @@ export default Home;
 ```
 
 :::note
+
 The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+
 :::
 
 ## Properties
@@ -356,7 +366,9 @@ Below is a full list of property changes when going from `IonSlides` to Swiper R
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
+
 All properties available in Swiper React can be found in the [Swiper React props documentation](https://swiperjs.com/react#swiper-props).
+
 :::
 
 ## Events
@@ -413,7 +425,9 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | `onIonSlidesDidLoad`        | `onInit`                       |
 
 :::note
+
 All events available in Swiper can be found in the [Swiper API events documentation](https://swiperjs.com/swiper-api#events).
+
 :::
 
 ## Methods
@@ -545,7 +559,9 @@ export default Home;
 ```
 
 :::note
+
 For more information on effects in Swiper, please refer to the [Swiper React effects documentation](https://swiperjs.com/react#effects).
+
 :::
 
 ## Wrap Up

--- a/docs/react/storage.md
+++ b/docs/react/storage.md
@@ -14,7 +14,9 @@ sidebar_label: Storage
 There are a variety of options available for storing data within an Ionic application. It is best to choose options that best fit the needs of your application. A single application may have requirements that span multiple options.
 
 :::info
+
 Some storage options involve third-party plugins or products. In such cases, we neither endorse nor support those plugins or products. We are mentioning them here for informational purposes only.
+
 :::
 
 Here are some common use cases and solutions:

--- a/docs/react/your-first-app.md
+++ b/docs/react/your-first-app.md
@@ -51,7 +51,9 @@ Download and install these right away to ensure an optimal Ionic development exp
 Run the following in the command line terminal to install the Ionic CLI (`ionic`), `native-run`, used to run native binaries on devices and simulators/emulators, and `cordova-res`, used to generate native app icons and splash screens:
 
 :::note
+
 To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
+
 :::
 
 ```shell
@@ -59,9 +61,11 @@ npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/docs/react/your-first-app/4-loading-photos.md
+++ b/docs/react/your-first-app/4-loading-photos.md
@@ -221,9 +221,11 @@ export interface UserPhoto {
 ```
 
 :::note
+
 If you encounter broken image links or missing photos after following these steps, you may need to open your browser's dev tools and clear both [localStorage](https://developer.chrome.com/docs/devtools/storage/localstorage) and [IndexedDB](https://developer.chrome.com/docs/devtools/storage/indexeddb).
 
 In localStorage, look for domain `http://localhost:8100` and key `CapacitorStorage.photos`. In IndexedDB, find a store called "FileStorage". Your photos will have a key like `/DATA/123456789012.jpeg`.
+
 :::
 
 That’s it! We’ve built a complete Photo Gallery feature in our Ionic app that works on the web. Next up, we’ll transform it into a mobile app for iOS and Android!

--- a/docs/react/your-first-app/6-deploying-mobile.md
+++ b/docs/react/your-first-app/6-deploying-mobile.md
@@ -47,7 +47,9 @@ ionic cap sync
 ## iOS Deployment
 
 :::important
+
 To build an iOS app, you’ll need a Mac computer.
+
 :::
 
 Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac IDE), with dependencies managed by [CocoaPods](https://cocoapods.org/). Before running this app on an iOS device, there's a couple of steps to complete.

--- a/docs/react/your-first-app/7-live-reload.md
+++ b/docs/react/your-first-app/7-live-reload.md
@@ -221,7 +221,9 @@ Remember that removing the photo from the `photos` array triggers the `setPhotos
 Tap on a photo again and choose the “Delete” option. The photo is deleted! Implemented much faster using Live Reload. 💪
 
 :::note
+
 Remember, you can find the [complete source code for this app](https://github.com/ionic-team/tutorial-photo-gallery-react) on GitHub.
+
 :::
 
 In the final portion of this tutorial, we’ll walk you through the basics of the Appflow product used to build and deploy your application to users' devices.

--- a/docs/reference/browser-support.md
+++ b/docs/reference/browser-support.md
@@ -26,7 +26,9 @@ In pursuit of [adaptive styling](../core-concepts/fundamentals.md#adaptive-styli
 | Ionic v4  |          4.4+          | 10.0+ |
 
 :::note
+
 Check the [latest Android stats](https://developer.android.com/about/dashboards/) and the [latest iOS stats](https://developer.apple.com/support/app-store/) for up-to-date platform information.
+
 :::
 
 ### A Note on Android Support

--- a/docs/techniques/security.md
+++ b/docs/techniques/security.md
@@ -68,7 +68,9 @@ To learn more about the security recommendations for binding to directives such 
 For developers who wish to add complex HTML to components such as `ion-toast`, they will need to eject from the sanitizer that is built into Ionic Framework. Developers can either disable the sanitizer across their entire app or bypass it on a case-by-case basis.
 
 :::note
+
 Bypassing sanitization functionality can make your application vulnerable to [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting). Please exercise extreme caution when disabling the sanitizer.
+
 :::
 
 ### Disabling the sanitizer via config
@@ -80,11 +82,13 @@ Ionic Framework provides an application config option called `sanitizerEnabled` 
 Developers can also choose to eject from the sanitizer in certain scenarios. Ionic Framework provides the `IonicSafeString` class that allows developers to do just that.
 
 :::note
+
 In order to bypass the sanitizer and use unsanitized custom HTML in the relevant Ionic components, `innerHTMLTemplatesEnabled` must be set to `true` in the Ionic config.
 
 `IonicSafeString` should not be used if `innerHTMLTemplatesEnabled` is set to `false`.
 
 Refer to [Enabling Custom HTML Parsing](#enabling-custom-html-parsing-via-innerhtml) for more information.
+
 :::
 
 #### Usage

--- a/docs/theming/advanced.md
+++ b/docs/theming/advanced.md
@@ -22,7 +22,9 @@ The `theme-color` value for a meta tag indicates a color that browsers can use t
 The `content` value for the `theme-color` meta must contain a valid [CSS Color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) and cannot contain CSS Variables.
 
 :::note
+
 The `theme-color` meta controls the interface theme when running in a web browser or as a PWA and has no effect when an app is deployed using Capacitor or Cordova. If you are looking to customize the area under the status bar, we recommend using the [Capacitor Status Bar Plugin](https://capacitorjs.com/docs/apis/status-bar).
+
 :::
 
 The example below demonstrates how to use `theme-color` to style the browser interface on iOS 15.
@@ -43,7 +45,9 @@ Safari on iOS 15 and macOS will automatically determine an appropriate theme col
 There is a small subset of colors that browsers will not use as they interfere with the browser interface. For example, setting `content="red"` will not work in Safari on macOS because that color interferes with the red close button in the toolbar. If you run into this situation, try altering your color selection slightly.
 
 :::note
+
 Browsers will prefer the `theme-color` meta over `theme` in `manifest.json` if both are present.
+
 :::
 
 For more information, refer to the [MDN theme-color documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color).
@@ -106,7 +110,9 @@ There is not yet full [browser support](https://developer.mozilla.org/en-US/docs
 ```
 
 :::note
+
 Refer to the [CSS Variables](css-variables.md) section for more information on how to get and set CSS variables.
+
 :::
 
 Ionic uses colors with an opacity (alpha) in several components. In order for this to work, those properties must be provided in RGB format. When changing any of the properties that have a variation ending in `-rgb`, it is important they are also provided in a comma separated format **without parentheses**. Below are some examples for changing text and background color.

--- a/docs/theming/colors.md
+++ b/docs/theming/colors.md
@@ -55,7 +55,9 @@ To change the default values of a color, all of the listed variations for that c
 When `secondary` is applied to a button, not only is the base color <CodeColor color="#006600">#006600</CodeColor> used, but the contrast color <CodeColor color="#ffffff">#ffffff</CodeColor> is used for the text, along with shade <CodeColor color="#005a00">#005a00</CodeColor> and tint <CodeColor color="#1a751a">#1a751a</CodeColor> colors for the different states of the button.
 
 :::note
+
 Not sure how to get the variation colors from the base color? Try out our [Color Generator](color-generator.md) that calculates all of the variations and provides code to copy/paste into an app!
+
 :::
 
 Refer to the [CSS Variables documentation](css-variables.md) for more information on CSS variables.

--- a/docs/theming/css-shadow-parts.md
+++ b/docs/theming/css-shadow-parts.md
@@ -17,7 +17,9 @@ CSS Shadow Parts allow developers to style CSS properties on an element inside o
 Ionic Framework is a distributed set of [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components). Web Components follow the [Shadow DOM specification](https://w3c.github.io/webcomponents/spec/shadow/) in order to encapsulate styles and markup.
 
 :::note
+
 Ionic Framework components are **not all** Shadow DOM components. If the component is a Shadow DOM component, there will be a badge in the top right of its [component documentation](../components.md). An example of a Shadow DOM component is the [button component](../api/button.md).
+
 :::
 
 Shadow DOM is useful for preventing styles from leaking out of components and unintentionally applying to other elements. For example, we assign a `.button` class to our `ion-button` component. Without Shadow DOM encapsulation, if a user were to set the class `.button` on one of their own elements, it would inherit the Ionic Framework button styles. Since `ion-button` is a Shadow component, this is not a problem.
@@ -98,7 +100,9 @@ ion-item::part(native):hover {
 ```
 
 :::note
+
 There are some known limitations with [vendor prefixed pseudo-elements](#vendor-prefixed-pseudo-elements) and [structural pseudo-classes](#structural-pseudo-classes).
+
 :::
 
 ## Ionic Framework Parts
@@ -112,7 +116,9 @@ In order to have parts a component must meet the following criteria:
 - The children elements are not structural. In certain components, including `ion-title`, the child element is a structural element used to position the inner elements. We do not recommend customizing structural elements as this can have unexpected results.
 
 :::note
+
 We welcome recommendations for additional parts. Please create a [new GitHub issue](https://github.com/ionic-team/ionic-framework/issues/new?assignees=&labels=&template=feature_request.md&title=feat%3A+) with as much information as possible when requesting a part.
+
 :::
 
 ## Known Limitations

--- a/docs/theming/dark-mode.md
+++ b/docs/theming/dark-mode.md
@@ -65,7 +65,9 @@ import AlwaysDarkMode from '@site/static/usage/v9/theming/always-dark-mode/index
 <AlwaysDarkMode />
 
 :::caution[Important]
+
 Avoid targeting the `.ios` or `.md` selectors to override the Ionic dark palette, as these classes are added to each component and will take priority over globally defined variables. Instead, we can target the mode-specific classes on the `:root` element.
+
 :::
 
 ### System
@@ -110,7 +112,9 @@ This sets the [application colors](/docs/theming/themes#application-colors) and 
 The following example uses the system settings to decide when to show dark mode.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable dark mode on [Windows 11](https://support.microsoft.com/en-us/windows/change-colors-in-windows-d26ef4d6-819a-581c-1581-493cfcc005fe) and on [macOS](https://support.apple.com/en-us/HT208976).
+
 :::
 
 import SystemDarkMode from '@site/static/usage/v9/theming/system-dark-mode/index.mdx';
@@ -118,7 +122,9 @@ import SystemDarkMode from '@site/static/usage/v9/theming/system-dark-mode/index
 <SystemDarkMode />
 
 :::caution[Important]
+
 Avoid targeting the `.ios` or `.md` selectors to override the Ionic dark palette, as these classes are added to each component and will take priority over globally defined variables. Instead, we can target the mode-specific classes on the `:root` element.
+
 :::
 
 ### CSS Class
@@ -163,7 +169,9 @@ This sets the [application colors](/docs/theming/themes#application-colors) and 
 The following example combines site settings, system settings, and the toggle to decide when to show dark mode. The site's palette takes precedence over system settings. If your system settings differ from the site's palette when the demo loads, it will use the site's palette.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable dark mode on [Windows 11](https://support.microsoft.com/en-us/windows/change-colors-in-windows-d26ef4d6-819a-581c-1581-493cfcc005fe) and on [macOS](https://support.apple.com/en-us/HT208976).
+
 :::
 
 import ClassDarkMode from '@site/static/usage/v9/theming/class-dark-mode/index.mdx';
@@ -171,7 +179,9 @@ import ClassDarkMode from '@site/static/usage/v9/theming/class-dark-mode/index.m
 <ClassDarkMode />
 
 :::caution[Important]
+
 The `.ion-palette-dark` class **must** be added to the `html` element in order to work with the imported dark palette.
+
 :::
 
 ## Adjusting System UI Components
@@ -197,11 +207,15 @@ color-scheme: light dark;
 For more information regarding `color-scheme`, please refer to the [Web.dev guide on color schemes](https://web.dev/color-scheme/).
 
 :::note
+
 `color-scheme` does not apply to the keyboard. For details on how dark mode works with the keyboard, refer to [Keyboard Documentation](../developing/keyboard.md#dark-mode).
+
 :::
 
 :::note
+
 For developers looking to customize the theme color under the status bar in Safari on iOS 15 or the toolbar in Safari on macOS, refer to [`theme-color` Meta](./advanced.md#theme-color-meta).
+
 :::
 
 ## Ionic Dark Palette
@@ -221,11 +235,15 @@ The **always** dark palette behaves in the following ways:
 3. Setting variables for the dark palette on `md` devices using the `:root.md` selector.
 
 :::caution
+
 It is important to pay attention to the specificity if you want to override any of the Ionic dark palette variables. For example, because the `--ion-item-background` variable is set for each mode, it cannot be overridden in the `:root` selector. A higher specificity selector, such as `:root.ios`, is required.
+
 :::
 
 :::info
+
 The contents of Ionic's dark palette can be [viewed on GitHub](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.scss). The CSS used to apply the **always** dark palette can be found in the [repository](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.always.scss).
+
 :::
 
 </TabItem>
@@ -240,11 +258,15 @@ The **system** dark palette behaves in the following ways:
 4. Only applies these variables when the [CSS media query for `prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) is `dark`.
 
 :::caution
+
 It is important to pay attention to the specificity if you want to override any of the Ionic dark palette variables. For example, because the `--ion-item-background` variable is set for each mode, it cannot be overridden in the `:root` selector. A higher specificity selector, such as `:root.ios`, is required.
+
 :::
 
 :::info
+
 The contents of Ionic's dark palette can be [viewed on GitHub](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.scss). The CSS used to apply the **system** dark palette can be found in the [repository](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.system.scsss).
+
 :::
 
 </TabItem>
@@ -258,11 +280,15 @@ The **class** dark palette behaves in the following ways:
 3. Setting variables for the dark palette on `md` devices using the `.ion-palette-dark.md` selector.
 
 :::caution
+
 It is important to pay attention to the specificity if you want to override any of the Ionic dark palette variables. For example, because the `--ion-item-background` variable is set for each mode, it cannot be overridden in the `.ion-palette-dark` selector. A higher specificity selector, such as `.ion-palette-dark.ios`, is required.
+
 :::
 
 :::info
+
 The contents of Ionic's dark palette can be [viewed on GitHub](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.scss). The CSS used to apply the **class** dark palette can be found in the [repository](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.class.scss).
+
 :::
 
 </TabItem>

--- a/docs/theming/high-contrast-mode.md
+++ b/docs/theming/high-contrast-mode.md
@@ -120,7 +120,9 @@ This approach activates the high contrast palette when the [CSS media query for 
 The following example uses the system settings to decide when to show high contrast mode.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable high contrast mode on [Windows 11](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) and on [macOS](https://support.apple.com/guide/mac-help/change-display-settings-for-accessibility-unac089/mac).
+
 :::
 
 import SystemHighContrastMode from '@site/static/usage/v9/theming/system-high-contrast-mode/index.mdx';
@@ -128,8 +130,10 @@ import SystemHighContrastMode from '@site/static/usage/v9/theming/system-high-co
 <SystemHighContrastMode />
 
 :::caution
+
 The high contrast light palette must be imported after [core.css](../layout/global-stylesheets.md#corecss), and the
 high contrast dark palette must be imported after `dark.system.css`. Otherwise, the standard contrast palette will take priority.
+
 :::
 
 ### CSS Class
@@ -178,7 +182,9 @@ This approach activates the high contrast palette when the `.ion-palette-high-co
 The following example combines site settings, system settings, and the toggle to decide when to show high contrast mode. The site's palette takes precedence over system settings. If your system settings differ from the site's palette when the demo loads, it will use the site's palette.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable high contrast mode on [Windows 11](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) and on [macOS](https://support.apple.com/guide/mac-help/change-display-settings-for-accessibility-unac089/mac).
+
 :::
 
 import ClassHighContrastMode from '@site/static/usage/v9/theming/class-high-contrast-mode/index.mdx';
@@ -186,13 +192,17 @@ import ClassHighContrastMode from '@site/static/usage/v9/theming/class-high-cont
 <ClassHighContrastMode />
 
 :::caution
+
 The high contrast light palette must be imported after [core.css](../layout/global-stylesheets.md#corecss),
 and the high contrast dark palette must be imported after `dark.class.css`. Otherwise, the standard contrast palette will take
 priority.
+
 :::
 
 :::caution
+
 The `.ion-palette-high-contrast` class **must** be added to the `html` element in order to work with the imported high contrast palette.
+
 :::
 
 ## Customizing Ionic High Contrast Theme

--- a/docs/troubleshooting/cors.md
+++ b/docs/troubleshooting/cors.md
@@ -23,7 +23,9 @@ When the origin where your app is served (e.g. `http://localhost:8100` with `ion
 CORS errors are common in web apps when a cross-origin request is made but the server doesn't return the required headers in the response (is not CORS-enabled):
 
 :::note
+
 XMLHttpRequest cannot load https://api.example.com. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:8100' is therefore not allowed access.
+
 :::
 
 ## How does CORS work

--- a/docs/troubleshooting/debugging.md
+++ b/docs/troubleshooting/debugging.md
@@ -50,7 +50,9 @@ On your device, open the Ionic app that you would like to debug using Chrome.
 With your app running on the device, head back to Chrome and click on **inspect** under your device in the list of remote targets. This will open the Chrome Developer Tools in a new window. You will then be able to use all of the Chrome DevTools to debug the application as it runs on your device.
 
 :::note
+
 The app preview may not automatically appear when you open Chrome Developer Tools due to a minor bug. To make it appear, click on the **Elements** tab then click on any DOM element then toggle off and on any CSS rule and the app preview window will appear.
+
 :::
 
 ## Debugging with Visual Studio locally in Chrome (both Android & iOS)
@@ -96,5 +98,7 @@ In the root of your Ionic project, create a folder called `.vscode` and inside t
 Next, launch the debugging process, selecting your device and Ionic app. VS Code will attach to both the Android device and Ionic app and you can now debug your app, which includes setting breakpoints.
 
 :::note
+
 If you are unable to set breakpoints and get an error saying, **"Breakpoint ignored because generated code not found (source map problem?)"** it means that the paths to the transpiled javascript files are incorrect. Use the `.scripts` command in the Debug console to list the loaded scripts. Make sure the paths of the scripts are correct by experimenting with different values in the `sourceMapPathOverrides` key in your `launch.json` configuration file.
+
 :::

--- a/docs/troubleshooting/runtime.md
+++ b/docs/troubleshooting/runtime.md
@@ -13,7 +13,9 @@ title: Runtime Issues
 ## Blank App
 
 :::note
+
 I have no errors in my app. Why does it show a blank screen?
+
 :::
 
 There are several different reasons this can happen. If you are unable to find a solution on the [Ionic forums](https://forum.ionicframework.com), make sure:
@@ -43,7 +45,9 @@ This will automatically include the polyfills for older browsers that need them.
 ## Directive Not Working
 
 :::note
+
 Why is my custom component/directive not working?
+
 :::
 
 There are a few things you can check. Make sure:
@@ -84,7 +88,9 @@ class MyPage { }
 ## Click Delays
 
 :::note
+
 Why is there a delay on my click event?
+
 :::
 
 In general, we recommend only adding `(click)` events to elements that are
@@ -104,7 +110,9 @@ add the `tappable` attribute to your element.
 ## Angular Change Detection
 
 :::note
+
 Why does Angular change detection run very frequently when my components are initializing?
+
 :::
 
 Angular uses a library called [zone.js](https://github.com/angular/angular/tree/master/packages/zone.js/)
@@ -138,7 +146,9 @@ This change will only affect applications that depend on zone.js `0.8.27` or
 newer. Older versions will not be affected by this change.
 
 :::note
+
 This flag is automatically included when creating an Ionic app via the Ionic CLI.
+
 :::
 
 ## Cordova plugins not working in the browser

--- a/docs/updating/4-0.md
+++ b/docs/updating/4-0.md
@@ -10,11 +10,15 @@ import TabItem from '@theme/TabItem';
 ## Updating from Ionic 3 to 4
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 3. If you are using Ionic 1 or 2, Make sure to follow the [Updating from Ionic 1 to 4 Guide](#updating-from-ionic-1-to-4) instead.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 3 to Ionic 4, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v4.md) in the Ionic Framework repository.
+
 :::
 
 We suggest the following general process when migrating an existing application from Ionic 3 to 4:

--- a/docs/updating/5-0.md
+++ b/docs/updating/5-0.md
@@ -7,11 +7,15 @@ title: Updating to v5
 Migrating an app from Ionic 4 to 5 requires a few updates to the API properties, CSS utilities, and the installed package dependencies.
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 4. Make sure you have followed the [Updating to Ionic 4 Guide](./4-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 4 to Ionic 5, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v5.md) in the Ionic Framework repository.
+
 :::
 
 ### Packages and Dependencies

--- a/docs/updating/6-0.md
+++ b/docs/updating/6-0.md
@@ -5,11 +5,15 @@ title: Updating to v6
 # Updating from Ionic 5 to 6
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 5. Make sure you have followed the [Updating to Ionic 5 Guide](./5-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 5 to Ionic 6, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v6.md) in the Ionic Framework repository.
+
 :::
 
 ## Getting Started
@@ -82,7 +86,9 @@ setupIonicReact({
 ```
 
 :::note
+
 Developers must import and call `setupIonicReact` even if they are not setting custom config.
+
 :::
 
 Refer to the [React Config Documentation](../developing/config) for more examples.
@@ -184,7 +190,9 @@ Refer to the [Testing section below](#testing) for more information.
 ```
 
 :::note
+
 This applies to `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `ion-picker`, `ion-popover`, and `ion-toast`.
+
 :::
 
 9. Pass in an `ion-router-outlet` into any `ion-tabs` that are being used:
@@ -315,7 +323,9 @@ npm install @ionic/core@6
 5. Remove any usage of the `displayFormat` or `displayTimezone` properties. To parse the UTC string provided in the payload of the `ionChange` event, we recommend using [date-fns](https://date-fns.org/). Refer to the [ion-datetime Parsing Dates Documentation](../api/datetime#parsing-dates) for examples.
 
 :::note
+
 Refer to the [Datetime Migration Sample Application](https://github.com/ionic-team/datetime-migration-samples) for more migration examples.
+
 :::
 
 ### Icon
@@ -443,7 +453,9 @@ module.exports = {
 ```
 
 :::note
+
 If you are using Ionic React or Ionic Vue, be sure to add the appropriate packages to the `transformIgnorePatterns` array. For Ionic React this includes `@ionic/react` and `@ionic/react-router`. For Ionic Vue this includes `@ionic/vue` and `@ionic/vue-router`.
+
 :::
 
 For developers using Create React App (CRA), there is currently no way to update the `transformIgnorePatterns` in a Jest config file. This is a CRA restriction and not something Ionic has control over. We can, however, pass the `transformIgnorePatterns` directly into the `react-scripts test` command:

--- a/docs/updating/7-0.md
+++ b/docs/updating/7-0.md
@@ -5,11 +5,15 @@ title: Updating to v7
 # Updating from Ionic 6 to 7
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Upgrading to Ionic 6 Guide](./6-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 6 to Ionic 7, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-7x) in the Ionic Framework repository.
+
 :::
 
 ## Getting Started

--- a/docs/updating/8-0.md
+++ b/docs/updating/8-0.md
@@ -5,11 +5,15 @@ title: Updating to v8
 # Updating from Ionic 7 to 8
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 7. Make sure you have followed the [Upgrading to Ionic 7 Guide](./7-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 7 to Ionic 8, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-8x) in the Ionic Framework repository.
+
 :::
 
 ## Getting Started

--- a/docs/updating/9-0.md
+++ b/docs/updating/9-0.md
@@ -5,11 +5,15 @@ title: Updating to v9
 # Updating from Ionic 8 to 9
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 8. Make sure you have followed the [Upgrading to Ionic 8 Guide](./8-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 8 to Ionic 9, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-9x) in the Ionic Framework repository.
+
 :::
 
 ## Automated Migration
@@ -17,7 +21,9 @@ For a **complete list of breaking changes** from Ionic 8 to Ionic 9, please refe
 Before manually working through the changes below, you can run the Ionic migration tool. It scans your app, automatically applies the breaking changes that can be safely migrated, and prints a checklist of the remaining updates that require manual work. Each item includes the affected file, line number, and a link to the corresponding section of this guide. Because the tool reads your framework and version from `package.json`, it only applies migrations that are relevant to your app.
 
 :::warning
+
 Commit your work first. The tool writes changes in place and refuses to run on a dirty working tree, or a project without git, unless you pass `--force`, so git is your undo.
+
 :::
 
 ```shell
@@ -64,7 +70,9 @@ Ionic 9 supports zoneless change detection. Angular 21 made zoneless the default
 Without Zone.js, Angular does not automatically re-render when you update component state from an asynchronous callback (awaiting an overlay result, `setTimeout`, RxJS subscriptions, `Platform` events). In those cases you must notify Angular with a signal or `ChangeDetectorRef.markForCheck()`. Refer to [Zoneless Change Detection](/docs/angular/zoneless.md) for the patterns Ionic apps use.
 
 :::note
+
 On Angular 18 through 20, Zone.js remains Angular's default, so those versions are unaffected and require no action. To adopt zoneless on Angular 18 through 20, add `provideZonelessChangeDetection()` (named `provideExperimentalZonelessChangeDetection()` on Angular 18 and 19) and remove `zone.js` from the `polyfills` array in `angular.json`.
+
 :::
 
 ##### Keeping Zone.js
@@ -135,7 +143,9 @@ Run `ng update` when upgrading to Angular 22; it migrates your existing componen
 ```
 
 :::note
+
 Ionic's own Angular components already declare `OnPush`, so they are unaffected. Angular 18 through 21 keep the eager default and require no change.
+
 :::
 
 #### TypeScript

--- a/docs/vue/lifecycle.md
+++ b/docs/vue/lifecycle.md
@@ -70,7 +70,9 @@ onIonViewWillLeave(() => {
 ```
 
 :::note
+
 Pages in your app need to be using the `IonPage` component in order for lifecycle methods and hooks to fire properly.
+
 :::
 
 ## How Ionic Framework Handles the Life of a Page

--- a/docs/vue/navigation.md
+++ b/docs/vue/navigation.md
@@ -163,7 +163,9 @@ ionRouter.navigate('/page2', 'forward', 'replace', customAnimation);
 The example above has the app navigate to `/page2` with a custom animation that uses the forward direction. In addition, the `replace` value ensures that the app replaces the current history entry when navigating.
 
 :::note
+
 `useIonRouter` uses the Vue `inject()` function and should only be used inside of your `setup()` function.
+
 :::
 
 Refer to the [useIonRouter documentation](./utility-functions#router) for more details as well as type information.

--- a/docs/vue/pwa.md
+++ b/docs/vue/pwa.md
@@ -42,7 +42,9 @@ Refer to the [Vite PWA "Deploy" Guide](https://vite-pwa-org.netlify.app/deployme
 ## Making your Vue app a PWA with Vue CLI
 
 :::note
+
 As of Ionic CLI v7, Ionic Vue starter apps ship with Vite instead of Vue CLI. Refer to [Making your Vue app a PWA with Vite](#making-your-vue-app-a-pwa-with-vite) for Vite instructions.
+
 :::
 
 The two main requirements of a PWA are a [Service Worker](https://developers.google.com/web/fundamentals/primers/service-workers/) and a [Web Application Manifest](https://developers.google.com/web/fundamentals/web-app-manifest/). While it's possible to add both of these to an app manually, the Vue CLI has some utilities for adding this for you.
@@ -54,7 +56,9 @@ vue add pwa
 ```
 
 :::note
+
 If you have changes already in place, be sure to commit them in Git.
+
 :::
 
 Once this is completed, Vue's CLI will have created a new `registerServiceWorker.ts` file and imported it into our `main.ts`.
@@ -165,7 +169,9 @@ npm install -g firebase-tools
 ```
 
 :::note
+
 If it's the first time you use firebase-tools, login to your Google account with `firebase login` command.
+
 :::
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -179,7 +185,9 @@ Create a new Firebase project or select an existing one.
 **"What do you want to use as your public directory?"** Enter "dist".
 
 :::note
+
 Answering this next question will ensure that routing, hard reload, and deep linking work in the app:
+
 :::
 
 **Configure as a single-page app (rewrite all urls to /index.html)?"** Enter "Yes".

--- a/docs/vue/quickstart.md
+++ b/docs/vue/quickstart.md
@@ -66,7 +66,9 @@ Your new app's directory will look like this:
 ```
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's walk through these files to understand the app's structure.
@@ -163,7 +165,9 @@ import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue
 This creates a page with a header and scrollable content area. The second header shows a [collapsible large title](/docs/api/title.md#collapsible-large-titles) that displays on iOS devices when at the top of the content, then condenses to show the smaller title in the first header when scrolling down.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 ## Add an Ionic Component
@@ -220,7 +224,9 @@ import { IonBackButton, IonButtons, IonContent, IonHeader, IonPage, IonTitle, Io
 This creates a page with a [Back Button](/docs/api/back-button.md) in the [Toolbar](/docs/api/toolbar.md). The back button will automatically handle navigation back to the previous page, or to `/` if there is no history.
 
 :::warning
+
 When creating your own pages, always use `ion-page` as the root component. This is essential for proper transitions between pages, base CSS styling that Ionic components depend on, and consistent layout behavior across your app.
+
 :::
 
 ## Navigate to the New Page
@@ -259,7 +265,9 @@ Once that is done, update the button in `HomePage.vue`:
 ```
 
 :::info
+
 Navigating can also be performed programmatically using Vue Router, and routes can be lazy loaded for better performance. Refer to the [Vue Navigation documentation](/docs/vue/navigation.md) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/docs/vue/slides.md
+++ b/docs/vue/slides.md
@@ -11,15 +11,19 @@ title: Migrating From ion-slides to Swiper.js
 </head>
 
 :::warning[Looking for `ion-slides`?]
+
 `ion-slides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
+
 :::
 
 We recommend [Swiper.js](http://swiperjs.com/) if you need a modern touch slider component. This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
 
 :::note
+
 Swiper's Vue component is set to be removed in a future release of Swiper, with [Swiper Element](https://swiperjs.com/element) as the replacement. However, this guide shows how to migrate to the Vue component because it provides the most stable experience at the time of writing.
 
 Using Swiper's Vue component is **not** required to use Swiper.js with Ionic Framework.
+
 :::
 
 ## Getting Started
@@ -56,7 +60,9 @@ import '@ionic/vue/css/ionic-swiper.css';
 ```
 
 :::note
+
 Importing `@ionic/vue/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+
 :::
 
 ### Updating Selectors
@@ -212,7 +218,9 @@ const modules = [Autoplay, Keyboard, Pagination, Scrollbar, Zoom];
 ```
 
 :::note
+
 Refer to [Swiper's Vue usage documentation](https://swiperjs.com/vue#usage) for a full list of modules.
+
 :::
 
 ## The IonicSlides Module
@@ -253,7 +261,9 @@ const modules = [Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonicSlides];
 ```
 
 :::note
+
 The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+
 :::
 
 ## Properties
@@ -294,7 +304,9 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
+
 All properties available in Swiper Vue can be found in the [Swiper Vue props documentation](https://swiperjs.com/vue#swiper-props).
+
 :::
 
 ## Events
@@ -347,7 +359,9 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `init`                       |
 
 :::note
+
 All events available in Swiper Vue can be found in the [Swiper Vue events documentation](https://swiperjs.com/vue#swiper-events).
+
 :::
 
 ## Methods
@@ -472,7 +486,9 @@ const modules = [EffectFade, IonicSlides];
 ```
 
 :::note
+
 For more information on effects in Swiper, please refer to the [Swiper Vue effects documentation](https://swiperjs.com/vue#effects).
+
 :::
 
 ## Wrap Up

--- a/docs/vue/storage.md
+++ b/docs/vue/storage.md
@@ -14,7 +14,9 @@ sidebar_label: Storage
 There are a variety of options available for storing data within an Ionic application. It is best to choose options that best fit the needs of your application. A single application may have requirements that span multiple options.
 
 :::info
+
 Some storage options involve third-party plugins or products. In such cases, we neither endorse nor support those plugins or products. We are mentioning them here for informational purposes only.
+
 :::
 
 Here are some common use cases and solutions:

--- a/docs/vue/utility-functions.md
+++ b/docs/vue/utility-functions.md
@@ -112,7 +112,9 @@ useBackButton(priority: number, handler: Handler): UseBackButtonResult;
 Refer to the [Hardware Back Button Documentation](../developing/hardware-back-button) for more information and usage examples.
 
 :::note
+
 The `useBackButton` callback will only fire when your app is running in Capacitor or Cordova. Refer to [Hardware Back Button in Capacitor and Cordova](../developing/hardware-back-button#hardware-back-button-in-capacitor-and-cordova) for more information.
+
 :::
 
 ## Keyboard
@@ -171,7 +173,9 @@ onIonViewWillLeave(() => {
 ```
 
 :::note
+
 Pages in your app need to be using the `IonPage` component in order for lifecycle methods and hooks to fire properly.
+
 :::
 
 Refer to the [Vue Lifecycle Documentation](./lifecycle) for more information and usage examples.

--- a/docs/vue/virtual-scroll.md
+++ b/docs/vue/virtual-scroll.md
@@ -15,7 +15,9 @@ npm install vue-virtual-scroller@next
 ```
 
 :::note
+
 Be sure to use the `next` tag otherwise you will get a version of `vue-virtual-scroll` that is only compatible with Vue 2.
+
 :::
 From here, we need to import the virtual scroller's CSS into our app. In `main.ts`, add the following line:
 
@@ -44,7 +46,9 @@ app.use(VueVirtualScroller);
 After doing this, all virtual scroll components will be available for use in our app.
 
 :::note
+
 Installing all components may result in unused virtual scroll components being added to your application bundle. Refer to the [Installing Specific Components](#installing-specific-components) section below for an approach that works better with treeshaking.
+
 :::
 
 ### Installing Specific Components

--- a/docs/vue/your-first-app.md
+++ b/docs/vue/your-first-app.md
@@ -51,7 +51,9 @@ Download and install these right away to ensure an optimal Ionic development exp
 Run the following in the command line terminal to install the Ionic CLI (`ionic`), `native-run`, used to run native binaries on devices and simulators/emulators, and `cordova-res`, used to generate native app icons and splash screens:
 
 :::note
+
 To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
+
 :::
 
 ```shell
@@ -59,9 +61,11 @@ npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/docs/vue/your-first-app/4-loading-photos.md
+++ b/docs/vue/your-first-app/4-loading-photos.md
@@ -344,9 +344,11 @@ export interface UserPhoto {
 ```
 
 :::note
+
 If you encounter broken image links or missing photos after following these steps, you may need to open your browser's dev tools and clear both [localStorage](https://developer.chrome.com/docs/devtools/storage/localstorage) and [IndexedDB](https://developer.chrome.com/docs/devtools/storage/indexeddb).
 
 In localStorage, look for domain `http://localhost:8100` and key `CapacitorStorage.photos`. In IndexedDB, find a store called "FileStorage". Your photos will have a key like `/DATA/123456789012.jpeg`.
+
 :::
 
 That’s it! We’ve built a complete Photo Gallery feature in our Ionic app that works on the web. Next up, we’ll transform it into a mobile app for iOS and Android!

--- a/docs/vue/your-first-app/6-deploying-mobile.md
+++ b/docs/vue/your-first-app/6-deploying-mobile.md
@@ -47,7 +47,9 @@ ionic cap sync
 ## iOS Deployment
 
 :::important
+
 To build an iOS app, you’ll need a Mac computer.
+
 :::
 
 Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac IDE), with dependencies managed by [CocoaPods](https://cocoapods.org/). Before running this app on an iOS device, there's a couple of steps to complete.

--- a/docs/vue/your-first-app/7-live-reload.md
+++ b/docs/vue/your-first-app/7-live-reload.md
@@ -197,7 +197,9 @@ Remember that removing the photo from the `photos` array triggers the `cachePhot
 Tap on a photo again and choose the “Delete” option. The photo is deleted! Implemented much faster using Live Reload. 💪
 
 :::note
+
 Remember, you can find the [complete source code for this app](https://github.com/ionic-team/tutorial-photo-gallery-vue) on GitHub.
+
 :::
 
 In the final portion of this tutorial, we’ll walk you through the basics of the Appflow product used to build and deploy your application to users' devices.

--- a/versioned_docs/version-v8/angular/build-options.md
+++ b/versioned_docs/version-v8/angular/build-options.md
@@ -10,7 +10,9 @@ While the Standalone approach is newer and makes use of more modern Angular APIs
 ## Standalone
 
 :::info
+
 Ionic UI components as Angular standalone components is supported starting in Ionic v7.5.
+
 :::
 
 ### Overview
@@ -32,7 +34,9 @@ Refer to the [Standalone Migration Guide](#migrating-from-modules-to-standalone)
 ### Usage with Standalone-based Applications
 
 :::warning
+
 All Ionic imports should be imported from the `@ionic/angular/standalone` submodule. This includes imports such as components, directives, providers, and types. Importing from `@ionic/angular` may pull in lazy loaded Ionic code which can interfere with treeshaking.
+
 :::
 
 **Bootstrapping and Configuration**
@@ -199,7 +203,9 @@ Ionic Angular's standalone components use ES Modules. As a result, developers us
 ### Usage with NgModule-based Applications
 
 :::warning
+
 All Ionic imports should be imported from the `@ionic/angular/standalone` submodule. This includes imports such as components, directives, providers, and types. Importing from `@ionic/angular` may pull in lazy loaded Ionic code which can interfere with treeshaking.
+
 :::
 
 **Bootstrapping and Configuration**
@@ -397,9 +403,11 @@ export class AppModule {}
 ## Migrating from Modules to Standalone
 
 :::tip
+
 Try our automated utility for migrating to standalone!
 
 See https://github.com/ionic-team/ionic-angular-standalone-codemods for instructions on how to get started. All issues related to the migration utility should be filed on the linked repo.
+
 :::
 
 The Standalone option is newer than the Modules option, so developers may wish to switch during the development of their application. This guide details the steps needed to migrate.

--- a/versioned_docs/version-v8/angular/lifecycle.md
+++ b/versioned_docs/version-v8/angular/lifecycle.md
@@ -27,7 +27,9 @@ Ionic embraces the life cycle events provided by Angular. The two Angular events
 For more info on the Angular Component Life Cycle events, visit their [component lifecycle docs](https://angular.io/guide/lifecycle-hooks).
 
 :::note
+
 Components that use `ion-nav` or `ion-router-outlet` should not use the `OnPush` change detection strategy. Doing so will prevent lifecycle hooks such as `ngOnInit` from firing. Additionally, asynchronous state changes may not render properly.
+
 :::
 
 ## Ionic Page Events

--- a/versioned_docs/version-v8/angular/navigation.md
+++ b/versioned_docs/version-v8/angular/navigation.md
@@ -168,7 +168,9 @@ import { LoginComponent } from './login.component';
 ```
 
 :::note
+
 We're excluding some additional content and only including the necessary parts.
+
 :::
 
 Here, we have a typical Angular Module setup, along with a RouterModule import, but we're now using `forChild` and declaring the component in that setup. With this setup, when we run our build, we will produce separate chunks for both the app component, the login component, and the detail component.
@@ -194,7 +196,9 @@ export class AppRoutingModule {}
 ```
 
 :::tip
+
 If you are using `routerLink`, `routerDirection`, or `routerAction` be sure to also import the `IonRouterLink` directive for Ionic components or the `IonRouterLinkWithHref` directive for `<a>` elements. An example of this is available in the [Ionic Angular Build Options docs](./build-options.md#migrating-from-modules-to-standalone).
+
 :::
 
 To get started with standalone components [visit Angular's official docs](https://angular.io/guide/standalone-components).

--- a/versioned_docs/version-v8/angular/performance.md
+++ b/versioned_docs/version-v8/angular/performance.md
@@ -69,5 +69,7 @@ For more information, refer to the [Angular NgForOf change propagation documenta
 {/* cspell:enable */}
 
 :::note
+
 Do you have a guide you'd like to share? Click the _Edit this page_ button below.
+
 :::

--- a/versioned_docs/version-v8/angular/pwa.md
+++ b/versioned_docs/version-v8/angular/pwa.md
@@ -25,11 +25,15 @@ ng add @angular/pwa
 Once this package has been added run `ionic build --prod` and the `www` directory will be ready to deploy as a PWA.
 
 :::note
+
 By default, the `@angular/pwa` package comes with the Angular logo for the app icons. Be sure to update the manifest to use the correct app name and also replace the icons.
+
 :::
 
 :::note
+
 Features like Service Workers and many JavaScript APIs (such as geolocation) require the app be hosted in a secure context. When deploying an app through a hosting service, be aware that HTTPS will be required to take full advantage of Service Workers.
+
 :::
 
 ## Service Worker configuration
@@ -77,7 +81,9 @@ npm install -g firebase-tools
 ```
 
 :::note
+
 If it's the first time you use firebase-tools, login to your Google account with `firebase login` command.
+
 :::
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -91,7 +97,9 @@ Create a new Firebase project or select an existing one.
 **"What do you want to use as your public directory?"** Enter "www".
 
 :::note
+
 Answering this next question will ensure that routing, hard reload, and deep linking work in the app:
+
 :::
 
 **Configure as a single-page app (rewrite all urls to /index.html)?"** Enter "Yes".

--- a/versioned_docs/version-v8/angular/quickstart.md
+++ b/versioned_docs/version-v8/angular/quickstart.md
@@ -72,7 +72,9 @@ Your new app's directory will look like this:
 ```
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's walk through these files to understand the app's structure.
@@ -175,7 +177,9 @@ And the template, in the `home.page.html` file, uses those components:
 This creates a page with a header and scrollable content area. The second header shows a [collapsible large title](/docs/api/title.md#collapsible-large-titles) that displays on iOS devices when at the top of the content, then condenses to show the smaller title in the first header when scrolling down.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 ## Add an Ionic Component
@@ -257,7 +261,9 @@ import { RouterLink } from '@angular/router';
 ```
 
 :::info
+
 Navigating can also be performed using Angular's Router service. Refer to the [Angular Navigation documentation](/docs/angular/navigation.md#navigating-to-different-routes) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/versioned_docs/version-v8/angular/slides.md
+++ b/versioned_docs/version-v8/angular/slides.md
@@ -14,7 +14,9 @@ import TabItem from '@theme/TabItem';
 </head>
 
 :::warning[Looking for `ion-slides`?]
+
 `ion-slides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
+
 :::
 
 We recommend [Swiper.js](http://swiperjs.com/) if you need a modern touch slider component. Swiper 9 introduced [Swiper Element](https://swiperjs.com/element) as a replacement for its Angular component, so this guide will go over how to get Swiper Element set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to Swiper Element.
@@ -191,7 +193,9 @@ export class HomePage {
 ```
 
 :::note
+
 If you are using the Core version of Swiper and have installed additional modules, ensure that `IonicSlides` is the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+
 :::
 
 ## Properties
@@ -227,7 +231,9 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | pager   | Use the `pagination` property instead.                                                                                                  |
 
 :::note
+
 All properties available in Swiper Element can be found in the [Swiper API parameters documentation](https://swiperjs.com/swiper-api#parameters).
+
 :::
 
 ## Events
@@ -276,7 +282,9 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `swiperinit`                       |
 
 :::note
+
 All events available in Swiper Element can be found in the [Swiper API events documentation](https://swiperjs.com/swiper-api#events) and should be lowercased and prefixed with the word `swiper`.
+
 :::
 
 ## Methods
@@ -328,7 +336,9 @@ Below is a full list of method changes when going from `ion-slides` to Swiper El
 | `stopAutoplay()`     | Use the `autoplay` property instead.                                                 |
 
 :::note
+
 All methods and properties available on the Swiper instance can be found in the [Swiper API methods and properties documentation](https://swiperjs.com/swiper-api#methods-and-properties).
+
 :::
 
 ## Effects
@@ -340,7 +350,9 @@ Effects such as Cube or Fade can be used in Swiper Element with no additional im
 ```
 
 :::note
+
 For more information on effects in Swiper, please refer to the [Swiper API fade effect documentation](https://swiperjs.com/swiper-api#fade-effect).
+
 :::
 
 ## Wrap Up

--- a/versioned_docs/version-v8/angular/storage.md
+++ b/versioned_docs/version-v8/angular/storage.md
@@ -14,7 +14,9 @@ sidebar_label: Storage
 There are a variety of options available for storing data within an Ionic application. It is best to choose options that best fit the needs of your application. A single application may have requirements that span multiple options.
 
 :::info
+
 Some storage options involve third-party plugins or products. In such cases, we neither endorse nor support those plugins or products. We are mentioning them here for informational purposes only.
+
 :::
 
 Here are some common use cases and solutions:

--- a/versioned_docs/version-v8/angular/your-first-app.md
+++ b/versioned_docs/version-v8/angular/your-first-app.md
@@ -25,7 +25,9 @@ Here’s the finished app running on all 3 platforms:
 ></iframe>
 
 :::note
+
 Looking for the previous version of this guide that covered Ionic 4 and Cordova? Refer to the [Ionic 4 and Cordova guide](../developer-resources/guides/first-app-v4/intro.md).
+
 :::
 
 ## What We'll Build
@@ -55,7 +57,9 @@ Download and install these right away to ensure an optimal Ionic development exp
 Run the following in the command line terminal to install the Ionic CLI (`ionic`), `native-run`, used to run native binaries on devices and simulators/emulators, and `cordova-res`, used to generate native app icons and splash screens:
 
 :::note
+
 To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
+
 :::
 
 ```shell
@@ -63,9 +67,11 @@ npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/versioned_docs/version-v8/angular/your-first-app/4-loading-photos.md
+++ b/versioned_docs/version-v8/angular/your-first-app/4-loading-photos.md
@@ -239,9 +239,11 @@ export class Tab2Page {
 ```
 
 :::note
+
 If you encounter broken image links or missing photos after following these steps, you may need to open your browser's dev tools and clear both [localStorage](https://developer.chrome.com/docs/devtools/storage/localstorage) and [IndexedDB](https://developer.chrome.com/docs/devtools/storage/indexeddb).
 
 In localStorage, look for domain `http://localhost:8100` and key `CapacitorStorage.photos`. In IndexedDB, find a store called "FileStorage". Your photos will have a key like `/DATA/123456789012.jpeg`.
+
 :::
 
 That’s it! We’ve built a complete Photo Gallery feature in our Ionic app that works on the web. Next up, we’ll transform it into a mobile app for iOS and Android!

--- a/versioned_docs/version-v8/angular/your-first-app/6-deploying-mobile.md
+++ b/versioned_docs/version-v8/angular/your-first-app/6-deploying-mobile.md
@@ -47,7 +47,9 @@ ionic cap sync
 ## iOS Deployment
 
 :::important
+
 To build an iOS app, you’ll need a Mac computer.
+
 :::
 
 Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac IDE), with dependencies managed by [CocoaPods](https://cocoapods.org/). Before running this app on an iOS device, there's a couple of steps to complete.

--- a/versioned_docs/version-v8/angular/your-first-app/7-live-reload.md
+++ b/versioned_docs/version-v8/angular/your-first-app/7-live-reload.md
@@ -165,7 +165,9 @@ Open `tab2.page.html` and add a new click handler to each `<ion-img>` element. W
 Tap on a photo again and choose the “Delete” option. The photo is deleted! Implemented much faster using Live Reload. 💪
 
 :::note
+
 Remember, you can find the [complete source code for this app](https://github.com/ionic-team/photo-gallery-capacitor-ng) on GitHub.
+
 :::
 
 In the final portion of this tutorial, we’ll walk you through the basics of the Appflow product used to build and deploy your application to users' devices.

--- a/versioned_docs/version-v8/api/accordion.md
+++ b/versioned_docs/version-v8/api/accordion.md
@@ -40,9 +40,11 @@ import Toggle from '@site/static/usage/v8/accordion/toggle/index.mdx';
 ## Listen for Accordion State Changes
 
 :::caution
+
 Most `ionChange` events emitted by other components such as [Input](./input) and [Textarea](./textarea) bubble. As a result, these events will bubble up and cause your `ionChange` listener on the Accordion Group to fire if the associated components are used inside of an Accordion.
 
 When using other components that emit `ionChange` inside of Accordion it is recommended to have the `ionChange` callback on Accordion Group check the `target` key on the event passed to the callback to verify that `ionChange` is coming from the Accordion Group and not any descendants.
+
 :::
 
 Developers can listen for the `ionChange` event to be notified when accordions expand or collapse.

--- a/versioned_docs/version-v8/api/alert.md
+++ b/versioned_docs/version-v8/api/alert.md
@@ -109,7 +109,9 @@ import Customization from '@site/static/usage/v8/alert/customization/index.mdx';
 <Customization />
 
 :::note
+
 If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file.
+
 :::
 
 ## Accessibility

--- a/versioned_docs/version-v8/api/badge.md
+++ b/versioned_docs/version-v8/api/badge.md
@@ -34,7 +34,9 @@ import Basic from '@site/static/usage/v8/badge/basic/index.mdx';
 Badges can be added inside a tab button, often used to indicate notifications or highlight additional items associated with the element.
 
 :::info
+
 Empty badges are only available for `md` mode.
+
 :::
 
 import InsideTabBar from '@site/static/usage/v8/badge/inside-tab-bar/index.mdx';

--- a/versioned_docs/version-v8/api/button.md
+++ b/versioned_docs/version-v8/api/button.md
@@ -92,7 +92,9 @@ There are many cases where a button's text content may overflow the container. I
 The button text does not automatically wrap to the next line when the text is too long to fit. In order to make the text wrap, the `ion-text-wrap` class can be added, which will set the `white-space` property to `"normal"`. This will become the default in a future major release.
 
 :::info
+
 The `max-width` style is set on the button below for demo purposes only. Text wrapping will work with a dynamic button width.
+
 :::
 
 import TextWrapping from '@site/static/usage/v8/button/text-wrapping/index.mdx';

--- a/versioned_docs/version-v8/api/checkbox.md
+++ b/versioned_docs/version-v8/api/checkbox.md
@@ -42,7 +42,9 @@ import LabelPlacement from '@site/static/usage/v8/checkbox/label-placement/index
 Developers can use the `alignment` property to control how the label and control are aligned on the cross axis. This property mirrors the flexbox `align-items` property.
 
 :::note
+
 Stacked checkboxes can be aligned using the `alignment` property. This can be useful when the label and control need to be centered horizontally.
+
 :::
 
 import Alignment from '@site/static/usage/v8/checkbox/alignment/index.mdx';
@@ -58,7 +60,9 @@ import Justify from '@site/static/usage/v8/checkbox/justify/index.mdx';
 <Justify />
 
 :::note
+
 `ion-item` is only used in the demos to emphasize how `justify` works. It is not needed in order for `justify` to function correctly.
+
 :::
 
 ## Indeterminate Checkboxes

--- a/versioned_docs/version-v8/api/datetime.md
+++ b/versioned_docs/version-v8/api/datetime.md
@@ -98,7 +98,9 @@ always in the 24-hour format, so `00` is `12am` on a 12-hour clock, `13` means
 `1pm`, and `23` means `11pm`.
 
 :::note
+
 While seconds, milliseconds, and time zone can be specified using the ISO 8601 datetime format, `ion-datetime` does not provide an interface for second, millisecond, and time zone selection. Any second, millisecond, or time zone values provided will be ignored.
+
 :::
 
 ## Basic Usage
@@ -153,7 +155,9 @@ The following example shows how to set the locale to Spanish (Spain).
 <CustomLocale />
 
 :::note
+
 The time label is not automatically localized. Refer to [Time Label](#time-label) for more information.
+
 :::
 
 ### Hour Cycle
@@ -170,7 +174,9 @@ There are 4 primary hour cycle types:
 | `'h24'`         | Hour system using 1–24; corresponds to 'k' in pattern. The 24 hour clock, with midnight starting at 24:00.     |
 
 :::note
+
 Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle
+
 :::
 
 There may be scenarios where you need to have more control over which hour cycle is used. This is where the `hourCycle` property can help.
@@ -200,7 +206,9 @@ For example, if you wanted to use a 12 hour cycle with the `en-GB` locale, you c
 <LocaleExtensionTags />
 
 :::note
+
 Be sure to check the [Browser Compatibility Chart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale#browser_compatibility) for `Intl.Locale` before using it in your app.
+
 :::
 
 ## Presentation
@@ -262,7 +270,9 @@ If the `showAdjacentDays` property is set to `true`, days from the previous and 
 The calendar view always displays 6 rows when `showAdjacentDays` is enabled, so days from the previous or next month will be shown as needed to fill the grid. For example, even if a month starts on the first day of the week and ends within the fifth row, days from the next month will appear at the end to complete the sixth row.
 
 :::note
+
 This property is only supported when using `presentation="date"` and `preferWheel="false"`.
+
 :::
 
 <ShowAdjacentDays />
@@ -272,7 +282,9 @@ This property is only supported when using `presentation="date"` and `preferWhee
 If the `multiple` property is set to `true`, multiple dates can be selected from the calendar picker. Clicking a selected date will deselect it.
 
 :::note
+
 This property is only supported when using `presentation="date"` and `preferWheel="false"`.
+
 :::
 
 <MultipleDateSelection />
@@ -332,7 +344,9 @@ When specifying colors, any valid CSS color format can be used. This includes he
 To maintain a consistent user experience, the style of selected date(s) will always override custom highlights.
 
 :::note
+
 This property is only supported when `preferWheel="false"`, and using a `presentation` of either `"date"`, `"date-time"`, or `"time-date"`.
+
 :::
 
 ### Using Array
@@ -362,7 +376,9 @@ The benefit of this approach is that every component, not just `ion-datetime`, c
 The datetime header manages the content for the `title` slot and the selected date.
 
 :::note
+
 The selected date will not render if `preferWheel` is set to `true`.
+
 :::
 
 <DatetimeHeaderStyling />
@@ -380,7 +396,9 @@ The header can be styled using CSS shadow parts.
 The calendar days in a grid-style `ion-datetime` can be styled using CSS shadow parts.
 
 :::note
+
 The example below selects the day 2 days ago, unless that day is in the previous month, then it selects a day 2 days in the future. This is done for demo purposes in order to show how to apply custom styling to all days, the current day, and the selected day.
+
 :::
 
 <CalendarDaysStyling />

--- a/versioned_docs/version-v8/api/input-otp.md
+++ b/versioned_docs/version-v8/api/input-otp.md
@@ -113,11 +113,13 @@ The `pattern` property enables custom validation using regular expressions. It a
 The component will prevent users from entering any characters that don't match the specified pattern. Developers can override these defaults by providing their own pattern string to match specific input requirements.
 
 :::tip
+
 When using a custom `pattern`, remember that the `type` property controls which keyboard appears on mobile devices:
 
 - Use `type="number"` for numeric-only patterns to show the numeric keyboard
 - Use `type="text"` for patterns that include letters to show the alphanumeric keyboard
-  :::
+
+:::
 
 import Pattern from '@site/static/usage/v8/input-otp/pattern/index.mdx';
 
@@ -130,7 +132,9 @@ import Pattern from '@site/static/usage/v8/input-otp/pattern/index.mdx';
 The `color` property changes the color palette for input boxes. For `outline` fills, this property changes the caret color, highlight color and border color. For `solid` fills, this property changes the caret color and highlight color.
 
 :::note
+
 The `color` property does _not_ change the text color of the input OTP. For that, use the [`--color` CSS property](#css-custom-properties-1).
+
 :::
 
 import Colors from '@site/static/usage/v8/input-otp/theming/colors/index.mdx';

--- a/versioned_docs/version-v8/api/input-password-toggle.md
+++ b/versioned_docs/version-v8/api/input-password-toggle.md
@@ -26,9 +26,11 @@ The InputPasswordToggle component is a companion component to [Input](./input). 
 ## Basic Usage
 
 :::info
+
 InputPasswordToggle must be used with an [Input](./input) that has its [`type`](./input/#type) property set to either `'text'` or `'password'`.
 
 Using any other `type` will cause a warning to be logged.
+
 :::
 
 import Basic from '@site/static/usage/v8/input-password-toggle/basic/index.mdx';

--- a/versioned_docs/version-v8/api/input.md
+++ b/versioned_docs/version-v8/api/input.md
@@ -86,7 +86,9 @@ Material Design offers filled styles for an input. The `fill` property on the in
 Filled inputs can be used on iOS by setting the input's `mode` to `md`.
 
 :::warning
+
 Inputs that use `fill` should not be used in an `ion-item` due to styling conflicts between the components.
+
 :::
 
 import Fill from '@site/static/usage/v8/input/fill/index.mdx';
@@ -156,9 +158,11 @@ The `start` and `end` slots can be used to place icons, buttons, or prefix/suffi
 Note that this feature is considered experimental because it relies on a simulated version of [Web Component slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots). As a result, the simulated behavior may not exactly match the native slot behavior.
 
 :::note
+
 In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. Refer to the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
 
 If slot content is meant to be interacted with, it should be wrapped in an interactive element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
 :::
 
 import StartEndSlots from '@site/static/usage/v8/input/start-end-slots/index.mdx';
@@ -172,7 +176,9 @@ import StartEndSlots from '@site/static/usage/v8/input/start-end-slots/index.mdx
 Setting the `color` property changes the color palette for each input. On `ios` mode, this property changes the caret color. On `md` mode, this property changes the caret color and the highlight/underline color.
 
 :::note
+
 The `color` property does _not_ change the text color of the input. For that, use the [`--color` CSS property](#css-custom-properties-1).
+
 :::
 
 import Colors from '@site/static/usage/v8/input/theming/colors/index.mdx';

--- a/versioned_docs/version-v8/api/loading.md
+++ b/versioned_docs/version-v8/api/loading.md
@@ -62,7 +62,9 @@ import Theming from '@site/static/usage/v8/loading/theming/index.mdx';
 <Theming />
 
 :::note
+
 `ion-loading` is presented at the root of your application, so we recommend placing any `ion-loading` styles in a global stylesheet.
+
 :::
 
 ## Accessibility

--- a/versioned_docs/version-v8/api/modal.md
+++ b/versioned_docs/version-v8/api/modal.md
@@ -58,7 +58,9 @@ When entering data into a modal, it is often desirable to have a way of preventi
 There are two different ways of using the `canDismiss` property: setting a boolean value or setting a callback function.
 
 :::note
+
 Note: When using a sheet modal, `canDismiss` will not be checked on swipe if there is no `0` breakpoint set. However, it will still be checked when pressing `Esc` or the hardware back button.
+
 :::
 
 ### Setting a boolean value
@@ -112,7 +114,9 @@ The `presentingElement` property accepts a reference to the element that should 
 The `canDismiss` property can be used to control whether or not the card modal can be swiped to close.
 
 :::note
+
 The card display style is only available on iOS.
+
 :::
 
 import CardExample from '@site/static/usage/v8/modal/card/basic/index.mdx';
@@ -122,7 +126,9 @@ import CardExample from '@site/static/usage/v8/modal/card/basic/index.mdx';
 ## Sheet Modal
 
 :::info
+
 [Content](./content) should be used inside of the sheet modal if you want your modal content to be scrollable.
+
 :::
 
 Developers can create a sheet modal effect similar to the drawer components available in maps applications. To create a sheet modal, developers need to set the `breakpoints` and `initialBreakpoint` properties on `ion-modal`.
@@ -174,11 +180,15 @@ import SheetScrollingContentExample from '@site/static/usage/v8/modal/sheet/expa
 Modals are presented at the root of your application so they overlay your entire app. This behavior applies to both inline modals and modals presented from a controller. As a result, custom modal styles can not be scoped to a particular component as they will not apply to the modal. Instead, styles must be applied globally. For most developers, placing the custom styles in `global.css` is sufficient.
 
 :::note
+
 If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file. Read [Style Placement](#style-placement) in the Angular section below for more information.
+
 :::
 
 :::note
+
 `ion-modal` works under the assumption that stacked modals are the same size. As a result, each subsequent modal will have no box shadow and a backdrop opacity of `0`. This is to avoid the effect of shadows and backdrops getting darker with each added modal. This can be changed by setting the `--box-shadow` and `--backdrop-opacity` CSS variables:
+
 :::
 
 ```

--- a/versioned_docs/version-v8/api/nav.md
+++ b/versioned_docs/version-v8/api/nav.md
@@ -26,7 +26,9 @@ Nav is a standalone component for loading arbitrary components and pushing new c
 Unlike Router Outlet, Nav is not tied to a particular router. This means that if we load a Nav component, and push other components to the stack, they will not affect the app's overall router. For example, you should not push a new component to `ion-nav` and expect the URL to update. This fits use cases where you could have a modal, which needs its own sub-navigation, without making it tied to the apps URL.
 
 :::note
+
 `ion-nav` is not meant to be used for routing. Instead, refer to the routing guides for [Angular](../angular/navigation), [React](../react/navigation), and [Vue](../vue/navigation), or [`ion-router`](./router) for vanilla JavaScript projects.
+
 :::
 
 ## Using NavLink

--- a/versioned_docs/version-v8/api/picker.md
+++ b/versioned_docs/version-v8/api/picker.md
@@ -65,7 +65,9 @@ Picker supports navigation using a screen reader by implementing the [`slider` r
 | Double Tap and Slide Up/Down | Adjust the selected option in the Picker Column. Can be used as an alternative to swiping up and down. |
 
 :::caution
+
 The Swipe Up and Swipe Down gestures rely on the correct key events being synthesized as noted on the [`slider` documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role). [Chromium-based browsers do not synthesize keyboard events correctly](https://issues.chromium.org/issues/40816094), but the "Double Tap and Slide Up/Down" gesture can be used as an alternative until this has been implemented in Chromium-based browsers.
+
 :::
 
 ### Keyboard Interactions

--- a/versioned_docs/version-v8/api/popover.md
+++ b/versioned_docs/version-v8/api/popover.md
@@ -54,7 +54,9 @@ Since the component you passed in needs to be created when the popover is presen
 A trigger for an inline `ion-popover` is the element that will open a popover when interacted with. The interaction behavior can be customized by setting the `trigger-action` property. Note that `trigger-action="context-menu"` will prevent your system's default context menu from opening.
 
 :::note
+
 Triggers are not applicable when using the `popoverController` because the `ion-popover` is not created ahead of time.
+
 :::
 
 import InlineTrigger from '@site/static/usage/v8/popover/presenting/inline-trigger/index.mdx';
@@ -94,7 +96,9 @@ import ControllerExample from '@site/static/usage/v8/popover/presenting/controll
 Popovers are presented at the root of your application so they overlay your entire app. This behavior applies to both inline popovers and popovers presented from a controller. As a result, custom popover styles can not be scoped to a particular component as they will not apply to the popover. Instead, styles must be applied globally. For most developers, placing the custom styles in `global.css` is sufficient.
 
 :::note
+
 If you are building an Ionic Angular app, the styles need to be added to a global stylesheet file.
+
 :::
 
 import Styling from '@site/static/usage/v8/popover/customization/styling/index.mdx';
@@ -142,7 +146,9 @@ When using `ion-popover` inline, you can nested popovers to create nested dropdo
 You can use the `dismissOnSelect` property to automatically close the popover when the popover content has been clicked. This behavior does not apply when clicking a trigger element for another popover.
 
 :::note
+
 Nested popovers cannot be created when using the `popoverController` because the popover is automatically added to the root of your application when the `create` method is called.
+
 :::
 
 import NestedPopover from '@site/static/usage/v8/popover/nested/index.mdx';

--- a/versioned_docs/version-v8/api/radio.md
+++ b/versioned_docs/version-v8/api/radio.md
@@ -60,7 +60,9 @@ import UsingComparewith from '@site/static/usage/v8/radio/using-comparewith/inde
 Developers can use the `alignment` property to control how the label and control are aligned on the cross axis. This property mirrors the flexbox `align-items` property.
 
 :::note
+
 Stacked radios can be aligned using the `alignment` property. This can be useful when the label and control need to be centered horizontally.
+
 :::
 
 import Alignment from '@site/static/usage/v8/radio/alignment/index.mdx';
@@ -76,7 +78,9 @@ import Justify from '@site/static/usage/v8/radio/justify/index.mdx';
 <Justify />
 
 :::note
+
 `ion-item` is only used in the demos to emphasize how `justify` works. It is not needed in order for `justify` to function correctly.
+
 :::
 
 ## Deselecting Radios

--- a/versioned_docs/version-v8/api/reorder.md
+++ b/versioned_docs/version-v8/api/reorder.md
@@ -88,7 +88,9 @@ import ReorderStartEndEvents from '@site/static/usage/v8/reorder/reorder-start-e
 The `ionReorderMove` event is emitted continuously during the reorder gesture as the user drags an item. The event includes the `from` and `to` indices of the item. Unlike `ionReorderEnd`, the `from` index in this event represents the last known position of the item (which updates as the item moves), while the `to` index represents its current position. If the item has not changed position since the last event, the `from` and `to` indices will be the same. This event is useful for tracking position changes during the drag operation. For example, the ranking or numbering of items can be updated in real-time as they are being dragged to maintain a logical ascending order.
 
 :::warning
+
 Do not call the `complete` method during the `ionReorderMove` event as it can break the gesture.
+
 :::
 
 import ReorderMoveEvent from '@site/static/usage/v8/reorder/reorder-move-event/index.mdx';

--- a/versioned_docs/version-v8/api/route-redirect.md
+++ b/versioned_docs/version-v8/api/route-redirect.md
@@ -22,7 +22,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 A route redirect can only be used with an `ion-router` as a direct child of it.
 
 :::note
+
 Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use [`ion-router-outlet`](router-outlet.md) and the Angular router.
+
 :::
 
 The route redirect has two configurable properties:

--- a/versioned_docs/version-v8/api/route.md
+++ b/versioned_docs/version-v8/api/route.md
@@ -25,7 +25,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The route component takes a component and renders it when the Browser URL matches the url property.
 
 :::note
+
 Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use [`ion-router-outlet`](router-outlet.md) and the Angular router.
+
 :::
 
 ## Navigation Hooks

--- a/versioned_docs/version-v8/api/router-link.md
+++ b/versioned_docs/version-v8/api/router-link.md
@@ -24,7 +24,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The router link component is used for navigating to a specified link. Similar to the browser's anchor tag, it can accept a href for the location, and a direction for the transition animation.
 
 :::note
+
 Note: this component should only be used with vanilla and Stencil JavaScript projects. For Angular projects, use an `<a>` and `routerLink` with the Angular router.
+
 :::
 
 Refer to the [Router](./router) documentation for more information.

--- a/versioned_docs/version-v8/api/router.md
+++ b/versioned_docs/version-v8/api/router.md
@@ -22,7 +22,9 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The router is a component for handling routing inside vanilla and Stencil JavaScript projects.
 
 :::note
+
 Note: This component should only be used with vanilla and Stencil JavaScript projects. See the routing guides for [Angular](../angular/navigation), [React](../react/navigation), and [Vue](../vue/navigation) for framework-specific routing solutions.
+
 :::
 
 Apps should have a single `ion-router` component in the codebase.

--- a/versioned_docs/version-v8/api/segment.md
+++ b/versioned_docs/version-v8/api/segment.md
@@ -55,9 +55,11 @@ when the segment is active. With this approach, each segment's content can be sw
 to reflect the currently visible content.
 
 :::warning
+
 If no initial `value` is assigned to the `ion-segment` when using swipeable segments, the segment will default to the value of the first segment button.
 
 Segment buttons cannot be disabled when used with swipeable segments.
+
 :::
 
 import Swipeable from '@site/static/usage/v8/segment/swipeable/index.mdx';

--- a/versioned_docs/version-v8/api/select.md
+++ b/versioned_docs/version-v8/api/select.md
@@ -156,7 +156,9 @@ Material Design offers filled styles for a select. The `fill` property on the se
 Filled selects can be used on iOS by setting the select's `mode` to `md`.
 
 :::warning
+
 Selects that use `fill` should not be used in an `ion-item` due to styling conflicts between the components.
+
 :::
 
 import FillExample from '@site/static/usage/v8/select/fill/index.mdx';
@@ -194,9 +196,11 @@ import InterfaceOptionsExample from '@site/static/usage/v8/select/customization/
 The `start` and `end` slots can be used to place icons, buttons, or prefix/suffix text on either side of the select. If the slot content is clicked, the select will not open.
 
 :::note
+
 In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. Refer to the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
 
 If slot content is meant to be interacted with, it should be wrapped in an interactive element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
 :::
 
 import StartEndSlots from '@site/static/usage/v8/select/start-end-slots/index.mdx';

--- a/versioned_docs/version-v8/api/split-pane.md
+++ b/versioned_docs/version-v8/api/split-pane.md
@@ -29,7 +29,9 @@ If the device's screen width is below a certain size, the split pane will collap
 ## Basic Usage
 
 :::note
+
 This demo sets the `when` property to `'xs'` so the split pane always shows up. Your Ionic application does not need this if you want the split pane to collapse on smaller viewports. Refer to [Setting Breakpoints](#setting-breakpoints) for more information.
+
 :::
 
 import Basic from '@site/static/usage/v8/split-pane/basic/index.mdx';

--- a/versioned_docs/version-v8/api/tab-bar.md
+++ b/versioned_docs/version-v8/api/tab-bar.md
@@ -141,7 +141,9 @@ export const TabBarExample: React.FC = () => (
 Badges can be added inside a tab button, often used to indicate notifications or highlight additional items associated with the element.
 
 :::info
+
 Empty badges are only available for `md` mode.
+
 :::
 
 import InsideTabBar from '@site/static/usage/v8/badge/inside-tab-bar/index.mdx';

--- a/versioned_docs/version-v8/api/tab.md
+++ b/versioned_docs/version-v8/api/tab.md
@@ -24,9 +24,11 @@ import EncapsulationPill from '@components/page/api/EncapsulationPill';
 The tab component is a child component of [tabs](tabs.md). Each tab can contain a top level navigation stack for an app or a single view. An app can have many tabs, all with their own independent navigation.
 
 :::note
+
 Angular, React, and Vue can only use this component when the `ion-tabs` component is configured for [basic usage](./tabs.md#basic-usage). When setting up tabs with routing, the `ion-tab` component cannot be used.
 
 In JavaScript, this component can be used with the `ion-tabs` component configured for either [basic usage](./tabs.md#basic-usage) or [usage with router](./tabs.md#usage-with-router).
+
 :::
 
 Refer to the [tabs documentation](tabs.md) for more details on configuring tabs.

--- a/versioned_docs/version-v8/api/textarea.md
+++ b/versioned_docs/version-v8/api/textarea.md
@@ -74,7 +74,9 @@ Material Design offers filled styles for a textarea. The `fill` property on the 
 Filled textareas can be used on iOS by setting the textarea's `mode` to `md`.
 
 :::warning
+
 Textareas that use `fill` should not be used in an `ion-item` due to styling conflicts between the components.
+
 :::
 
 import Fill from '@site/static/usage/v8/textarea/fill/index.mdx';
@@ -122,9 +124,11 @@ The `start` and `end` slots can be used to place icons, buttons, or prefix/suffi
 Note that this feature is considered experimental because it relies on a simulated version of [Web Component slots](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots). As a result, the simulated behavior may not exactly match the native slot behavior.
 
 :::note
+
 In most cases, [Icon](./icon.md) components placed in these slots should have `aria-hidden="true"`. Refer to the [Icon accessibility docs](https://ionicframework.com/docs/api/icon#accessibility) for more information.
 
 If slot content is meant to be interacted with, it should be wrapped in an interactive element such as a [Button](./button.md). This ensures that the content can be tabbed to.
+
 :::
 
 import StartEndSlots from '@site/static/usage/v8/textarea/start-end-slots/index.mdx';

--- a/versioned_docs/version-v8/api/toggle.md
+++ b/versioned_docs/version-v8/api/toggle.md
@@ -58,7 +58,9 @@ import LabelPlacement from '@site/static/usage/v8/toggle/label-placement/index.m
 Developers can use the `alignment` property to control how the label and control are aligned on the cross axis. This property mirrors the flexbox `align-items` property.
 
 :::note
+
 Stacked toggles can be aligned using the `alignment` property. This can be useful when the label and control need to be centered horizontally.
+
 :::
 
 import Alignment from '@site/static/usage/v8/toggle/alignment/index.mdx';

--- a/versioned_docs/version-v8/cli.md
+++ b/versioned_docs/version-v8/cli.md
@@ -32,9 +32,11 @@ $ ionic <command> <subcommand> --help
 ```
 
 :::note
+
 Be sure to run `ionic <command> --help` in your project directory.
 
 For some commands, such as `ionic serve`, the help documentation is contextual to the type of your project, e.g. React vs Angular.
+
 :::
 
 ## Architecture

--- a/versioned_docs/version-v8/cli/configuration.md
+++ b/versioned_docs/version-v8/cli/configuration.md
@@ -124,9 +124,11 @@ module.exports = function (ctx) {
 The Ionic CLI supports a multi-app configuration setup, which involves multiple Ionic apps and shared code within a single repository, or [monorepo](../reference/glossary.md#monorepo).
 
 :::note
+
 These docs give an overview of the multi-app feature of the Ionic CLI, but don't really go into details for each framework.
 
 If you're using Angular, please refer to [the Angular monorepo guide](https://github.com/ionic-team/ionic-cli/wiki/Angular-Monorepo) for examples.
+
 :::
 
 ### Setup Steps
@@ -207,7 +209,9 @@ $ ionic start "My New App" --no-deps
 If an app was created in a way other than `ionic start`, for example by using a prebuilt template, use `ionic init` to register the existing app with the multi-app project.
 
 :::note
+
 Make sure the app doesn't have an existing `ionic.config.json`.
+
 :::
 
 ```shell

--- a/versioned_docs/version-v8/cli/livereload.md
+++ b/versioned_docs/version-v8/cli/livereload.md
@@ -22,7 +22,9 @@ $ ionic capacitor run android -l --external
 ```
 
 :::note
+
 Remember, with the `--external` option, others on your Wi-Fi network will be able to access your app.
+
 :::
 
 ### Cordova
@@ -50,7 +52,9 @@ ionic cordova run ios -l --external
 ```
 
 :::note
+
 Remember, with the `--external` option, others on your Wi-Fi network will be able to access your app.
+
 :::
 
 ## Tips

--- a/versioned_docs/version-v8/deployment/app-store.md
+++ b/versioned_docs/version-v8/deployment/app-store.md
@@ -84,7 +84,9 @@ This will generate the minified code for the web portion of an app and copy it o
 From here, open the `.xcworkspace` file in `./platforms/ios/` to start Xcode.
 
 :::tip
+
 You can also have a release build generated automatically by using the `--release` flag.
+
 :::
 
 </TabItem>
@@ -119,5 +121,7 @@ An app can be updated by either submitting a new version to Apple, or by using a
 With <strong>Live Updates</strong>, app changes can be pushed in realtime directly to users from the Appflow dashboard, without waiting for App Store approvals.
 
 :::note
+
 In order for the iOS App Store to accept the updated build, the config.xml file will need to be edited to increment the version value, then rebuild the app for release following the same instructions above.
+
 :::

--- a/versioned_docs/version-v8/deployment/play-store.mdx
+++ b/versioned_docs/version-v8/deployment/play-store.mdx
@@ -91,7 +91,9 @@ To opt into app signing, you'll need to upload the app signing key used to sign 
 ![The opt-in options for Play App Signing in the Google Play Console.](https://blog.ionicframework.com/wp-content/uploads/2021/12/existingapps-optin.png 'Google Play Console Opt-in to Play App Signing')
 
 :::tip
+
 With smaller app sizes, improved performance, and enhanced security, the AAB binary format is a win for app developers and users alike. If you have an existing Android app using the APK format, consider migrating to AAB to take advantage of all the great features it provides.
+
 :::
 
 </TabItem>
@@ -106,7 +108,9 @@ keytool -genkey -v -keystore my-release-key.keystore -alias alias_name -keyalg R
 Once that command has been ran and its prompts have been answered a file called `my-release-key.keystore` will be created in the current directory.
 
 :::warning
+
 Save this file and keep it somewhere safe. If it is lost the Google Play Store will not accept updates for this app!
+
 :::
 
 To sign the unsigned APK, run the jarsigner tool which is also included in the Android SDK:
@@ -135,7 +139,9 @@ Now that a release AAB/APK has been generated, a Play Store listing can be writt
 To start, visit the [Google Play Store Developer Console](https://play.google.com/apps/publish) and create a new developer account.
 
 :::note
+
 Making a developer account with Google Play costs $25 USD.
+
 :::
 
 Once a developer account has been created, go ahead and click the `Create an Application`
@@ -153,14 +159,18 @@ As an app evolves, it will need to be updated with new features and fixes. An ap
 <TabItem value="capacitor" label="Capacitor" default>
 
 :::note
+
 In order for the Google Play Store to accept updated AAB/APK, the `android/app/build.gradle` file will need to be edited to increment the `versionCode` value, then rebuild the app for release following the instructions above.
+
 :::
 
 </TabItem>
 <TabItem value="cordova" label="Cordova">
 
 :::note
+
 In order for the Google Play Store to accept updated AAB/APK, the config.xml file will need to be edited to increment the version value, then rebuild the app for release following the instructions above.
+
 :::
 
 </TabItem>

--- a/versioned_docs/version-v8/developer-resources/guides/first-app-v4/intro.md
+++ b/versioned_docs/version-v8/developer-resources/guides/first-app-v4/intro.md
@@ -28,9 +28,11 @@ npm install -g @ionic/cli cordova
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../../../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/versioned_docs/version-v8/developing/config/per-platform/index.md
+++ b/versioned_docs/version-v8/developing/config/per-platform/index.md
@@ -14,9 +14,11 @@ import TabItem from '@theme/TabItem';
 <TabItem value="angular">
 
 :::note
+
 Since the config is set at runtime, you will not have access to the Platform Dependency Injection. Instead, you can use the underlying functions that the provider uses directly.
 
 Refer to the [Angular Platform Documentation](../angular/platform) for the types of platforms you can detect.
+
 :::
 
 ```ts title="app.module.ts"
@@ -37,9 +39,11 @@ import { isPlatform, IonicModule } from '@ionic/angular';
 <TabItem value="angular-standalone">
 
 :::note
+
 Since the config is set at runtime, you will not have access to the Platform Dependency Injection. Instead, you can use the underlying functions that the provider uses directly.
 
 Refer to the [Angular Platform Documentation](../angular/platform) for the types of platforms you can detect.
+
 :::
 
 ```ts title="main.ts"
@@ -59,7 +63,9 @@ bootstrapApplication(AppComponent, {
 <TabItem value="react">
 
 :::note
+
 Refer to the [React Platform Documentation](../react/platform) for the types of platforms you can detect.
+
 :::
 
 ```tsx title="App.tsx"
@@ -74,7 +80,9 @@ setupIonicReact({
 <TabItem value="vue">
 
 :::note
+
 Refer to the [Vue Platform Documentation](../vue/platform) for the types of platforms you can detect.
+
 :::
 
 ```ts title="main.ts"

--- a/versioned_docs/version-v8/developing/hardware-back-button.md
+++ b/versioned_docs/version-v8/developing/hardware-back-button.md
@@ -16,7 +16,9 @@ import TabItem from '@theme/TabItem';
 The hardware back button is found on most Android devices. In native applications it can be used to close modals, navigate to the previous view, exit an app, and more. By default in Ionic, when the back button is pressed, the current view will be popped off the navigation stack, and the previous view will be displayed. If no previous view exists in the navigation stack, nothing will happen. This guide will show how to customize the behavior of the hardware back button.
 
 :::note
+
 The hardware back button refers to the physical back button on an Android device and should not be confused with either the browser back button or `ion-back-button`. The information in this guide only applies to Android devices.
+
 :::
 
 ## Overview
@@ -47,7 +49,9 @@ Chrome has support for Close Watcher starting in [Chrome 120](https://developer.
 For complete hardware back button support, we recommend using Capacitor or Cordova.
 
 :::note
+
 The `ionBackButton` event will not be emitted when running an app in a browser or as a PWA if Close Watcher is unsupported or `experimentalCloseWatcher` is `false`.
+
 :::
 
 ## Basic Usage

--- a/versioned_docs/version-v8/developing/keyboard.md
+++ b/versioned_docs/version-v8/developing/keyboard.md
@@ -32,7 +32,9 @@ import Inputmode from '@site/static/usage/v8/keyboard/inputmode/index.mdx';
 <Inputmode />
 
 :::note
+
 The `inputmode` attribute is supported on devices running Chrome 66+ and iOS Safari 12.2+: https://caniuse.com/#search=inputmode
+
 :::
 
 ## enterkeyhint
@@ -50,7 +52,9 @@ import Enterkeyhint from '@site/static/usage/v8/keyboard/enterkeyhint/index.mdx'
 <Enterkeyhint />
 
 :::note
+
 The `enterkeyhint` attribute is supported on devices running Chrome 77+ and iOS Safari 13.4+.
+
 :::
 
 ## Dark Mode
@@ -171,5 +175,7 @@ watch(keyboardHeight, () => {
 ````
 
 :::note
+
 For apps running in a mobile web browser or as a PWA, Keyboard Lifecycle Events are only supported on Chrome 62+ and iOS Safari 13.0+.
+
 :::

--- a/versioned_docs/version-v8/developing/managing-focus.md
+++ b/versioned_docs/version-v8/developing/managing-focus.md
@@ -262,7 +262,9 @@ The following table explains what each content type represents:
 | `banner`  | The header of the view.       | [Header](../api/header)   | [`header`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) | [`role="banner"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_Role)                                                                                                                  |
 
 :::important
+
 Developers should assign `role="heading"` and `aria-level="1"` to the primary [Title](../api/title) on each view. Since multiple [Title](../api/title) components can be used in a single view, Ionic does not automatically assign these attributes.
+
 :::
 
 ### Specifying Priority

--- a/versioned_docs/version-v8/developing/scaffolding.md
+++ b/versioned_docs/version-v8/developing/scaffolding.md
@@ -45,7 +45,9 @@ The `src/app/` directory contains the root app component and module as well as a
 ## Generating New Features
 
 :::note
+
 This command is only supported in Ionic Angular.
+
 :::
 
 The Ionic CLI can generate new app features with the [`ionic generate`](../cli/commands/generate.md) command. By running `ionic generate` in the command line, a selection prompt is displayed which lists the available features that can be generated.
@@ -65,7 +67,9 @@ $ ionic generate
 After a selection is made, the Ionic CLI will prompt for a name. The name can be a path, allowing easy generation of features within an organized project structure.
 
 :::note
+
 Any level of nesting is allowed, such as `portfolio/intro`. You can easily scope components to pages by using `ionic g component "portfolio/intro/About Me"`, for example.
+
 :::
 
 ```shell-session

--- a/versioned_docs/version-v8/developing/tips.md
+++ b/versioned_docs/version-v8/developing/tips.md
@@ -15,7 +15,9 @@ title: Development Tips
 `EACCES` permission errors can occur when packages are installed globally. If this is the case, npm may need to be set up to operate without elevated permissions.
 
 :::note
+
 Using `sudo` with npm is **not recommended** because it can lead to further complications.
+
 :::
 
 This guide offers two options for resolving permission issues. Refer to the [npm docs](https://docs.npmjs.com/resolving-eacces-permissions-errors-when-installing-packages-globally) for full documentation and additional options.
@@ -118,7 +120,9 @@ When an app runs, it will pause at this function. From there, the developer tool
 By default, when an app is viewed in the browser, Ionic will apply the `md` mode. However, since Ionic components adapt according to their platform, it is helpful to be able to view what the app will look like on iOS. To do this, add `?ionic:mode=ios` to the URL where the app is being served. For example, if the app is served on port `8100`, the url would be: `http://localhost:8100/?ionic:mode=ios`.
 
 :::note
+
 This will not change which platform the browser detects. The platform is determined by device detection and inspecting the user-agent. To change the platform, the user-agent must be changed. To do this, open up Chrome DevTools with <kbd>Ctrl+Shift+I</kbd>(<kbd>Cmd+Option+I</kbd> on Mac), and then toggle device mode on with <kbd>Ctrl+Shift+M</kbd>(<kbd>Cmd+Option+M</kbd> on Mac).
+
 :::
 
 ![Chrome DevTools showing the device mode with iPhone X selected.](/img/faq/tips/change-device-platform.png 'Chrome DevTools Device Mode')

--- a/versioned_docs/version-v8/intro/cli.md
+++ b/versioned_docs/version-v8/intro/cli.md
@@ -36,8 +36,10 @@ $ npm install -g @ionic/cli
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Start an App

--- a/versioned_docs/version-v8/intro/environment.md
+++ b/versioned_docs/version-v8/intro/environment.md
@@ -17,7 +17,9 @@ Of course, a code editor is also required. [Visual Studio Code](https://code.vis
 ## Terminal
 
 :::note
+
 Much of Ionic development requires familiarity with the command line. If you're new to the command line, refer to the [New to the Command Line](https://ionicframework.com/blog/new-to-the-command-line/) blog post for a quick introduction.
+
 :::
 
 In general, we recommend using the built-in terminals. Many third-party terminals work well with Ionic, but may not be supported.
@@ -41,7 +43,9 @@ $ npm --version
 ```
 
 :::note
+
 Permission errors are common on macOS when installing global packages with `npm`. If you get an `EACCES` error, refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors).
+
 :::
 
 ## Git

--- a/versioned_docs/version-v8/javascript/quickstart.md
+++ b/versioned_docs/version-v8/javascript/quickstart.md
@@ -68,11 +68,15 @@ Your new app's directory will look like this:
 ```
 
 :::warning[Delete files]
+
 The `counter.js` and `style.css` files can be deleted. We will not be using them.
+
 :::
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's configure the project, initialize Ionic, and add components to create our app.
@@ -227,7 +231,9 @@ customElements.define('home-page', HomePage);
 This creates a custom element called `home-page` that contains the layout for your Home page. The page uses Ionic's layout components to create a header with a toolbar and scrollable content area.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 Next, add a `<script>` tag before the `main.js` import in `index.html` to import the Home page:
@@ -325,7 +331,9 @@ To navigate to the new page, update the button in `HomePage.js` to be inside of 
 When the button is clicked, Ionic's router will automatically navigate to the `/new` route and display the `new-page` component.
 
 :::info
+
 Navigating can also be performed programmatically using `document.querySelector('ion-router').push('/new')`. Refer to the [Ionic Router documentation](/docs/api/router.md) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/versioned_docs/version-v8/layout/css-utilities.md
+++ b/versioned_docs/version-v8/layout/css-utilities.md
@@ -13,7 +13,9 @@ title: CSS Utilities
 Ionic Framework provides a set of CSS utility classes that can be used on any element in order to modify the text, element placement or adjust the padding and margin.
 
 :::important
+
 If your app was not started using an available Ionic Framework starter, the stylesheets listed in the [optional section of the global stylesheets](global-stylesheets.md#optional) will need to be included in order for these styles to work.
+
 :::
 
 ## Text Modification

--- a/versioned_docs/version-v8/layout/dynamic-font-scaling.md
+++ b/versioned_docs/version-v8/layout/dynamic-font-scaling.md
@@ -5,9 +5,11 @@ Dynamic Font Scaling is a feature that allows users to choose the size of the te
 ## Try It Out
 
 :::tip
+
 Be sure to try this on an Android, iOS, or iPadOS device.
 
 If you are testing on Chrome for Android, make sure ["Accessibility Page Zoom"](#chrome-for-android) is enabled.
+
 :::
 
 Follow the [Changing the Font Size on a Device](#changing-the-font-size-on-a-device) guide to set your preferred font size, and watch the text in the demo below grow or shrink according to your preferences.
@@ -156,7 +158,9 @@ Refer to [Apple Support](https://support.apple.com/en-us/102453) for more inform
 Where users access the font scaling configuration varies across devices, but it is typically found in the "Accessibility" page in the Settings app.
 
 :::info
+
 The Chrome Web Browser on Android has some limitations with respecting system-level font scales. Refer to [Chrome for Android](#chrome-for-android) for more information.
+
 :::
 
 ## Troubleshooting
@@ -190,5 +194,7 @@ Certain native iOS components such as the Action Sheet make use of private font 
 The root element's default font size is typically `16px`. However, Dynamic Font Scaling on iOS devices make use of the ["Body" text style](https://developer.apple.com/design/human-interface-guidelines/typography#Specifications) which has a default font size of `17px`. Since the text in Ionic components is scaled relative to the root element's font size, some text may get larger or smaller when Dynamic Font Scaling is enabled, even if the system-level text scale did not change.
 
 :::info
+
 iOS provides a "Callout" text style which has a default font size of `16px`. However, this font style is currently not exposed to web content. Refer to [the supported text styles in WebKit](https://webkit.org/blog/3709/using-the-system-font-in-web-content/) for more information.
+
 :::

--- a/versioned_docs/version-v8/react/lifecycle.md
+++ b/versioned_docs/version-v8/react/lifecycle.md
@@ -37,7 +37,9 @@ export default withIonLifeCycle(HomePage);
 ```
 
 :::note
+
 `withIonLifeCycle` is imported from `@ionic/react`
+
 :::
 
 You can then create the appropriate lifecycle method on your class component, and the HOC calls that method when the event happens. Below is the entire component with each of the lifecycle methods implemented:
@@ -130,7 +132,9 @@ export default HomePage;
 ```
 
 :::note
+
 Functional components don't need to be wrapped with the `withIonLifeCycle` HOC as class components do.
+
 :::
 
 Developers can also optionally pass reactive dependencies to each lifecycle hook. These are then passed to the underlying [React useEffect hook](https://react.dev/reference/react/useEffect#useeffect):

--- a/versioned_docs/version-v8/react/navigation.md
+++ b/versioned_docs/version-v8/react/navigation.md
@@ -223,7 +223,9 @@ A programmatic option for navigation is using the [`history`](https://v5.reactro
 ```
 
 :::note
+
 `history` is a prop.
+
 :::
 
 ### Navigating using `history.go`
@@ -468,7 +470,9 @@ export default Tabs;
 If you have worked with Ionic Framework before, this should feel familiar. We create an `IonTabs` component and provide an `IonTabBar`. The `IonTabBar` provides `IonTabButton` components, each with a `tab` property that is associated with its corresponding tab in the router config. We also provide an `IonRouterOutlet` to give `IonTabs` an outlet to render the different tab views in.
 
 :::tip
+
 `IonTabs` renders an `IonPage` for you, so you do not need to add `IonPage` manually here.
+
 :::
 
 ### How Tabs in Ionic Work

--- a/versioned_docs/version-v8/react/overlays.md
+++ b/versioned_docs/version-v8/react/overlays.md
@@ -23,7 +23,9 @@ const [showAlert, hideAlert] = useIonAlert();
 ```
 
 :::note
+
 Overlays often dismiss themselves when the user is done interacting with them, so you might not need to use dismiss/hide method.
+
 :::
 
 To display the overlay, you use the present method, which we destructured to the name `showAlert`. The method takes in a set of parameters that vary depending on each overlay, but generally, they can either take in a simple set of common parameters or an object to specify additional options.
@@ -75,7 +77,9 @@ For overlays that display custom components, such as [modals](https://ionicframe
 ```
 
 :::note
+
 The Overlay Components are still a valid way of displaying overlays and are in no way a deprecated method. Use whichever method best fits your application.
+
 :::
 
 ## Docs for Overlays in Ionic

--- a/versioned_docs/version-v8/react/pwa.md
+++ b/versioned_docs/version-v8/react/pwa.md
@@ -42,7 +42,9 @@ Refer to the [Vite PWA "Deploy" Guide](https://vite-pwa-org.netlify.app/deployme
 ## Making your React app a PWA with Create React App
 
 :::note
+
 As of Ionic CLI v7, Ionic React starter apps ship with Vite instead of Create React App. Refer to [Making your React app a PWA with Vite](#making-your-react-app-a-pwa-with-vite) for Vite instructions.
+
 :::
 
 The two main requirements of a PWA are a [Service Worker](https://developers.google.com/web/fundamentals/primers/service-workers/) and a [Web Application Manifest](https://developers.google.com/web/fundamentals/web-app-manifest/). While it's possible to add both of these to an app manually, a base project from Create React App (CRA) and the Ionic CLI provides this already.
@@ -72,11 +74,15 @@ serviceWorkerRegistration.register();
 Once this package has been added, run `ionic build` and the `build` directory will be ready to deploy as a PWA.
 
 :::note
+
 By default, react apps package comes with the Ionic logo for the app icons. Be sure to update the manifest to use the correct app name and also replace the icons.
+
 :::
 
 :::note
+
 Features like Service Workers and many JavaScript APIs (such as geolocation) require the app to be hosted in a secure context. When deploying an app through a hosting service, be aware that HTTPS will be required to take full advantage of Service Workers.
+
 :::
 
 ### Service Worker configuration
@@ -100,7 +106,9 @@ npm install -g firebase-tools
 ```
 
 :::note
+
 If it's the first time you use firebase-tools, login to your Google account with `firebase login` command.
+
 :::
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -114,7 +122,9 @@ Create a new Firebase project or select an existing one.
 **"What do you want to use as your public directory?"** Enter "dist".
 
 :::note
+
 Answering this next question will ensure that routing, hard reload, and deep linking work in the app:
+
 :::
 
 **Configure as a single-page app (rewrite all urls to /index.html)?"** Enter "Yes".

--- a/versioned_docs/version-v8/react/quickstart.md
+++ b/versioned_docs/version-v8/react/quickstart.md
@@ -68,7 +68,9 @@ Your new app's directory will look like this:
 ```
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's walk through these files to understand the app's structure.
@@ -159,7 +161,9 @@ export default Home;
 This creates a page with a header and scrollable content area. The `IonPage` component provides the basic page structure and must be used on every page. The second header shows a [collapsible large title](/docs/api/title.md#collapsible-large-titles) that displays on iOS devices when at the top of the content, then condenses to show the smaller title in the first header when scrolling down.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 ## Add an Ionic Component
@@ -225,7 +229,9 @@ export default New;
 This creates a page with a [Back Button](/docs/api/back-button.md) in the [Toolbar](/docs/api/toolbar.md). The back button will automatically handle navigation back to the previous page, or to `/` if there is no history.
 
 :::warning
+
 When creating your own pages, always use `IonPage` as the root component. This is essential for proper transitions between pages, base CSS styling that Ionic components depend on, and consistent layout behavior across your app.
+
 :::
 
 ## Navigate to the New Page
@@ -259,7 +265,9 @@ Once that is done, update the button in `Home.tsx`:
 ```
 
 :::info
+
 Navigating can also be performed programmatically using React Router's `history` prop. Refer to the [React Navigation documentation](/docs/react/navigation.md#navigating-using-history) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/versioned_docs/version-v8/react/slides.md
+++ b/versioned_docs/version-v8/react/slides.md
@@ -19,9 +19,11 @@ title: Migrating From IonSlides to Swiper.js
 We recommend [Swiper.js](http://swiperjs.com/) if you need a modern touch slider component. This guide will go over how to get Swiper for React set up in your Ionic Framework application. It will also go over any migration information you may need to move from `IonSlides` to the official Swiper React integration.
 
 :::note
+
 Swiper's React component is set to be removed in a future release of Swiper, with [Swiper Element](https://swiperjs.com/element) as the replacement. However, this guide shows how to migrate to the React component because it provides the most stable experience at the time of writing. Notably, React does not have strong support for Web Components yet.
 
 Using Swiper's React component is **not** required to use Swiper.js with Ionic Framework.
+
 :::
 
 ## Getting Started
@@ -39,7 +41,9 @@ npm install swiper@latest
 ```
 
 :::note
+
 Developers using Create React App must use `react-scripts` v5.0.0+ with the latest version of Swiper.
+
 :::
 
 ## Swiping with Style
@@ -65,7 +69,9 @@ export default Home;
 ```
 
 :::note
+
 Importing `@ionic/react/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `IonSlides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+
 :::
 
 ### Updating Selectors
@@ -257,7 +263,9 @@ export default Home;
 ```
 
 :::note
+
 Refer to [Swiper's React usage documentation](https://swiperjs.com/react#usage) for a full list of modules.
+
 :::
 
 ## The IonicSlides Module
@@ -306,7 +314,9 @@ export default Home;
 ```
 
 :::note
+
 The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+
 :::
 
 ## Properties
@@ -356,7 +366,9 @@ Below is a full list of property changes when going from `IonSlides` to Swiper R
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
+
 All properties available in Swiper React can be found in the [Swiper React props documentation](https://swiperjs.com/react#swiper-props).
+
 :::
 
 ## Events
@@ -413,7 +425,9 @@ Below is a full list of event name changes when going from `IonSlides` to Swiper
 | `onIonSlidesDidLoad`        | `onInit`                       |
 
 :::note
+
 All events available in Swiper can be found in the [Swiper API events documentation](https://swiperjs.com/swiper-api#events).
+
 :::
 
 ## Methods
@@ -545,7 +559,9 @@ export default Home;
 ```
 
 :::note
+
 For more information on effects in Swiper, please refer to the [Swiper React effects documentation](https://swiperjs.com/react#effects).
+
 :::
 
 ## Wrap Up

--- a/versioned_docs/version-v8/react/storage.md
+++ b/versioned_docs/version-v8/react/storage.md
@@ -14,7 +14,9 @@ sidebar_label: Storage
 There are a variety of options available for storing data within an Ionic application. It is best to choose options that best fit the needs of your application. A single application may have requirements that span multiple options.
 
 :::info
+
 Some storage options involve third-party plugins or products. In such cases, we neither endorse nor support those plugins or products. We are mentioning them here for informational purposes only.
+
 :::
 
 Here are some common use cases and solutions:

--- a/versioned_docs/version-v8/react/your-first-app.md
+++ b/versioned_docs/version-v8/react/your-first-app.md
@@ -51,7 +51,9 @@ Download and install these right away to ensure an optimal Ionic development exp
 Run the following in the command line terminal to install the Ionic CLI (`ionic`), `native-run`, used to run native binaries on devices and simulators/emulators, and `cordova-res`, used to generate native app icons and splash screens:
 
 :::note
+
 To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
+
 :::
 
 ```shell
@@ -59,9 +61,11 @@ npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/versioned_docs/version-v8/react/your-first-app/4-loading-photos.md
+++ b/versioned_docs/version-v8/react/your-first-app/4-loading-photos.md
@@ -218,9 +218,11 @@ export interface UserPhoto {
 ```
 
 :::note
+
 If you encounter broken image links or missing photos after following these steps, you may need to open your browser's dev tools and clear both [localStorage](https://developer.chrome.com/docs/devtools/storage/localstorage) and [IndexedDB](https://developer.chrome.com/docs/devtools/storage/indexeddb).
 
 In localStorage, look for domain `http://localhost:8100` and key `CapacitorStorage.photos`. In IndexedDB, find a store called "FileStorage". Your photos will have a key like `/DATA/123456789012.jpeg`.
+
 :::
 
 That’s it! We’ve built a complete Photo Gallery feature in our Ionic app that works on the web. Next up, we’ll transform it into a mobile app for iOS and Android!

--- a/versioned_docs/version-v8/react/your-first-app/6-deploying-mobile.md
+++ b/versioned_docs/version-v8/react/your-first-app/6-deploying-mobile.md
@@ -47,7 +47,9 @@ ionic cap sync
 ## iOS Deployment
 
 :::important
+
 To build an iOS app, you’ll need a Mac computer.
+
 :::
 
 Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac IDE), with dependencies managed by [CocoaPods](https://cocoapods.org/). Before running this app on an iOS device, there's a couple of steps to complete.

--- a/versioned_docs/version-v8/react/your-first-app/7-live-reload.md
+++ b/versioned_docs/version-v8/react/your-first-app/7-live-reload.md
@@ -199,7 +199,9 @@ Remember that removing the photo from the `photos` array triggers the `setPhotos
 Tap on a photo again and choose the “Delete” option. The photo is deleted! Implemented much faster using Live Reload. 💪
 
 :::note
+
 Remember, you can find the [complete source code for this app](https://github.com/ionic-team/tutorial-photo-gallery-react) on GitHub.
+
 :::
 
 In the final portion of this tutorial, we’ll walk you through the basics of the Appflow product used to build and deploy your application to users' devices.

--- a/versioned_docs/version-v8/reference/browser-support.md
+++ b/versioned_docs/version-v8/reference/browser-support.md
@@ -25,7 +25,9 @@ In pursuit of [adaptive styling](../core-concepts/fundamentals.md#adaptive-styli
 | Ionic v4  |          4.4+          | 10.0+ |
 
 :::note
+
 Check the [latest Android stats](https://developer.android.com/about/dashboards/) and the [latest iOS stats](https://developer.apple.com/support/app-store/) for up-to-date platform information.
+
 :::
 
 ### A Note on Android Support

--- a/versioned_docs/version-v8/techniques/security.md
+++ b/versioned_docs/version-v8/techniques/security.md
@@ -68,7 +68,9 @@ To learn more about the security recommendations for binding to directives such 
 For developers who wish to add complex HTML to components such as `ion-toast`, they will need to eject from the sanitizer that is built into Ionic Framework. Developers can either disable the sanitizer across their entire app or bypass it on a case-by-case basis.
 
 :::note
+
 Bypassing sanitization functionality can make your application vulnerable to [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting). Please exercise extreme caution when disabling the sanitizer.
+
 :::
 
 ### Disabling the sanitizer via config
@@ -80,11 +82,13 @@ Ionic Framework provides an application config option called `sanitizerEnabled` 
 Developers can also choose to eject from the sanitizer in certain scenarios. Ionic Framework provides the `IonicSafeString` class that allows developers to do just that.
 
 :::note
+
 In order to bypass the sanitizer and use unsanitized custom HTML in the relevant Ionic components, `innerHTMLTemplatesEnabled` must be set to `true` in the Ionic config.
 
 `IonicSafeString` should not be used if `innerHTMLTemplatesEnabled` is set to `false`.
 
 Refer to [Enabling Custom HTML Parsing](#enabling-custom-html-parsing-via-innerhtml) for more information.
+
 :::
 
 #### Usage

--- a/versioned_docs/version-v8/theming/advanced.md
+++ b/versioned_docs/version-v8/theming/advanced.md
@@ -22,7 +22,9 @@ The `theme-color` value for a meta tag indicates a color that browsers can use t
 The `content` value for the `theme-color` meta must contain a valid [CSS Color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) and cannot contain CSS Variables.
 
 :::note
+
 The `theme-color` meta controls the interface theme when running in a web browser or as a PWA and has no effect when an app is deployed using Capacitor or Cordova. If you are looking to customize the area under the status bar, we recommend using the [Capacitor Status Bar Plugin](https://capacitorjs.com/docs/apis/status-bar).
+
 :::
 
 The example below demonstrates how to use `theme-color` to style the browser interface on iOS 15.
@@ -43,7 +45,9 @@ Safari on iOS 15 and macOS will automatically determine an appropriate theme col
 There is a small subset of colors that browsers will not use as they interfere with the browser interface. For example, setting `content="red"` will not work in Safari on macOS because that color interferes with the red close button in the toolbar. If you run into this situation, try altering your color selection slightly.
 
 :::note
+
 Browsers will prefer the `theme-color` meta over `theme` in `manifest.json` if both are present.
+
 :::
 
 For more information, refer to the [MDN theme-color documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color).
@@ -106,7 +110,9 @@ There is not yet full [browser support](https://developer.mozilla.org/en-US/docs
 ```
 
 :::note
+
 Refer to the [CSS Variables](css-variables.md) section for more information on how to get and set CSS variables.
+
 :::
 
 Ionic uses colors with an opacity (alpha) in several components. In order for this to work, those properties must be provided in RGB format. When changing any of the properties that have a variation ending in `-rgb`, it is important they are also provided in a comma separated format **without parentheses**. Below are some examples for changing text and background color.

--- a/versioned_docs/version-v8/theming/colors.md
+++ b/versioned_docs/version-v8/theming/colors.md
@@ -55,7 +55,9 @@ To change the default values of a color, all of the listed variations for that c
 When `secondary` is applied to a button, not only is the base color <CodeColor color="#006600">#006600</CodeColor> used, but the contrast color <CodeColor color="#ffffff">#ffffff</CodeColor> is used for the text, along with shade <CodeColor color="#005a00">#005a00</CodeColor> and tint <CodeColor color="#1a751a">#1a751a</CodeColor> colors for the different states of the button.
 
 :::note
+
 Not sure how to get the variation colors from the base color? Try out our [Color Generator](color-generator.md) that calculates all of the variations and provides code to copy/paste into an app!
+
 :::
 
 Refer to the [CSS Variables documentation](css-variables.md) for more information on CSS variables.

--- a/versioned_docs/version-v8/theming/css-shadow-parts.md
+++ b/versioned_docs/version-v8/theming/css-shadow-parts.md
@@ -17,7 +17,9 @@ CSS Shadow Parts allow developers to style CSS properties on an element inside o
 Ionic Framework is a distributed set of [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components). Web Components follow the [Shadow DOM specification](https://w3c.github.io/webcomponents/spec/shadow/) in order to encapsulate styles and markup.
 
 :::note
+
 Ionic Framework components are **not all** Shadow DOM components. If the component is a Shadow DOM component, there will be a badge in the top right of its [component documentation](../components.md). An example of a Shadow DOM component is the [button component](../api/button.md).
+
 :::
 
 Shadow DOM is useful for preventing styles from leaking out of components and unintentionally applying to other elements. For example, we assign a `.button` class to our `ion-button` component. Without Shadow DOM encapsulation, if a user were to set the class `.button` on one of their own elements, it would inherit the Ionic Framework button styles. Since `ion-button` is a Shadow component, this is not a problem.
@@ -98,7 +100,9 @@ ion-item::part(native):hover {
 ```
 
 :::note
+
 There are some known limitations with [vendor prefixed pseudo-elements](#vendor-prefixed-pseudo-elements) and [structural pseudo-classes](#structural-pseudo-classes).
+
 :::
 
 ## Ionic Framework Parts
@@ -112,7 +116,9 @@ In order to have parts a component must meet the following criteria:
 - The children elements are not structural. In certain components, including `ion-title`, the child element is a structural element used to position the inner elements. We do not recommend customizing structural elements as this can have unexpected results.
 
 :::note
+
 We welcome recommendations for additional parts. Please create a [new GitHub issue](https://github.com/ionic-team/ionic-framework/issues/new?assignees=&labels=&template=feature_request.md&title=feat%3A+) with as much information as possible when requesting a part.
+
 :::
 
 ## Known Limitations

--- a/versioned_docs/version-v8/theming/dark-mode.md
+++ b/versioned_docs/version-v8/theming/dark-mode.md
@@ -65,7 +65,9 @@ import AlwaysDarkMode from '@site/static/usage/v8/theming/always-dark-mode/index
 <AlwaysDarkMode />
 
 :::caution[Important]
+
 Avoid targeting the `.ios` or `.md` selectors to override the Ionic dark palette, as these classes are added to each component and will take priority over globally defined variables. Instead, we can target the mode-specific classes on the `:root` element.
+
 :::
 
 ### System
@@ -110,7 +112,9 @@ This sets the [application colors](/docs/theming/themes#application-colors) and 
 The following example uses the system settings to decide when to show dark mode.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable dark mode on [Windows 11](https://support.microsoft.com/en-us/windows/change-colors-in-windows-d26ef4d6-819a-581c-1581-493cfcc005fe) and on [macOS](https://support.apple.com/en-us/HT208976).
+
 :::
 
 import SystemDarkMode from '@site/static/usage/v8/theming/system-dark-mode/index.mdx';
@@ -118,7 +122,9 @@ import SystemDarkMode from '@site/static/usage/v8/theming/system-dark-mode/index
 <SystemDarkMode />
 
 :::caution[Important]
+
 Avoid targeting the `.ios` or `.md` selectors to override the Ionic dark palette, as these classes are added to each component and will take priority over globally defined variables. Instead, we can target the mode-specific classes on the `:root` element.
+
 :::
 
 ### CSS Class
@@ -163,7 +169,9 @@ This sets the [application colors](/docs/theming/themes#application-colors) and 
 The following example combines site settings, system settings, and the toggle to decide when to show dark mode. The site's palette takes precedence over system settings. If your system settings differ from the site's palette when the demo loads, it will use the site's palette.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable dark mode on [Windows 11](https://support.microsoft.com/en-us/windows/change-colors-in-windows-d26ef4d6-819a-581c-1581-493cfcc005fe) and on [macOS](https://support.apple.com/en-us/HT208976).
+
 :::
 
 import ClassDarkMode from '@site/static/usage/v8/theming/class-dark-mode/index.mdx';
@@ -171,7 +179,9 @@ import ClassDarkMode from '@site/static/usage/v8/theming/class-dark-mode/index.m
 <ClassDarkMode />
 
 :::caution[Important]
+
 The `.ion-palette-dark` class **must** be added to the `html` element in order to work with the imported dark palette.
+
 :::
 
 ## Adjusting System UI Components
@@ -197,11 +207,15 @@ color-scheme: light dark;
 For more information regarding `color-scheme`, please refer to the [Web.dev guide on color schemes](https://web.dev/color-scheme/).
 
 :::note
+
 `color-scheme` does not apply to the keyboard. For details on how dark mode works with the keyboard, refer to [Keyboard Documentation](../developing/keyboard.md#dark-mode).
+
 :::
 
 :::note
+
 For developers looking to customize the theme color under the status bar in Safari on iOS 15 or the toolbar in Safari on macOS, refer to [`theme-color` Meta](./advanced.md#theme-color-meta).
+
 :::
 
 ## Ionic Dark Palette
@@ -221,11 +235,15 @@ The **always** dark palette behaves in the following ways:
 3. Setting variables for the dark palette on `md` devices using the `:root.md` selector.
 
 :::caution
+
 It is important to pay attention to the specificity if you want to override any of the Ionic dark palette variables. For example, because the `--ion-item-background` variable is set for each mode, it cannot be overridden in the `:root` selector. A higher specificity selector, such as `:root.ios`, is required.
+
 :::
 
 :::info
+
 The contents of Ionic's dark palette can be [viewed on GitHub](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.scss). The CSS used to apply the **always** dark palette can be found in the [repository](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.always.scss).
+
 :::
 
 </TabItem>
@@ -240,11 +258,15 @@ The **system** dark palette behaves in the following ways:
 4. Only applies these variables when the [CSS media query for `prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) is `dark`.
 
 :::caution
+
 It is important to pay attention to the specificity if you want to override any of the Ionic dark palette variables. For example, because the `--ion-item-background` variable is set for each mode, it cannot be overridden in the `:root` selector. A higher specificity selector, such as `:root.ios`, is required.
+
 :::
 
 :::info
+
 The contents of Ionic's dark palette can be [viewed on GitHub](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.scss). The CSS used to apply the **system** dark palette can be found in the [repository](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.system.scsss).
+
 :::
 
 </TabItem>
@@ -258,11 +280,15 @@ The **class** dark palette behaves in the following ways:
 3. Setting variables for the dark palette on `md` devices using the `.ion-palette-dark.md` selector.
 
 :::caution
+
 It is important to pay attention to the specificity if you want to override any of the Ionic dark palette variables. For example, because the `--ion-item-background` variable is set for each mode, it cannot be overridden in the `.ion-palette-dark` selector. A higher specificity selector, such as `.ion-palette-dark.ios`, is required.
+
 :::
 
 :::info
+
 The contents of Ionic's dark palette can be [viewed on GitHub](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.scss). The CSS used to apply the **class** dark palette can be found in the [repository](https://github.com/ionic-team/ionic-framework/blob/main/core/src/css/palettes/dark.class.scss).
+
 :::
 
 </TabItem>

--- a/versioned_docs/version-v8/theming/high-contrast-mode.md
+++ b/versioned_docs/version-v8/theming/high-contrast-mode.md
@@ -120,7 +120,9 @@ This approach activates the high contrast palette when the [CSS media query for 
 The following example uses the system settings to decide when to show high contrast mode.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable high contrast mode on [Windows 11](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) and on [macOS](https://support.apple.com/guide/mac-help/change-display-settings-for-accessibility-unac089/mac).
+
 :::
 
 import SystemHighContrastMode from '@site/static/usage/v8/theming/system-high-contrast-mode/index.mdx';
@@ -128,8 +130,10 @@ import SystemHighContrastMode from '@site/static/usage/v8/theming/system-high-co
 <SystemHighContrastMode />
 
 :::caution
+
 The high contrast light palette must be imported after [core.css](../layout/global-stylesheets.md#corecss), and the
 high contrast dark palette must be imported after `dark.system.css`. Otherwise, the standard contrast palette will take priority.
+
 :::
 
 ### CSS Class
@@ -178,7 +182,9 @@ This approach activates the high contrast palette when the `.ion-palette-high-co
 The following example combines site settings, system settings, and the toggle to decide when to show high contrast mode. The site's palette takes precedence over system settings. If your system settings differ from the site's palette when the demo loads, it will use the site's palette.
 
 :::info
+
 Not sure how to change the system settings? Here's how to enable high contrast mode on [Windows 11](https://support.microsoft.com/en-us/windows/turn-high-contrast-mode-on-or-off-in-windows-909e9d89-a0f9-a3a9-b993-7a6dcee85025) and on [macOS](https://support.apple.com/guide/mac-help/change-display-settings-for-accessibility-unac089/mac).
+
 :::
 
 import ClassHighContrastMode from '@site/static/usage/v8/theming/class-high-contrast-mode/index.mdx';
@@ -186,13 +192,17 @@ import ClassHighContrastMode from '@site/static/usage/v8/theming/class-high-cont
 <ClassHighContrastMode />
 
 :::caution
+
 The high contrast light palette must be imported after [core.css](../layout/global-stylesheets.md#corecss),
 and the high contrast dark palette must be imported after `dark.class.css`. Otherwise, the standard contrast palette will take
 priority.
+
 :::
 
 :::caution
+
 The `.ion-palette-high-contrast` class **must** be added to the `html` element in order to work with the imported high contrast palette.
+
 :::
 
 ## Customizing Ionic High Contrast Theme

--- a/versioned_docs/version-v8/troubleshooting/cors.md
+++ b/versioned_docs/version-v8/troubleshooting/cors.md
@@ -23,7 +23,9 @@ When the origin where your app is served (e.g. `http://localhost:8100` with `ion
 CORS errors are common in web apps when a cross-origin request is made but the server doesn't return the required headers in the response (is not CORS-enabled):
 
 :::note
+
 XMLHttpRequest cannot load https://api.example.com. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:8100' is therefore not allowed access.
+
 :::
 
 ## How does CORS work

--- a/versioned_docs/version-v8/troubleshooting/debugging.md
+++ b/versioned_docs/version-v8/troubleshooting/debugging.md
@@ -50,7 +50,9 @@ On your device, open the Ionic app that you would like to debug using Chrome.
 With your app running on the device, head back to Chrome and click on **inspect** under your device in the list of remote targets. This will open the Chrome Developer Tools in a new window. You will then be able to use all of the Chrome DevTools to debug the application as it runs on your device.
 
 :::note
+
 The app preview may not automatically appear when you open Chrome Developer Tools due to a minor bug. To make it appear, click on the **Elements** tab then click on any DOM element then toggle off and on any CSS rule and the app preview window will appear.
+
 :::
 
 ## Debugging with Visual Studio locally in Chrome (both Android & iOS)
@@ -96,5 +98,7 @@ In the root of your Ionic project, create a folder called `.vscode` and inside t
 Next, launch the debugging process, selecting your device and Ionic app. VS Code will attach to both the Android device and Ionic app and you can now debug your app, which includes setting breakpoints.
 
 :::note
+
 If you are unable to set breakpoints and get an error saying, **"Breakpoint ignored because generated code not found (source map problem?)"** it means that the paths to the transpiled javascript files are incorrect. Use the `.scripts` command in the Debug console to list the loaded scripts. Make sure the paths of the scripts are correct by experimenting with different values in the `sourceMapPathOverrides` key in your `launch.json` configuration file.
+
 :::

--- a/versioned_docs/version-v8/troubleshooting/runtime.md
+++ b/versioned_docs/version-v8/troubleshooting/runtime.md
@@ -13,7 +13,9 @@ title: Runtime Issues
 ## Blank App
 
 :::note
+
 I have no errors in my app. Why does it show a blank screen?
+
 :::
 
 There are several different reasons this can happen. If you are unable to find a solution on the [Ionic forums](https://forum.ionicframework.com), make sure:
@@ -43,7 +45,9 @@ This will automatically include the polyfills for older browsers that need them.
 ## Directive Not Working
 
 :::note
+
 Why is my custom component/directive not working?
+
 :::
 
 There are a few things you can check. Make sure:
@@ -84,7 +88,9 @@ class MyPage { }
 ## Click Delays
 
 :::note
+
 Why is there a delay on my click event?
+
 :::
 
 In general, we recommend only adding `(click)` events to elements that are
@@ -104,7 +110,9 @@ add the `tappable` attribute to your element.
 ## Angular Change Detection
 
 :::note
+
 Why does Angular change detection run very frequently when my components are initializing?
+
 :::
 
 Angular uses a library called [zone.js](https://github.com/angular/angular/tree/master/packages/zone.js/)
@@ -138,7 +146,9 @@ This change will only affect applications that depend on zone.js `0.8.27` or
 newer. Older versions will not be affected by this change.
 
 :::note
+
 This flag is automatically included when creating an Ionic app via the Ionic CLI.
+
 :::
 
 ## Cordova plugins not working in the browser

--- a/versioned_docs/version-v8/updating/4-0.md
+++ b/versioned_docs/version-v8/updating/4-0.md
@@ -10,11 +10,15 @@ import TabItem from '@theme/TabItem';
 ## Updating from Ionic 3 to 4
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 3. If you are using Ionic 1 or 2, Make sure to follow the [Updating from Ionic 1 to 4 Guide](#updating-from-ionic-1-to-4) instead.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 3 to Ionic 4, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v4.md) in the Ionic Framework repository.
+
 :::
 
 We suggest the following general process when migrating an existing application from Ionic 3 to 4:

--- a/versioned_docs/version-v8/updating/5-0.md
+++ b/versioned_docs/version-v8/updating/5-0.md
@@ -7,11 +7,15 @@ title: Updating to v5
 Migrating an app from Ionic 4 to 5 requires a few updates to the API properties, CSS utilities, and the installed package dependencies.
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 4. Make sure you have followed the [Updating to Ionic 4 Guide](./4-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 4 to Ionic 5, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v5.md) in the Ionic Framework repository.
+
 :::
 
 ### Packages and Dependencies

--- a/versioned_docs/version-v8/updating/6-0.md
+++ b/versioned_docs/version-v8/updating/6-0.md
@@ -5,11 +5,15 @@ title: Updating to v6
 # Updating from Ionic 5 to 6
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 5. Make sure you have followed the [Updating to Ionic 5 Guide](./5-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 5 to Ionic 6, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING_ARCHIVE/v6.md) in the Ionic Framework repository.
+
 :::
 
 ## Getting Started
@@ -82,7 +86,9 @@ setupIonicReact({
 ```
 
 :::note
+
 Developers must import and call `setupIonicReact` even if they are not setting custom config.
+
 :::
 
 Refer to the [React Config Documentation](../developing/config) for more examples.
@@ -184,7 +190,9 @@ Refer to the [Testing section below](#testing) for more information.
 ```
 
 :::note
+
 This applies to `ion-action-sheet`, `ion-alert`, `ion-loading`, `ion-modal`, `ion-picker`, `ion-popover`, and `ion-toast`.
+
 :::
 
 9. Pass in an `ion-router-outlet` into any `ion-tabs` that are being used:
@@ -315,7 +323,9 @@ npm install @ionic/core@6
 5. Remove any usage of the `displayFormat` or `displayTimezone` properties. To parse the UTC string provided in the payload of the `ionChange` event, we recommend using [date-fns](https://date-fns.org/). Refer to the [ion-datetime Parsing Dates Documentation](../api/datetime#parsing-dates) for examples.
 
 :::note
+
 Refer to the [Datetime Migration Sample Application](https://github.com/ionic-team/datetime-migration-samples) for more migration examples.
+
 :::
 
 ### Icon
@@ -443,7 +453,9 @@ module.exports = {
 ```
 
 :::note
+
 If you are using Ionic React or Ionic Vue, be sure to add the appropriate packages to the `transformIgnorePatterns` array. For Ionic React this includes `@ionic/react` and `@ionic/react-router`. For Ionic Vue this includes `@ionic/vue` and `@ionic/vue-router`.
+
 :::
 
 For developers using Create React App (CRA), there is currently no way to update the `transformIgnorePatterns` in a Jest config file. This is a CRA restriction and not something Ionic has control over. We can, however, pass the `transformIgnorePatterns` directly into the `react-scripts test` command:

--- a/versioned_docs/version-v8/updating/7-0.md
+++ b/versioned_docs/version-v8/updating/7-0.md
@@ -5,11 +5,15 @@ title: Updating to v7
 # Updating from Ionic 6 to 7
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 6. Make sure you have followed the [Upgrading to Ionic 6 Guide](./6-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 6 to Ionic 7, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-7x) in the Ionic Framework repository.
+
 :::
 
 ## Getting Started

--- a/versioned_docs/version-v8/updating/8-0.md
+++ b/versioned_docs/version-v8/updating/8-0.md
@@ -5,11 +5,15 @@ title: Updating to v8
 # Updating from Ionic 7 to 8
 
 :::note
+
 This guide assumes that you have already updated your app to the latest version of Ionic 7. Make sure you have followed the [Upgrading to Ionic 7 Guide](./7-0) before starting this guide.
+
 :::
 
 :::info[Breaking Changes]
+
 For a **complete list of breaking changes** from Ionic 7 to Ionic 8, please refer to [the breaking changes document](https://github.com/ionic-team/ionic-framework/blob/main/BREAKING.md#version-8x) in the Ionic Framework repository.
+
 :::
 
 ## Getting Started

--- a/versioned_docs/version-v8/vue/lifecycle.md
+++ b/versioned_docs/version-v8/vue/lifecycle.md
@@ -70,7 +70,9 @@ onIonViewWillLeave(() => {
 ```
 
 :::note
+
 Pages in your app need to be using the `IonPage` component in order for lifecycle methods and hooks to fire properly.
+
 :::
 
 ## How Ionic Framework Handles the Life of a Page

--- a/versioned_docs/version-v8/vue/navigation.md
+++ b/versioned_docs/version-v8/vue/navigation.md
@@ -163,7 +163,9 @@ ionRouter.navigate('/page2', 'forward', 'replace', customAnimation);
 The example above has the app navigate to `/page2` with a custom animation that uses the forward direction. In addition, the `replace` value ensures that the app replaces the current history entry when navigating.
 
 :::note
+
 `useIonRouter` uses the Vue `inject()` function and should only be used inside of your `setup()` function.
+
 :::
 
 Refer to the [useIonRouter documentation](./utility-functions#router) for more details as well as type information.

--- a/versioned_docs/version-v8/vue/pwa.md
+++ b/versioned_docs/version-v8/vue/pwa.md
@@ -42,7 +42,9 @@ Refer to the [Vite PWA "Deploy" Guide](https://vite-pwa-org.netlify.app/deployme
 ## Making your Vue app a PWA with Vue CLI
 
 :::note
+
 As of Ionic CLI v7, Ionic Vue starter apps ship with Vite instead of Vue CLI. Refer to [Making your Vue app a PWA with Vite](#making-your-vue-app-a-pwa-with-vite) for Vite instructions.
+
 :::
 
 The two main requirements of a PWA are a [Service Worker](https://developers.google.com/web/fundamentals/primers/service-workers/) and a [Web Application Manifest](https://developers.google.com/web/fundamentals/web-app-manifest/). While it's possible to add both of these to an app manually, the Vue CLI has some utilities for adding this for you.
@@ -54,7 +56,9 @@ vue add pwa
 ```
 
 :::note
+
 If you have changes already in place, be sure to commit them in Git.
+
 :::
 
 Once this is completed, Vue's CLI will have created a new `registerServiceWorker.ts` file and imported it into our `main.ts`.
@@ -165,7 +169,9 @@ npm install -g firebase-tools
 ```
 
 :::note
+
 If it's the first time you use firebase-tools, login to your Google account with `firebase login` command.
+
 :::
 
 With the Firebase CLI installed, run `firebase init` within your Ionic project. The CLI prompts:
@@ -179,7 +185,9 @@ Create a new Firebase project or select an existing one.
 **"What do you want to use as your public directory?"** Enter "dist".
 
 :::note
+
 Answering this next question will ensure that routing, hard reload, and deep linking work in the app:
+
 :::
 
 **Configure as a single-page app (rewrite all urls to /index.html)?"** Enter "Yes".

--- a/versioned_docs/version-v8/vue/quickstart.md
+++ b/versioned_docs/version-v8/vue/quickstart.md
@@ -66,7 +66,9 @@ Your new app's directory will look like this:
 ```
 
 :::info
+
 All file paths in the examples below are relative to the project root directory.
+
 :::
 
 Let's walk through these files to understand the app's structure.
@@ -163,7 +165,9 @@ import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue
 This creates a page with a header and scrollable content area. The second header shows a [collapsible large title](/docs/api/title.md#collapsible-large-titles) that displays on iOS devices when at the top of the content, then condenses to show the smaller title in the first header when scrolling down.
 
 :::tip[Learn More]
+
 For detailed information about Ionic layout components, refer to the [Header](/docs/api/header.md), [Toolbar](/docs/api/toolbar.md), [Title](/docs/api/title.md), and [Content](/docs/api/content.md) documentation.
+
 :::
 
 ## Add an Ionic Component
@@ -220,7 +224,9 @@ import { IonBackButton, IonButtons, IonContent, IonHeader, IonPage, IonTitle, Io
 This creates a page with a [Back Button](/docs/api/back-button.md) in the [Toolbar](/docs/api/toolbar.md). The back button will automatically handle navigation back to the previous page, or to `/` if there is no history.
 
 :::warning
+
 When creating your own pages, always use `ion-page` as the root component. This is essential for proper transitions between pages, base CSS styling that Ionic components depend on, and consistent layout behavior across your app.
+
 :::
 
 ## Navigate to the New Page
@@ -259,7 +265,9 @@ Once that is done, update the button in `HomePage.vue`:
 ```
 
 :::info
+
 Navigating can also be performed programmatically using Vue Router, and routes can be lazy loaded for better performance. Refer to the [Vue Navigation documentation](/docs/vue/navigation.md) for more information.
+
 :::
 
 ## Add Icons to the New Page

--- a/versioned_docs/version-v8/vue/slides.md
+++ b/versioned_docs/version-v8/vue/slides.md
@@ -11,15 +11,19 @@ title: Migrating From ion-slides to Swiper.js
 </head>
 
 :::warning[Looking for `ion-slides`?]
+
 `ion-slides` was deprecated in v6.0.0 and removed in v7.0.0. We recommend using the Swiper.js library directly. The migration process is detailed below.
+
 :::
 
 We recommend [Swiper.js](http://swiperjs.com/) if you need a modern touch slider component. This guide will go over how to get Swiper for Vue set up in your Ionic Framework application. It will also go over any migration information you may need to move from `ion-slides` to the official Swiper Vue integration.
 
 :::note
+
 Swiper's Vue component is set to be removed in a future release of Swiper, with [Swiper Element](https://swiperjs.com/element) as the replacement. However, this guide shows how to migrate to the Vue component because it provides the most stable experience at the time of writing.
 
 Using Swiper's Vue component is **not** required to use Swiper.js with Ionic Framework.
+
 :::
 
 ## Getting Started
@@ -56,7 +60,9 @@ import '@ionic/vue/css/ionic-swiper.css';
 ```
 
 :::note
+
 Importing `@ionic/vue/css/ionic-swiper.css` is **not** required to use Swiper.js with Ionic. This files is used for backward-compatibility with the `ion-slides` component and can be safely omitted if you prefer not to use the CSS Variables provided in the stylesheet.
+
 :::
 
 ### Updating Selectors
@@ -212,7 +218,9 @@ const modules = [Autoplay, Keyboard, Pagination, Scrollbar, Zoom];
 ```
 
 :::note
+
 Refer to [Swiper's Vue usage documentation](https://swiperjs.com/vue#usage) for a full list of modules.
+
 :::
 
 ## The IonicSlides Module
@@ -253,7 +261,9 @@ const modules = [Autoplay, Keyboard, Pagination, Scrollbar, Zoom, IonicSlides];
 ```
 
 :::note
+
 The `IonicSlides` module must be the last module in the array. This will let it automatically customize the settings of modules such as Pagination, Scrollbar, Zoom, and more.
+
 :::
 
 ## Properties
@@ -294,7 +304,9 @@ Below is a full list of property changes when going from `ion-slides` to Swiper 
 | scrollbar | You can continue to use the `scrollbar` property, just be sure to install the Scrollbar module first.                 |
 
 :::note
+
 All properties available in Swiper Vue can be found in the [Swiper Vue props documentation](https://swiperjs.com/vue#swiper-props).
+
 :::
 
 ## Events
@@ -347,7 +359,9 @@ Below is a full list of event name changes when going from `ion-slides` to Swipe
 | `ionSlidesDidLoad`        | `init`                       |
 
 :::note
+
 All events available in Swiper Vue can be found in the [Swiper Vue events documentation](https://swiperjs.com/vue#swiper-events).
+
 :::
 
 ## Methods
@@ -472,7 +486,9 @@ const modules = [EffectFade, IonicSlides];
 ```
 
 :::note
+
 For more information on effects in Swiper, please refer to the [Swiper Vue effects documentation](https://swiperjs.com/vue#effects).
+
 :::
 
 ## Wrap Up

--- a/versioned_docs/version-v8/vue/storage.md
+++ b/versioned_docs/version-v8/vue/storage.md
@@ -14,7 +14,9 @@ sidebar_label: Storage
 There are a variety of options available for storing data within an Ionic application. It is best to choose options that best fit the needs of your application. A single application may have requirements that span multiple options.
 
 :::info
+
 Some storage options involve third-party plugins or products. In such cases, we neither endorse nor support those plugins or products. We are mentioning them here for informational purposes only.
+
 :::
 
 Here are some common use cases and solutions:

--- a/versioned_docs/version-v8/vue/utility-functions.md
+++ b/versioned_docs/version-v8/vue/utility-functions.md
@@ -101,7 +101,9 @@ useBackButton(priority: number, handler: Handler): UseBackButtonResult;
 Refer to the [Hardware Back Button Documentation](../developing/hardware-back-button) for more information and usage examples.
 
 :::note
+
 The `useBackButton` callback will only fire when your app is running in Capacitor or Cordova. Refer to [Hardware Back Button in Capacitor and Cordova](../developing/hardware-back-button#hardware-back-button-in-capacitor-and-cordova) for more information.
+
 :::
 
 ## Keyboard
@@ -160,7 +162,9 @@ onIonViewWillLeave(() => {
 ```
 
 :::note
+
 Pages in your app need to be using the `IonPage` component in order for lifecycle methods and hooks to fire properly.
+
 :::
 
 Refer to the [Vue Lifecycle Documentation](./lifecycle) for more information and usage examples.

--- a/versioned_docs/version-v8/vue/virtual-scroll.md
+++ b/versioned_docs/version-v8/vue/virtual-scroll.md
@@ -15,7 +15,9 @@ npm install vue-virtual-scroller@next
 ```
 
 :::note
+
 Be sure to use the `next` tag otherwise you will get a version of `vue-virtual-scroll` that is only compatible with Vue 2.
+
 :::
 From here, we need to import the virtual scroller's CSS into our app. In `main.ts`, add the following line:
 
@@ -44,7 +46,9 @@ app.use(VueVirtualScroller);
 After doing this, all virtual scroll components will be available for use in our app.
 
 :::note
+
 Installing all components may result in unused virtual scroll components being added to your application bundle. Refer to the [Installing Specific Components](#installing-specific-components) section below for an approach that works better with treeshaking.
+
 :::
 
 ### Installing Specific Components

--- a/versioned_docs/version-v8/vue/your-first-app.md
+++ b/versioned_docs/version-v8/vue/your-first-app.md
@@ -51,7 +51,9 @@ Download and install these right away to ensure an optimal Ionic development exp
 Run the following in the command line terminal to install the Ionic CLI (`ionic`), `native-run`, used to run native binaries on devices and simulators/emulators, and `cordova-res`, used to generate native app icons and splash screens:
 
 :::note
+
 To open a terminal in Visual Studio Code, go to Terminal -> New Terminal.
+
 :::
 
 ```shell
@@ -59,9 +61,11 @@ npm install -g @ionic/cli native-run cordova-res
 ```
 
 :::note
+
 The `-g` option means _install globally_. When packages are installed globally, `EACCES` permission errors can occur.
 
 Consider setting up npm to operate globally without elevated permissions. Refer to [Resolving Permission Errors](../developing/tips.md#resolving-permission-errors) for more information.
+
 :::
 
 ## Create an App

--- a/versioned_docs/version-v8/vue/your-first-app/4-loading-photos.md
+++ b/versioned_docs/version-v8/vue/your-first-app/4-loading-photos.md
@@ -332,9 +332,11 @@ export interface UserPhoto {
 ```
 
 :::note
+
 If you encounter broken image links or missing photos after following these steps, you may need to open your browser's dev tools and clear both [localStorage](https://developer.chrome.com/docs/devtools/storage/localstorage) and [IndexedDB](https://developer.chrome.com/docs/devtools/storage/indexeddb).
 
 In localStorage, look for domain `http://localhost:8100` and key `CapacitorStorage.photos`. In IndexedDB, find a store called "FileStorage". Your photos will have a key like `/DATA/123456789012.jpeg`.
+
 :::
 
 That’s it! We’ve built a complete Photo Gallery feature in our Ionic app that works on the web. Next up, we’ll transform it into a mobile app for iOS and Android!

--- a/versioned_docs/version-v8/vue/your-first-app/6-deploying-mobile.md
+++ b/versioned_docs/version-v8/vue/your-first-app/6-deploying-mobile.md
@@ -47,7 +47,9 @@ ionic cap sync
 ## iOS Deployment
 
 :::important
+
 To build an iOS app, you’ll need a Mac computer.
+
 :::
 
 Capacitor iOS apps are configured and managed through Xcode (Apple’s iOS/Mac IDE), with dependencies managed by [CocoaPods](https://cocoapods.org/). Before running this app on an iOS device, there's a couple of steps to complete.

--- a/versioned_docs/version-v8/vue/your-first-app/7-live-reload.md
+++ b/versioned_docs/version-v8/vue/your-first-app/7-live-reload.md
@@ -176,7 +176,9 @@ Remember that removing the photo from the `photos` array triggers the `cachePhot
 Tap on a photo again and choose the “Delete” option. The photo is deleted! Implemented much faster using Live Reload. 💪
 
 :::note
+
 Remember, you can find the [complete source code for this app](https://github.com/ionic-team/tutorial-photo-gallery-vue) on GitHub.
+
 :::
 
 In the final portion of this tutorial, we’ll walk you through the basics of the Appflow product used to build and deploy your application to users' devices.


### PR DESCRIPTION
Issue URL:

## What is the current behavior?

Admonition content sits flush against its fences, with no blank lines:

```md
:::tip
Text here.
:::
```

Prettier's markdown parser doesn't know `:::` is a Docusaurus directive. When a closing fence follows a list item directly, CommonMark reads it as a lazy continuation of that item, so Prettier re-indents it to the item's content column. That's what happened to `docs/api/input-otp.md`, which came out of `.prettierignore` in #4670 and got formatted for the first time:

```md
- Use `type="text"` for patterns that include letters to show the alphanumeric keyboard
   :::
```


## What is the new behavior?

Every admonition in `docs/` and `versioned_docs/version-v8/` is padded, which keeps the closing fence a sibling of the opening one and out of reach of the list:

```md
:::tip

Text here.

:::
```

**904 of the 906 added lines are blank.** The only two substantive changes are the dedented `:::` in `docs/api/input-otp.md` and its v8 copy, which is the bug this fixes.

A blank line on its own isn't enough. Indented content after a blank line is still a loose-list continuation, so Prettier kept the two-space indent until the fence was realigned with its opener as well.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Admonitions render identically. CommonMark allows up to three spaces of indentation on a block, so even the broken one parsed correctly. This was only ever a source-formatting problem.

## Other information

N/A
