### PR TITLE
chore(i18n, api): generate component API partials as .mdx

### DIFF
--- a/plugins/docusaurus-plugin-ionic-component-api/index.js
+++ b/plugins/docusaurus-plugin-ionic-component-api/index.js
@@ -90,11 +90,26 @@ module.exports = function (context, options) {
          * directory within the plugin directory.
          */
         promises.push(
+          createData(`${basePath}/props.mdx`, data.props),
+          createData(`${basePath}/events.mdx`, data.events),
+          createData(`${basePath}/methods.mdx`, data.methods),
+          createData(`${basePath}/parts.mdx`, data.parts),
+          createData(`${basePath}/custom-props.mdx`, data.customProps),
+          createData(`${basePath}/slots.mdx`, data.slots)
+        );
+
+        /**
+         * TODO(FW-6456): Remove once every page on this branch imports the `.mdx` names.
+         *
+         * Transitional: this branch's `docs/` pages and its `versioned_docs` copies still
+         * import the `.md` names. Those are rewritten separately, so the old names have to
+         * keep being emitted until they are.
+         */
+        promises.push(
           createData(`${basePath}/props.md`, data.props),
           createData(`${basePath}/events.md`, data.events),
           createData(`${basePath}/methods.md`, data.methods),
           createData(`${basePath}/parts.md`, data.parts),
-          createData(`${basePath}/custom-props.mdx`, data.customProps),
           createData(`${basePath}/slots.md`, data.slots)
         );
       }
@@ -111,6 +126,17 @@ module.exports = function (context, options) {
         resolve: {
           alias: {
             '@ionic-internal/component-api': `${context.siteDir}/.docusaurus/docusaurus-plugin-ionic-component-api/default`,
+          },
+          /**
+           * TODO(FW-6456): Remove once every page on this branch imports the `.mdx` names.
+           *
+           * Lets a `.md` import resolve to a `.mdx` file, so pages can be moved over in
+           * batches rather than all at once. Matches the entry on `main`.
+           *
+           * Applies to every `.md` import, so a stale `.mdx` next to a `.md` will shadow it.
+           */
+          extensionAlias: {
+            '.md': ['.mdx', '.md'],
           },
         },
       };


### PR DESCRIPTION
Issue URL: internal


## What is the current behavior?

The component API tables are generated at build time into `.docusaurus`, and this branch's copy of the plugin writes them with `.md` names. Only `custom-props` is already `.mdx`.

That is the state main was in before it moved these partials to `.mdx`. Because this branch is a full fork of the repository rather than a prose only branch, its preview build resolves imports against this copy of the plugin, not against main's, so the change has to be made here too.

Nothing on this branch can move to the `.mdx` names until it is: an import written as `.mdx` would point at a file the plugin never writes.

## What is the new behavior?

The plugin now writes all six partials as `.mdx`, and continues to write five of them as `.md` alongside. It also gains a `resolve.extensionAlias` entry mapping `.md` to `.mdx` and then `.md`.

Nothing changes today. This branch's 465 `docs` imports and the 94 in `versioned_docs/version-v8` all still use the `.md` names and all still resolve. The point is that the `.mdx` names now exist, so the pages can be moved over in a follow-up rather than in one commit alongside a plugin change.

Both transitional pieces carry a `TODO(FW-6456)` note and come out once every page on this branch imports the `.mdx` names.

This is the same change main made in #4640, applied to this branch's copy. Only the generated output and the resolver entry are ported. The `node-fetch` import that main has since dropped is left alone, since that is a separate change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This does not depend on anything landing on main first, and nothing on main depends on it. It only affects how this branch's own preview build resolves the generated partials, so it can merge at any point.

The follow-up PR is what actually moves this branch's pages: 266 renames, 381 internal links, and the 470 imports. That one needs this to be in place first.

Verified locally with a full build of this branch: 2326 pages, 0 errors, no unresolved modules. The plugin writes 1728 `.mdx` partials and 1440 `.md` partials, which is six and five per component respectively, the difference being that `custom-props` was already `.mdx` and needs no duplicate.

### How to test

Open any component API page, for example [Button](https://ionic-docs-git-fw-6456-pt4b-jp-ionic1.vercel.app/docs/api/button), and confirm the Properties, Events, Methods, Parts, Custom Properties, and Slots tables all render. Those tables are the generated partials, so an empty or missing section is what a failure looks like.

Check one v8 page too, for example [Button, v8](https://ionic-docs-git-fw-6456-pt4b-jp-ionic1.vercel.app/docs/v8/api/button), since those pages import the `.md` names and confirm the old names are still being written.