### PR TITLE
chore(typescript): scope typechecking to src and add it to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,8 @@ jobs:
       run: npm run lint
     - name: Test
       run: npm run test
+    - name: 🧩 Typecheck
+      run: npm run typecheck
     - name: 🔤 Spell Check
       run: npm run spellcheck
     - uses: ./.github/workflows/actions/check-translations

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.10.2",
         "@docusaurus/tsconfig": "^3.10.2",
+        "@docusaurus/types": "^3.10.2",
         "@ionic/prettier-config": "^4.0.0",
         "@types/react": "^19.2.18",
         "cspell": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prettier": "prettier \"./**/*.{html,ts,tsx,js,jsx,md,mdx}\" --cache",
     "start": "docusaurus start",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "swizzle": "docusaurus swizzle",
     "spellcheck": "cspell --no-progress --gitignore \"**/*.{md,mdx}\""
   },
@@ -65,6 +66,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.2",
     "@docusaurus/tsconfig": "^3.10.2",
+    "@docusaurus/types": "^3.10.2",
     "@ionic/prettier-config": "^4.0.0",
     "@types/react": "^19.2.18",
     "cspell": "^10.0.1",

--- a/src/components/page/reference/ReleaseNotes/release-notes.d.json.ts
+++ b/src/components/page/reference/ReleaseNotes/release-notes.d.json.ts
@@ -1,0 +1,20 @@
+/**
+ * Types the sibling `release-notes.json`, which `scripts/release-notes.mjs` writes
+ * during `generate-markdown`. That file is gitignored and does not exist until a
+ * build runs, so this declaration keeps type checking independent of the GitHub API
+ * fetch that produces it.
+ *
+ * The `.d.json.ts` name is how TypeScript types a non-JS import; it requires
+ * `allowArbitraryExtensions`.
+ */
+
+declare const releases: {
+  body: string;
+  name: string;
+  published_at: string;
+  tag_name: string;
+  type: string;
+  version: string;
+}[];
+
+export default releases;

--- a/src/components/page/theming/SteppedColorGenerator/index.tsx
+++ b/src/components/page/theming/SteppedColorGenerator/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Component, Element, Listen, State, h } from '@stencil/core';
 import { useEffect, useState } from 'react';
 import CodeColor from '../CodeColor';
 

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,12 +1,15 @@
 /**
  * Type declarations for custom elements used in JSX.
  *
- * These are web components registered at runtime (not React components), so
- * TypeScript has no types for them and would otherwise reject the JSX usage.
+ * These are not React components, so TypeScript has no types for them and would
+ * otherwise reject the JSX usage:
  *
  * - `device-preview`: defined in src/components/global/Playground/device-preview.js
  *   and registered via `defineCustomElement()`. Used by the Playground to render
  *   examples inside an iOS/MD device frame.
+ * - `ion-icon`: registered by Ionic Framework, which the docs site loads globally.
+ * - `docs-card` / `docs-cards`: no JavaScript definition anywhere in this repo. They
+ *   are unregistered tags used purely as styling hooks by DocsCard and DocsCards.
  */
 // The import makes this file a module, so the block below augments React's
 // existing types instead of replacing them.
@@ -16,6 +19,9 @@ declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       'device-preview': any;
+      'ion-icon': any;
+      'docs-card': any;
+      'docs-cards': any;
     }
   }
 }

--- a/src/theme/DocItem/Layout/frontMatter.interface.ts
+++ b/src/theme/DocItem/Layout/frontMatter.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * Front matter fields this site adds on top of the ones Docusaurus defines. They are
+ * set in the front matter of pages under `docs/` and `versioned_docs/`, and read by
+ * the sibling `index.tsx`.
+ *
+ * This file is ours. Only `index.tsx` in this folder is a copy of upstream.
+ *
+ * Docusaurus exports `DocFrontMatter` as a type alias rather than an interface, so
+ * declaration merging cannot add to it in place. Intersecting with it here keeps the
+ * upstream fields, so reads of both these and Docusaurus's own stay checked.
+ */
+
+import type { DocFrontMatter } from '@docusaurus/plugin-content-docs';
+
+export type DocsFrontMatter = DocFrontMatter & {
+  /**
+   * Renders a phone demo beside the page content. Setting it also suppresses the
+   * table of contents, since the two compete for the same column.
+   */
+  demoUrl?: string;
+  /** Source link shown alongside the phone demo. */
+  demoSourceUrl?: string;
+};

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -26,6 +26,7 @@ import styles from '@docusaurus/theme-classic/lib/theme/DocItem/Layout/styles.mo
 
 // CUSTOM CODE
 import DocDemo from '@components/global/DocDemo';
+import type {DocsFrontMatter} from './frontMatter.interface';
 // CUSTOM CODE END
 
 /**
@@ -37,7 +38,7 @@ function useDocTOC() {
 
   const hidden = frontMatter.hide_table_of_contents;
   // CUSTOM CODE
-  const demoUrl = frontMatter.demoUrl;
+  const demoUrl = (frontMatter as DocsFrontMatter).demoUrl;
   const canRender = !hidden && toc.length > 0 && !demoUrl;
   // CUSTOM CODE END
 
@@ -57,8 +58,7 @@ function useDocTOC() {
 // CUSTOM CODE
 function useDocDemo() {
   const {frontMatter} = useDoc();
-  const demoUrl = frontMatter.demoUrl;
-  const demoSourceUrl = frontMatter.demoSourceUrl;
+  const {demoUrl, demoSourceUrl} = frontMatter as DocsFrontMatter;
   return {
     demoUrl,
     demoSourceUrl,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,37 @@
 {
   "extends": "@docusaurus/tsconfig",
-  "exclude": ["static/code/stackblitz/"],
+  "compilerOptions": {
+    /*
+     * `@docusaurus/tsconfig` sets `baseUrl` alongside a `@site/*` path mapping, but
+     * `extends` resolves `baseUrl` relative to the file that declares it, so the
+     * mapping points inside `node_modules/@docusaurus/tsconfig`. Redeclaring it here
+     * anchors it to the project root.
+     *
+     * TypeScript 6 deprecates `baseUrl` and 7 removes it. Dropping it here will not
+     * unblock those versions on its own, because the inherited one from
+     * `@docusaurus/tsconfig` triggers the same error, so this goes when upstream
+     * drops it. A `paths` mapping is not a substitute: the inherited `baseUrl`
+     * still wins.
+     */
+    "baseUrl": ".",
+    /*
+     * Real ambient declarations for `@theme/*` and `@docusaurus/*`. Without them the
+     * catch-all `declare module` fallbacks in `index.d.ts` win and every swizzled
+     * component is typed as `any`.
+     */
+    "types": ["@docusaurus/module-type-aliases", "@docusaurus/theme-classic"],
+    /*
+     * Lets `release-notes.d.json.ts` describe the generated `release-notes.json`.
+     * Ambient `declare module` cannot do this, as it does not apply to relative
+     * imports.
+     */
+    "allowArbitraryExtensions": true
+  },
+  /*
+   * `src` holds every TypeScript file in the project, and `index.d.ts` declares the
+   * `*.module.scss` imports those files rely on. Listing them explicitly also restores
+   * TypeScript's default excludes, notably `node_modules`, which the previous
+   * `exclude`-only config silently overrode.
+   */
+  "include": ["src", "index.d.ts"]
 }


### PR DESCRIPTION
Issue URL: internal

## What is the current behavior?

`tsconfig.json` is three lines:

```json
{
  "extends": "@docusaurus/tsconfig",
  "exclude": ["static/code/stackblitz/"]
}
```

Specifying `exclude` replaces TypeScript's defaults, and `node_modules` is one of them. So TypeScript walks `node_modules` and `build/`, pulling in **995 project files** and 2,039 in total. Nothing runs `tsc`, so none of the **126 errors** it reports have ever surfaced.

**97 of those 126 are inside `build/`**, which means the error count depends on whether you happen to have run a build. That scan is also load-bearing by accident: the real `@theme/*` types arrive only because `node_modules` is being walked, not because anything asks for them.

## What is the new behavior?

`npm run typecheck` runs `tsc --noEmit` over **61 files at zero errors**, and CI runs it.

Config:

- `include` scopes to `src` plus `index.d.ts`, the only declaration for `*.module.scss`. This also restores the default excludes, which is the actual fix for the above.
- `types` names `@docusaurus/module-type-aliases` and `@docusaurus/theme-classic` deliberately. Without it the catch-all `declare module '@theme/*'` in `index.d.ts` wins and every swizzled component becomes `any`.
- `baseUrl` is redeclared. Docusaurus sets it, but `extends` resolves it relative to the declaring file, so `@site/*` pointed inside `node_modules/@docusaurus/tsconfig`.
- `allowArbitraryExtensions` lets `release-notes.d.json.ts` type the generated `release-notes.json`, so typechecking needs neither a build nor a GitHub token.

Code:

- Declared `ion-icon`, `docs-card` and `docs-cards` in `src/declarations.d.ts`
- Added `DocsFrontMatter` for our `demoUrl` and `demoSourceUrl` front matter, intersected with Docusaurus's `DocFrontMatter`
- Removed a dead `@stencil/core` import left over from a Stencil to React port
- Declared `@docusaurus/types`, which `@docusaurus/module-type-aliases` imports from in 12 places and which resolved only because npm hoists it out of `@docusaurus/core`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**`strict` is not enabled.** It surfaces 144 errors concentrated in four files, with `Playground/index.tsx` alone at 60. That belongs in its own PR, and it is worth doing before Docusaurus v4, which requires TypeScript 6, where `strict` defaults to on.

**TypeScript stays at 5.9.3**, the newest 5.x. 6 and 7 are [blocked](https://github.com/facebook/docusaurus/issues/11893) by `@docusaurus/tsconfig` setting `baseUrl`, which 6 deprecates and 7 removes outright. Docusaurus drops it in v4 (facebook/docusaurus#11915). The `ignoreDeprecations: "6.0"` escape hatch works, but it silences the whole deprecation class permanently, so it is not worth taking.

**Ejected theme components are checked rather than skipped.** The three errors in `DocItem/Layout` came from our own front matter fields, so the type lives beside it in `frontMatter.interface.ts` instead of being invented inline. The change to the upstream copy is 3 lines, all inside existing `// CUSTOM CODE` markers. The other 8 ejected files needed nothing once `types` was set.
