### PR TITLE
chore(scripts): generate CLI and native pages as .mdx

### DIFF
--- a/docs/angular/your-first-app.mdx
+++ b/docs/angular/your-first-app.mdx
@@ -38,7 +38,7 @@ Highlights include:
 
 - One Angular-based codebase that runs on the web, iOS, and Android using Ionic Framework [UI components](../components.mdx).
 - Deployed as a native iOS and Android mobile app using [Capacitor](https://capacitorjs.com), Ionic's official native app runtime.
-- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.md), [Filesystem](../native/filesystem.md), and [Preferences](../native/preferences.md) APIs.
+- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.mdx), [Filesystem](../native/filesystem.mdx), and [Preferences](../native/preferences.mdx) APIs.
 
 Find the [complete app code](https://github.com/ionic-team/tutorial-photo-gallery-angular) referenced in this guide on GitHub.
 
@@ -104,7 +104,7 @@ npm install @capacitor/camera @capacitor/preferences @capacitor/filesystem
 
 ### PWA Elements
 
-Some Capacitor plugins, including the [Camera API](../native/camera.md), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
+Some Capacitor plugins, including the [Camera API](../native/camera.mdx), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
 
 It's a separate dependency, so install it next:
 

--- a/docs/angular/your-first-app/2-taking-photos.mdx
+++ b/docs/angular/your-first-app/2-taking-photos.mdx
@@ -11,7 +11,7 @@ sidebar_label: Taking Photos
   />
 </head>
 
-Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.md). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
+Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.mdx). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
 
 ## Photo Service
 

--- a/docs/angular/your-first-app/3-saving-photos.mdx
+++ b/docs/angular/your-first-app/3-saving-photos.mdx
@@ -86,7 +86,7 @@ export interface UserPhoto {
 }
 ```
 
-We'll use the Capacitor [Filesystem API](../../native/filesystem.md) to save the photo. First, convert the photo to base64 format.
+We'll use the Capacitor [Filesystem API](../../native/filesystem.mdx) to save the photo. First, convert the photo to base64 format.
 
 Then, pass the data to the Filesystem's `writeFile` method. Recall that we display photos by setting the image's source path (`src`) to the `webviewPath` property. So, set the `webviewPath` and return the new `Photo` object.
 

--- a/docs/angular/your-first-app/4-loading-photos.mdx
+++ b/docs/angular/your-first-app/4-loading-photos.mdx
@@ -13,7 +13,7 @@ sidebar_label: Loading Photos
 
 We’ve implemented photo taking and saving to the filesystem. There’s one last piece of functionality missing: the photos are stored in the filesystem, but we need a way to save pointers to each file so that they can be displayed again in the photo gallery.
 
-Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.md) to store our array of Photos in a key-value store.
+Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.mdx) to store our array of Photos in a key-value store.
 
 ## Preferences API
 

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -14,7 +14,7 @@ title: Configuration
 
 Configuration values are stored in JSON files. The Ionic CLI maintains a global configuration file, usually located at `~/.ionic/config.json`, and project configuration files, usually at the project's root directory as `ionic.config.json`.
 
-The CLI provides commands for setting and printing config values from project config files and the global CLI config file. Run `ionic config --help` or refer to the documentation for usage of [`ionic config get`](commands/config-get.md) and [`ionic config set`](commands/config-set.md).
+The CLI provides commands for setting and printing config values from project config files and the global CLI config file. Run `ionic config --help` or refer to the documentation for usage of [`ionic config get`](commands/config-get.mdx) and [`ionic config set`](commands/config-set.mdx).
 
 ### Project Configuration File
 

--- a/docs/cli/livereload.mdx
+++ b/docs/cli/livereload.mdx
@@ -59,7 +59,7 @@ Remember, with the `--external` option, others on your Wi-Fi network will be abl
 
 ## Tips
 
-- With Cordova, use the `--device`, `--emulator`, and `--target` options to narrow down target devices. Use the `--list` option to list all targets. See usage in the [command docs](commands/cordova-run.md).
+- With Cordova, use the `--device`, `--emulator`, and `--target` options to narrow down target devices. Use the `--list` option to list all targets. See usage in the [command docs](commands/cordova-run.mdx).
 - You can separate the dev server process and the deploy process by using `ionic serve` and the `--livereload-url` option of `ionic cordova run` or `ionic capacitor run`.
 - For Android, it is possible to configure [adb](https://developer.android.com/studio/command-line/adb) to always forward ports while the adb server is running (refer to `adb reverse`). With port forwarding set up, an external address would no longer be required. You can also setup the adb bridge over TCP such that subsequent deploys no longer need a USB cable.
 - If you are using a development container with Angular, live reload may not work. To fix it, set `projects.app.architect.serve.configurations.development.poll` to `1` in `angular.json`.

--- a/docs/developing/scaffolding.mdx
+++ b/docs/developing/scaffolding.mdx
@@ -50,7 +50,7 @@ This command is only supported in Ionic Angular.
 
 :::
 
-The Ionic CLI can generate new app features with the [`ionic generate`](../cli/commands/generate.md) command. By running `ionic generate` in the command line, a selection prompt is displayed which lists the available features that can be generated.
+The Ionic CLI can generate new app features with the [`ionic generate`](../cli/commands/generate.mdx) command. By running `ionic generate` in the command line, a selection prompt is displayed which lists the available features that can be generated.
 
 ```shell-session
 $ ionic generate
@@ -96,4 +96,4 @@ The Ionic CLI uses the underlying framework tooling to stay close to best practi
 
 After creating the files and directories for the new page, the CLI will also update the router configuration to include the new page. This reduces the amount of manual work needed to keep the development lifecycle moving.
 
-For more details, run `ionic g --help` from the command line or refer to the [`ionic generate` documentation](../cli/commands/generate.md).
+For more details, run `ionic g --help` from the command line or refer to the [`ionic generate` documentation](../cli/commands/generate.mdx).

--- a/docs/native-setup.mdx
+++ b/docs/native-setup.mdx
@@ -37,7 +37,7 @@ $ npm install @capacitor/camera
 
 Once installed, plugins can be imported into a component and you can call the native functionality directly from your code.
 
-Using the [Camera plugin](native/camera.md) as an example, first install it:
+Using the [Camera plugin](native/camera.mdx) as an example, first install it:
 
 ````mdx-code-block
 <Tabs

--- a/docs/react/your-first-app.mdx
+++ b/docs/react/your-first-app.mdx
@@ -32,7 +32,7 @@ Highlights include:
 
 - One React-based codebase that runs on the web, iOS, and Android using Ionic Framework [UI components](../components.mdx).
 - Deployed as a native iOS and Android mobile app using [Capacitor](https://capacitorjs.com), Ionic's official native app runtime.
-- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.md), [Filesystem](../native/filesystem.md), and [Preferences](../native/preferences.md) APIs.
+- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.mdx), [Filesystem](../native/filesystem.mdx), and [Preferences](../native/preferences.mdx) APIs.
 
 Find the [complete app code](https://github.com/ionic-team/tutorial-photo-gallery-react) referenced in this guide on GitHub.
 
@@ -92,7 +92,7 @@ npm install @capacitor/camera @capacitor/preferences @capacitor/filesystem
 
 ### PWA Elements
 
-Some Capacitor plugins, including the [Camera API](../native/camera.md), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
+Some Capacitor plugins, including the [Camera API](../native/camera.mdx), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
 
 It's a separate dependency, so install it next:
 

--- a/docs/react/your-first-app/2-taking-photos.mdx
+++ b/docs/react/your-first-app/2-taking-photos.mdx
@@ -11,7 +11,7 @@ sidebar_label: Taking Photos
   />
 </head>
 
-Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.md). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
+Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.mdx). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
 
 ## Photo Gallery Hook
 

--- a/docs/react/your-first-app/3-saving-photos.mdx
+++ b/docs/react/your-first-app/3-saving-photos.mdx
@@ -93,7 +93,7 @@ export interface UserPhoto {
 }
 ```
 
-We'll use the Capacitor [Filesystem API](../../native/filesystem.md) to save the photo. First, convert the photo to base64 format.
+We'll use the Capacitor [Filesystem API](../../native/filesystem.mdx) to save the photo. First, convert the photo to base64 format.
 
 Then, pass the data to the Filesystem's `writeFile` method. Recall that we display photos by setting the image's source path (`src`) to the `webviewPath` property. So, set the `webviewPath` and return the new `Photo` object.
 

--- a/docs/react/your-first-app/4-loading-photos.mdx
+++ b/docs/react/your-first-app/4-loading-photos.mdx
@@ -13,7 +13,7 @@ sidebar_label: Loading Photos
 
 We’ve implemented photo taking and saving to the filesystem. There’s one last piece of functionality missing: the photos are stored in the filesystem, but we need a way to save pointers to each file so that they can be displayed again in the photo gallery.
 
-Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.md) to store our array of Photos in a key-value store.
+Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.mdx) to store our array of Photos in a key-value store.
 
 ## Preferences API
 

--- a/docs/vue/your-first-app.mdx
+++ b/docs/vue/your-first-app.mdx
@@ -32,7 +32,7 @@ Highlights include:
 
 - One Vue-based codebase that runs on the web, iOS, and Android using Ionic Framework [UI components](../components.mdx).
 - Deployed as a native iOS and Android mobile app using [Capacitor](https://capacitorjs.com), Ionic's official native app runtime.
-- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.md), [Filesystem](../native/filesystem.md), and [Preferences](../native/preferences.md) APIs.
+- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.mdx), [Filesystem](../native/filesystem.mdx), and [Preferences](../native/preferences.mdx) APIs.
 
 Find the [complete app code](https://github.com/ionic-team/tutorial-photo-gallery-vue) referenced in this guide on GitHub.
 
@@ -92,7 +92,7 @@ npm install @capacitor/camera @capacitor/preferences @capacitor/filesystem
 
 ### PWA Elements
 
-Some Capacitor plugins, including the [Camera API](../native/camera.md), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
+Some Capacitor plugins, including the [Camera API](../native/camera.mdx), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
 
 It's a separate dependency, so install it next:
 

--- a/docs/vue/your-first-app/2-taking-photos.mdx
+++ b/docs/vue/your-first-app/2-taking-photos.mdx
@@ -11,7 +11,7 @@ sidebar_label: Taking Photos
   />
 </head>
 
-Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.md). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
+Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.mdx). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
 
 ## Photo Gallery Composable
 

--- a/docs/vue/your-first-app/3-saving-photos.mdx
+++ b/docs/vue/your-first-app/3-saving-photos.mdx
@@ -92,7 +92,7 @@ export interface UserPhoto {
 }
 ```
 
-We'll use the Capacitor [Filesystem API](../../native/filesystem.md) to save the photo. First, convert the photo to base64 format.
+We'll use the Capacitor [Filesystem API](../../native/filesystem.mdx) to save the photo. First, convert the photo to base64 format.
 
 Then, pass the data to the Filesystem's `writeFile` method. Recall that we display photos by setting the image's source path (`src`) to the `webviewPath` property. So, set the `webviewPath` and return the new `Photo` object.
 

--- a/docs/vue/your-first-app/4-loading-photos.mdx
+++ b/docs/vue/your-first-app/4-loading-photos.mdx
@@ -13,7 +13,7 @@ sidebar_label: Loading Photos
 
 We’ve implemented photo taking and saving to the filesystem. There’s one last piece of functionality missing: the photos are stored in the filesystem, but we need a way to save pointers to each file so that they can be displayed again in the photo gallery.
 
-Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.md) to store our array of Photos in a key-value store.
+Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.mdx) to store our array of Photos in a key-value store.
 
 ## Preferences API
 

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -28,7 +28,7 @@ function writePage(page) {
     renderExamples(page),
   ].join('');
 
-  const path = `cli/commands/${commandToKebab(page.name)}.md`;
+  const path = `cli/commands/${commandToKebab(page.name)}.mdx`;
   writeFileSync(`docs/${path}`, data);
   writeFileSync(`versioned_docs/version-v8/${path}`, data);
 }

--- a/scripts/native.mjs
+++ b/scripts/native.mjs
@@ -33,7 +33,7 @@ async function buildPluginApiDocs(pluginId) {
   const [readme, pkgJson] = await Promise.all([getReadme(pluginId), getPkgJsonData(pluginId)]);
 
   const apiContent = createApiPage(pluginId, readme, pkgJson);
-  const fileName = `${pluginId}.md`;
+  const fileName = `${pluginId}.mdx`;
 
   writeFileSync(`docs/native/${fileName}`, apiContent);
   writeFileSync(`versioned_docs/version-v8/native/${fileName}`, apiContent);

--- a/versioned_docs/version-v8/angular/your-first-app.mdx
+++ b/versioned_docs/version-v8/angular/your-first-app.mdx
@@ -38,7 +38,7 @@ Highlights include:
 
 - One Angular-based codebase that runs on the web, iOS, and Android using Ionic Framework [UI components](../components.mdx).
 - Deployed as a native iOS and Android mobile app using [Capacitor](https://capacitorjs.com), Ionic's official native app runtime.
-- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.md), [Filesystem](../native/filesystem.md), and [Preferences](../native/preferences.md) APIs.
+- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.mdx), [Filesystem](../native/filesystem.mdx), and [Preferences](../native/preferences.mdx) APIs.
 
 Find the [complete app code](https://github.com/ionic-team/tutorial-photo-gallery-angular) referenced in this guide on GitHub.
 
@@ -104,7 +104,7 @@ npm install @capacitor/camera @capacitor/preferences @capacitor/filesystem
 
 ### PWA Elements
 
-Some Capacitor plugins, including the [Camera API](../native/camera.md), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
+Some Capacitor plugins, including the [Camera API](../native/camera.mdx), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
 
 It's a separate dependency, so install it next:
 

--- a/versioned_docs/version-v8/angular/your-first-app/2-taking-photos.mdx
+++ b/versioned_docs/version-v8/angular/your-first-app/2-taking-photos.mdx
@@ -11,7 +11,7 @@ sidebar_label: Taking Photos
   />
 </head>
 
-Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.md). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
+Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.mdx). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
 
 ## Photo Service
 

--- a/versioned_docs/version-v8/angular/your-first-app/3-saving-photos.mdx
+++ b/versioned_docs/version-v8/angular/your-first-app/3-saving-photos.mdx
@@ -86,7 +86,7 @@ export interface UserPhoto {
 }
 ```
 
-We'll use the Capacitor [Filesystem API](../../native/filesystem.md) to save the photo. First, convert the photo to base64 format.
+We'll use the Capacitor [Filesystem API](../../native/filesystem.mdx) to save the photo. First, convert the photo to base64 format.
 
 Then, pass the data to the Filesystem's `writeFile` method. Recall that we display photos by setting the image's source path (`src`) to the `webviewPath` property. So, set the `webviewPath` and return the new `Photo` object.
 

--- a/versioned_docs/version-v8/angular/your-first-app/4-loading-photos.mdx
+++ b/versioned_docs/version-v8/angular/your-first-app/4-loading-photos.mdx
@@ -13,7 +13,7 @@ sidebar_label: Loading Photos
 
 We’ve implemented photo taking and saving to the filesystem. There’s one last piece of functionality missing: the photos are stored in the filesystem, but we need a way to save pointers to each file so that they can be displayed again in the photo gallery.
 
-Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.md) to store our array of Photos in a key-value store.
+Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.mdx) to store our array of Photos in a key-value store.
 
 ## Preferences API
 

--- a/versioned_docs/version-v8/cli/configuration.mdx
+++ b/versioned_docs/version-v8/cli/configuration.mdx
@@ -14,7 +14,7 @@ title: Configuration
 
 Configuration values are stored in JSON files. The Ionic CLI maintains a global configuration file, usually located at `~/.ionic/config.json`, and project configuration files, usually at the project's root directory as `ionic.config.json`.
 
-The CLI provides commands for setting and printing config values from project config files and the global CLI config file. Run `ionic config --help` or refer to the documentation for usage of [`ionic config get`](commands/config-get.md) and [`ionic config set`](commands/config-set.md).
+The CLI provides commands for setting and printing config values from project config files and the global CLI config file. Run `ionic config --help` or refer to the documentation for usage of [`ionic config get`](commands/config-get.mdx) and [`ionic config set`](commands/config-set.mdx).
 
 ### Project Configuration File
 

--- a/versioned_docs/version-v8/cli/livereload.mdx
+++ b/versioned_docs/version-v8/cli/livereload.mdx
@@ -59,7 +59,7 @@ Remember, with the `--external` option, others on your Wi-Fi network will be abl
 
 ## Tips
 
-- With Cordova, use the `--device`, `--emulator`, and `--target` options to narrow down target devices. Use the `--list` option to list all targets. See usage in the [command docs](commands/cordova-run.md).
+- With Cordova, use the `--device`, `--emulator`, and `--target` options to narrow down target devices. Use the `--list` option to list all targets. See usage in the [command docs](commands/cordova-run.mdx).
 - You can separate the dev server process and the deploy process by using `ionic serve` and the `--livereload-url` option of `ionic cordova run` or `ionic capacitor run`.
 - For Android, it is possible to configure [adb](https://developer.android.com/studio/command-line/adb) to always forward ports while the adb server is running (refer to `adb reverse`). With port forwarding set up, an external address would no longer be required. You can also setup the adb bridge over TCP such that subsequent deploys no longer need a USB cable.
 - If you are using a development container with Angular, live reload may not work. To fix it, set `projects.app.architect.serve.configurations.development.poll` to `1` in `angular.json`.

--- a/versioned_docs/version-v8/developing/scaffolding.mdx
+++ b/versioned_docs/version-v8/developing/scaffolding.mdx
@@ -50,7 +50,7 @@ This command is only supported in Ionic Angular.
 
 :::
 
-The Ionic CLI can generate new app features with the [`ionic generate`](../cli/commands/generate.md) command. By running `ionic generate` in the command line, a selection prompt is displayed which lists the available features that can be generated.
+The Ionic CLI can generate new app features with the [`ionic generate`](../cli/commands/generate.mdx) command. By running `ionic generate` in the command line, a selection prompt is displayed which lists the available features that can be generated.
 
 ```shell-session
 $ ionic generate
@@ -96,4 +96,4 @@ The Ionic CLI uses the underlying framework tooling to stay close to best practi
 
 After creating the files and directories for the new page, the CLI will also update the router configuration to include the new page. This reduces the amount of manual work needed to keep the development lifecycle moving.
 
-For more details, run `ionic g --help` from the command line or refer to the [`ionic generate` documentation](../cli/commands/generate.md).
+For more details, run `ionic g --help` from the command line or refer to the [`ionic generate` documentation](../cli/commands/generate.mdx).

--- a/versioned_docs/version-v8/native-setup.mdx
+++ b/versioned_docs/version-v8/native-setup.mdx
@@ -37,7 +37,7 @@ $ npm install @capacitor/camera
 
 Once installed, plugins can be imported into a component and you can call the native functionality directly from your code.
 
-Using the [Camera plugin](native/camera.md) as an example, first install it:
+Using the [Camera plugin](native/camera.mdx) as an example, first install it:
 
 ````mdx-code-block
 <Tabs

--- a/versioned_docs/version-v8/react/your-first-app.mdx
+++ b/versioned_docs/version-v8/react/your-first-app.mdx
@@ -32,7 +32,7 @@ Highlights include:
 
 - One React-based codebase that runs on the web, iOS, and Android using Ionic Framework [UI components](../components.mdx).
 - Deployed as a native iOS and Android mobile app using [Capacitor](https://capacitorjs.com), Ionic's official native app runtime.
-- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.md), [Filesystem](../native/filesystem.md), and [Preferences](../native/preferences.md) APIs.
+- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.mdx), [Filesystem](../native/filesystem.mdx), and [Preferences](../native/preferences.mdx) APIs.
 
 Find the [complete app code](https://github.com/ionic-team/tutorial-photo-gallery-react) referenced in this guide on GitHub.
 
@@ -92,7 +92,7 @@ npm install @capacitor/camera @capacitor/preferences @capacitor/filesystem
 
 ### PWA Elements
 
-Some Capacitor plugins, including the [Camera API](../native/camera.md), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
+Some Capacitor plugins, including the [Camera API](../native/camera.mdx), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
 
 It's a separate dependency, so install it next:
 

--- a/versioned_docs/version-v8/react/your-first-app/2-taking-photos.mdx
+++ b/versioned_docs/version-v8/react/your-first-app/2-taking-photos.mdx
@@ -11,7 +11,7 @@ sidebar_label: Taking Photos
   />
 </head>
 
-Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.md). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
+Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.mdx). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
 
 ## Photo Gallery Hook
 

--- a/versioned_docs/version-v8/react/your-first-app/3-saving-photos.mdx
+++ b/versioned_docs/version-v8/react/your-first-app/3-saving-photos.mdx
@@ -93,7 +93,7 @@ export interface UserPhoto {
 }
 ```
 
-We'll use the Capacitor [Filesystem API](../../native/filesystem.md) to save the photo. First, convert the photo to base64 format.
+We'll use the Capacitor [Filesystem API](../../native/filesystem.mdx) to save the photo. First, convert the photo to base64 format.
 
 Then, pass the data to the Filesystem's `writeFile` method. Recall that we display photos by setting the image's source path (`src`) to the `webviewPath` property. So, set the `webviewPath` and return the new `Photo` object.
 

--- a/versioned_docs/version-v8/react/your-first-app/4-loading-photos.mdx
+++ b/versioned_docs/version-v8/react/your-first-app/4-loading-photos.mdx
@@ -13,7 +13,7 @@ sidebar_label: Loading Photos
 
 We’ve implemented photo taking and saving to the filesystem. There’s one last piece of functionality missing: the photos are stored in the filesystem, but we need a way to save pointers to each file so that they can be displayed again in the photo gallery.
 
-Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.md) to store our array of Photos in a key-value store.
+Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.mdx) to store our array of Photos in a key-value store.
 
 ## Preferences API
 

--- a/versioned_docs/version-v8/vue/your-first-app.mdx
+++ b/versioned_docs/version-v8/vue/your-first-app.mdx
@@ -32,7 +32,7 @@ Highlights include:
 
 - One Vue-based codebase that runs on the web, iOS, and Android using Ionic Framework [UI components](../components.mdx).
 - Deployed as a native iOS and Android mobile app using [Capacitor](https://capacitorjs.com), Ionic's official native app runtime.
-- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.md), [Filesystem](../native/filesystem.md), and [Preferences](../native/preferences.md) APIs.
+- Photo Gallery functionality powered by the Capacitor [Camera](../native/camera.mdx), [Filesystem](../native/filesystem.mdx), and [Preferences](../native/preferences.mdx) APIs.
 
 Find the [complete app code](https://github.com/ionic-team/tutorial-photo-gallery-vue) referenced in this guide on GitHub.
 
@@ -92,7 +92,7 @@ npm install @capacitor/camera @capacitor/preferences @capacitor/filesystem
 
 ### PWA Elements
 
-Some Capacitor plugins, including the [Camera API](../native/camera.md), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
+Some Capacitor plugins, including the [Camera API](../native/camera.mdx), provide the web-based functionality and UI via the Ionic [PWA Elements library](https://github.com/ionic-team/pwa-elements).
 
 It's a separate dependency, so install it next:
 

--- a/versioned_docs/version-v8/vue/your-first-app/2-taking-photos.mdx
+++ b/versioned_docs/version-v8/vue/your-first-app/2-taking-photos.mdx
@@ -11,7 +11,7 @@ sidebar_label: Taking Photos
   />
 </head>
 
-Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.md). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
+Now for the fun part - adding the ability to take photos with the device’s camera using the Capacitor [Camera API](../../native/camera.mdx). We’ll begin with building it for the web, then make some small tweaks to make it work on mobile (iOS and Android).
 
 ## Photo Gallery Composable
 

--- a/versioned_docs/version-v8/vue/your-first-app/3-saving-photos.mdx
+++ b/versioned_docs/version-v8/vue/your-first-app/3-saving-photos.mdx
@@ -92,7 +92,7 @@ export interface UserPhoto {
 }
 ```
 
-We'll use the Capacitor [Filesystem API](../../native/filesystem.md) to save the photo. First, convert the photo to base64 format.
+We'll use the Capacitor [Filesystem API](../../native/filesystem.mdx) to save the photo. First, convert the photo to base64 format.
 
 Then, pass the data to the Filesystem's `writeFile` method. Recall that we display photos by setting the image's source path (`src`) to the `webviewPath` property. So, set the `webviewPath` and return the new `Photo` object.
 

--- a/versioned_docs/version-v8/vue/your-first-app/4-loading-photos.mdx
+++ b/versioned_docs/version-v8/vue/your-first-app/4-loading-photos.mdx
@@ -13,7 +13,7 @@ sidebar_label: Loading Photos
 
 We’ve implemented photo taking and saving to the filesystem. There’s one last piece of functionality missing: the photos are stored in the filesystem, but we need a way to save pointers to each file so that they can be displayed again in the photo gallery.
 
-Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.md) to store our array of Photos in a key-value store.
+Fortunately, this is easy: we’ll leverage the Capacitor [Preferences API](../../native/preferences.mdx) to store our array of Photos in a key-value store.
 
 ## Preferences API
 


### PR DESCRIPTION
Issue URL: internal


## What is the current behavior?

Every doc page in the repository is now named `.mdx` except two directories: the CLI command pages and the Capacitor plugin pages, which are written by `scripts/cli.mjs` and `scripts/native.mjs` on every build and still land as `.md`.

These are pages, not fragments. They get routes, sidebar entries, and URLs like any other page, so the rule worth having is simply that doc pages are `.mdx`. Right now it is that doc pages are `.mdx` except two directories, and the exception is invisible: the output is gitignored, so it only appears on a local disk after a build.

There is also a practical risk. If anyone adds an import or a component to those generator templates, the output breaks once Strict MDX is enabled, and the failure shows up as a blank section rather than an error.

## What is the new behavior?

The two generators emit `.mdx`, and the 54 links pointing into those trees are updated to match.

That is the whole change: two lines in the generators, and 32 pages containing links to the pages they produce. Nothing is renamed in git, because the output is untracked. The old `.md` files disappear the next time the generators run.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This deliberately lands before the removal of the transitional MDX compatibility code, so it can be verified on its own.

That ordering matters for an unobvious reason. The `resolve.extensionAlias` entry currently maps a `.md` import onto a `.mdx` file, so while it is in place a missed link would resolve anyway and the build would stay green. A passing build here is therefore weaker evidence than it looks.

What actually verifies this change is a static check rather than the build: every link was resolved against a real file on disk, and there are now zero `.md` links and zero `.md` imports left anywhere in `docs` or `versioned_docs/version-v8`. That check does not depend on the alias. Removing the alias in the follow-up is what proves it properly, since anything missed will then fail loudly.

Verification, compared against a build taken before the change:

The build completes with 0 errors. Broken links stay at 21 and broken anchors at 47, with none introduced. Prettier reports no differences, and the spell checker reports none across 10,918 files. All 73 generated pages build and are reachable.

### How to test

Nothing should look different. These pages are generated from the same source data as before, so a failure shows up as a missing page or a dead link rather than as changed content.

Check that a CLI command page and a Capacitor plugin page still render, for example the `ionic build` command page and the Camera plugin page, and that both appear in the sidebar in their usual positions.

Then follow a link into one of those trees from a hand-written page. The framework getting-started guides link to the Camera, Filesystem, and Preferences plugin pages, and the CLI configuration and livereload pages link to individual command pages. Those inbound links are the part this PR changes.