### PR TITLE
chore(renovate): manage the root package.json and scope every rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "semanticCommits": "enabled",
   "rebaseWhen": "never",
   "includePaths": [
+    "package.json",
     "static/code/stackblitz/**/*/package.json", 
     ".github/workflows/**"
   ],
@@ -22,21 +23,25 @@
     {
       "matchPackageNames": ["@ionic/**"],
       "minimumReleaseAge": "0 days",
-      "groupName": "ionic"
+      "groupName": "ionic",
+      "matchFileNames": ["static/code/stackblitz/**"]
     },
     {
       "description": "Angular majors land on a fixed cadence, so this group is restricted to the 1st of each month, 6-10am ET.",
       "matchPackageNames": ["@angular/**", "@angular-devkit/**"],
       "groupName": "angular",
-      "schedule": ["* 6-10 1 * *"]
+      "schedule": ["* 6-10 1 * *"],
+      "matchFileNames": ["static/code/stackblitz/**"]
     },
     {
       "matchPackageNames": ["react", "react-dom"],
-      "groupName": "react"
+      "groupName": "react",
+      "matchFileNames": ["static/code/stackblitz/**"]
     },
     {
       "matchPackageNames": ["react-router", "react-router-dom"],
-      "groupName": "react-router"
+      "groupName": "react-router",
+      "matchFileNames": ["static/code/stackblitz/**"]
     },
     {
       "matchPackageNames": ["vite", "vite-plugin-static-copy"],
@@ -126,6 +131,24 @@
         "static/code/stackblitz/v9/react/package.json",
         "static/code/stackblitz/v9/vue/package.json"
       ]
+    },
+    {
+      "matchPackageNames": ["@docusaurus/**"],
+      "groupName": "docusaurus",
+      "matchFileNames": ["package.json"]
+    },
+    {
+      "description": "Docusaurus 3 supports react 19.",
+      "matchPackageNames": ["react", "react-dom"],
+      "allowedVersions": "<20.0.0",
+      "groupName": "react-root",
+      "matchFileNames": ["package.json"]
+    },
+    {
+      "description": "Docusaurus 3 requires typescript v5.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<6.0.0",
+      "matchFileNames": ["package.json"]
     }
   ]
 }


### PR DESCRIPTION
Issue URL: internal

## What is the current behavior?

Renovate's `includePaths` covers only `static/code/stackblitz/**/*/package.json` and `.github/workflows/**`, so the root `package.json` gets no dependency PRs at all. Every upgrade there is manual, which is how `typescript` came to read `^5.9.3` while 5.3.3 was actually installed.

## What is the new behavior?

The root `package.json` is in scope.

Three rules were added for it, all at the end of `packageRules`:

- **`docusaurus`** groups the six `@docusaurus/*` packages, which sit at `^3.10.2` and must move together
- **`react-root`** caps react and react-dom below 20. `@docusaurus/core` declares `"react": "^18.0.0 || ^19.0.0"`
- **`typescript`** stays below 6, since `@docusaurus/tsconfig` sets `baseUrl`, which 6 deprecates and 7 removes

Each names the Docusaurus constraint behind it, so they can be revisited together at v4.

**Every rule now carries `matchFileNames`.** Four didn't, and they were all written when stackblitz was the only thing managed. Left alone, `@ionic/**` and `react` would have quietly started applying to the root: the first carries `"minimumReleaseAge": "0 days"` so Ionic releases reach the examples immediately, which would have let `@ionic/prettier-config` skip the repo's 3-day soak and land grouped with example bumps.

That's the reason for the blanket rule rather than only fixing the two that bite. An unscoped rule widens on its own whenever a path is added to `includePaths`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Config only. Validated with `renovate-config-validator`.

## Other information

The `docusaurus` group is strictly redundant: `config:recommended` extends `group:monorepos`, and Docusaurus is in Renovate's monorepo data, so those packages would group anyway. Kept deliberately, because the rule documents the constraint rather than leaving it implicit in data we don't control.