### PR TITLE
docs(gallery): add to the sidebar

### DIFF
--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -72,6 +72,10 @@ Ionic apps are made of high-level building blocks called Components, which allow
   <p>Floating action buttons are circular buttons that perform a primary action on a screen.</p>
 </DocsCard>
 
+<DocsCard header="Gallery" href="api/gallery">
+  <p>Galleries arrange images, cards, and other content in responsive uniform or masonry layouts.</p>
+</DocsCard>
+
 <DocsCard header="Grid" href="api/grid" icon="/icons/component-grid-icon.png">
   <p>The grid is a powerful mobile-first system for building custom layouts.</p>
 </DocsCard>

--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -72,10 +72,6 @@ Ionic apps are made of high-level building blocks called Components, which allow
   <p>Floating action buttons are circular buttons that perform a primary action on a screen.</p>
 </DocsCard>
 
-<DocsCard header="Gallery" href="api/gallery">
-  <p>Galleries arrange images, cards, and other content in responsive uniform or masonry layouts.</p>
-</DocsCard>
-
 <DocsCard header="Grid" href="api/grid" icon="/icons/component-grid-icon.png">
   <p>The grid is a powerful mobile-first system for building custom layouts.</p>
 </DocsCard>

--- a/sidebars.js
+++ b/sidebars.js
@@ -350,15 +350,9 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'Gallery',
+      label: 'Grids',
       collapsed: false,
-      items: ['api/gallery', 'api/gallery-item'],
-    },
-    {
-      type: 'category',
-      label: 'Grid',
-      collapsed: false,
-      items: ['api/grid', 'api/col', 'api/row'],
+      items: ['api/grid', 'api/col', 'api/row', 'api/gallery', 'api/gallery-item'],
     },
     {
       type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -350,6 +350,12 @@ module.exports = {
     },
     {
       type: 'category',
+      label: 'Gallery',
+      collapsed: false,
+      items: ['api/gallery', 'api/gallery-item'],
+    },
+    {
+      type: 'category',
       label: 'Grid',
       collapsed: false,
       items: ['api/grid', 'api/col', 'api/row'],


### PR DESCRIPTION
Issue URL: internal

## What is the current behavior?

`docs/api/gallery.mdx` and `docs/api/gallery-item.mdx` exist but aren't reachable by browsing. Gallery is missing from both the API sidebar and the components index, so the only way to the pages is a direct link or search.

## What is the new behavior?

Gallery appears in both, between Floating Action Button and Grid:

- **`sidebars.js`** gets the `Grid` category updated to include `api/gallery` and `api/gallery-item`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A