### PR TITLE
chore(mdx): enable the v4 strict MDX flag and guard admonition syntax

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,7 @@ jobs:
       run: npm run typecheck
     - name: 🔤 Spell Check
       run: npm run spellcheck
+    - uses: ./.github/workflows/actions/check-admonitions
     - uses: ./.github/workflows/actions/check-translations
     # Lint and spell check changes should be pushed
     # to the branch before the branch is merge eligible.

--- a/.github/workflows/actions/check-admonitions/action.yml
+++ b/.github/workflows/actions/check-admonitions/action.yml
@@ -58,6 +58,11 @@ runs:
           .split('\n')
           .filter(compiled);
 
+        if (!files.length) {
+          console.log('No MDX files changed.');
+          process.exit(0);
+        }
+
         const findings = [];
         for (const file of files) {
           const source = readFileSync(file, 'utf8');

--- a/.github/workflows/actions/check-admonitions/action.yml
+++ b/.github/workflows/actions/check-admonitions/action.yml
@@ -1,0 +1,84 @@
+name: 'Check Admonitions'
+description: 'Fails on admonition titles using the MDX v1 syntax'
+runs:
+  using: 'composite'
+  steps:
+    # `:::note My Title` was MDX v1 syntax that Docusaurus rewrote for us.
+    # With `future.v4.mdx1CompatDisabledByDefault` that shim is off, and
+    # the block `:::note My Title` stops being a directive: it renders as
+    # literal `:::note` text on the page, with no warning and a successful
+    # build.
+    #
+    # The other MDX v1 forms, HTML comments and `{#heading-ids}`, fail the
+    # build on their own, so this only covers the one that fails silently.
+    #
+    # Only the files the pull request touches are checked, so an existing
+    # page is never anyone else's problem to fix.
+    #
+    # The event payload has no file list, so the changed files come from a
+    # diff. The checkout is shallow and the base commit is fetched here
+    # rather than through `fetch-depth` on the checkout, which would pull
+    # the full history for every step in the job just to serve this one.
+    - name: 🔎 Check Admonitions
+      shell: bash
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        CHANGED_FILES: ${{ runner.temp }}/changed-files.txt
+      run: |
+        git fetch --no-tags --depth=1 origin "$BASE_SHA"
+        git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD > "$CHANGED_FILES"
+        node <<'JS'
+        const { readFileSync } = require('fs');
+
+        // Files Docusaurus compiles as MDX. Under `static/usage` that is
+        // only the `index` files; the rest are raw code samples.
+        const compiled = (f) =>
+          !f.endsWith('README.md') &&
+          ((/^(docs|versioned_docs|src\/pages)\//.test(f) && /\.mdx?$/.test(f)) ||
+            (f.startsWith('static/usage/') && f.endsWith('.mdx')));
+
+        // Defaults from `@docusaurus/mdx-loader/lib/remark/admonitions`.
+        const keywords =
+          'secondary|info|success|danger|note|tip|warning|important|caution';
+        const legacyTitle = new RegExp(
+          `^[ \\t]*:::(?:${keywords})[ \\t]+(?!\\[)\\S[^\\n]*`,
+          'gm'
+        );
+
+        // A `:::note` in a code sample is an example, not a directive.
+        // Blank out code samples with spaces, same length so line numbers
+        // still match.
+        const blank = (m) => m.replace(/[^\n]/g, ' ');
+        const mask = (t) =>
+          t
+            .replace(/^([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?^\1\2[ \t]*$/gm, blank)
+            .replace(/(`+)(?:(?!\1)[\s\S])+?\1/g, blank);
+
+        const files = readFileSync(process.env.CHANGED_FILES, 'utf8')
+          .split('\n')
+          .filter(compiled);
+
+        const findings = [];
+        for (const file of files) {
+          const source = readFileSync(file, 'utf8');
+          for (const m of mask(source).matchAll(legacyTitle)) {
+            findings.push({
+              file,
+              line: source.slice(0, m.index).split('\n').length,
+              text: source.slice(m.index, m.index + m[0].length).trim(),
+            });
+          }
+        }
+
+        if (!findings.length) {
+          console.log(`No MDX v1 admonition titles in ${files.length} changed file(s).`);
+          process.exit(0);
+        }
+
+        console.error(`Found ${findings.length} admonition title(s) using MDX v1 syntax.`);
+        console.error('Wrap the title in brackets, for example `:::note[My Title]`.\n');
+        for (const { file, line, text } of findings) {
+          console.error(`  ${file}:${line}  ${text}`);
+        }
+        process.exit(1);
+        JS

--- a/.github/workflows/actions/check-admonitions/action.yml
+++ b/.github/workflows/actions/check-admonitions/action.yml
@@ -25,7 +25,7 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         CHANGED_FILES: ${{ runner.temp }}/changed-files.txt
       run: |
-        git fetch --no-tags --depth=1 origin "$BASE_SHA"
+        git fetch --quiet --no-tags --depth=1 origin "$BASE_SHA"
         git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD > "$CHANGED_FILES"
         node <<'JS'
         const { readFileSync } = require('fs');
@@ -80,10 +80,13 @@ runs:
           process.exit(0);
         }
 
-        console.error(`Found ${findings.length} admonition title(s) using MDX v1 syntax.`);
-        console.error('Wrap the title in brackets, for example `:::note[My Title]`.\n');
+        // `::error` puts each one on the offending line in the Files changed
+        // tab and prints it in red in the log, so the failure is not something
+        // to go hunting for. The message leads with the fix because the found
+        // text starts with `:::`, which reads badly right after the delimiter.
         for (const { file, line, text } of findings) {
-          console.error(`  ${file}:${line}  ${text}`);
+          const fix = 'Wrap the title in brackets, for example :::note[My Title]';
+          console.log(`::error file=${file},line=${line},title=MDX v1 admonition title::${fix}%0A%0AFound: ${text}`);
         }
         process.exit(1);
         JS

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,18 +46,27 @@ module.exports = {
     },
   },
   onBrokenLinks: 'warn',
-  /**
-   * Docusaurus Faster replaces the Webpack/Babel/Terser toolchain with
-   * Rspack/SWC/Lightning CSS, which cuts build times and memory usage on a
-   * site with this many versioned pages. It becomes the default in v4.
-   *
-   * `removeLegacyPostBuildHeadAttribute` is required by the `ssgWorkerThreads`
-   * part of `faster`, so it has to be enabled alongside it.
-   */
   future: {
     v4: {
+      /**
+       * Turns off the MDX v1 shims for comments, admonition titles and
+       * heading ids. Every page uses the native syntax, so the shims are
+       * no-ops, and disabling them means a page that reintroduces the old
+       * syntax fails the build now rather than on the upgrade. It becomes
+       * the default in v4.
+       */
+      mdx1CompatDisabledByDefault: true,
+      /**
+       * Required by the `ssgWorkerThreads` part of `faster`, so it has to
+       * be enabled alongside it. It becomes the default in v4.
+       */
       removeLegacyPostBuildHeadAttribute: true,
     },
+    /**
+     * Replaces the Webpack/Babel/Terser toolchain with Rspack/SWC/Lightning
+     * CSS, which cuts build times and memory usage on a site with this many
+     * versioned pages. It becomes the default in v4.
+     */
     faster: true,
   },
   markdown: {


### PR DESCRIPTION
Issue URL: internal


## What is the current behavior?

Docusaurus still applies the MDX v1 compatibility shims: `mdx1Compat.comments`, `.admonitions` and `.headingIds` all default to `true`. Nothing in the repo relies on them any more, so they are no-ops that hide regressions. A page reintroducing `<!-- comment -->`, `:::note Title` or `{#heading-id}` builds fine today and breaks on the v4 upgrade instead.


## What is the new behavior?

`future.v4.mdx1CompatDisabledByDefault: true`, which flips all three to `false`. One functional line; the rest of that diff moves the existing `future` comment so each key is documented above itself.

Two of the three now fail the build outright. The third does not: `:::note My Title` stops being a directive and renders as literal `:::note` text on the page, with no warning and a successful build. A new `check-admonitions` action covers that one case, on the files each PR changes.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Verified on a throwaway PR against this branch, #4724, which plants one legacy title alongside four forms that must not be flagged. The [failing check run](https://github.com/ionic-team/ionic-docs/actions/runs/34516694957/job/103003754714?pr=4724) reports only the legacy one, and the annotation lands [on the offending line](https://github.com/ionic-team/ionic-docs/pull/4724/changes#diff-db7c35e431e7659fc0d4a3dd9c24ff796f2574a405792760c49de43d47cd27f5R28) in the Files changed tab. The bracketed, untitled, fenced and inline-code forms in the same file are correctly ignored.

On this PR the check reports `No MDX files changed`, since it touches none.

Docusaurus's own `unusedDirectives` warning is already enabled and catches `:::typo`, but it cannot catch this: it visits directive nodes, and `:::note My Title` parses to a plain paragraph. There is no node to visit, which is why the check has to work on the raw text before parsing.

Both locales build with **716** pages each and **1029** warnings, identical to the same tree with the flag off. The `ja` tree is pulled from `translation/jp` at build time rather than living here, so no CI covers it; the 267 files it fetched are clean.

### How to test

1. `npm run build` and confirm both locales complete
2. Add `<!-- test -->` to any page under `docs/` and rebuild. It should now fail with `Could not parse expression with acorn` or `Unexpected character !`, where before it built silently. Revert.

Archived v5 to v7 are not built by default. To check them:

1. Set `versions.json` to `["v8", "v7", "v6", "v5"]`
2. Run `npx docusaurus clear` (clearing only `.docusaurus` leaves the rspack cache)
3. Run `npm run build`
4. Revert

All five versions build clean.